### PR TITLE
Include device-local timestamp in Snack Feed AI prompts

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,28 @@
+const pad = (value: number) => value.toString().padStart(2, '0')
+
+const formatOffset = (offsetMinutes: number) => {
+  const sign = offsetMinutes >= 0 ? '+' : '-'
+  const absoluteMinutes = Math.abs(offsetMinutes)
+  const hours = pad(Math.floor(absoluteMinutes / 60))
+  const minutes = pad(absoluteMinutes % 60)
+  return `${sign}${hours}:${minutes}`
+}
+
+export const formatLocalTimestamp = (isoString: string) => {
+  const date = new Date(isoString)
+  if (Number.isNaN(date.getTime())) {
+    return '1970-01-01 00:00 +00:00'
+  }
+
+  const year = date.getFullYear()
+  const month = pad(date.getMonth() + 1)
+  const day = pad(date.getDate())
+  const hours = pad(date.getHours())
+  const minutes = pad(date.getMinutes())
+  const offset = formatOffset(-date.getTimezoneOffset())
+
+  return `${year}-${month}-${day} ${hours}:${minutes} ${offset}`
+}
+
+export const withTimePrefix = (text: string, isoString: string) =>
+  `[${formatLocalTimestamp(isoString)}] ${text}`


### PR DESCRIPTION
### Motivation
- The model replying to Snack Feed posts lacked device-local post time context, causing time-related misunderstandings. 
- The goal is to surface a stable, low-token timestamp in model context without changing database schema or persistence.

### Description
- Added a small time utility `src/utils/time.ts` providing `formatLocalTimestamp(isoString)` and `withTimePrefix(text, isoString)` that format device-local time as `YYYY-MM-DD HH:mm ±HH:MM`.
- Updated Snack Feed prompt construction in `src/pages/SnacksPage.tsx` to import the helpers and prefix the sent post content with the local timestamp via `withTimePrefix(post.content, post.createdAt)`.
- Added a light system instruction (`timestampUsageInstruction`) and an extra user message with the comment request time using `formatLocalTimestamp(new Date().toISOString())`; all changes are limited to message/prompt construction and do not touch DB or schema.

### Testing
- Built the project with `npm run build` and the build succeeded.
- Ran lint with `npm run lint` and there were no lint errors.
- Verified no TypeScript build errors during the production build (includes `tsc -b` and `vite build`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998005bd05c8330877b794dd262226a)