### PR TITLE
Add supabase invoke ping for JWT debugging

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,3 +17,32 @@ button {
   font-size: 16px;
   color: #475569;
 }
+
+.dev-ping {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 20px;
+  background: #e2e8f0;
+  color: #0f172a;
+  font-size: 14px;
+}
+
+.dev-ping button {
+  border: 1px solid #94a3b8;
+  background: #f8fafc;
+  color: #0f172a;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.dev-ping button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dev-ping__status {
+  color: #0f766e;
+}


### PR DESCRIPTION
### Motivation
- Diagnose and bypass `401 Invalid JWT` responses by using `supabase.functions.invoke` so the Supabase client constructs auth headers correctly for the function call. 
- Provide a quick dev-only check that proves whether auth headers sent via `supabase-js` succeed (to help distinguish client header bug vs. auth/session issues). 
- Improve developer feedback and CORS handling so preflight and missing-env/session cases are clearer.

### Description
- Added a dev-only ping panel in `src/App.tsx` (guarded by `import.meta.env.DEV`) that calls `supabase.functions.invoke('openrouter-chat', { body: { ping: true } })` and displays Chinese status messages for success/failure. 
- Implemented a short-circuit ping handler in `supabase/functions/openrouter-chat/index.ts` that returns `200 { ok: true }` when the request body contains `{ ping: true }` before any upstream OpenRouter call. 
- Added `apikey` to `Access-Control-Allow-Headers` in the function to ensure CORS preflight allows the `apikey` header. 
- Updated UI text to show clearer Chinese alerts for missing Supabase anon key (`Supabase 环境变量未配置`) and missing session token (`登录状态异常，请重新登录`). 
- Added minimal styling for the debug ping banner in `src/App.css` and minor callback dependency fixes in `src/App.tsx`.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which reported Vite ready and served the app successfully. (Succeeded.)
- Ran an automated Playwright script that opened `http://127.0.0.1:4173/auth` and captured a screenshot `artifacts/dev-ping-banner.png` showing the debug ping banner; the script completed successfully. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a14742988330ac1014bf723f18f1)