### PR TITLE
Add global and per-session 思考链 (reasoning) toggles and wire through OpenRouter requests

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -316,6 +316,25 @@
   color: #64748b;
 }
 
+.composer-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  color: #0f172a;
+}
+
+.composer-toggle input {
+  accent-color: #0f172a;
+}
+
+.composer-toggle .toggle-hint {
+  color: #64748b;
+}
+
 .composer-row {
   display: flex;
   gap: 8px;

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -19,6 +19,8 @@ export type ChatPageProps = {
   enabledModels: string[]
   defaultModel: string
   onSelectModel: (model: string | null) => void
+  defaultReasoning: boolean
+  onSelectReasoning: (reasoning: boolean | null) => void
 }
 
 const formatTime = (timestamp: string) =>
@@ -38,6 +40,8 @@ const ChatPage = ({
   enabledModels,
   defaultModel,
   onSelectModel,
+  defaultReasoning,
+  onSelectReasoning,
 }: ChatPageProps) => {
   const [draft, setDraft] = useState('')
   const [openActionsId, setOpenActionsId] = useState<string | null>(null)
@@ -87,6 +91,9 @@ const ChatPage = ({
   const sessionOverride = session.overrideModel?.trim() || null
   const selectedModel = sessionOverride ?? defaultModel
   const hasOverride = Boolean(sessionOverride && sessionOverride !== defaultModel)
+  const sessionOverrideReasoning = session.overrideReasoning ?? null
+  const reasoningEnabled = sessionOverrideReasoning ?? defaultReasoning
+  const reasoningHint = sessionOverrideReasoning === null ? '（默认）' : '（会话覆盖）'
   const modelOptions = useMemo(() => {
     const unique = new Set<string>()
     enabledModels.forEach((model) => unique.add(model))
@@ -254,6 +261,15 @@ const ChatPage = ({
             当前：{selectedModel}
             {hasOverride ? '（会话覆盖）' : '（默认）'}
           </span>
+          <label className="composer-toggle">
+            <input
+              type="checkbox"
+              checked={reasoningEnabled}
+              onChange={(event) => onSelectReasoning(event.target.checked)}
+            />
+            <span>思考链</span>
+            <span className="toggle-hint">{reasoningHint}</span>
+          </label>
         </div>
         <div className="composer-row">
           <textarea

--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -210,6 +210,23 @@
   font-family: inherit;
 }
 
+.toggle-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  width: fit-content;
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.toggle-control input {
+  accent-color: #0f172a;
+}
+
 .field-error {
   color: #b91c1c;
   font-size: 12px;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -261,6 +261,16 @@ const SettingsPage = ({ user, settings, ready, onUpdateSettings }: SettingsPageP
     }
   }
 
+  const handleReasoningToggle = (enabled: boolean) => {
+    if (!settings) {
+      return
+    }
+    applySettingsUpdate((current) => ({
+      ...current,
+      enableReasoning: enabled,
+    }))
+  }
+
   const handleSystemPromptChange = (value: string) => {
     setDraftSystemPrompt(value)
     if (systemPromptStatus !== 'idle') {
@@ -432,6 +442,18 @@ const SettingsPage = ({ user, settings, ready, onUpdateSettings }: SettingsPageP
             onChange={(event) => handleMaxTokensChange(event.target.value)}
           />
           {errors.maxTokens ? <span className="field-error">{errors.maxTokens}</span> : null}
+        </div>
+        <div className="field-group">
+          <label htmlFor="enableReasoning">思考链（默认）</label>
+          <label className="toggle-control">
+            <input
+              id="enableReasoning"
+              type="checkbox"
+              checked={settings.enableReasoning}
+              onChange={(event) => handleReasoningToggle(event.target.checked)}
+            />
+            <span>{settings.enableReasoning ? '已开启' : '已关闭'}</span>
+          </label>
         </div>
       </section>
 

--- a/src/storage/chatStorage.ts
+++ b/src/storage/chatStorage.ts
@@ -99,6 +99,7 @@ export const createSession = (title?: string): ChatSession => {
     createdAt: now,
     updatedAt: now,
     overrideModel: null,
+    overrideReasoning: null,
   }
   snapshot.sessions = sortSessions([...snapshot.sessions, session])
   scheduleWrite()
@@ -181,6 +182,25 @@ export const updateSessionOverride = (
       return session
     }
     updatedSession = { ...session, overrideModel }
+    return updatedSession
+  })
+  if (!updatedSession) {
+    return null
+  }
+  scheduleWrite()
+  return updatedSession
+}
+
+export const updateSessionReasoningOverride = (
+  sessionId: string,
+  overrideReasoning: boolean | null,
+): ChatSession | null => {
+  let updatedSession: ChatSession | null = null
+  snapshot.sessions = snapshot.sessions.map((session) => {
+    if (session.id !== sessionId) {
+      return session
+    }
+    updatedSession = { ...session, overrideReasoning }
     return updatedSession
   })
   if (!updatedSession) {

--- a/src/storage/userSettings.ts
+++ b/src/storage/userSettings.ts
@@ -9,6 +9,7 @@ type UserSettingsRow = {
   top_p: number | null
   max_tokens: number | null
   system_prompt: string | null
+  enable_reasoning: boolean | null
   updated_at: string
 }
 
@@ -22,6 +23,7 @@ export const createDefaultSettings = (userId: string): UserSettings => ({
   topP: 0.9,
   maxTokens: 1024,
   systemPrompt: '',
+  enableReasoning: false,
   updatedAt: new Date().toISOString(),
 })
 
@@ -33,6 +35,7 @@ const mapSettingsRow = (row: UserSettingsRow): UserSettings => ({
   topP: row.top_p ?? 0.9,
   maxTokens: row.max_tokens ?? 1024,
   systemPrompt: row.system_prompt ?? '',
+  enableReasoning: row.enable_reasoning ?? false,
   updatedAt: row.updated_at,
 })
 
@@ -43,7 +46,7 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
   const { data, error } = await supabase
     .from('user_settings')
     .select(
-      'user_id,enabled_models,default_model,temperature,top_p,max_tokens,system_prompt,updated_at',
+      'user_id,enabled_models,default_model,temperature,top_p,max_tokens,system_prompt,enable_reasoning,updated_at',
     )
     .eq('user_id', userId)
     .maybeSingle()
@@ -63,10 +66,11 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
         top_p: defaults.topP,
         max_tokens: defaults.maxTokens,
         system_prompt: defaults.systemPrompt,
+        enable_reasoning: defaults.enableReasoning,
         updated_at: now,
       })
       .select(
-        'user_id,enabled_models,default_model,temperature,top_p,max_tokens,system_prompt,updated_at',
+        'user_id,enabled_models,default_model,temperature,top_p,max_tokens,system_prompt,enable_reasoning,updated_at',
       )
       .single()
     if (insertError || !inserted) {
@@ -91,6 +95,7 @@ export const updateUserSettings = async (settings: UserSettings): Promise<void> 
       top_p: settings.topP,
       max_tokens: settings.maxTokens,
       system_prompt: settings.systemPrompt,
+      enable_reasoning: settings.enableReasoning,
       updated_at: now,
     })
     .eq('user_id', settings.userId)

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type ChatSession = {
   createdAt: string
   updatedAt: string
   overrideModel?: string | null
+  overrideReasoning?: boolean | null
 }
 
 export type ChatMessage = {
@@ -36,5 +37,6 @@ export type UserSettings = {
   topP: number
   maxTokens: number
   systemPrompt: string
+  enableReasoning: boolean
   updatedAt: string
 }

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -11,6 +11,7 @@ type OpenRouterPayload = {
   temperature?: number
   top_p?: number
   max_tokens?: number
+  reasoning?: boolean
   stream?: boolean
 }
 
@@ -114,7 +115,7 @@ serve(async (req) => {
     })
   }
 
-  const { messages, model, temperature, top_p, max_tokens } = payload
+  const { messages, model, temperature, top_p, max_tokens, reasoning } = payload
   const stream = payload.stream ?? true
 
   try {
@@ -130,6 +131,7 @@ serve(async (req) => {
         temperature,
         top_p,
         max_tokens,
+        ...(reasoning ? { reasoning: { effort: 'medium' } } : {}),
         stream,
       }),
     })


### PR DESCRIPTION
### Motivation
- Some upstream models require an explicit flag to request chain-of-thought/reasoning, so add a global default and a per-session override to request reasoning when supported. 
- Expose controls in the Chinese UI: a global toggle on Settings and a small per-session toggle in the chat composer that overrides the global default.

### Description
- Add persistent state: `UserSettings.enableReasoning` and `ChatSession.overrideReasoning` (types updated in `src/types.ts`) and persist these to Supabase in `src/storage/userSettings.ts` and session rows in `src/storage/supabaseSync.ts` with local snapshot support in `src/storage/chatStorage.ts`.
- New helpers: `updateSessionReasoningOverride` (local) and `updateRemoteSessionReasoningOverride` (Supabase) to update per-session reasoning overrides.
- UI: Settings page adds a Chinese toggle labeled `思考链（默认）` to control the global default, and the chat composer adds a compact `思考链` checkbox for the active session with a hint showing whether it is default or overridden; relevant CSS added/adjusted (`src/pages/SettingsPage.tsx`, `src/pages/ChatPage.tsx`, `src/pages/SettingsPage.css`, `src/pages/ChatPage.css`).
- Request wiring: `App.tsx` adds `resolveSessionReasoning` and sends a `reasoning` boolean in the payload to the OpenRouter edge function; the Supabase function `supabase/functions/openrouter-chat/index.ts` now accepts a `reasoning` flag and conditionally includes a best-effort `reasoning: { effort: 'medium' }` field when true.
- Display: existing reasoning rendering is unchanged; reasoning content continues to be placed in `message.meta.reasoning` and the `ReasoningPanel` remains visible only when reasoning content is present.

### Testing
- Installed dependencies and ran the dev server with `npm install` and `npm run dev`, after resolving an initial missing-deps warning; the dev server started successfully and served the app locally.
- Ran an automated Playwright script that opened `/settings` and produced a screenshot artifact to validate the page loads; the script completed and produced an artifact (screenshot) successfully.
- Committed the changes locally (`git commit`) after verification; no automated unit tests were present or executed beyond the above dev/run and browser check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69830b2e040c83309da5c7917e4a5122)