### PR TITLE
Convert model lists to dropdown selectors (mobile-friendly)

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -98,6 +98,44 @@
   gap: 4px;
 }
 
+.model-select-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.model-select-row {
+  display: grid;
+  grid-template-columns: minmax(72px, auto) minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.model-select-row label {
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.model-select-row select {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  background: #fff;
+  width: 100%;
+}
+
+.model-selected-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .model-id {
   font-size: 12px;
   color: #94a3b8;
@@ -126,6 +164,11 @@
   background: transparent;
   color: #0f172a;
   border: 1px solid #cbd5f5;
+}
+
+.settings-page button.small {
+  padding: 6px 10px;
+  font-size: 12px;
 }
 
 .settings-page button.danger {
@@ -179,6 +222,43 @@
 
 .search-input {
   width: 100%;
+}
+
+.catalog-dropdown {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.catalog-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.catalog-result-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+}
+
+.catalog-hint,
+.catalog-empty {
+  font-size: 12px;
+  color: #64748b;
 }
 
 .catalog-status {


### PR DESCRIPTION
### Motivation
- Prevent long model lists from overflowing mobile settings UI by replacing list renderings with compact dropdowns and focused actions.
- Keep search-driven discovery for the OpenRouter catalog while avoiding rendering the entire catalog on the page.

### Description
- Replace the enabled models list with a compact select UI showing `user_settings.default_model` as the selected value and options from `enabled_models`, plus a small `停用` action for the selected model; added `selectedModelId` helper to display meta info.
- Add fallback logic to automatically set `defaultModel` to `openrouter/auto` or the first enabled model when the current default is no longer enabled via a `useEffect` that calls `applySettingsUpdate`.
- Turn the OpenRouter catalog into a search-driven dropdown: keep the search input, show only `filteredCatalog.slice(0, 20)` as `visibleCatalog`, display hints (`继续输入以缩小范围` / `结果较多，请继续输入以缩小范围。` / `未找到匹配模型。`), and allow enabling models from the compact result items.
- UI strings remain Chinese and Supabase persistence is unchanged because updates still use the existing `onUpdateSettings` flow; added CSS rules for `.model-select-card`, `.catalog-dropdown`, and related styles in `src/pages/SettingsPage.css`.

### Testing
- Started the development server with `npm run dev` and it served the app successfully at the local dev URL. (succeeded)
- Ran an automated Playwright script that navigated to `/settings` at a mobile viewport and produced a screenshot to verify the compact dropdown and catalog dropdown render; the script completed and produced the artifact. (succeeded)
- No unit or integration test suites were executed for this UI-only change. (none run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982b92c70e083309e3f0731b4891b9c)