### PR TITLE
Fix snack delete RLS 403 by minimizing soft-delete payload

### DIFF
--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -98,7 +98,7 @@ const SnacksPage = ({ user }: SnacksPageProps) => {
       setPendingDelete(null)
     } catch (deleteError) {
       console.warn('删除零食记录失败', deleteError)
-      setError('删除失败，请稍后重试。')
+      setError('删除失败，请重试；若仍失败请稍后再试。')
       setPendingDelete(null)
     }
   }

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -292,10 +292,7 @@ export const softDeleteSnackPost = async (postId: string): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
-  const { error } = await supabase
-    .from('snack_posts')
-    .update({ is_deleted: true, updated_at: new Date().toISOString() })
-    .eq('id', postId)
+  const { error } = await supabase.from('snack_posts').update({ is_deleted: true }).eq('id', postId)
 
   if (error) {
     throw error


### PR DESCRIPTION
### Motivation
- Supabase RLS caused 403 when soft-deleting snack posts because the update payload included fields beyond `is_deleted`, so the request must be minimized to only set `is_deleted: true`.
- Keep the existing UX flow and confirmation dialog text (`确定删除这条记录吗？`).

### Description
- Change `softDeleteSnackPost` to call `supabase.from('snack_posts').update({ is_deleted: true }).eq('id', postId)` and remove the extra `updated_at` field from the update payload in `src/storage/supabaseSync.ts`.
- Preserve immediate UI removal of the post after a successful delete by keeping the `setPosts((current) => current.filter(...))` logic in `src/pages/SnacksPage.tsx`.
- Update the delete failure message in `src/pages/SnacksPage.tsx` to a clearer Chinese retry hint: `删除失败，请重试；若仍失败请稍后再试。`.

### Testing
- Ran `npm run build` and the project built successfully (TypeScript compile + Vite build completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984468a6b8c83309fd645d8e2551a61)