### PR TITLE
Improve reasoning panel layout and scrolling

### DIFF
--- a/src/components/ReasoningPanel.css
+++ b/src/components/ReasoningPanel.css
@@ -1,5 +1,5 @@
 .reasoning-panel {
-  margin-top: 12px;
+  margin-bottom: 8px;
 }
 
 .reasoning-panel__toggle {
@@ -26,19 +26,35 @@
 }
 
 .reasoning-panel__content.is-open {
-  max-height: 240px;
+  max-height: 360px;
   opacity: 1;
 }
 
-.reasoning-panel__body {
+.reasoning-panel__body,
+.reasoning-content {
   margin-top: 8px;
-  padding: 10px 12px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  border-radius: 10px;
-  background: rgba(248, 250, 252, 0.8);
+  max-height: min(300px, 50vh);
+  overflow-y: auto;
+  padding: 12px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.03);
   color: #6b7280;
-  font-size: 13px;
+  font-size: 0.9em;
   font-style: italic;
-  line-height: 1.5;
+  line-height: 1.6;
   white-space: pre-wrap;
+  word-break: break-word;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.15) transparent;
+}
+
+.reasoning-panel__body::-webkit-scrollbar,
+.reasoning-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.reasoning-panel__body::-webkit-scrollbar-thumb,
+.reasoning-content::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 3px;
 }

--- a/src/components/ReasoningPanel.tsx
+++ b/src/components/ReasoningPanel.tsx
@@ -19,7 +19,7 @@ const ReasoningPanel = ({ reasoning }: ReasoningPanelProps) => {
         💭 思考过程
       </button>
       <div className={`reasoning-panel__content ${isOpen ? 'is-open' : ''}`}>
-        <div className="reasoning-panel__body">{reasoning}</div>
+        <div className="reasoning-panel__body reasoning-content">{reasoning}</div>
       </div>
     </div>
   )

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -147,10 +147,10 @@ const ChatPage = ({
               className={`message ${message.role === 'user' ? 'out' : 'in'}`}
             >
               <div className="bubble">
-                <p>{message.content}</p>
                 {message.meta?.reasoning?.trim() ? (
                   <ReasoningPanel reasoning={message.meta.reasoning} />
                 ) : null}
+                <p>{message.content}</p>
                 <div className="message-footer">
                   {message.role === 'assistant' && message.meta?.model ? (
                     <span className="model-tag">


### PR DESCRIPTION
### Motivation

- Prevent the reasoning panel content from being clipped and make long reasoning visible via scrolling.
- Place the reasoning (thinking) content above the message body to follow a natural reading order.
- Make the reasoning area visually distinct and readable with subtle styling and spacing.

### Description

- Updated `src/components/ReasoningPanel.css` to add a `max-height` constraint, `overflow-y: auto`, padding, subtle background, rounded corners, adjusted font-size/line-height, and thin scrollbar styling for the reasoning area.
- Introduced a shared `.reasoning-content` class and applied it to the panel body for consistent styling and word-wrapping support.
- Adjusted `.reasoning-panel__content.is-open` max-height and changed panel spacing from top to bottom via margin tweaks.
- Moved the `<ReasoningPanel />` render above the main message content in `src/pages/ChatPage.tsx` so the reasoning appears before the message text.
- Updated `src/components/ReasoningPanel.tsx` to add the `reasoning-content` class to the content container.

### Testing

- Started the dev server with `npm run dev` and the Vite server came up successfully and served the app at `http://localhost:4173/`.
- Executed a Playwright script that loaded `http://127.0.0.1:4173/`, took a full-page screenshot, and produced an artifact to verify the visual changes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982f8f6fc30833093902866d1a27890)