### PR TITLE
Add session-level model override selector in chat composer

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -284,6 +284,38 @@
   font-weight: 600;
 }
 
+.composer-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: #475569;
+}
+
+.model-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.model-selector select {
+  border: none;
+  background: transparent;
+  font-size: 12px;
+  color: #0f172a;
+  outline: none;
+}
+
+.model-hint {
+  font-size: 12px;
+  color: #64748b;
+}
+
 .composer-row {
   display: flex;
   gap: 8px;

--- a/src/storage/chatStorage.ts
+++ b/src/storage/chatStorage.ts
@@ -98,6 +98,7 @@ export const createSession = (title?: string): ChatSession => {
     title: title ?? '新会话',
     createdAt: now,
     updatedAt: now,
+    overrideModel: null,
   }
   snapshot.sessions = sortSessions([...snapshot.sessions, session])
   scheduleWrite()
@@ -168,4 +169,23 @@ export const deleteSession = (sessionId: string) => {
   snapshot.sessions = snapshot.sessions.filter((session) => session.id !== sessionId)
   snapshot.messages = snapshot.messages.filter((message) => message.sessionId !== sessionId)
   scheduleWrite()
+}
+
+export const updateSessionOverride = (
+  sessionId: string,
+  overrideModel: string | null,
+): ChatSession | null => {
+  let updatedSession: ChatSession | null = null
+  snapshot.sessions = snapshot.sessions.map((session) => {
+    if (session.id !== sessionId) {
+      return session
+    }
+    updatedSession = { ...session, overrideModel }
+    return updatedSession
+  })
+  if (!updatedSession) {
+    return null
+  }
+  scheduleWrite()
+  return updatedSession
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type ChatSession = {
   title: string
   createdAt: string
   updatedAt: string
+  overrideModel?: string | null
 }
 
 export type ChatMessage = {

--- a/supabase/migrations/20250115090000_add_sessions_override_model.sql
+++ b/supabase/migrations/20250115090000_add_sessions_override_model.sql
@@ -1,0 +1,2 @@
+alter table if exists public.sessions
+add column if not exists override_model text;


### PR DESCRIPTION
### Motivation
- Allow users to switch model for the current chat session directly in the composer without changing their global default. 
- Persist a per-session override so the selection survives refresh and (if available) syncs across devices via Supabase. 
- Ensure subsequent assistant replies use the session override while still recording the actual model in message metadata.

### Description
- Added `overrideModel` to `ChatSession` type and persisted it in local storage via `updateSessionOverride` in `src/storage/chatStorage.ts`.
- Extended Supabase sync code in `src/storage/supabaseSync.ts` to read/write `override_model` and added `updateRemoteSessionOverride` for cloud persistence, plus a SQL migration `supabase/migrations/20250115090000_add_sessions_override_model.sql`.
- Implemented session resolution logic in `src/App.tsx` with `resolveSessionModel(sessionId)` and `handleSessionOverrideChange(sessionId, model)`, and wired the resolved model into the existing `sendMessage` flow so chat requests use the session override when present.
- Added a compact, mobile-friendly model selector UI to the composer in `src/pages/ChatPage.tsx` and corresponding styles in `src/pages/ChatPage.css`, and passed `enabledModels`, `defaultModel`, and `onSelectModel` from `App` into `ChatPage`.

### Testing
- Ran `npm install` which completed successfully and fixed initial missing-dependency errors. 
- Started the dev server with `npm run dev` and Vite reported the server ready (succeeded). 
- Executed Playwright scripts to capture the app: an initial malformed script failed (syntax error), then a corrected Playwright run succeeded and produced a screenshot of the served auth page (succeeded). 
- Note: the automated browser screenshot shows the app landing on the auth screen due to no Supabase session, so full end-to-end verification of the composer model selector against `openrouter-chat` was not possible in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69830319ea3c83309d2cbf08bc9d082d)