### PR TITLE
Add Snack AI replies (🐹) with chat-matched model settings and Supabase persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,19 @@ const App = () => {
     return Array.from(unique)
   }, [activeSettings.enabledModels, defaultModelId])
 
+  const latestSession = useMemo(() => selectMostRecentSession(sessions), [sessions])
+  const snackAiConfig = useMemo(() => {
+    const overrideModel = latestSession?.overrideModel?.trim() || null
+    return {
+      model: overrideModel ?? defaultModelId,
+      reasoning: latestSession?.overrideReasoning ?? activeSettings.enableReasoning,
+      temperature: activeSettings.temperature,
+      topP: activeSettings.topP,
+      maxTokens: activeSettings.maxTokens,
+      systemPrompt: activeSettings.systemPrompt,
+    }
+  }, [activeSettings, defaultModelId, latestSession])
+
   useEffect(() => {
     sessionsRef.current = sessions
   }, [sessions])
@@ -1127,7 +1140,7 @@ const App = () => {
           path="/snacks"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <SnacksPage user={user} />
+              <SnacksPage user={user} snackAiConfig={snackAiConfig} />
             </RequireAuth>
           }
         />

--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -88,3 +88,44 @@
   padding: 4px 10px;
   font-size: 13px;
 }
+
+.post-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reply-list {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.reply-bubble {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.reply-bubble p {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.reply-bubble.pending {
+  color: #64748b;
+}
+
+.reply-time {
+  display: inline-block;
+  margin-top: 6px;
+  color: #94a3b8;
+  font-size: 12px;
+}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ChatSession, SnackPost } from '../types'
+import type { ChatMessage, ChatSession, SnackPost, SnackReply } from '../types'
 import { supabase } from '../supabase/client'
 
 type SessionRow = {
@@ -33,6 +33,16 @@ type SnackPostRow = {
   is_deleted: boolean
 }
 
+type SnackReplyRow = {
+  id: string
+  user_id: string
+  post_id: string
+  content: string
+  meta: SnackReply['meta'] | null
+  created_at: string
+  is_deleted: boolean
+}
+
 const mapSnackPostRow = (row: SnackPostRow): SnackPost => ({
   id: row.id,
   userId: row.user_id,
@@ -40,6 +50,16 @@ const mapSnackPostRow = (row: SnackPostRow): SnackPost => ({
   createdAt: row.created_at,
   updatedAt: row.updated_at,
   isDeleted: row.is_deleted,
+})
+
+const mapSnackReplyRow = (row: SnackReplyRow): SnackReply => ({
+  id: row.id,
+  userId: row.user_id,
+  postId: row.post_id,
+  content: row.content,
+  createdAt: row.created_at,
+  isDeleted: row.is_deleted,
+  meta: row.meta ?? undefined,
 })
 
 const mapSessionRow = (row: SessionRow): ChatSession => ({
@@ -315,6 +335,55 @@ export const softDeleteSnackPost = async (postId: string): Promise<void> => {
     throw new Error('Supabase 客户端未配置')
   }
   const { error } = await supabase.rpc('soft_delete_snack_post', { p_post_id: postId })
+
+  if (error) {
+    throw error
+  }
+}
+
+export const fetchSnackReplies = async (postIds: string[]): Promise<SnackReply[]> => {
+  if (!supabase || postIds.length === 0) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('snack_replies')
+    .select('id,user_id,post_id,content,meta,created_at,is_deleted')
+    .in('post_id', postIds)
+    .eq('is_deleted', false)
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapSnackReplyRow(row as SnackReplyRow))
+}
+
+export const createSnackReply = async (
+  postId: string,
+  content: string,
+  meta: SnackReply['meta'],
+): Promise<SnackReply> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { data, error } = await supabase
+    .from('snack_replies')
+    .insert({ post_id: postId, content, meta: meta ?? {} })
+    .select('id,user_id,post_id,content,meta,created_at,is_deleted')
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('保存零食回复失败')
+  }
+  return mapSnackReplyRow(data as SnackReplyRow)
+}
+
+export const softDeleteSnackReply = async (replyId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('snack_replies')
+    .update({ is_deleted: true })
+    .eq('id', replyId)
 
   if (error) {
     throw error

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,17 @@ export type SnackPost = {
   updatedAt: string
   isDeleted: boolean
 }
+
+export type SnackReply = {
+  id: string
+  userId: string
+  postId: string
+  content: string
+  createdAt: string
+  isDeleted: boolean
+  meta?: {
+    provider?: string
+    model?: string
+    reasoning_text?: string
+  }
+}


### PR DESCRIPTION
### Motivation
- Add AI-generated replies for snack posts that reuse the exact same prompt and model settings as the main chat pipeline. 
- Persist replies to Supabase so they sync across devices and can be soft-deleted.
- Provide a compact, localized UI affordance (🐹) to generate replies and show generation state without changing chat behavior or model instructions.

### Description
- Introduce a `SnackReply` type and Supabase helpers in `src/storage/supabaseSync.ts`: `fetchSnackReplies`, `createSnackReply`, and `softDeleteSnackReply`, plus row mapping for `snack_replies`.
- Extend `src/App.tsx` to compute `snackAiConfig` (model, reasoning, temperature, topP, maxTokens, systemPrompt) derived from the latest session override and user settings so snacks reuse chat settings.
- Implement `src/pages/SnacksPage.tsx` additions: per-post 🐹 button to call the existing `openrouter-chat` edge function, render reply threads under posts, show a `生成中…` pending bubble during generation, and add per-reply delete confirmation; generated replies are persisted via `createSnackReply` with `meta` including `provider`, `model`, and `reasoning_text`.
- Add styles in `src/pages/SnacksPage.css` for reply list, reply bubbles, actions, and the pending state.
- The snack generation request uses `system` = `user_settings.system_prompt` and `user` = snack post content only, and mirrors chat parameters (model selection, temperature/top_p/max_tokens, and reasoning toggle); no extra snack-specific instructions are injected.

### Testing
- Built the app with `npm run build` which completed successfully. 
- Ran the dev server and captured a UI snapshot via Playwright: `artifacts/snacks-page.png` (screenshot created). 
- Verified changes committed and a PR description prepared; all automated build / smoke checks performed here succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997045bf2888330988fdd91e317f29c)