### PR TITLE
Persist reasoning/thinking into message meta and show reasoning panel

### DIFF
--- a/src/components/ReasoningPanel.tsx
+++ b/src/components/ReasoningPanel.tsx
@@ -16,7 +16,7 @@ const ReasoningPanel = ({ reasoning }: ReasoningPanelProps) => {
         aria-expanded={isOpen}
         onClick={() => setIsOpen((current) => !current)}
       >
-        💭 思考过程
+        查看思考
       </button>
       <div className={`reasoning-panel__content ${isOpen ? 'is-open' : ''}`}>
         <div className="reasoning-panel__body reasoning-content">{reasoning}</div>

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -184,9 +184,11 @@ const ChatPage = ({
               className={`message ${message.role === 'user' ? 'out' : 'in'}`}
             >
               <div className="bubble">
-                {message.meta?.reasoning?.trim() ? (
-                  <ReasoningPanel reasoning={message.meta.reasoning} />
-                ) : null}
+                {(() => {
+                  const reasoningText =
+                    message.meta?.reasoning_text?.trim() ?? message.meta?.reasoning?.trim()
+                  return reasoningText ? <ReasoningPanel reasoning={reasoningText} /> : null
+                })()}
                 {message.role === 'assistant' ? (
                   <div className="assistant-markdown">
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export type ChatMessage = {
     model?: string
     streaming?: boolean
     reasoning?: string
+    reasoning_text?: string
+    reasoning_type?: 'reasoning' | 'thinking'
     params?: {
       temperature?: number
       top_p?: number


### PR DESCRIPTION
### Motivation
- Reasoning/thinking returned by models (streamed or non-streamed) must be captured and persisted so it is visible across refreshes and devices and not mixed into visible assistant content. 
- Claude/Anthropic providers may return reasoning under different keys or require a request flag; support should be best-effort without breaking other providers.

### Description
- Capture reasoning from streaming SSE deltas and non-stream JSON responses into a new persistent field `meta.reasoning_text` and track the kind in `meta.reasoning_type` (`"reasoning" | "thinking"`), while keeping visible assistant `content` unchanged by reasoning extraction (changes in `src/App.tsx` and `src/types.ts`).
- Support legacy and alternate keys by collecting from `reasoning`, `thinking`, `reasoning_content`, `thinking_content` and stream-inserted `<think>...</think>` blocks; pending streaming deltas are accumulated then flushed to the message meta (`src/App.tsx`).
- Add a best-effort Claude/Anthropic trigger by including a `thinking` object in the request body when reasoning is enabled and a Claude-like model is used, without failing if unsupported (`src/App.tsx`).
- Update UI to only show the reasoning fold when a persisted reasoning string exists (prefer `meta.reasoning_text` then `meta.reasoning`), and change the toggle label to the required Chinese string `查看思考` (`src/pages/ChatPage.tsx`, `src/components/ReasoningPanel.tsx`).
- Extend TypeScript message types to include `reasoning_text` and `reasoning_type` in `ChatMessage.meta` (`src/types.ts`).

### Testing
- Started the local dev server with `npm run dev` and confirmed Vite served the app successfully (success).
- Ran a headless Playwright script that navigated to the app auth page and captured a screenshot to verify UI boot (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985e683bfe083308c615a9dbf09befb)