### PR TITLE
Editable Supabase-synced Snack Feed style overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { supabase } from './supabase/client'
 import './App.css'
 import SettingsPage from './pages/SettingsPage'
 import SnacksPage from './pages/SnacksPage'
+import { resolveSnackSystemOverlay } from './constants/aiOverlays'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
@@ -167,6 +168,7 @@ const App = () => {
       topP: activeSettings.topP,
       maxTokens: activeSettings.maxTokens,
       systemPrompt: activeSettings.systemPrompt,
+      snackSystemOverlay: resolveSnackSystemOverlay(activeSettings.snackSystemOverlay),
     }
   }, [activeSettings, defaultModelId, latestSession])
 

--- a/src/constants/aiOverlays.ts
+++ b/src/constants/aiOverlays.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_SNACK_SYSTEM_OVERLAY = `你正在以“朋友圈/社交平台评论”的方式回复用户动态。
+要求：
+- 用中文，语气亲近自然，有一点社交网络感，但不要油腻。
+- 评论保持简短：1-3 句为主，总字数尽量不超过 80 字。
+- 不要长篇分析、不要分点罗列、不要复述整段动态。
+- 可以轻轻回应情绪、夸一句或关心一句；时间戳只在确实有意义时顺带提到。`
+
+export const resolveSnackSystemOverlay = (overlay: string | null | undefined) => {
+  const trimmed = overlay?.trim()
+  return trimmed && trimmed.length > 0 ? overlay ?? '' : DEFAULT_SNACK_SYSTEM_OVERLAY
+}

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -29,6 +29,7 @@ type SnacksPageProps = {
     topP: number
     maxTokens: number
     systemPrompt: string
+    snackSystemOverlay: string
   }
 }
 
@@ -323,6 +324,7 @@ const SnacksPage = ({ user, snackAiConfig }: SnacksPageProps) => {
       if (prompt) {
         messagesPayload.push({ role: 'system', content: prompt })
       }
+      messagesPayload.push({ role: 'system', content: snackAiConfig.snackSystemOverlay })
       messagesPayload.push({ role: 'system', content: timestampUsageInstruction })
 
       const requestTimeIso = new Date().toISOString()

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type UserSettings = {
   topP: number
   maxTokens: number
   systemPrompt: string
+  snackSystemOverlay: string
   enableReasoning: boolean
   updatedAt: string
 }

--- a/supabase/migrations/20260220110000_add_ai_overlays_to_user_settings.sql
+++ b/supabase/migrations/20260220110000_add_ai_overlays_to_user_settings.sql
@@ -1,0 +1,16 @@
+alter table public.user_settings
+  add column if not exists ai_overlays jsonb not null default '{}'::jsonb;
+
+update public.user_settings
+set ai_overlays = jsonb_set(
+  coalesce(ai_overlays, '{}'::jsonb),
+  '{snack_system}',
+  to_jsonb('你正在以“朋友圈/社交平台评论”的方式回复用户动态。
+要求：
+- 用中文，语气亲近自然，有一点社交网络感，但不要油腻。
+- 评论保持简短：1-3 句为主，总字数尽量不超过 80 字。
+- 不要长篇分析、不要分点罗列、不要复述整段动态。
+- 可以轻轻回应情绪、夸一句或关心一句；时间戳只在确实有意义时顺带提到。'::text),
+  true
+)
+where coalesce(nullif(ai_overlays->>'snack_system', ''), '') = '';


### PR DESCRIPTION
### Motivation
- Provide a per-module, user-editable “style overlay” for Snack Feed so replies can use a short social-comment style without code changes.
- Persist the overlay in Supabase and sync across devices using the existing `user_settings` persistence pattern to avoid local-only storage.
- Ensure a safe default Chinese template is used when empty and apply this overlay only to Snack Feed model calls (Chitchat remains unchanged).

### Description
- Added `DEFAULT_SNACK_SYSTEM_OVERLAY` and `resolveSnackSystemOverlay` utility in `src/constants/aiOverlays.ts` to supply the required Chinese default and handle blank fallbacks.
- Extended `UserSettings` (`src/types.ts`) with `snackSystemOverlay` and wired Supabase mapping in `src/storage/userSettings.ts` to read/write `ai_overlays.snack_system` (uses JSONB `ai_overlays` to avoid big schema changes).
- Added a minimal Supabase migration `supabase/migrations/20260220110000_add_ai_overlays_to_user_settings.sql` to add `ai_overlays` JSONB (if missing) and backfill `snack_system` defaults for existing rows.
- Added Settings UI controls in `src/pages/SettingsPage.tsx`: a multiline textarea labeled “Snack Feed Style (Model Overlay)”, `保存` and `恢复默认` buttons, unsaved-change protection integrated with the existing prompt guard, and resolver usage to normalize values.
- Plumbed the resolved overlay through app state (`src/App.tsx`) and applied it at runtime in Snack Feed requests (`src/pages/SnacksPage.tsx`) by appending a second `system` message after the base system prompt; Chitchat code paths are untouched.

### Testing
- Ran a full TypeScript and production build with `npm run build`, which completed successfully.
- Ran linting via `npm run lint`, which succeeded with no errors.
- Performed a headless UI smoke check using a dev server and an automated browser script to capture the Settings page showing the new Snack overlay section, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699809637bd48330bc8ab5d6febb33e4)