### PR TITLE
Add API 设置页、Supabase 用户设置同步与 OpenRouter 模型库代理

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -41,6 +41,39 @@
   color: #94a3b8;
 }
 
+.header-actions {
+  position: relative;
+}
+
+.header-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+  z-index: 3;
+}
+
+.header-menu button {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.header-menu button:hover {
+  background: #f1f5f9;
+}
+
 .chat-messages {
   flex: 1;
   overflow-y: auto;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
 import type { ChatMessage, ChatSession } from '../types'
 import ConfirmDialog from '../components/ConfirmDialog'
 import './ChatPage.css'
@@ -31,8 +32,11 @@ const ChatPage = ({
 }: ChatPageProps) => {
   const [draft, setDraft] = useState('')
   const [openActionsId, setOpenActionsId] = useState<string | null>(null)
+  const [openHeaderMenu, setOpenHeaderMenu] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<ChatMessage | null>(null)
   const bottomRef = useRef<HTMLDivElement | null>(null)
+  const headerMenuRef = useRef<HTMLDivElement | null>(null)
+  const navigate = useNavigate()
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
@@ -75,6 +79,25 @@ const ChatPage = ({
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages.length])
 
+  useEffect(() => {
+    if (!openHeaderMenu) {
+      return
+    }
+    const handleClick = (event: MouseEvent) => {
+      if (!headerMenuRef.current) {
+        return
+      }
+      if (headerMenuRef.current.contains(event.target as Node)) {
+        return
+      }
+      setOpenHeaderMenu(false)
+    }
+    document.addEventListener('click', handleClick)
+    return () => {
+      document.removeEventListener('click', handleClick)
+    }
+  }, [openHeaderMenu])
+
   return (
     <div className="chat-page">
       <header className="chat-header">
@@ -85,9 +108,31 @@ const ChatPage = ({
           <h1>{session.title}</h1>
           <span className="subtitle">单聊</span>
         </div>
-        <button type="button" className="ghost">
-          聊天操作
-        </button>
+        <div className="header-actions" ref={headerMenuRef}>
+          <button
+            type="button"
+            className="ghost"
+            onClick={(event) => {
+              event.stopPropagation()
+              setOpenHeaderMenu((current) => !current)
+            }}
+          >
+            聊天操作
+          </button>
+          {openHeaderMenu ? (
+            <div className="header-menu">
+              <button
+                type="button"
+                onClick={() => {
+                  setOpenHeaderMenu(false)
+                  navigate('/settings')
+                }}
+              >
+                API设置
+              </button>
+            </div>
+          ) : null}
+        </div>
       </header>
       <main className="chat-messages">
         {messages.length === 0 ? (

--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -1,0 +1,196 @@
+.settings-page {
+  min-height: 100dvh;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: calc(24px + env(safe-area-inset-bottom));
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: calc(12px + env(safe-area-inset-top)) 16px 12px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.settings-header h1 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.settings-header .ghost {
+  border: none;
+  background: transparent;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.header-spacer {
+  width: 40px;
+}
+
+.settings-loading {
+  padding: 24px 16px;
+  color: #64748b;
+  font-size: 14px;
+}
+
+.settings-page .empty-state {
+  color: #64748b;
+  font-size: 13px;
+  background: #f1f5f9;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.settings-section {
+  background: #fff;
+  border-radius: 16px;
+  margin: 0 16px;
+  padding: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-title h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.section-title p {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.model-list,
+.catalog-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.model-item,
+.catalog-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.model-meta,
+.catalog-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.model-id {
+  font-size: 12px;
+  color: #94a3b8;
+  word-break: break-all;
+}
+
+.model-actions,
+.catalog-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-page button {
+  border: none;
+  border-radius: 10px;
+  padding: 8px 12px;
+  background: #0f172a;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.settings-page button.ghost {
+  background: transparent;
+  color: #0f172a;
+  border: 1px solid #cbd5f5;
+}
+
+.settings-page button.danger {
+  color: #b91c1c;
+  border-color: rgba(185, 28, 28, 0.3);
+}
+
+.badge {
+  background: #0f172a;
+  color: #fff;
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.badge.subtle {
+  background: rgba(15, 23, 42, 0.1);
+  color: #0f172a;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-group label {
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.field-group input,
+.system-prompt,
+.search-input {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.field-error {
+  color: #b91c1c;
+  font-size: 12px;
+}
+
+.system-prompt {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.search-input {
+  width: 100%;
+}
+
+.catalog-status {
+  color: #64748b;
+  font-size: 13px;
+}
+
+.catalog-status.error {
+  color: #b91c1c;
+}
+
+.context-length {
+  font-size: 12px;
+  color: #475569;
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,405 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
+import ConfirmDialog from '../components/ConfirmDialog'
+import type { UserSettings } from '../types'
+import { supabase } from '../supabase/client'
+import './SettingsPage.css'
+
+type OpenRouterModel = {
+  id: string
+  name?: string
+  context_length?: number | null
+}
+
+type SettingsPageProps = {
+  user: User | null
+  settings: UserSettings | null
+  ready: boolean
+  onUpdateSettings: (updater: (current: UserSettings) => UserSettings) => void
+}
+
+const defaultModelId = 'openrouter/auto'
+
+const SettingsPage = ({ user, settings, ready, onUpdateSettings }: SettingsPageProps) => {
+  const navigate = useNavigate()
+  const [searchTerm, setSearchTerm] = useState('')
+  const [catalog, setCatalog] = useState<OpenRouterModel[]>([])
+  const [catalogStatus, setCatalogStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [catalogError, setCatalogError] = useState<string | null>(null)
+  const [pendingDisable, setPendingDisable] = useState<string | null>(null)
+  const [temperatureInput, setTemperatureInput] = useState('')
+  const [topPInput, setTopPInput] = useState('')
+  const [maxTokensInput, setMaxTokensInput] = useState('')
+  const [errors, setErrors] = useState<{ temperature?: string; topP?: string; maxTokens?: string }>(
+    {},
+  )
+
+  useEffect(() => {
+    if (!settings) {
+      return
+    }
+    setTemperatureInput(settings.temperature.toString())
+    setTopPInput(settings.topP.toString())
+    setMaxTokensInput(settings.maxTokens.toString())
+  }, [settings])
+
+  useEffect(() => {
+    if (!user || !supabase) {
+      return
+    }
+    let active = true
+    setCatalogStatus('loading')
+    setCatalogError(null)
+    supabase.functions
+      .invoke('openrouter-models')
+      .then(({ data, error }) => {
+        if (!active) {
+          return
+        }
+        if (error) {
+          setCatalogStatus('error')
+          setCatalogError('无法加载 OpenRouter 模型库')
+          return
+        }
+        const models = (data?.models ?? []) as OpenRouterModel[]
+        setCatalog(models)
+        setCatalogStatus('idle')
+      })
+      .catch(() => {
+        if (!active) {
+          return
+        }
+        setCatalogStatus('error')
+        setCatalogError('无法加载 OpenRouter 模型库')
+      })
+    return () => {
+      active = false
+    }
+  }, [user])
+
+  const catalogMap = useMemo(() => {
+    return new Map(catalog.map((model) => [model.id, model.name ?? model.id]))
+  }, [catalog])
+
+  const filteredCatalog = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase()
+    if (!term) {
+      return catalog
+    }
+    return catalog.filter((model) => {
+      const name = model.name?.toLowerCase() ?? ''
+      return model.id.toLowerCase().includes(term) || name.includes(term)
+    })
+  }, [catalog, searchTerm])
+
+  const applySettingsUpdate = (updater: (current: UserSettings) => UserSettings) => {
+    onUpdateSettings((current) => ({
+      ...updater(current),
+      updatedAt: new Date().toISOString(),
+    }))
+  }
+
+  const handleDisableModel = () => {
+    if (!settings || !pendingDisable) {
+      return
+    }
+    const modelId = pendingDisable
+    applySettingsUpdate((current) => {
+      const nextEnabled = current.enabledModels.filter((id) => id !== modelId)
+      const nextDefault =
+        current.defaultModel === modelId ? nextEnabled[0] ?? defaultModelId : current.defaultModel
+      return {
+        ...current,
+        enabledModels: nextEnabled,
+        defaultModel: nextDefault,
+      }
+    })
+    setPendingDisable(null)
+  }
+
+  const handleEnableModel = (modelId: string, setDefault: boolean) => {
+    if (!settings) {
+      return
+    }
+    applySettingsUpdate((current) => {
+      const alreadyEnabled = current.enabledModels.includes(modelId)
+      const nextEnabled = alreadyEnabled
+        ? current.enabledModels
+        : [...current.enabledModels, modelId]
+      const nextDefault = setDefault
+        ? modelId
+        : current.defaultModel || (alreadyEnabled ? current.defaultModel : modelId)
+      return {
+        ...current,
+        enabledModels: nextEnabled,
+        defaultModel: nextDefault,
+      }
+    })
+  }
+
+  const handleSetDefault = (modelId: string) => {
+    if (!settings) {
+      return
+    }
+    applySettingsUpdate((current) => {
+      const nextEnabled = current.enabledModels.includes(modelId)
+        ? current.enabledModels
+        : [...current.enabledModels, modelId]
+      return {
+        ...current,
+        enabledModels: nextEnabled,
+        defaultModel: modelId,
+      }
+    })
+  }
+
+  const handleTemperatureChange = (value: string) => {
+    setTemperatureInput(value)
+    const parsed = Number(value)
+    if (Number.isNaN(parsed)) {
+      setErrors((prev) => ({ ...prev, temperature: '请输入数字' }))
+      return
+    }
+    if (parsed < 0 || parsed > 2) {
+      setErrors((prev) => ({ ...prev, temperature: '温度需在 0 到 2 之间' }))
+      return
+    }
+    setErrors((prev) => ({ ...prev, temperature: undefined }))
+    if (settings) {
+      applySettingsUpdate((current) => ({ ...current, temperature: parsed }))
+    }
+  }
+
+  const handleTopPChange = (value: string) => {
+    setTopPInput(value)
+    const parsed = Number(value)
+    if (Number.isNaN(parsed)) {
+      setErrors((prev) => ({ ...prev, topP: '请输入数字' }))
+      return
+    }
+    if (parsed < 0 || parsed > 1) {
+      setErrors((prev) => ({ ...prev, topP: 'Top P 需在 0 到 1 之间' }))
+      return
+    }
+    setErrors((prev) => ({ ...prev, topP: undefined }))
+    if (settings) {
+      applySettingsUpdate((current) => ({ ...current, topP: parsed }))
+    }
+  }
+
+  const handleMaxTokensChange = (value: string) => {
+    setMaxTokensInput(value)
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isNaN(parsed)) {
+      setErrors((prev) => ({ ...prev, maxTokens: '请输入整数' }))
+      return
+    }
+    if (parsed < 32 || parsed > 4000) {
+      setErrors((prev) => ({ ...prev, maxTokens: '最大 token 需在 32 到 4000 之间' }))
+      return
+    }
+    setErrors((prev) => ({ ...prev, maxTokens: undefined }))
+    if (settings) {
+      applySettingsUpdate((current) => ({ ...current, maxTokens: parsed }))
+    }
+  }
+
+  if (!ready || !settings) {
+    return (
+      <div className="settings-page">
+        <header className="settings-header">
+          <button type="button" className="ghost" onClick={() => navigate(-1)}>
+            返回
+          </button>
+          <h1>API设置</h1>
+          <span className="header-spacer" />
+        </header>
+        <div className="settings-loading">正在加载设置...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="settings-page">
+        <header className="settings-header">
+          <button type="button" className="ghost" onClick={() => navigate(-1)}>
+            返回
+          </button>
+          <h1>API设置</h1>
+          <span className="header-spacer" />
+        </header>
+
+      <section className="settings-section">
+        <div className="section-title">
+          <h2>仓鼠模型库</h2>
+          <p>管理已启用的 OpenRouter 模型，并选择默认模型。</p>
+        </div>
+        {settings.enabledModels.length === 0 ? (
+          <div className="empty-state">暂无启用模型，请从下方模型库启用。</div>
+        ) : (
+          <ul className="model-list">
+            {settings.enabledModels.map((modelId) => (
+              <li key={modelId} className="model-item">
+                <div className="model-meta">
+                  <strong>{catalogMap.get(modelId) ?? modelId}</strong>
+                  <span className="model-id">{modelId}</span>
+                </div>
+                <div className="model-actions">
+                  {settings.defaultModel === modelId ? (
+                    <span className="badge">默认</span>
+                  ) : (
+                    <button type="button" className="ghost" onClick={() => handleSetDefault(modelId)}>
+                      设为默认
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="ghost danger"
+                    onClick={() => setPendingDisable(modelId)}
+                  >
+                    停用
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="settings-section">
+        <div className="section-title">
+          <h2>参数设置</h2>
+          <p>调整生成参数以适配你的对话风格。</p>
+        </div>
+        <div className="field-group">
+          <label htmlFor="temperature">温度 (0 - 2)</label>
+          <input
+            id="temperature"
+            type="number"
+            min="0"
+            max="2"
+            step="0.1"
+            value={temperatureInput}
+            onChange={(event) => handleTemperatureChange(event.target.value)}
+          />
+          {errors.temperature ? <span className="field-error">{errors.temperature}</span> : null}
+        </div>
+        <div className="field-group">
+          <label htmlFor="topP">Top P (0 - 1)</label>
+          <input
+            id="topP"
+            type="number"
+            min="0"
+            max="1"
+            step="0.05"
+            value={topPInput}
+            onChange={(event) => handleTopPChange(event.target.value)}
+          />
+          {errors.topP ? <span className="field-error">{errors.topP}</span> : null}
+        </div>
+        <div className="field-group">
+          <label htmlFor="maxTokens">最大 tokens (32 - 4000)</label>
+          <input
+            id="maxTokens"
+            type="number"
+            min="32"
+            max="4000"
+            step="1"
+            value={maxTokensInput}
+            onChange={(event) => handleMaxTokensChange(event.target.value)}
+          />
+          {errors.maxTokens ? <span className="field-error">{errors.maxTokens}</span> : null}
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-title">
+          <h2>系统提示词</h2>
+          <p>用于引导模型的全局指令，仅对当前用户生效。</p>
+        </div>
+        <textarea
+          className="system-prompt"
+          placeholder="例如：你是一个耐心的助手，请用简洁的方式回答。"
+          value={settings.systemPrompt}
+          onChange={(event) =>
+            applySettingsUpdate((current) => ({
+              ...current,
+              systemPrompt: event.target.value,
+            }))
+          }
+        />
+      </section>
+
+      <section className="settings-section">
+        <div className="section-title">
+          <h2>OpenRouter 模型库</h2>
+          <p>搜索并启用你想使用的模型。</p>
+        </div>
+        <input
+          className="search-input"
+          type="search"
+          placeholder="搜索模型名称或 ID"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+        />
+        {catalogStatus === 'loading' ? (
+          <div className="catalog-status">正在加载模型库...</div>
+        ) : null}
+        {catalogStatus === 'error' ? (
+          <div className="catalog-status error">{catalogError}</div>
+        ) : null}
+        <ul className="catalog-list">
+          {filteredCatalog.map((model) => {
+            const enabled = settings.enabledModels.includes(model.id)
+            return (
+              <li key={model.id} className="catalog-item">
+                <div className="catalog-meta">
+                  <strong>{model.name ?? model.id}</strong>
+                  <span className="model-id">{model.id}</span>
+                  {model.context_length ? (
+                    <span className="context-length">上下文 {model.context_length}</span>
+                  ) : null}
+                </div>
+                <div className="catalog-actions">
+                  {enabled ? (
+                    <>
+                      {settings.defaultModel === model.id ? (
+                        <span className="badge">默认</span>
+                      ) : (
+                        <button type="button" className="ghost" onClick={() => handleSetDefault(model.id)}>
+                          设为默认
+                        </button>
+                      )}
+                      <span className="badge subtle">已启用</span>
+                    </>
+                  ) : (
+                    <>
+                      <button type="button" onClick={() => handleEnableModel(model.id, false)}>
+                        启用
+                      </button>
+                      <button type="button" className="ghost" onClick={() => handleEnableModel(model.id, true)}>
+                        启用并设为默认
+                      </button>
+                    </>
+                  )}
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      </section>
+
+      <ConfirmDialog
+        open={pendingDisable !== null}
+        title="停用这个模型？"
+        description="停用后模型会从仓鼠模型库移除，并不会删除云端数据。"
+        confirmLabel="停用"
+        onCancel={() => setPendingDisable(null)}
+        onConfirm={handleDisableModel}
+      />
+    </div>
+  )
+}
+
+export default SettingsPage

--- a/src/storage/userSettings.ts
+++ b/src/storage/userSettings.ts
@@ -1,0 +1,100 @@
+import type { UserSettings } from '../types'
+import { supabase } from '../supabase/client'
+
+type UserSettingsRow = {
+  user_id: string
+  enabled_models: string[] | null
+  default_model: string | null
+  temperature: number | null
+  top_p: number | null
+  max_tokens: number | null
+  system_prompt: string | null
+  updated_at: string
+}
+
+const defaultModel = 'openrouter/auto'
+
+export const createDefaultSettings = (userId: string): UserSettings => ({
+  userId,
+  enabledModels: [defaultModel],
+  defaultModel,
+  temperature: 0.7,
+  topP: 0.9,
+  maxTokens: 1024,
+  systemPrompt: '',
+  updatedAt: new Date().toISOString(),
+})
+
+const mapSettingsRow = (row: UserSettingsRow): UserSettings => ({
+  userId: row.user_id,
+  enabledModels: row.enabled_models ?? [defaultModel],
+  defaultModel: row.default_model ?? defaultModel,
+  temperature: row.temperature ?? 0.7,
+  topP: row.top_p ?? 0.9,
+  maxTokens: row.max_tokens ?? 1024,
+  systemPrompt: row.system_prompt ?? '',
+  updatedAt: row.updated_at,
+})
+
+export const ensureUserSettings = async (userId: string): Promise<UserSettings> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { data, error } = await supabase
+    .from('user_settings')
+    .select(
+      'user_id,enabled_models,default_model,temperature,top_p,max_tokens,system_prompt,updated_at',
+    )
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (error) {
+    throw error
+  }
+  if (!data) {
+    const defaults = createDefaultSettings(userId)
+    const now = defaults.updatedAt
+    const { data: inserted, error: insertError } = await supabase
+      .from('user_settings')
+      .insert({
+        user_id: defaults.userId,
+        enabled_models: defaults.enabledModels,
+        default_model: defaults.defaultModel,
+        temperature: defaults.temperature,
+        top_p: defaults.topP,
+        max_tokens: defaults.maxTokens,
+        system_prompt: defaults.systemPrompt,
+        updated_at: now,
+      })
+      .select(
+        'user_id,enabled_models,default_model,temperature,top_p,max_tokens,system_prompt,updated_at',
+      )
+      .single()
+    if (insertError || !inserted) {
+      throw insertError ?? new Error('初始化设置失败')
+    }
+    return mapSettingsRow(inserted as UserSettingsRow)
+  }
+  return mapSettingsRow(data as UserSettingsRow)
+}
+
+export const updateUserSettings = async (settings: UserSettings): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const now = new Date().toISOString()
+  const { error } = await supabase
+    .from('user_settings')
+    .update({
+      enabled_models: settings.enabledModels,
+      default_model: settings.defaultModel,
+      temperature: settings.temperature,
+      top_p: settings.topP,
+      max_tokens: settings.maxTokens,
+      system_prompt: settings.systemPrompt,
+      updated_at: now,
+    })
+    .eq('user_id', settings.userId)
+  if (error) {
+    throw error
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,22 @@ export type ChatMessage = {
     provider?: string
     model?: string
     streaming?: boolean
+    params?: {
+      temperature?: number
+      top_p?: number
+      max_tokens?: number
+    }
   }
   pending?: boolean
+}
+
+export type UserSettings = {
+  userId: string
+  enabledModels: string[]
+  defaultModel: string
+  temperature: number
+  topP: number
+  maxTokens: number
+  systemPrompt: string
+  updatedAt: string
 }

--- a/supabase/functions/openrouter-models/index.ts
+++ b/supabase/functions/openrouter-models/index.ts
@@ -1,0 +1,132 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
+
+const allowedOrigins = [/^https:\/\/.+\.github\.io$/, /^http:\/\/localhost:\d+$/]
+
+const isAllowedOrigin = (origin: string | null) => {
+  if (!origin) {
+    return true
+  }
+  return allowedOrigins.some((pattern) => pattern.test(origin))
+}
+
+const buildCorsHeaders = (origin: string | null) => ({
+  'Access-Control-Allow-Origin': origin ?? '*',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Max-Age': '86400',
+})
+
+serve(async (req) => {
+  const origin = req.headers.get('origin')
+  if (!isAllowedOrigin(origin)) {
+    return new Response(JSON.stringify({ error: '不允许的来源' }), {
+      status: 403,
+      headers: {
+        ...buildCorsHeaders(origin),
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: buildCorsHeaders(origin),
+    })
+  }
+
+  const authHeader = req.headers.get('authorization')
+  const apiKeyHeader = req.headers.get('apikey')
+  if (!authHeader || !apiKeyHeader) {
+    return new Response(JSON.stringify({ error: '缺少身份令牌' }), {
+      status: 401,
+      headers: {
+        ...buildCorsHeaders(origin),
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  try {
+    const authUrl = new URL('/auth/v1/user', new URL(req.url).origin)
+    const authResponse = await fetch(authUrl, {
+      headers: {
+        apikey: apiKeyHeader,
+        Authorization: authHeader,
+      },
+    })
+    if (!authResponse.ok) {
+      return new Response(JSON.stringify({ error: '身份令牌无效' }), {
+        status: 401,
+        headers: {
+          ...buildCorsHeaders(origin),
+          'Content-Type': 'application/json',
+        },
+      })
+    }
+  } catch {
+    return new Response(JSON.stringify({ error: '身份令牌无效' }), {
+      status: 401,
+      headers: {
+        ...buildCorsHeaders(origin),
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  const apiKey = Deno.env.get('OPENROUTER_API_KEY')
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: '服务未配置' }), {
+      status: 500,
+      headers: {
+        ...buildCorsHeaders(origin),
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  try {
+    const upstream = await fetch('https://openrouter.ai/api/v1/models', {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (!upstream.ok) {
+      const errorText = await upstream.text()
+      return new Response(JSON.stringify({ error: errorText || '上游服务错误' }), {
+        status: upstream.status,
+        headers: {
+          ...buildCorsHeaders(origin),
+          'Content-Type': 'application/json',
+        },
+      })
+    }
+
+    const payload = await upstream.json()
+    const models = Array.isArray(payload?.data)
+      ? payload.data.map((model: { id: string; name?: string; context_length?: number }) => ({
+          id: model.id,
+          name: model.name,
+          context_length: model.context_length ?? null,
+        }))
+      : []
+
+    return new Response(JSON.stringify({ models }), {
+      status: 200,
+      headers: {
+        ...buildCorsHeaders(origin),
+        'Content-Type': 'application/json',
+      },
+    })
+  } catch {
+    return new Response(JSON.stringify({ error: '请求失败' }), {
+      status: 500,
+      headers: {
+        ...buildCorsHeaders(origin),
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+})


### PR DESCRIPTION
### Motivation

- 提供每用户可配置的 OpenRouter 设置（启用模型列表、默认模型、生成参数与系统提示词）并在多设备间持久化到 `user_settings` 表。 
- 增加可搜索的 OpenRouter 模型目录以便启用/停用模型且不泄露 OpenRouter API key（通过 Edge Function 代理）。
- 将用户设置注入到聊天请求中（模型、`temperature`/`top_p`/`max_tokens`、以及作为 system 消息的 `system_prompt`），并在消息元数据中记录参数快照。

### Description

- 新增类型与存储：添加 `UserSettings` 类型并实现 `src/storage/userSettings.ts`，包含 `ensureUserSettings` 与 `updateUserSettings`，在登录时从 `user_settings` 表加载或初始化默认行，变更保存带防抖（约 400ms）。
- 新增设置页面：添加移动优先的设置页组件与样式 `src/pages/SettingsPage.tsx` / `src/pages/SettingsPage.css`，界面中文化，包括“仓鼠模型库”、“参数设置”、“系统提示词”与“OpenRouter 模型库（搜索/启用/设为默认/停用）”。
- 前端接入与消息注入：在 `src/App.tsx` 中加载/保存用户设置，暴露 `#/settings` 路由并在聊天页菜单中增加入口；构建消息时将 `system_prompt` 作为首条 system 消息插入；发送请求时将用户选定的 `model` 与参数快照传给 `openrouter-chat` 函数，并把参数快照写入消息 `meta`。
- 模型目录代理函数：新增 Supabase Edge Function `supabase/functions/openrouter-models/index.ts`，使用 `OPENROUTER_API_KEY` 环境变量调用 `https://openrouter.ai/api/v1/models`，并配置 CORS 与 Supabase 身份校验，前端通过 `supabase.functions.invoke('openrouter-models')` 获取模型列表。
- 其他改动：更新 `src/types.ts`（消息 meta 支持 `params`、新增 `UserSettings`），在 `src/pages/ChatPage.tsx` 中添加聊天操作菜单入口以进入设置页。

### Testing

- 启动本地开发服务器：运行 `npm run dev -- --host 0.0.0.0 --port 4173`，Vite 服务启动正常并监听（成功）。
- UI smoke test：使用 Playwright 脚本访问 `http://127.0.0.1:4173/#/settings` 并截取页面截图，脚本执行成功并生成截图（用于视觉检查）。
- 无单元测试改动；已在运行环境下手动验证设置页可打开、模型目录请求通过代理函数返回数据（在已配置 `OPENROUTER_API_KEY` 与 Supabase 环境下）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982adfb4c84833083f6975c353a36a3)