### PR TITLE
OpenRouter streaming via Supabase Edge Function (frontend streaming + deploy workflow)

### DIFF
--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -1,0 +1,28 @@
+name: Deploy Supabase Functions
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+
+      - name: Deploy openrouter-chat
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: supabase functions deploy openrouter-chat --no-verify-jwt=false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,8 @@ const mergeMessages = (localMessages: ChatMessage[], remoteMessages: ChatMessage
 const createClientId = () =>
   globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
 
+const defaultOpenRouterModel = 'openrouter/auto'
+
 const updateMessage = (messages: ChatMessage[], next: ChatMessage) =>
   sortMessages(
     messages.map((message) =>
@@ -79,6 +81,16 @@ const updateMessage = (messages: ChatMessage[], next: ChatMessage) =>
   )
 
 const initialSnapshot = loadSnapshot()
+
+const buildOpenAiMessages = (sessionId: string, messages: ChatMessage[]) =>
+  messages
+    .filter(
+      (message) =>
+        message.sessionId === sessionId &&
+        message.content.trim().length > 0 &&
+        !message.meta?.streaming,
+    )
+    .map((message) => ({ role: message.role, content: message.content }))
 
 const App = () => {
   const [sessions, setSessions] = useState<ChatSession[]>(initialSnapshot.sessions)
@@ -268,19 +280,32 @@ const App = () => {
         meta: {},
         pending: true,
       }
-      const nextMessages = sortMessages([...messagesRef.current, optimisticMessage])
+      const assistantClientId = createClientId()
+      const assistantClientCreatedAt = new Date(
+        new Date(clientCreatedAt).getTime() + 200,
+      ).toISOString()
+      const optimisticAssistant: ChatMessage = {
+        id: assistantClientId,
+        sessionId,
+        role: 'assistant',
+        content: '',
+        createdAt: assistantClientCreatedAt,
+        clientId: assistantClientId,
+        clientCreatedAt: assistantClientCreatedAt,
+        meta: { model: defaultOpenRouterModel, provider: 'openrouter', streaming: true },
+        pending: true,
+      }
+      const nextMessages = sortMessages([
+        ...messagesRef.current,
+        optimisticMessage,
+        optimisticAssistant,
+      ])
       const nextSessions = sessionsRef.current.map((session) =>
         session.id === sessionId ? { ...session, updatedAt: clientCreatedAt } : session,
       )
       applySnapshot(nextSessions, nextMessages)
 
       const persist = async () => {
-        const assistantContent = '这是一个模拟回复。'
-        const assistantClientId = createClientId()
-        const assistantClientCreatedAt = new Date(
-          new Date(clientCreatedAt).getTime() + 200,
-        ).toISOString()
-
         if (!user || !supabase) {
           const localMessages = updateMessage(messagesRef.current, {
             ...optimisticMessage,
@@ -290,11 +315,11 @@ const App = () => {
             id: assistantClientId,
             sessionId,
             role: 'assistant',
-            content: assistantContent,
+            content: '当前未登录或服务未配置，无法获取回复。',
             createdAt: assistantClientCreatedAt,
             clientId: assistantClientId,
             clientCreatedAt: assistantClientCreatedAt,
-            meta: { model: 'mock-model', provider: 'mock' },
+            meta: { model: 'offline', provider: 'openrouter' },
             pending: false,
           }
           const localNextMessages = sortMessages([...localMessages, assistantMessage])
@@ -331,7 +356,83 @@ const App = () => {
           return
         }
 
+        let assistantContent = ''
+        let actualModel = defaultOpenRouterModel
         try {
+          const { data } = await supabase.auth.getSession()
+          const accessToken = data.session?.access_token
+          if (!accessToken) {
+            throw new Error('未获取到登录凭证')
+          }
+          const messagesPayload = buildOpenAiMessages(sessionId, messagesRef.current)
+          const response = await fetch(
+            `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,
+            {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                model: defaultOpenRouterModel,
+                messages: messagesPayload,
+                stream: true,
+              }),
+            },
+          )
+          if (!response.ok || !response.body) {
+            const errorText = await response.text()
+            throw new Error(errorText || '请求失败')
+          }
+          const reader = response.body.getReader()
+          const decoder = new TextDecoder('utf-8')
+          let buffer = ''
+          let done = false
+          while (!done) {
+            const { value, done: readerDone } = await reader.read()
+            if (readerDone) {
+              break
+            }
+            buffer += decoder.decode(value, { stream: true })
+            const lines = buffer.split('\n')
+            buffer = lines.pop() ?? ''
+            for (const line of lines) {
+              const trimmed = line.trim()
+              if (!trimmed.startsWith('data:')) {
+                continue
+              }
+              const data = trimmed.replace(/^data:\s*/, '')
+              if (data === '[DONE]') {
+                done = true
+                break
+              }
+              try {
+                const payload = JSON.parse(data)
+                const delta = payload?.choices?.[0]?.delta?.content ?? ''
+                if (payload?.model) {
+                  actualModel = payload.model
+                }
+                if (delta) {
+                  assistantContent += delta
+                  const streamingUpdate = updateMessage(messagesRef.current, {
+                    id: assistantClientId,
+                    clientId: assistantClientId,
+                    content: assistantContent,
+                    meta: {
+                      model: actualModel,
+                      provider: 'openrouter',
+                      streaming: true,
+                    },
+                    pending: true,
+                  })
+                  applySnapshot(sessionsRef.current, streamingUpdate)
+                }
+              } catch (error) {
+                console.warn('解析流式响应失败', error)
+              }
+            }
+          }
+
           const { message: assistantMessage, updatedAt } = await addRemoteMessage(
             sessionId,
             user.id,
@@ -339,16 +440,27 @@ const App = () => {
             assistantContent,
             assistantClientId,
             assistantClientCreatedAt,
-            { model: 'mock-model', provider: 'mock' },
+            { model: actualModel, provider: 'openrouter' },
           )
-          const updatedMessages = sortMessages([...messagesRef.current, assistantMessage])
+          const updatedMessages = updateMessage(messagesRef.current, {
+            ...assistantMessage,
+            pending: false,
+          })
           const updatedSessions = sessionsRef.current.map((session) =>
             session.id === sessionId ? { ...session, updatedAt } : session,
           )
           applySnapshot(updatedSessions, updatedMessages)
         } catch (error) {
-          console.warn('写入云端模拟回复失败', error)
-          window.alert('模拟回复发送失败，请稍后重试。')
+          console.warn('流式回复失败', error)
+          const failedMessages = updateMessage(messagesRef.current, {
+            id: assistantClientId,
+            clientId: assistantClientId,
+            content: assistantContent || '回复失败，请稍后重试。',
+            meta: { model: actualModel, provider: 'openrouter', streaming: false },
+            pending: false,
+          })
+          applySnapshot(sessionsRef.current, failedMessages)
+          window.alert('回复失败，请稍后重试。')
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type ChatMessage = {
   meta?: {
     provider?: string
     model?: string
+    streaming?: boolean
   }
   pending?: boolean
 }


### PR DESCRIPTION
### Motivation
- Proxy OpenRouter requests through a Supabase Edge Function so the OpenRouter API key remains server-side and is not exposed to the frontend.
- Replace the app's mock assistant replies with real streaming responses to improve UX and maintain token-level updates in the UI.
- Provide automated deployment for the Edge Function via GitHub Actions so functions are deployed on pushes to `main`.

### Description
- Added a Supabase Edge Function at `supabase/functions/openrouter-chat/index.ts` (Deno) that enforces CORS for GitHub Pages/localhost, verifies `Authorization: Bearer <user_jwt>`, forwards the posted payload to `https://openrouter.ai/api/v1/chat/completions` using `OPENROUTER_API_KEY` from environment, and streams the upstream SSE body directly back as `text/event-stream` while returning JSON errors for upstream failures.
- Implemented client-side streaming integration in `src/App.tsx` by adding `buildOpenAiMessages`, creating an optimistic assistant message with `meta.streaming=true`, calling the Edge Function via `fetch` to `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat` with the Supabase access token, parsing SSE `data:` chunks to accumulate deltas and update the assistant message in-place, and persisting the final assistant message with `addRemoteMessage` including the actual `meta.model` used.
- Updated type definitions in `src/types.ts` to include `meta.streaming?: boolean` for chat messages.
- Added a GitHub Actions workflow ` .github/workflows/deploy-supabase-functions.yml` to deploy the `openrouter-chat` function using the Supabase CLI with `supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}` and `supabase functions deploy openrouter-chat --no-verify-jwt=false`.
- Ensured no OpenRouter API key is checked into the repository and preserved Chinese user-visible strings (including fallback/offline messages).

### Testing
- No automated tests were executed as part of this change.
- Manual runtime validation was not performed in this PR; function deployment and streaming behavior should be validated in a staging environment after setting `SUPABASE_ACCESS_TOKEN` and `SUPABASE_PROJECT_REF` and configuring the `OPENROUTER_API_KEY` in Supabase function secrets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981932a68dc8330842f17e03760bdf4)