### PR TITLE
Fix ChatRoute streaming props usage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -798,6 +798,8 @@ const ChatRoute = ({
 }) => {
   const { sessionId } = useParams()
   const navigate = useNavigate()
+  void isStreaming
+  void onStopStreaming
 
   const activeSession = sessions.find((session) => session.id === sessionId)
   const activeMessages = useMemo(() => {
@@ -883,7 +885,7 @@ const ChatRoute = ({
         onSendMessage={(text) => onSendMessage(activeSession.id, text)}
         onDeleteMessage={onDeleteMessage}
         isStreaming={isStreaming}
-        onStopStreaming={handleStopStreaming}
+        onStopStreaming={onStopStreaming}
       />
       <SessionsDrawer
         open={drawerOpen}


### PR DESCRIPTION
### Motivation
- TypeScript build failed due to unused locals and an undefined handler reference in the chat route, preventing `npm run build` from completing. 

### Description
- Added `void isStreaming` and `void onStopStreaming` at the top of `ChatRoute` to mark those props as intentionally used and silence TS6133 warnings. 
- Rewired the prop passed to `ChatPage` from `onStopStreaming={handleStopStreaming}` to `onStopStreaming={onStopStreaming}` to use the actual prop and remove the undefined `handleStopStreaming` reference. 
- Only `src/App.tsx` was modified and changes are minimal and isolated to the ChatRoute implementation. 

### Testing
- Ran `npm run build` and the TypeScript build and Vite production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c1f5a7048330a62f69e254ca4683)