### PR TITLE
Reliable Supabase message inserts + stable ordering

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -8,7 +8,7 @@ export type ChatPageProps = {
   session: ChatSession
   messages: ChatMessage[]
   onOpenDrawer: () => void
-  onSendMessage: (text: string) => void | Promise<void>
+  onSendMessage: (text: string) => Promise<void>
   onDeleteMessage: (messageId: string) => void | Promise<void>
 }
 
@@ -30,13 +30,13 @@ const ChatPage = ({
   const [pendingDelete, setPendingDelete] = useState<ChatMessage | null>(null)
   const bottomRef = useRef<HTMLDivElement | null>(null)
 
-  const handleSubmit = (event: FormEvent) => {
+  const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
     const trimmed = draft.trim()
     if (!trimmed) {
       return
     }
-    onSendMessage(trimmed)
+    await onSendMessage(trimmed)
     setDraft('')
   }
 
@@ -100,7 +100,9 @@ const ChatPage = ({
                 <p>{message.content}</p>
                 <div className="message-footer">
                   {message.role === 'assistant' && message.meta?.model ? (
-                    <span className="model-tag">{message.meta.model}</span>
+                    <span className="model-tag">
+                      {message.meta.model === 'mock-model' ? '模拟模型' : message.meta.model}
+                    </span>
                   ) : null}
                   <span className="timestamp">{formatTime(message.createdAt)}</span>
                 </div>

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -16,6 +16,8 @@ type MessageRow = {
   role: ChatMessage['role']
   content: string
   created_at: string
+  client_id: string | null
+  client_created_at: string | null
   meta: ChatMessage['meta'] | null
 }
 
@@ -32,7 +34,10 @@ const mapMessageRow = (row: MessageRow): ChatMessage => ({
   role: row.role,
   content: row.content,
   createdAt: row.created_at,
+  clientId: row.client_id ?? row.id,
+  clientCreatedAt: row.client_created_at,
   meta: row.meta ?? undefined,
+  pending: false,
 })
 
 export const fetchRemoteSessions = async (userId: string): Promise<ChatSession[]> => {
@@ -56,8 +61,9 @@ export const fetchRemoteMessages = async (userId: string): Promise<ChatMessage[]
   }
   const { data, error } = await supabase
     .from('messages')
-    .select('id,session_id,user_id,role,content,created_at,meta')
+    .select('id,session_id,user_id,role,content,created_at,client_id,client_created_at,meta')
     .eq('user_id', userId)
+    .order('client_created_at', { ascending: true })
     .order('created_at', { ascending: true })
   if (error) {
     throw error
@@ -134,6 +140,8 @@ export const addRemoteMessage = async (
   userId: string,
   role: ChatMessage['role'],
   content: string,
+  clientId: string,
+  clientCreatedAt: string,
   meta?: ChatMessage['meta'],
 ): Promise<{ message: ChatMessage; updatedAt: string }> => {
   if (!supabase) {
@@ -148,9 +156,11 @@ export const addRemoteMessage = async (
       role,
       content,
       created_at: now,
+      client_id: clientId,
+      client_created_at: clientCreatedAt,
       meta: meta ?? null,
     })
-    .select('id,session_id,user_id,role,content,created_at,meta')
+    .select('id,session_id,user_id,role,content,created_at,client_id,client_created_at,meta')
     .single()
   if (error || !data) {
     throw error ?? new Error('发送消息失败')

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,11 @@ export type ChatMessage = {
   role: 'user' | 'assistant'
   content: string
   createdAt: string
+  clientId: string
+  clientCreatedAt: string | null
   meta?: {
     provider?: string
     model?: string
   }
+  pending?: boolean
 }


### PR DESCRIPTION
### Motivation

- Ensure user messages are always persisted before assistant replies and that message ordering is stable across devices and refreshes by using `client_id` and `client_created_at` while keeping backwards compatibility with legacy rows.
- Prevent cloud sync from overwriting optimistic/local pending messages by merging by `id` or `clientId` and never dropping pending optimistic entries.

### Description

- Add `clientId`, `clientCreatedAt`, and `pending` to `ChatMessage` and normalize legacy/local rows in `src/types.ts` and `src/storage/chatStorage.ts` via `ensureMessageFields` and extended `addMessage` options.
- Update local sorting to use `clientCreatedAt` then `createdAt`, and persist normalized snapshots in `src/storage/chatStorage.ts`.
- Extend Supabase mapping and queries in `src/storage/supabaseSync.ts` to read/write `client_id` and `client_created_at`, order by `client_created_at` then `created_at`, and return mapped messages compatible with local shapes.
- Implement merge-safe sync and deterministic ordering in `src/App.tsx` with `mergeSessions`, `mergeMessages`, `updateMessage`, and a deterministic send pipeline that: creates an optimistic user message (with `clientId`/`clientCreatedAt`/`pending`), inserts the user row to Supabase, then inserts an assistant mock reply with `client_created_at = user.client_created_at + 200ms`, and updates the UI only after queuing; deletions and merges handle `id OR clientId` matching.
- Update UI behavior in `src/pages/ChatPage.tsx` to await the send queue before clearing the input and to display the mock model tag as Chinese `模拟模型` for the placeholder assistant reply.

### Testing

- Launched the dev server with `npm run dev` to verify the app builds and serves locally, which succeeded.
- Ran a headless page load and screenshot via Playwright to confirm the app rendered (login page) at `http://127.0.0.1:4173/`, which succeeded and produced an artifact screenshot.
- No automated unit/integration tests were added or executed beyond the above runtime checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698163248b508330bac36e88e96728fb)