### PR TITLE
Fix Supabase anon key usage and CORS header for openrouter-chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -362,12 +362,12 @@ const App = () => {
           const { data } = await supabase.auth.getSession()
           const accessToken = data.session?.access_token
           if (!accessToken) {
-            window.alert('未获取到登录凭证，请重新登录。')
+            window.alert('登录状态异常，请重新登录')
             return
           }
           const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
           if (!anonKey) {
-            window.alert('服务未配置，请稍后重试。')
+            window.alert('Supabase 环境变量未配置')
             return
           }
           const messagesPayload = buildOpenAiMessages(sessionId, messagesRef.current)

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -25,7 +25,7 @@ const isAllowedOrigin = (origin: string | null) => {
 
 const buildCorsHeaders = (origin: string | null) => ({
   'Access-Control-Allow-Origin': origin ?? '*',
-  'Access-Control-Allow-Headers': 'authorization, content-type',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Max-Age': '86400',
 })


### PR DESCRIPTION
### Motivation
- Prevent 401 Invalid JWT by ensuring the Supabase function call uses the anon key in `apikey` and the session `access_token` only in `Authorization`.
- Ensure browser preflight succeeds by allowing the `apikey` header in CORS responses.
- Surface clear Chinese error messages when environment or session values are missing.

### Description
- Updated `src/App.tsx` to display the required Chinese error messages `Supabase 环境变量未配置` when the anon key is missing and `登录状态异常，请重新登录` when the session token is missing before building request headers.
- Kept frontend fetch headers set as `apikey: anonKey` and `Authorization: Bearer ${accessToken}` to avoid sending the session JWT as the `apikey` header.
- Added `apikey` to `Access-Control-Allow-Headers` in `supabase/functions/openrouter-chat/index.ts` so preflight requests allow the header.
- Changes touch `src/App.tsx` and `supabase/functions/openrouter-chat/index.ts` and preserve existing OPTIONS handling and CORS header usage.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a14742988330ac1014bf723f18f1)