### PR TITLE
Fix CORS preflight to allow apikey header

### DIFF
--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -25,7 +25,7 @@ const isAllowedOrigin = (origin: string | null) => {
 
 const buildCorsHeaders = (origin: string | null) => ({
   'Access-Control-Allow-Origin': origin ?? '*',
-  'Access-Control-Allow-Headers': 'authorization, content-type',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Max-Age': '86400',
 })


### PR DESCRIPTION
### Motivation

- Browser preflight was blocked because the `apikey` request header was not included in `Access-Control-Allow-Headers`, causing CORS failures for the Supabase function.

### Description

- Added `apikey` to `Access-Control-Allow-Headers` in `supabase/functions/openrouter-chat/index.ts`, preserving the existing `OPTIONS` handling (returns 204) and ensuring `buildCorsHeaders` is used for all responses so CORS headers are included on success and error responses.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a14742988330ac1014bf723f18f1)