### PR TITLE
Fix magic link redirect for GitHub Pages auth route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -269,10 +269,7 @@ const App = () => {
   return (
     <div className="app-shell">
       <Routes>
-        <Route
-          path="/login"
-          element={<AuthPage user={user} />}
-        />
+        <Route path="/auth" element={<AuthPage user={user} />} />
         <Route
           path="/"
           element={
@@ -325,7 +322,7 @@ const RequireAuth = ({
     )
   }
   if (!user) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/auth" replace />
   }
   return children
 }

--- a/src/supabase/client.ts
+++ b/src/supabase/client.ts
@@ -4,4 +4,11 @@ const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
 
 export const supabase =
-  supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey, {
+        auth: {
+          detectSessionInUrl: true,
+          persistSession: true,
+        },
+      })
+    : null


### PR DESCRIPTION
### Motivation

- Email magic links generated by Supabase were redirecting to the site root instead of the GitHub Pages base path, causing broken redirects or 404s for the project site.
- The app needs to detect and complete session information from the URL after the magic-link redirect so users are automatically signed in and taken to the chat.
- The router must expose an `/auth` hash route so the magic link can land on `#/auth` (project base path preserved) and then navigate to the application after sign-in.

### Description

- Updated `src/pages/AuthPage.tsx` to include `options.emailRedirectTo: `${window.location.origin}${import.meta.env.BASE_URL}#/auth`` when calling `supabase.auth.signInWithOtp` so the magic link preserves the GitHub Pages project base path.
- Added a `useEffect` in `src/pages/AuthPage.tsx` that calls `supabase.auth.getSession()` and subscribes to `supabase.auth.onAuthStateChange` to navigate to the main app when a session/user is present.
- Changed routing in `src/App.tsx` to mount the auth page at `/auth` and updated unauthenticated redirects to `Navigate to="/auth"` so the app uses the `#/auth` entrypoint.
- Enabled URL session detection and session persistence in `src/supabase/client.ts` by creating the client with `auth: { detectSessionInUrl: true, persistSession: true }`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698066b544488330be393853c53f01eb)