### PR TITLE
Add “保存” button and unsaved-changes guard for system prompt

### DIFF
--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -39,6 +39,11 @@
   color: #1f2937;
 }
 
+.confirm-actions .tertiary {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
 .confirm-actions .primary {
   background: #0f172a;
   color: #fff;

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -7,8 +7,10 @@ export type ConfirmDialogProps = {
   description?: string
   confirmLabel?: string
   cancelLabel?: string
+  neutralLabel?: string
   onConfirm: () => void
   onCancel: () => void
+  onNeutral?: () => void
 }
 
 const ConfirmDialog = ({
@@ -17,8 +19,10 @@ const ConfirmDialog = ({
   description,
   confirmLabel = '确认',
   cancelLabel = '取消',
+  neutralLabel,
   onConfirm,
   onCancel,
+  onNeutral,
 }: ConfirmDialogProps) => {
   if (!open) {
     return null
@@ -33,6 +37,11 @@ const ConfirmDialog = ({
           <button type="button" className="secondary" onClick={onCancel}>
             {cancelLabel}
           </button>
+          {neutralLabel && onNeutral ? (
+            <button type="button" className="tertiary" onClick={onNeutral}>
+              {neutralLabel}
+            </button>
+          ) : null}
           <button type="button" className="primary" onClick={onConfirm}>
             {confirmLabel}
           </button>

--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -220,6 +220,33 @@
   resize: vertical;
 }
 
+.system-prompt-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.system-prompt-actions .primary {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  background: #0f172a;
+  color: #fff;
+}
+
+.system-prompt-actions .primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.system-prompt-status {
+  font-size: 13px;
+  color: #0f172a;
+}
+
 .search-input {
   width: 100%;
 }


### PR DESCRIPTION
### Motivation
- System prompt edits should not auto-save globally; users must explicitly save changes and be warned when navigating away with unsaved edits.
- The UI must be Chinese and match existing settings behavior while preserving other settings' auto-save flow.

### Description
- Added a separate `draftSystemPrompt` state in `src/pages/SettingsPage.tsx` and render a Chinese `保存` button that is enabled only when the draft differs from the saved `systemPrompt` and shows a `已保存` status after saving.
- Implemented an unsaved-changes guard using `useBlocker` that opens a three-option confirm dialog with Chinese labels `保存并离开` / `不保存离开` / `取消` when navigation is attempted with unsaved prompt edits.
- Extended `ConfirmDialog` (in `src/components/ConfirmDialog.tsx`) to support an optional neutral action and added styles for the neutral button and the system prompt action row in `ConfirmDialog.css` and `SettingsPage.css`.
- Kept existing settings behavior unchanged: the saved `systemPrompt` is only applied via the explicit Save flow (the `applySettingsUpdate` call runs only on Save), leaving the rest of the auto-save pipeline intact.

### Testing
- Started the dev server with `npm run dev` and loaded `/settings` in a headless browser, and a Playwright script captured a screenshot of the Settings page showing the new system prompt UI successfully.
- No unit tests were added or run; the manual/automation smoke test described above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982be00de4c8330a7c60252dc07fa29)