### PR TITLE
Soft-delete snack_posts: scope update by user_id for RLS

### DIFF
--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -89,16 +89,16 @@ const SnacksPage = ({ user }: SnacksPageProps) => {
   }
 
   const handleDelete = async () => {
-    if (!pendingDelete) {
+    if (!pendingDelete || !user) {
       return
     }
     try {
-      await softDeleteSnackPost(pendingDelete.id)
+      await softDeleteSnackPost(pendingDelete.id, user.id)
       setPosts((current) => current.filter((post) => post.id !== pendingDelete.id))
       setPendingDelete(null)
     } catch (deleteError) {
       console.warn('删除零食记录失败', deleteError)
-      setError('删除失败，请稍后重试。')
+      setError('删除失败，请重试；若仍失败请稍后再试。')
       setPendingDelete(null)
     }
   }

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -288,14 +288,16 @@ export const createSnackPost = async (userId: string, content: string): Promise<
   return mapSnackPostRow(data as SnackPostRow)
 }
 
-export const softDeleteSnackPost = async (postId: string): Promise<void> => {
+export const softDeleteSnackPost = async (postId: string, userId: string): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
+  const now = new Date().toISOString()
   const { error } = await supabase
     .from('snack_posts')
-    .update({ is_deleted: true, updated_at: new Date().toISOString() })
+    .update({ is_deleted: true, updated_at: now })
     .eq('id', postId)
+    .eq('user_id', userId)
 
   if (error) {
     throw error


### PR DESCRIPTION
### Motivation
- Supabase row-level security causes `403` on soft-delete when the update isn't explicitly scoped to the post owner, so the soft-delete must include a `user_id` filter and updated timestamp to satisfy policies.
- Ensure TypeScript safety when calling the updated soft-delete API from the UI.

### Description
- Change `softDeleteSnackPost` signature to `async (postId: string, userId: string)` and apply `.eq('id', postId).eq('user_id', userId)` while updating `{ is_deleted: true, updated_at: now }` in `src/storage/supabaseSync.ts`.
- Update the delete call site in `src/pages/SnacksPage.tsx` to pass `user.id` and add a `!user` guard in `handleDelete` to fix a TypeScript `user`-null error.
- Preserve immediate UI removal of the deleted post and improve the delete-failure message to `删除失败，请重试；若仍失败请稍后再试。`.

### Testing
- Ran `npm run build` (which runs `tsc -b` and `vite build`) and the final build completed successfully.
- An initial `tsc` error (`TS18047: 'user' is possibly 'null'`) was caught by the build and was fixed by adding the null guard, after which the build passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984468a6b8c83309fd645d8e2551a61)