### PR TITLE
Add Supabase email-OTP auth and cloud sync for sessions/messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ham",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.57.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.0"
@@ -1367,6 +1368,86 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.93.3.tgz",
+      "integrity": "sha512-JdnkHZPKexVGSNONtu89RHU4bxz3X9kxx+f5ZnR5osoCIX+vs/MckwWRPZEybAEvlJXt5xjomDb3IB876QCxWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.93.3.tgz",
+      "integrity": "sha512-qWO0gHNDm/5jRjROv/nv9L6sYabCWS1kzorOLUv3kqCwRvEJLYZga93ppJPrZwOgoZfXmJzvpjY8fODA4HQfBw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.93.3.tgz",
+      "integrity": "sha512-+iJ96g94skO2e4clsRSmEXg22NUOjh9BziapsJSAvnB1grOBf/BA8vGtCHjNOA+Z6lvKXL1jwBqcL9+fS1W/Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.93.3.tgz",
+      "integrity": "sha512-gnYpcFzwy8IkezRP4CDbT5I8jOsiOjrWrqTY1B+7jIriXsnpifmlM6RRjLBm9oD7OwPG0/WksniGPdKW67sXOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.93.3.tgz",
+      "integrity": "sha512-cw4qXiLrx3apglDM02Tx/w/stvFlrkKocC6vCvuFAz3JtVEl1zH8MUfDQDTH59kJAQVaVdbewrMWSoBob7REnA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.93.3.tgz",
+      "integrity": "sha512-paUqEqdBI9ztr/4bbMoCgeJ6M8ZTm2fpfjSOlzarPuzYveKFM20ZfDZqUpi9CFfYagYj5Iv3m3ztUjaI9/tM1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.93.3",
+        "@supabase/functions-js": "2.93.3",
+        "@supabase/postgrest-js": "2.93.3",
+        "@supabase/realtime-js": "2.93.3",
+        "@supabase/storage-js": "2.93.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1430,11 +1511,16 @@
       "version": "24.10.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.10",
@@ -1454,6 +1540,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2437,6 +2532,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3068,6 +3172,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3123,7 +3233,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3266,6 +3375,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.57.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.0"

--- a/src/App.css
+++ b/src/App.css
@@ -8,3 +8,12 @@
 button {
   font-family: inherit;
 }
+
+.loading-state {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  color: #475569;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import type { User } from '@supabase/supabase-js'
 import { Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom'
 import ChatPage from './pages/ChatPage'
+import AuthPage from './pages/AuthPage'
 import SessionsDrawer from './components/SessionsDrawer'
 import type { ChatMessage, ChatSession } from './types'
 import {
@@ -10,11 +12,27 @@ import {
   deleteSession,
   loadSnapshot,
   renameSession,
+  setSnapshot,
 } from './storage/chatStorage'
+import {
+  addRemoteMessage,
+  createRemoteSession,
+  deleteRemoteMessage,
+  deleteRemoteSession,
+  fetchRemoteMessages,
+  fetchRemoteSessions,
+  renameRemoteSession,
+} from './storage/supabaseSync'
+import { supabase } from './supabase/client'
 import './App.css'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  )
+
+const sortMessages = (messages: ChatMessage[]) =>
+  [...messages].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
   )
 
@@ -24,6 +42,82 @@ const App = () => {
   const [sessions, setSessions] = useState<ChatSession[]>(initialSnapshot.sessions)
   const [messages, setMessages] = useState<ChatMessage[]>(initialSnapshot.messages)
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [user, setUser] = useState<User | null>(null)
+  const [authReady, setAuthReady] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const sessionsRef = useRef(sessions)
+  const messagesRef = useRef(messages)
+
+  useEffect(() => {
+    sessionsRef.current = sessions
+  }, [sessions])
+
+  useEffect(() => {
+    messagesRef.current = messages
+  }, [messages])
+
+  const applySnapshot = useCallback((nextSessions: ChatSession[], nextMessages: ChatMessage[]) => {
+    const orderedSessions = sortSessions(nextSessions)
+    const orderedMessages = sortMessages(nextMessages)
+    sessionsRef.current = orderedSessions
+    messagesRef.current = orderedMessages
+    setSessions(orderedSessions)
+    setMessages(orderedMessages)
+    setSnapshot({ sessions: orderedSessions, messages: orderedMessages })
+  }, [])
+
+  useEffect(() => {
+    if (!supabase) {
+      setAuthReady(true)
+      return
+    }
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null)
+      setAuthReady(true)
+    })
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+      setAuthReady(true)
+    })
+    return () => {
+      data.subscription.unsubscribe()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!authReady) {
+      return
+    }
+    if (!user) {
+      const fallback = loadSnapshot()
+      applySnapshot(fallback.sessions, fallback.messages)
+      return
+    }
+    let active = true
+    const loadRemote = async () => {
+      setSyncing(true)
+      try {
+        const [remoteSessions, remoteMessages] = await Promise.all([
+          fetchRemoteSessions(user.id),
+          fetchRemoteMessages(user.id),
+        ])
+        if (!active) {
+          return
+        }
+        applySnapshot(remoteSessions, remoteMessages)
+      } catch (error) {
+        console.warn('无法加载 Supabase 数据', error)
+      } finally {
+        if (active) {
+          setSyncing(false)
+        }
+      }
+    }
+    loadRemote()
+    return () => {
+      active = false
+    }
+  }, [applySnapshot, authReady, user])
 
   const messageCounts = useMemo(() => {
     return messages.reduce<Record<string, number>>((accumulator, message) => {
@@ -32,29 +126,77 @@ const App = () => {
     }, {})
   }, [messages])
 
-  const createSessionEntry = useCallback((title?: string) => {
-    const newSession = createSession(title)
-    setSessions((prev) => sortSessions([...prev, newSession]))
-    return newSession
-  }, [])
+  const createSessionEntry = useCallback(
+    async (title?: string) => {
+      const sessionTitle = title ?? '新会话'
+      if (user && supabase) {
+        try {
+          const remoteSession = await createRemoteSession(user.id, sessionTitle)
+          const nextSessions = sortSessions([...sessionsRef.current, remoteSession])
+          applySnapshot(nextSessions, messagesRef.current)
+          return remoteSession
+        } catch (error) {
+          console.warn('创建云端会话失败，已切换本地存储', error)
+        }
+      }
+      const newSession = createSession(sessionTitle)
+      setSessions((prev) => sortSessions([...prev, newSession]))
+      return newSession
+    },
+    [applySnapshot, user],
+  )
 
-  const renameSessionEntry = useCallback((sessionId: string, title: string) => {
-    const updated = renameSession(sessionId, title)
-    if (!updated) {
-      return
-    }
-    setSessions((prev) =>
-      prev.map((session) => (session.id === sessionId ? updated : session)),
-    )
-  }, [])
+  const renameSessionEntry = useCallback(
+    async (sessionId: string, title: string) => {
+      if (user && supabase) {
+        try {
+          const updated = await renameRemoteSession(sessionId, title)
+          const nextSessions = sessionsRef.current.map((session) =>
+            session.id === sessionId ? updated : session,
+          )
+          applySnapshot(nextSessions, messagesRef.current)
+          return
+        } catch (error) {
+          console.warn('更新云端会话失败，已切换本地存储', error)
+        }
+      }
+      const updated = renameSession(sessionId, title)
+      if (!updated) {
+        return
+      }
+      setSessions((prev) =>
+        prev.map((session) => (session.id === sessionId ? updated : session)),
+      )
+    },
+    [applySnapshot, user],
+  )
 
   const appendMessage = useCallback(
-    (
+    async (
       sessionId: string,
       role: ChatMessage['role'],
       content: string,
       meta?: ChatMessage['meta'],
     ) => {
+      if (user && supabase) {
+        try {
+          const { message, updatedAt } = await addRemoteMessage(
+            sessionId,
+            user.id,
+            role,
+            content,
+            meta,
+          )
+          const nextMessages = [...messagesRef.current, message]
+          const nextSessions = sessionsRef.current.map((session) =>
+            session.id === sessionId ? { ...session, updatedAt } : session,
+          )
+          applySnapshot(nextSessions, nextMessages)
+          return message
+        } catch (error) {
+          console.warn('写入云端消息失败，已切换本地存储', error)
+        }
+      }
       const result = addMessage(sessionId, role, content, meta)
       if (!result) {
         return null
@@ -67,50 +209,97 @@ const App = () => {
       )
       return result.message
     },
-    [],
+    [applySnapshot, user],
   )
 
   const sendMessage = useCallback(
-    (sessionId: string, content: string) => {
-      appendMessage(sessionId, 'user', content)
-      appendMessage(sessionId, 'assistant', '这是一个模拟回复。', {
+    async (sessionId: string, content: string) => {
+      await appendMessage(sessionId, 'user', content)
+      await appendMessage(sessionId, 'assistant', '这是一个模拟回复。', {
         model: '模拟模型',
       })
     },
     [appendMessage],
   )
 
-  const removeMessage = useCallback((messageId: string) => {
-    deleteMessage(messageId)
-    setMessages((prev) => prev.filter((message) => message.id !== messageId))
-  }, [])
+  const removeMessage = useCallback(
+    async (messageId: string) => {
+      if (user && supabase) {
+        try {
+          await deleteRemoteMessage(messageId)
+          const nextMessages = messagesRef.current.filter(
+            (message) => message.id !== messageId,
+          )
+          applySnapshot(sessionsRef.current, nextMessages)
+          return
+        } catch (error) {
+          console.warn('删除云端消息失败，已切换本地存储', error)
+        }
+      }
+      deleteMessage(messageId)
+      setMessages((prev) => prev.filter((message) => message.id !== messageId))
+    },
+    [applySnapshot, user],
+  )
 
-  const removeSession = useCallback((sessionId: string) => {
-    deleteSession(sessionId)
-    setSessions((prev) => prev.filter((session) => session.id !== sessionId))
-    setMessages((prev) => prev.filter((message) => message.sessionId !== sessionId))
-  }, [])
+  const removeSession = useCallback(
+    async (sessionId: string) => {
+      if (user && supabase) {
+        try {
+          await deleteRemoteSession(sessionId)
+          const nextSessions = sessionsRef.current.filter(
+            (session) => session.id !== sessionId,
+          )
+          const nextMessages = messagesRef.current.filter(
+            (message) => message.sessionId !== sessionId,
+          )
+          applySnapshot(nextSessions, nextMessages)
+          return
+        } catch (error) {
+          console.warn('删除云端会话失败，已切换本地存储', error)
+        }
+      }
+      deleteSession(sessionId)
+      setSessions((prev) => prev.filter((session) => session.id !== sessionId))
+      setMessages((prev) => prev.filter((message) => message.sessionId !== sessionId))
+    },
+    [applySnapshot, user],
+  )
 
   return (
     <div className="app-shell">
       <Routes>
-        <Route path="/" element={<NewSessionRedirect onCreateSession={createSessionEntry} />} />
+        <Route
+          path="/login"
+          element={<AuthPage user={user} />}
+        />
+        <Route
+          path="/"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <NewSessionRedirect onCreateSession={createSessionEntry} />
+            </RequireAuth>
+          }
+        />
         <Route
           path="/chat/:sessionId"
           element={
-            <ChatRoute
-              sessions={sessions}
-              messages={messages}
-              messageCounts={messageCounts}
-              drawerOpen={drawerOpen}
-              onOpenDrawer={() => setDrawerOpen(true)}
-              onCloseDrawer={() => setDrawerOpen(false)}
-              onCreateSession={createSessionEntry}
-              onRenameSession={renameSessionEntry}
-              onSendMessage={sendMessage}
-              onDeleteMessage={removeMessage}
-              onDeleteSession={removeSession}
-            />
+            <RequireAuth ready={authReady} user={user}>
+              <ChatRoute
+                sessions={sessions}
+                messages={messages}
+                messageCounts={messageCounts}
+                drawerOpen={drawerOpen}
+                syncing={syncing}
+                onOpenDrawer={() => setDrawerOpen(true)}
+                onCloseDrawer={() => setDrawerOpen(false)}
+                onCreateSession={createSessionEntry}
+                onRenameSession={renameSessionEntry}
+                onSendMessage={sendMessage}
+                onDeleteMessage={removeMessage}
+                onDeleteSession={removeSession}
+              />
+            </RequireAuth>
           }
         />
         <Route path="*" element={<Navigate to="/" replace />} />
@@ -119,15 +308,47 @@ const App = () => {
   )
 }
 
+const RequireAuth = ({
+  ready,
+  user,
+  children,
+}: {
+  ready: boolean
+  user: User | null
+  children: ReactNode
+}) => {
+  if (!ready) {
+    return (
+      <div className="loading-state">
+        <p>正在检查登录状态...</p>
+      </div>
+    )
+  }
+  if (!user) {
+    return <Navigate to="/login" replace />
+  }
+  return children
+}
+
 const NewSessionRedirect = ({
   onCreateSession,
 }: {
-  onCreateSession: (title?: string) => ChatSession
+  onCreateSession: (title?: string) => Promise<ChatSession>
 }) => {
   const navigate = useNavigate()
   useEffect(() => {
-    const newSession = onCreateSession()
-    navigate(`/chat/${newSession.id}`, { replace: true })
+    let active = true
+    const create = async () => {
+      const newSession = await onCreateSession()
+      if (!active) {
+        return
+      }
+      navigate(`/chat/${newSession.id}`, { replace: true })
+    }
+    create()
+    return () => {
+      active = false
+    }
   }, [navigate, onCreateSession])
   return null
 }
@@ -137,6 +358,7 @@ const ChatRoute = ({
   messages,
   messageCounts,
   drawerOpen,
+  syncing,
   onOpenDrawer,
   onCloseDrawer,
   onCreateSession,
@@ -149,13 +371,14 @@ const ChatRoute = ({
   messages: ChatMessage[]
   messageCounts: Record<string, number>
   drawerOpen: boolean
+  syncing: boolean
   onOpenDrawer: () => void
   onCloseDrawer: () => void
-  onCreateSession: (title?: string) => ChatSession
-  onRenameSession: (sessionId: string, title: string) => void
-  onSendMessage: (sessionId: string, text: string) => void
-  onDeleteMessage: (messageId: string) => void
-  onDeleteSession: (sessionId: string) => void
+  onCreateSession: (title?: string) => Promise<ChatSession>
+  onRenameSession: (sessionId: string, title: string) => Promise<void>
+  onSendMessage: (sessionId: string, text: string) => Promise<void>
+  onDeleteMessage: (messageId: string) => Promise<void>
+  onDeleteSession: (sessionId: string) => Promise<void>
 }) => {
   const { sessionId } = useParams()
   const navigate = useNavigate()
@@ -170,8 +393,8 @@ const ChatRoute = ({
       )
   }, [messages, sessionId])
 
-  const handleCreateSession = useCallback(() => {
-    const newSession = onCreateSession()
+  const handleCreateSession = useCallback(async () => {
+    const newSession = await onCreateSession()
     navigate(`/chat/${newSession.id}`)
     onCloseDrawer()
   }, [navigate, onCloseDrawer, onCreateSession])
@@ -185,14 +408,14 @@ const ChatRoute = ({
   )
 
   const handleDeleteSession = useCallback(
-    (id: string) => {
+    async (id: string) => {
       let nextSessionId: string | null = null
       if (activeSession?.id === id) {
         const remaining = sessions.filter((session) => session.id !== id)
         if (remaining.length > 0) {
           nextSessionId = remaining[0].id
         } else {
-          const newSession = onCreateSession('新会话')
+          const newSession = await onCreateSession('新会话')
           nextSessionId = newSession.id
         }
       }
@@ -200,21 +423,24 @@ const ChatRoute = ({
       if (nextSessionId) {
         navigate(`/chat/${nextSessionId}`, { replace: true })
       }
-      onDeleteSession(id)
+      await onDeleteSession(id)
     },
     [activeSession?.id, navigate, onCreateSession, onDeleteSession, sessions],
   )
 
   useEffect(() => {
-  if (!activeSession) {
-    if (sessions.length > 0) {
-      navigate(`/chat/${sessions[0].id}`, { replace: true })
-    } else {
-      const fallback = onCreateSession('新会话')
-      navigate(`/chat/${fallback.id}`, { replace: true })
+    if (!activeSession) {
+      if (sessions.length > 0) {
+        navigate(`/chat/${sessions[0].id}`, { replace: true })
+      } else {
+        const ensureSession = async () => {
+          const fallback = await onCreateSession('新会话')
+          navigate(`/chat/${fallback.id}`, { replace: true })
+        }
+        ensureSession()
+      }
     }
-  }
-}, [activeSession, navigate, onCreateSession, sessions])
+  }, [activeSession, navigate, onCreateSession, sessions])
 
   if (!activeSession) {
     return null
@@ -234,6 +460,7 @@ const ChatRoute = ({
         sessions={sessions}
         messageCounts={messageCounts}
         activeSessionId={activeSession.id}
+        syncing={syncing}
         onClose={onCloseDrawer}
         onCreateSession={handleCreateSession}
         onSelectSession={handleSelectSession}

--- a/src/components/SessionsDrawer.css
+++ b/src/components/SessionsDrawer.css
@@ -41,6 +41,17 @@
   justify-content: space-between;
 }
 
+.drawer-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.syncing {
+  font-size: 12px;
+  color: #64748b;
+}
+
 .drawer-header h2 {
   margin: 0;
   font-size: 18px;

--- a/src/components/SessionsDrawer.tsx
+++ b/src/components/SessionsDrawer.tsx
@@ -8,11 +8,12 @@ export type SessionsDrawerProps = {
   sessions: ChatSession[]
   messageCounts: Record<string, number>
   activeSessionId?: string
+  syncing?: boolean
   onClose: () => void
-  onCreateSession: () => void
+  onCreateSession: () => void | Promise<void>
   onSelectSession: (sessionId: string) => void
-  onRenameSession: (sessionId: string, title: string) => void
-  onDeleteSession: (sessionId: string) => void
+  onRenameSession: (sessionId: string, title: string) => Promise<void> | void
+  onDeleteSession: (sessionId: string) => Promise<void> | void
 }
 
 type SessionRowProps = {
@@ -101,6 +102,7 @@ const SessionsDrawer = ({
   sessions,
   messageCounts,
   activeSessionId,
+  syncing,
   onClose,
   onCreateSession,
   onSelectSession,
@@ -172,9 +174,12 @@ const SessionsDrawer = ({
       <aside className={`sessions-drawer ${open ? 'open' : ''}`}>
         <div className="drawer-header">
           <h2>会话</h2>
-          <button type="button" className="ghost" onClick={onClose}>
-            关闭
-          </button>
+          <div className="drawer-header-actions">
+            {syncing ? <span className="syncing">同步中...</span> : null}
+            <button type="button" className="ghost" onClick={onClose}>
+              关闭
+            </button>
+          </div>
         </div>
         <button type="button" className="primary" onClick={onCreateSession}>
           + 新建聊天

--- a/src/pages/AuthPage.css
+++ b/src/pages/AuthPage.css
@@ -1,0 +1,111 @@
+.auth-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  background: radial-gradient(circle at top, rgba(75, 103, 255, 0.12), transparent 60%),
+    #0f1115;
+  color: #f5f5f5;
+}
+
+.auth-card {
+  width: min(480px, 100%);
+  background: #171a21;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.auth-card .subtitle {
+  margin: 0;
+  color: #a9b1c7;
+  font-size: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  color: #c5cbe0;
+}
+
+.field input {
+  border-radius: 12px;
+  border: 1px solid #2b2f3b;
+  background: #10121a;
+  padding: 10px 12px;
+  color: #f5f5f5;
+  font-size: 14px;
+}
+
+.auth-card .primary {
+  border-radius: 12px;
+  padding: 10px 12px;
+  border: none;
+  background: #4b67ff;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.auth-card .primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.auth-card .ghost,
+.auth-card .danger {
+  border-radius: 12px;
+  padding: 8px 12px;
+  border: 1px solid #2b2f3b;
+  background: transparent;
+  color: #c5cbe0;
+  cursor: pointer;
+}
+
+.auth-card .danger {
+  border-color: rgba(255, 107, 107, 0.4);
+  color: #ff8a8a;
+}
+
+.status {
+  color: #6cf7b1;
+  margin: 0;
+}
+
+.error {
+  color: #ff8a8a;
+  margin: 0;
+}
+
+.divider {
+  height: 1px;
+  background: #262a36;
+  margin: 8px 0;
+}
+
+.auth-user {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.user-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.hint {
+  color: #8a92aa;
+  margin: 0;
+}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { User } from '@supabase/supabase-js'
+import { supabase } from '../supabase/client'
+import './AuthPage.css'
+
+type AuthPageProps = {
+  user: User | null
+}
+
+const AuthPage = ({ user }: AuthPageProps) => {
+  const [email, setEmail] = useState('')
+  const [otp, setOtp] = useState('')
+  const [status, setStatus] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [sending, setSending] = useState(false)
+  const [verifying, setVerifying] = useState(false)
+  const navigate = useNavigate()
+
+  const handleSendOtp = useCallback(async () => {
+    const trimmed = email.trim()
+    if (!trimmed) {
+      setError('请输入邮箱地址。')
+      return
+    }
+    if (!supabase) {
+      setError('尚未配置 Supabase 环境变量。')
+      return
+    }
+    setSending(true)
+    setError(null)
+    setStatus(null)
+    const { error: signInError } = await supabase.auth.signInWithOtp({
+      email: trimmed,
+    })
+    setSending(false)
+    if (signInError) {
+      setError('验证码发送失败，请稍后再试。')
+      return
+    }
+    setStatus('验证码已发送，请查收邮箱。')
+  }, [email])
+
+  const handleVerifyOtp = useCallback(async () => {
+    const trimmedEmail = email.trim()
+    const trimmedOtp = otp.trim()
+    if (!trimmedEmail) {
+      setError('请输入邮箱地址。')
+      return
+    }
+    if (!trimmedOtp) {
+      setError('请输入验证码。')
+      return
+    }
+    if (!supabase) {
+      setError('尚未配置 Supabase 环境变量。')
+      return
+    }
+    setVerifying(true)
+    setError(null)
+    setStatus(null)
+    const { error: verifyError } = await supabase.auth.verifyOtp({
+      email: trimmedEmail,
+      token: trimmedOtp,
+      type: 'email',
+    })
+    setVerifying(false)
+    if (verifyError) {
+      setError('验证码无效或已过期。')
+      return
+    }
+    setStatus('登录成功，欢迎回来。')
+  }, [email, otp])
+
+  const handleLogout = useCallback(async () => {
+    if (!supabase) {
+      setError('尚未配置 Supabase 环境变量。')
+      return
+    }
+    setError(null)
+    setStatus(null)
+    await supabase.auth.signOut()
+  }, [])
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <h1>邮箱验证码登录</h1>
+        <p className="subtitle">使用邮箱验证码登录后即可同步云端会话。</p>
+        <label className="field">
+          <span>邮箱地址</span>
+          <input
+            type="email"
+            placeholder="输入你的邮箱"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </label>
+        <button
+          type="button"
+          className="primary"
+          onClick={handleSendOtp}
+          disabled={sending}
+        >
+          {sending ? '发送中...' : '发送验证码'}
+        </button>
+        <label className="field">
+          <span>验证码</span>
+          <input
+            type="text"
+            placeholder="输入邮箱中的验证码"
+            value={otp}
+            onChange={(event) => setOtp(event.target.value)}
+          />
+        </label>
+        <button
+          type="button"
+          className="primary"
+          onClick={handleVerifyOtp}
+          disabled={verifying}
+        >
+          {verifying ? '验证中...' : '验证并登录'}
+        </button>
+        {status ? <p className="status">{status}</p> : null}
+        {error ? <p className="error">{error}</p> : null}
+        <div className="divider" />
+        {user ? (
+          <div className="auth-user">
+            <p>
+              当前用户：<strong>{user.email ?? '未知邮箱'}</strong>
+            </p>
+            <div className="user-actions">
+              <button type="button" className="ghost" onClick={() => navigate('/')}>
+                进入聊天
+              </button>
+              <button type="button" className="danger" onClick={handleLogout}>
+                退出登录
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="hint">登录后将自动同步你的会话与消息。</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AuthPage

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -8,8 +8,8 @@ export type ChatPageProps = {
   session: ChatSession
   messages: ChatMessage[]
   onOpenDrawer: () => void
-  onSendMessage: (text: string) => void
-  onDeleteMessage: (messageId: string) => void
+  onSendMessage: (text: string) => void | Promise<void>
+  onDeleteMessage: (messageId: string) => void | Promise<void>
 }
 
 const formatTime = (timestamp: string) =>

--- a/src/storage/chatStorage.ts
+++ b/src/storage/chatStorage.ts
@@ -69,6 +69,12 @@ export const loadSnapshot = (): StorageSnapshot => {
   }
 }
 
+export const setSnapshot = (next: StorageSnapshot) => {
+  snapshot.sessions = sortSessions(next.sessions)
+  snapshot.messages = sortMessages(next.messages)
+  scheduleWrite()
+}
+
 export const createSession = (title?: string): ChatSession => {
   const now = new Date().toISOString()
   const session: ChatSession = {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1,0 +1,176 @@
+import type { ChatMessage, ChatSession } from '../types'
+import { supabase } from '../supabase/client'
+
+type SessionRow = {
+  id: string
+  user_id: string
+  title: string
+  created_at: string
+  updated_at: string
+}
+
+type MessageRow = {
+  id: string
+  session_id: string
+  user_id: string
+  role: ChatMessage['role']
+  content: string
+  created_at: string
+  meta: ChatMessage['meta'] | null
+}
+
+const mapSessionRow = (row: SessionRow): ChatSession => ({
+  id: row.id,
+  title: row.title,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const mapMessageRow = (row: MessageRow): ChatMessage => ({
+  id: row.id,
+  sessionId: row.session_id,
+  role: row.role,
+  content: row.content,
+  createdAt: row.created_at,
+  meta: row.meta ?? undefined,
+})
+
+export const fetchRemoteSessions = async (userId: string): Promise<ChatSession[]> => {
+  if (!supabase) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('sessions')
+    .select('id,user_id,title,created_at,updated_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map(mapSessionRow)
+}
+
+export const fetchRemoteMessages = async (userId: string): Promise<ChatMessage[]> => {
+  if (!supabase) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id,session_id,user_id,role,content,created_at,meta')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map(mapMessageRow)
+}
+
+export const createRemoteSession = async (
+  userId: string,
+  title: string,
+): Promise<ChatSession> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('sessions')
+    .insert({
+      user_id: userId,
+      title,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id,user_id,title,created_at,updated_at')
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('创建会话失败')
+  }
+  return mapSessionRow(data as SessionRow)
+}
+
+export const renameRemoteSession = async (
+  sessionId: string,
+  title: string,
+): Promise<ChatSession> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('sessions')
+    .update({ title, updated_at: now })
+    .eq('id', sessionId)
+    .select('id,user_id,title,created_at,updated_at')
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('更新会话失败')
+  }
+  return mapSessionRow(data as SessionRow)
+}
+
+export const deleteRemoteSession = async (sessionId: string) => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error: messagesError } = await supabase
+    .from('messages')
+    .delete()
+    .eq('session_id', sessionId)
+  if (messagesError) {
+    throw messagesError
+  }
+  const { error: sessionError } = await supabase
+    .from('sessions')
+    .delete()
+    .eq('id', sessionId)
+  if (sessionError) {
+    throw sessionError
+  }
+}
+
+export const addRemoteMessage = async (
+  sessionId: string,
+  userId: string,
+  role: ChatMessage['role'],
+  content: string,
+  meta?: ChatMessage['meta'],
+): Promise<{ message: ChatMessage; updatedAt: string }> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('messages')
+    .insert({
+      session_id: sessionId,
+      user_id: userId,
+      role,
+      content,
+      created_at: now,
+      meta: meta ?? null,
+    })
+    .select('id,session_id,user_id,role,content,created_at,meta')
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('发送消息失败')
+  }
+  const { error: sessionError } = await supabase
+    .from('sessions')
+    .update({ updated_at: now })
+    .eq('id', sessionId)
+  if (sessionError) {
+    throw sessionError
+  }
+  return { message: mapMessageRow(data as MessageRow), updatedAt: now }
+}
+
+export const deleteRemoteMessage = async (messageId: string) => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase.from('messages').delete().eq('id', messageId)
+  if (error) {
+    throw error
+  }
+}

--- a/src/supabase/client.ts
+++ b/src/supabase/client.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
+
+export const supabase =
+  supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null


### PR DESCRIPTION
### Motivation
- 支持使用 Supabase 的邮箱验证码（Email OTP）登录并在登录后将会话与消息同步到云端，使数据跨设备一致且在刷新后保持登录态。 
- 保持现有本地存储为回退机制，当云端不可用时继续使用本地快照。

### Description
- 新增 Supabase 客户端与同步层：`src/supabase/client.ts` 和 `src/storage/supabaseSync.ts`，实现对 `sessions` 与 `messages` 表的 CRUD 与读取（假设表结构如任务卡所述）。
- 新增邮箱验证码登录页及样式：`src/pages/AuthPage.tsx`、`src/pages/AuthPage.css`，所有用户可见文本为中文，支持发送 OTP、验证、查看当前用户并登出。 
- 在应用入口 `src/App.tsx` 中加入认证状态管理与路由守卫：检查 Supabase 会话、在未登录时重定向到 `/login`、登录后从 Supabase 加载并回填会话/消息，操作（创建/重命名/删除会话、增删消息）优先写入 Supabase 并在失败时回退到本地实现。 
- 增强本地存储以支持覆盖快照：`setSnapshot` 已加入 `src/storage/chatStorage.ts`，并在同步时用以写穿本地持久化。 
- 在会话侧栏增加同步状态提示并调整若干类型/异步签名：`src/components/SessionsDrawer.tsx`/`.css` 与 `src/pages/ChatPage.tsx` 的参数签名已更新以支持异步操作。 
- 更新包依赖：在 `package.json` 中加入 `@supabase/supabase-js` 并安装相关依赖（锁文件已更新）。

### Testing
- Ran `npm install` to install new dependency and update lockfile — succeeded. 
- Launched dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported ready and served the app — succeeded. 
- Performed an automated UI check via Playwright to open `/#/login` and capture a screenshot; the Firefox-based run completed and produced a screenshot of the login page, while a Chromium run failed due to a browser crash in the environment. 
- No unit tests or type-check/build steps were explicitly run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698055ff7af083309314eb5b033aa90a)