### PR TITLE
Persist sessions/messages to localStorage and add per-message actions

### DIFF
--- a/src/components/SessionsDrawer.tsx
+++ b/src/components/SessionsDrawer.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react'
-import { ChatSession } from '../types'
+import type { ChatSession } from '../types'
 import ConfirmDialog from './ConfirmDialog'
 import './SessionsDrawer.css'
 
 export type SessionsDrawerProps = {
   open: boolean
   sessions: ChatSession[]
+  messageCounts: Record<string, number>
   activeSessionId?: string
   onClose: () => void
   onCreateSession: () => void
@@ -17,6 +18,7 @@ export type SessionsDrawerProps = {
 const SessionsDrawer = ({
   open,
   sessions,
+  messageCounts,
   activeSessionId,
   onClose,
   onCreateSession,
@@ -122,7 +124,9 @@ const SessionsDrawer = ({
                     onClick={() => onSelectSession(session.id)}
                   >
                     <span>{session.title}</span>
-                    <span className="count">{session.messages.length} msgs</span>
+                    <span className="count">
+                      {messageCounts[session.id] ?? 0} msgs
+                    </span>
                   </button>
                 )}
                 {editingId !== session.id ? (

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -52,6 +52,8 @@
 
 .message {
   display: flex;
+  align-items: flex-end;
+  gap: 8px;
 }
 
 .message.in {
@@ -70,7 +72,7 @@
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
 .message.out .bubble {
@@ -78,13 +80,79 @@
   color: #fff;
 }
 
-.message .bubble span {
+.message-footer {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.message-footer .timestamp {
   font-size: 11px;
   color: rgba(148, 163, 184, 0.8);
 }
 
-.message.out .bubble span {
+.message.out .message-footer .timestamp {
   color: rgba(226, 232, 240, 0.8);
+}
+
+.model-tag {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #475569;
+  background: rgba(148, 163, 184, 0.2);
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+
+.message.out .model-tag {
+  color: #cbd5f5;
+  background: rgba(226, 232, 240, 0.2);
+}
+
+.message-actions {
+  position: relative;
+}
+
+.action-trigger {
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-weight: 700;
+}
+
+.actions-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+  z-index: 2;
+}
+
+.actions-menu button {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.actions-menu button:hover {
+  background: #f1f5f9;
+}
+
+.actions-menu .danger {
+  color: #b91c1c;
 }
 
 .chat-composer {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,15 +1,33 @@
-import { FormEvent, useState } from 'react'
-import { ChatSession } from '../types'
+import { useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+import type { ChatMessage, ChatSession } from '../types'
+import ConfirmDialog from '../components/ConfirmDialog'
 import './ChatPage.css'
 
 export type ChatPageProps = {
   session: ChatSession
+  messages: ChatMessage[]
   onOpenDrawer: () => void
   onSendMessage: (text: string) => void
+  onDeleteMessage: (messageId: string) => void
 }
 
-const ChatPage = ({ session, onOpenDrawer, onSendMessage }: ChatPageProps) => {
+const formatTime = (timestamp: string) =>
+  new Date(timestamp).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+const ChatPage = ({
+  session,
+  messages,
+  onOpenDrawer,
+  onSendMessage,
+  onDeleteMessage,
+}: ChatPageProps) => {
   const [draft, setDraft] = useState('')
+  const [openActionsId, setOpenActionsId] = useState<string | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<ChatMessage | null>(null)
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
@@ -20,6 +38,33 @@ const ChatPage = ({ session, onOpenDrawer, onSendMessage }: ChatPageProps) => {
     onSendMessage(trimmed)
     setDraft('')
   }
+
+  const handleCopy = async (message: ChatMessage) => {
+    try {
+      await navigator.clipboard.writeText(message.content)
+    } catch (error) {
+      console.warn('Unable to copy message', error)
+    } finally {
+      setOpenActionsId(null)
+    }
+  }
+
+  const handleDelete = (message: ChatMessage) => {
+    setPendingDelete(message)
+    setOpenActionsId(null)
+  }
+
+  const handleConfirmDelete = () => {
+    if (!pendingDelete) {
+      return
+    }
+    onDeleteMessage(pendingDelete.id)
+    setPendingDelete(null)
+  }
+
+  const actionsLabel = useMemo(() => {
+    return openActionsId ? 'Close actions' : 'Open actions'
+  }, [openActionsId])
 
   return (
     <div className="chat-page">
@@ -36,14 +81,49 @@ const ChatPage = ({ session, onOpenDrawer, onSendMessage }: ChatPageProps) => {
         </button>
       </header>
       <main className="chat-messages">
-        {session.messages.map((message) => (
+        {messages.map((message) => (
           <div
             key={message.id}
-            className={`message ${message.author === 'user' ? 'out' : 'in'}`}
+            className={`message ${message.role === 'user' ? 'out' : 'in'}`}
           >
             <div className="bubble">
-              <p>{message.text}</p>
-              <span>{message.timestamp}</span>
+              <p>{message.content}</p>
+              <div className="message-footer">
+                {message.role === 'assistant' && message.meta?.model ? (
+                  <span className="model-tag">{message.meta.model}</span>
+                ) : null}
+                <span className="timestamp">{formatTime(message.createdAt)}</span>
+              </div>
+            </div>
+            <div className="message-actions">
+              <button
+                type="button"
+                className="ghost action-trigger"
+                aria-expanded={openActionsId === message.id}
+                aria-label={actionsLabel}
+                onClick={() =>
+                  setOpenActionsId((current) =>
+                    current === message.id ? null : message.id,
+                  )
+                }
+              >
+                •••
+              </button>
+              {openActionsId === message.id ? (
+                <div className="actions-menu" role="menu">
+                  <button type="button" role="menuitem" onClick={() => handleCopy(message)}>
+                    Copy
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="danger"
+                    onClick={() => handleDelete(message)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              ) : null}
             </div>
           </div>
         ))}
@@ -59,6 +139,14 @@ const ChatPage = ({ session, onOpenDrawer, onSendMessage }: ChatPageProps) => {
           Send
         </button>
       </form>
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete message?"
+        description="This will remove the message from this session."
+        confirmLabel="Delete"
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   )
 }

--- a/src/storage/chatStorage.ts
+++ b/src/storage/chatStorage.ts
@@ -1,0 +1,128 @@
+import type { ChatMessage, ChatSession } from '../types'
+
+const STORAGE_KEY = 'hamster-nest.chat-data.v1'
+
+type StorageSnapshot = {
+  sessions: ChatSession[]
+  messages: ChatMessage[]
+}
+
+const createId = () =>
+  globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+const readSnapshot = (): StorageSnapshot => {
+  if (typeof localStorage === 'undefined') {
+    return { sessions: [], messages: [] }
+  }
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) {
+    return { sessions: [], messages: [] }
+  }
+  try {
+    const parsed = JSON.parse(raw) as StorageSnapshot
+    return {
+      sessions: Array.isArray(parsed.sessions) ? parsed.sessions : [],
+      messages: Array.isArray(parsed.messages) ? parsed.messages : [],
+    }
+  } catch (error) {
+    console.warn('Failed to parse chat storage', error)
+    return { sessions: [], messages: [] }
+  }
+}
+
+const writeSnapshot = (snapshot: StorageSnapshot) => {
+  if (typeof localStorage === 'undefined') {
+    return
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
+}
+
+const sortSessions = (sessions: ChatSession[]) =>
+  [...sessions].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  )
+
+const sortMessages = (messages: ChatMessage[]) =>
+  [...messages].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  )
+
+export const loadSnapshot = (): StorageSnapshot => {
+  const snapshot = readSnapshot()
+  return {
+    sessions: sortSessions(snapshot.sessions),
+    messages: sortMessages(snapshot.messages),
+  }
+}
+
+export const createSession = (title?: string): ChatSession => {
+  const snapshot = readSnapshot()
+  const now = new Date().toISOString()
+  const session: ChatSession = {
+    id: createId(),
+    title: title ?? 'New chat',
+    createdAt: now,
+    updatedAt: now,
+  }
+  const sessions = sortSessions([...snapshot.sessions, session])
+  writeSnapshot({ ...snapshot, sessions })
+  return session
+}
+
+export const renameSession = (sessionId: string, title: string): ChatSession | null => {
+  const snapshot = readSnapshot()
+  let updatedSession: ChatSession | null = null
+  const sessions = snapshot.sessions.map((session) => {
+    if (session.id !== sessionId) {
+      return session
+    }
+    updatedSession = { ...session, title }
+    return updatedSession
+  })
+  if (!updatedSession) {
+    return null
+  }
+  writeSnapshot({ ...snapshot, sessions })
+  return updatedSession
+}
+
+export const addMessage = (
+  sessionId: string,
+  role: ChatMessage['role'],
+  content: string,
+  meta?: ChatMessage['meta'],
+): { message: ChatMessage; session: ChatSession } | null => {
+  const snapshot = readSnapshot()
+  const now = new Date().toISOString()
+  const sessionIndex = snapshot.sessions.findIndex((session) => session.id === sessionId)
+  if (sessionIndex === -1) {
+    return null
+  }
+  const message: ChatMessage = {
+    id: createId(),
+    sessionId,
+    role,
+    content,
+    createdAt: now,
+    meta,
+  }
+  const sessions = [...snapshot.sessions]
+  const updatedSession = { ...sessions[sessionIndex], updatedAt: now }
+  sessions[sessionIndex] = updatedSession
+  const messages = [...snapshot.messages, message]
+  writeSnapshot({ sessions, messages })
+  return { message, session: updatedSession }
+}
+
+export const deleteMessage = (messageId: string) => {
+  const snapshot = readSnapshot()
+  const messages = snapshot.messages.filter((message) => message.id !== messageId)
+  writeSnapshot({ ...snapshot, messages })
+}
+
+export const deleteSession = (sessionId: string) => {
+  const snapshot = readSnapshot()
+  const sessions = snapshot.sessions.filter((session) => session.id !== sessionId)
+  const messages = snapshot.messages.filter((message) => message.sessionId !== sessionId)
+  writeSnapshot({ sessions, messages })
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,18 @@
-export type ChatMessage = {
-  id: string
-  author: 'user' | 'assistant'
-  text: string
-  timestamp: string
-}
-
 export type ChatSession = {
   id: string
   title: string
-  messages: ChatMessage[]
+  createdAt: string
+  updatedAt: string
+}
+
+export type ChatMessage = {
+  id: string
+  sessionId: string
+  role: 'user' | 'assistant'
+  content: string
+  createdAt: string
+  meta?: {
+    provider?: string
+    model?: string
+  }
 }


### PR DESCRIPTION
### Motivation
- Persist chat sessions and messages so conversations survive page refresh and can be managed locally.
- Define core types to support session-level metadata (`createdAt`/`updatedAt`) and message metadata (`provider`/`model`).
- Provide per-message UX (copy/delete) and session management (delete with confirmation) to make the UI usable for basic flows.

### Description
- Add a local storage module `src/storage/chatStorage.ts` that implements JSON-backed CRUD for sessions and messages, sorts sessions/messages by `createdAt`, and updates session `updatedAt` when messages are added.
- Replace previous lightweight types with `ChatSession` and `ChatMessage` in `src/types.ts` to include `createdAt`/`updatedAt`, `sessionId`, `role`, `content`, and optional `meta` fields.
- Wire the app to persistence in `src/App.tsx` by loading `loadSnapshot()` on start, using `createSession`, `addMessage`, `renameSession`, `deleteMessage`, and `deleteSession`, and injecting a mocked assistant reply with `meta.model = "mock-model"` when sending messages.
- Implement message actions and UI changes in `src/pages/ChatPage.tsx` and `src/pages/ChatPage.css` to render assistant model labels, provide an actions menu with `Copy` and `Delete` (delete uses `ConfirmDialog`), and add session message counts to `src/components/SessionsDrawer.tsx` with deletion confirmation.

### Testing
- Built the project with `npm run build` (runs `tsc -b && vite build`) and the build completed successfully after fixing type-only import usage; the command succeeded.
- Started the dev server with `npm run dev` and ran an automated Playwright script to capture a screenshot of the chat page, which executed successfully and produced an artifact screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980470e66308330b1a080d24158fb70)