### PR TITLE
Add collapsible mixed-role snack reply threads

### DIFF
--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -95,6 +95,46 @@
   gap: 8px;
 }
 
+.reply-collapsed-row {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reply-toggle {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  border-radius: 10px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.reply-toggle-main {
+  color: #334155;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.reply-preview {
+  color: #64748b;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reply-chevron {
+  color: #64748b;
+  font-size: 12px;
+}
+
 .reply-list {
   margin-top: 10px;
   display: flex;
@@ -108,9 +148,24 @@
   border-radius: 10px;
   padding: 8px 10px;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
+}
+
+.reply-bubble.user {
+  background: #eff6ff;
+}
+
+.reply-content-wrap {
+  flex: 1;
+  min-width: 0;
+}
+
+.reply-role {
+  font-size: 12px;
+  color: #475569;
+  margin-bottom: 4px;
 }
 
 .reply-bubble p {
@@ -128,4 +183,42 @@
   margin-top: 6px;
   color: #94a3b8;
   font-size: 12px;
+}
+
+.reply-composer {
+  display: flex;
+  gap: 8px;
+}
+
+.reply-composer textarea {
+  flex: 1;
+  resize: vertical;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 14px;
+  line-height: 1.5;
+  font-family: inherit;
+}
+
+.reply-composer button {
+  align-self: flex-end;
+}
+
+.assistant-markdown > :first-child {
+  margin-top: 0;
+}
+
+.assistant-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.assistant-markdown p {
+  margin: 0 0 8px;
+}
+
+.assistant-markdown ul,
+.assistant-markdown ol {
+  margin: 0 0 8px;
+  padding-left: 20px;
 }

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -37,6 +37,7 @@ type SnackReplyRow = {
   id: string
   user_id: string
   post_id: string
+  role: SnackReply['role']
   content: string
   meta: SnackReply['meta'] | null
   created_at: string
@@ -56,6 +57,7 @@ const mapSnackReplyRow = (row: SnackReplyRow): SnackReply => ({
   id: row.id,
   userId: row.user_id,
   postId: row.post_id,
+  role: row.role,
   content: row.content,
   createdAt: row.created_at,
   isDeleted: row.is_deleted,
@@ -347,7 +349,7 @@ export const fetchSnackReplies = async (postIds: string[]): Promise<SnackReply[]
   }
   const { data, error } = await supabase
     .from('snack_replies')
-    .select('id,user_id,post_id,content,meta,created_at,is_deleted')
+    .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
     .in('post_id', postIds)
     .eq('is_deleted', false)
     .order('created_at', { ascending: true })
@@ -359,6 +361,7 @@ export const fetchSnackReplies = async (postIds: string[]): Promise<SnackReply[]
 
 export const createSnackReply = async (
   postId: string,
+  role: SnackReply['role'],
   content: string,
   meta: SnackReply['meta'],
 ): Promise<SnackReply> => {
@@ -367,8 +370,8 @@ export const createSnackReply = async (
   }
   const { data, error } = await supabase
     .from('snack_replies')
-    .insert({ post_id: postId, content, meta: meta ?? {} })
-    .select('id,user_id,post_id,content,meta,created_at,is_deleted')
+    .insert({ post_id: postId, role, content, meta: meta ?? {} })
+    .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
     .single()
   if (error || !data) {
     throw error ?? new Error('保存零食回复失败')

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type SnackReply = {
   id: string
   userId: string
   postId: string
+  role: 'user' | 'assistant'
   content: string
   createdAt: string
   isDeleted: boolean


### PR DESCRIPTION
### Motivation
- Merge AI replies and user follow-ups into a single lightweight thread per snack post and reduce screen space with a collapsed view.
- Preserve existing AI generation, model/parameter behavior and reply soft-delete semantics while enabling user follow-ups to be stored alongside assistant replies.
- Keep UI copy in Chinese and limit scope to the snacks area.

### Description
- Add `role` to `SnackReply` and update Supabase mapping/queries to read/write `role` for `snack_replies` (changed `src/types.ts` and `src/storage/supabaseSync.ts`).
- Update `createSnackReply` to accept a `role` parameter and include `role` on insert and in select results (`src/storage/supabaseSync.ts`).
- Revamp snacks UI to a per-post collapsible thread: collapsed row shows `回复（N）`, a 30-char latest-reply preview and a chevron, with a small `🐹` AI button and a `回复` button that auto-expands and focuses the input (`src/pages/SnacksPage.tsx`, `src/pages/SnacksPage.css`).
- In expanded state render chronological replies where `role === 'assistant'` uses Markdown rendering and `role === 'user'` shows plain text preserving line breaks; bottom of thread has a per-post composer that inserts `role='user'` replies with `meta={}`.
- AI reply flow unchanged except UI now auto-expands when generating and shows a `生成中…` pending bubble; deletion still calls `soft_delete_snack_reply` and the UI list is updated immediately.

### Testing
- Ran `npm run lint` and the linter completed successfully.
- Ran `npm run build` and production build completed successfully.
- Started the dev server and captured a Playwright screenshot of the updated snacks page to validate the mobile UI; server and screenshot run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69970b53f1f48330be90654b346589bc)