### PR TITLE
PR-019: True streaming UI and SSE headers

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -169,12 +169,31 @@
 .chat-composer {
   padding: 12px 16px calc(20px + env(safe-area-inset-bottom));
   display: flex;
+  flex-direction: column;
   gap: 8px;
   background: #fff;
   border-top: 1px solid #e2e8f0;
   position: sticky;
   bottom: 0;
   z-index: 3;
+}
+
+.streaming-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.streaming-status .stop-button {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.composer-row {
+  display: flex;
+  gap: 8px;
 }
 
 .chat-composer textarea {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -10,6 +10,8 @@ export type ChatPageProps = {
   onOpenDrawer: () => void
   onSendMessage: (text: string) => Promise<void>
   onDeleteMessage: (messageId: string) => void | Promise<void>
+  isStreaming: boolean
+  onStopStreaming: () => void
 }
 
 const formatTime = (timestamp: string) =>
@@ -24,6 +26,8 @@ const ChatPage = ({
   onOpenDrawer,
   onSendMessage,
   onDeleteMessage,
+  isStreaming,
+  onStopStreaming,
 }: ChatPageProps) => {
   const [draft, setDraft] = useState('')
   const [openActionsId, setOpenActionsId] = useState<string | null>(null)
@@ -143,15 +147,25 @@ const ChatPage = ({
         <div ref={bottomRef} />
       </main>
       <form className="chat-composer" onSubmit={handleSubmit}>
-        <textarea
-          placeholder="输入你的消息"
-          rows={2}
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-        />
-        <button type="submit" className="primary">
-          发送
-        </button>
+        {isStreaming ? (
+          <div className="streaming-status">
+            <span>生成中…</span>
+            <button type="button" className="ghost stop-button" onClick={onStopStreaming}>
+              停止生成
+            </button>
+          </div>
+        ) : null}
+        <div className="composer-row">
+          <textarea
+            placeholder="输入你的消息"
+            rows={2}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+          />
+          <button type="submit" className="primary">
+            发送
+          </button>
+        </div>
       </form>
       <ConfirmDialog
         open={pendingDelete !== null}

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -157,23 +157,34 @@ serve(async (req) => {
       })
     }
 
-    if (!upstream.body) {
-      return new Response(JSON.stringify({ error: '无响应内容' }), {
-        status: 502,
+    if (stream) {
+      if (!upstream.body) {
+        return new Response(JSON.stringify({ error: '无响应内容' }), {
+          status: 502,
+          headers: {
+            ...buildCorsHeaders(origin),
+            'Content-Type': 'application/json',
+          },
+        })
+      }
+
+      return new Response(upstream.body, {
+        status: 200,
         headers: {
           ...buildCorsHeaders(origin),
-          'Content-Type': 'application/json',
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache, no-transform',
+          Connection: 'keep-alive',
         },
       })
     }
 
-    return new Response(upstream.body, {
+    const payloadText = await upstream.text()
+    return new Response(payloadText, {
       status: 200,
       headers: {
         ...buildCorsHeaders(origin),
-        'Content-Type': 'text/event-stream; charset=utf-8',
-        'Cache-Control': 'no-cache, no-transform',
-        Connection: 'keep-alive',
+        'Content-Type': 'application/json',
       },
     })
   } catch {


### PR DESCRIPTION
### Motivation
- Users experienced buffered replies that appeared only after generation finished, so the client must render assistant text incrementally while the model streams.
- The edge function must return true SSE response headers when `stream: true` so browsers (especially mobile) can consume events progressively instead of receiving a JSON blob.
- UI should support cancelling an in-flight stream and preserve partial assistant text to keep DB persistence and cross-device sync intact.
- Mobile updates must be throttled to avoid excessive re-renders and improve perceived performance.

### Description
- Edge function (`supabase/functions/openrouter-chat/index.ts`) now returns `Content-Type: text/event-stream; charset=utf-8`, `Cache-Control: no-cache, no-transform`, and `Connection: keep-alive` only when the incoming request sets `stream: true`, and returns JSON otherwise; error responses keep `application/json` headers.
- Frontend (`src/App.tsx`) added an `AbortController`-backed streaming flow, an `isStreaming` state, and incremental SSE parsing using `response.body.getReader()` with `TextDecoder` to extract `data:` lines and OpenRouter/OpenAI-compatible delta payloads.
- Streaming updates are buffered and flushed on a ~50ms timer to throttle UI updates and improve mobile smoothness, and the final assistant message is persisted via the existing `addRemoteMessage` flow; partial content is saved if the stream is aborted.
- UI changes in `src/pages/ChatPage.tsx` and `src/pages/ChatPage.css` add a Chinese `生成中…` indicator and a `停止生成` button that aborts the stream, and layout adjustments to the composer to accommodate the new status UI.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server reported ready without errors (succeeded).
- Ran a Playwright script to load the app and capture a screenshot (`artifacts/chat-page.png`) to verify the chat UI renders after changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b613a8748330981b5eb1cda13bcf)