### PR TITLE
Fix snack thread state overwrite for alternating replies

### DIFF
--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -162,10 +162,24 @@
   min-width: 0;
 }
 
+
 .reply-role {
   font-size: 12px;
   color: #475569;
   margin-bottom: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.reply-model-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #334155;
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 .reply-bubble p {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -351,8 +351,26 @@ export const fetchSnackReplies = async (postIds: string[]): Promise<SnackReply[]
     .from('snack_replies')
     .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
     .in('post_id', postIds)
+    .in('role', ['user', 'assistant'])
     .eq('is_deleted', false)
     .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapSnackReplyRow(row as SnackReplyRow))
+}
+
+export const fetchSnackRepliesByPost = async (postId: string): Promise<SnackReply[]> => {
+  if (!supabase) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('snack_replies')
+    .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
+    .eq('post_id', postId)
+    .eq('is_deleted', false)
+    .order('created_at', { ascending: true })
+
   if (error) {
     throw error
   }


### PR DESCRIPTION
### Motivation
- The replies list for a snack post could be overwritten during AI reply generation, causing subsequent user follow-ups to disappear and preventing alternating assistant/user threads from displaying correctly.
- Fetching and state reconciliation needed to ensure the full reply thread is preserved and shown in chronological order after streaming or optimistic updates.

### Description
- Added `fetchSnackRepliesByPost(postId)` in `src/storage/supabaseSync.ts` to return all non-deleted replies for a single post ordered by `created_at` (`eq('post_id', postId).eq('is_deleted', false).order(...)`).
- Changed user follow-up flow in `src/pages/SnacksPage.tsx` to optimistic append: insert a temporary pending reply (generated via `createPendingReplyId`), call `createSnackReply`, then replace the pending item with the saved row or remove it on error.
- Reworked AI generation flow in `src/pages/SnacksPage.tsx` to append a pending assistant reply, update only that pending item while streaming, and after saving call `fetchSnackRepliesByPost` to sync the full, DB-ordered thread; on failure only the pending item is removed.
- Updated UI rendering and styles to show assistant label and model badge and adjusted layout by changing `src/pages/SnacksPage.tsx` and `src/pages/SnacksPage.css` so role/model are displayed (`Syzygy` + `reply-model-badge`) and user shown as `串串`.

### Testing
- Ran `npm run build` and TypeScript/Vite build completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the app became accessible locally.
- Executed a Playwright script to open `/snacks` and capture a screenshot (`artifacts/snacks-thread-pr45.png`) for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69970f21b5108330aabb01cdbbf27b06)