### PR TITLE
Add collapsible reasoning panel & capture streaming chain-of-thought

### DIFF
--- a/src/components/ReasoningPanel.css
+++ b/src/components/ReasoningPanel.css
@@ -1,0 +1,44 @@
+.reasoning-panel {
+  margin-top: 12px;
+}
+
+.reasoning-panel__toggle {
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.reasoning-panel__toggle:hover {
+  color: #374151;
+}
+
+.reasoning-panel__content {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease, opacity 0.25s ease;
+}
+
+.reasoning-panel__content.is-open {
+  max-height: 240px;
+  opacity: 1;
+}
+
+.reasoning-panel__body {
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 10px;
+  background: rgba(248, 250, 252, 0.8);
+  color: #6b7280;
+  font-size: 13px;
+  font-style: italic;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}

--- a/src/components/ReasoningPanel.tsx
+++ b/src/components/ReasoningPanel.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import './ReasoningPanel.css'
+
+type ReasoningPanelProps = {
+  reasoning: string
+}
+
+const ReasoningPanel = ({ reasoning }: ReasoningPanelProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className="reasoning-panel">
+      <button
+        type="button"
+        className="reasoning-panel__toggle"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        💭 思考过程
+      </button>
+      <div className={`reasoning-panel__content ${isOpen ? 'is-open' : ''}`}>
+        <div className="reasoning-panel__body">{reasoning}</div>
+      </div>
+    </div>
+  )
+}
+
+export default ReasoningPanel

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ChatMessage, ChatSession } from '../types'
 import ConfirmDialog from '../components/ConfirmDialog'
+import ReasoningPanel from '../components/ReasoningPanel'
 import './ChatPage.css'
 
 export type ChatPageProps = {
@@ -147,6 +148,9 @@ const ChatPage = ({
             >
               <div className="bubble">
                 <p>{message.content}</p>
+                {message.meta?.reasoning?.trim() ? (
+                  <ReasoningPanel reasoning={message.meta.reasoning} />
+                ) : null}
                 <div className="message-footer">
                   {message.role === 'assistant' && message.meta?.model ? (
                     <span className="model-tag">

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type ChatMessage = {
     provider?: string
     model?: string
     streaming?: boolean
+    reasoning?: string
     params?: {
       temperature?: number
       top_p?: number


### PR DESCRIPTION
### Motivation
- Some OpenRouter / extended-thinking models stream a separate reasoning/think process that should be captured, persisted, and shown to users as an optional, collapsible panel in the message bubble.
- Persisting reasoning alongside assistant messages allows the UI to display model internal reasoning when available without altering message text.

### Description
- Added `reasoning?: string` to `ChatMessage.meta` in `src/types.ts` to store chain-of-thought data.
- Updated the streaming handler in `src/App.tsx` to accumulate reasoning from `choices[0].delta.reasoning` and to extract `<think>...</think>` blocks embedded in `delta.content`, keeping reasoning separate from visible assistant content and including it in streaming updates.
- Included reasoning when calling `addRemoteMessage` so the reasoning is saved to Supabase as part of the message `meta`.
- Added a new `ReasoningPanel` component (`src/components/ReasoningPanel.tsx` and `src/components/ReasoningPanel.css`) which is collapsed by default and toggles a styled container showing the reasoning text.
- Integrated the `ReasoningPanel` into the chat UI (`src/pages/ChatPage.tsx`) so it renders when `message.meta?.reasoning` is present.

### Testing
- Started the dev server with `npm run dev` and verified the app served successfully at the local URL, which completed without errors.
- Captured a UI screenshot using a Playwright script pointing at the running dev server which produced an artifact (login screen) indicating the app rendered, but no reasoning content was visible because the session was not populated by a model stream.
- No unit or integration test suite was run for the new parsing logic in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982ce09c92c8330ac6d4d3130e85ee1)