### PR TITLE
Polish mobile chat UX and debounce storage writes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,34 +170,40 @@ const ChatRoute = ({
       )
   }, [messages, sessionId])
 
-  const handleCreateSession = () => {
+  const handleCreateSession = useCallback(() => {
     const newSession = onCreateSession()
     navigate(`/chat/${newSession.id}`)
     onCloseDrawer()
-  }
+  }, [navigate, onCloseDrawer, onCreateSession])
 
-  const handleSelectSession = (id: string) => {
-    navigate(`/chat/${id}`)
-    onCloseDrawer()
-  }
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      navigate(`/chat/${id}`)
+      onCloseDrawer()
+    },
+    [navigate, onCloseDrawer],
+  )
 
-  const handleDeleteSession = (id: string) => {
-    let nextSessionId: string | null = null
-    onDeleteSession(id)
-    if (activeSession?.id === id) {
-      const remaining = sessions.filter((session) => session.id !== id)
-      if (remaining.length > 0) {
-        nextSessionId = remaining[0].id
-      } else {
-        const newSession = onCreateSession('新的开始')
-        nextSessionId = newSession.id
+  const handleDeleteSession = useCallback(
+    (id: string) => {
+      let nextSessionId: string | null = null
+      onDeleteSession(id)
+      if (activeSession?.id === id) {
+        const remaining = sessions.filter((session) => session.id !== id)
+        if (remaining.length > 0) {
+          nextSessionId = remaining[0].id
+        } else {
+          const newSession = onCreateSession('新的开始')
+          nextSessionId = newSession.id
+        }
       }
-    }
 
-    if (nextSessionId) {
-      navigate(`/chat/${nextSessionId}`, { replace: true })
-    }
-  }
+      if (nextSessionId) {
+        navigate(`/chat/${nextSessionId}`, { replace: true })
+      }
+    },
+    [activeSession?.id, navigate, onCreateSession, onDeleteSession, sessions],
+  )
 
   useEffect(() => {
     if (!activeSession) {

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom'
 import './ConfirmDialog.css'
 
 export type ConfirmDialogProps = {
@@ -23,7 +24,7 @@ const ConfirmDialog = ({
     return null
   }
 
-  return (
+  const dialog = (
     <div className="confirm-backdrop" role="dialog" aria-modal="true">
       <div className="confirm-dialog">
         <h2>{title}</h2>
@@ -39,6 +40,12 @@ const ConfirmDialog = ({
       </div>
     </div>
   )
+
+  if (typeof document === 'undefined') {
+    return dialog
+  }
+
+  return createPortal(dialog, document.body)
 }
 
 export default ConfirmDialog

--- a/src/components/SessionsDrawer.css
+++ b/src/components/SessionsDrawer.css
@@ -21,6 +21,7 @@
   width: min(320px, 85vw);
   background: #f8fafc;
   padding: 20px;
+  padding-top: calc(20px + env(safe-area-inset-top));
   transform: translateX(-100%);
   transition: transform 0.25s ease;
   z-index: 30;

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -1,7 +1,7 @@
 .chat-page {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100dvh;
   background: #f1f5f9;
 }
 
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: calc(12px + env(safe-area-inset-top)) 16px 12px;
   background: #fff;
   border-bottom: 1px solid #e2e8f0;
   gap: 8px;
@@ -48,6 +48,17 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  font-size: 14px;
+  text-align: center;
+  padding: 24px;
 }
 
 .message {
@@ -156,11 +167,14 @@
 }
 
 .chat-composer {
-  padding: 12px 16px 20px;
+  padding: 12px 16px calc(20px + env(safe-area-inset-bottom));
   display: flex;
   gap: 8px;
   background: #fff;
   border-top: 1px solid #e2e8f0;
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
 }
 
 .chat-composer textarea {


### PR DESCRIPTION
### Motivation
- Improve mobile UX so the drawer and chat feel smooth and input is not obscured by device safe areas.
- Remove noticeable freezes when creating/deleting sessions or messages by avoiding synchronous large `localStorage` writes.
- Reduce unnecessary re-renders in the sessions list to make UI interactions feel instant.

### Description
- Render `ConfirmDialog` through a portal using `createPortal` to avoid layout reflow when dialogs open (`src/components/ConfirmDialog.tsx`).
- Replace session list markup with a memoized `SessionRow` component and add stable callbacks via `useCallback` to reduce re-renders (`src/components/SessionsDrawer.tsx`).
- Add safe-area padding and mobile layout fixes: top safe-area for the drawer/header, sticky composer with bottom safe-area inset, and `min-height:100dvh` for the chat page (`src/components/SessionsDrawer.css`, `src/pages/ChatPage.css`).
- Chat page UX: add Chinese empty state text, auto-scroll to the latest message using a `ref` and `scrollIntoView`, and ensure the input composer stays visible on mobile (`src/pages/ChatPage.tsx`).
- Storage performance: keep a single in-memory `snapshot`, mutate it synchronously and debounce writes to `localStorage` with a 150ms timer via `scheduleWrite` to avoid repeated JSON re-serialization on every change (`src/storage/chatStorage.ts`).
- Stabilize route/drawer handlers with `useCallback` in `App.tsx` to avoid passing new function references on each render (`src/App.tsx`).

### Testing
- Installed dependencies with `npm install` which completed without vulnerabilities, and started the dev server with `npm run dev`, which reported Vite ready and serving locally (succeeded).
- Ran a Playwright script to load the app at the dev server and capture a mobile viewport screenshot, producing an artifact (succeeded).
- No automated unit tests were added or run for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69804e4bc5788330841a6f5b6b49a4ef)