### PR TITLE
Add editable Syzygy post/reply prompts and wire them into Snacks flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import {
   createDefaultSettings,
   ensureUserSettings,
   saveSnackSystemPrompt,
+  saveSyzygyPostSystemPrompt,
+  saveSyzygyReplySystemPrompt,
   updateUserSettings,
 } from './storage/userSettings'
 import {
@@ -36,7 +38,11 @@ import { supabase } from './supabase/client'
 import './App.css'
 import SettingsPage from './pages/SettingsPage'
 import SnacksPage from './pages/SnacksPage'
-import { resolveSnackSystemOverlay } from './constants/aiOverlays'
+import {
+  resolveSnackSystemOverlay,
+  resolveSyzygyPostPrompt,
+  resolveSyzygyReplyPrompt,
+} from './constants/aiOverlays'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
@@ -168,6 +174,8 @@ const App = () => {
       maxTokens: activeSettings.maxTokens,
       systemPrompt: activeSettings.systemPrompt,
       snackSystemOverlay: resolveSnackSystemOverlay(activeSettings.snackSystemOverlay),
+      syzygyPostSystemPrompt: resolveSyzygyPostPrompt(activeSettings.syzygyPostSystemPrompt),
+      syzygyReplySystemPrompt: resolveSyzygyReplyPrompt(activeSettings.syzygyReplySystemPrompt),
     }
   }, [activeSettings, defaultModelId, latestSession])
 
@@ -1073,6 +1081,38 @@ const App = () => {
     }
     setUserSettings(nextSettings)
   }, [user])
+  const handleSaveSyzygyPostSystemPrompt = useCallback(async (nextPrompt: string) => {
+    if (!user) {
+      return
+    }
+    const nextSettings = {
+      ...(settingsRef.current ?? createDefaultSettings(user.id)),
+      userId: user.id,
+      syzygyPostSystemPrompt: nextPrompt,
+      updatedAt: new Date().toISOString(),
+    }
+    if (supabase) {
+      await saveSyzygyPostSystemPrompt(user.id, nextPrompt)
+    }
+    setUserSettings(nextSettings)
+  }, [user])
+
+  const handleSaveSyzygyReplySystemPrompt = useCallback(async (nextPrompt: string) => {
+    if (!user) {
+      return
+    }
+    const nextSettings = {
+      ...(settingsRef.current ?? createDefaultSettings(user.id)),
+      userId: user.id,
+      syzygyReplySystemPrompt: nextPrompt,
+      updatedAt: new Date().toISOString(),
+    }
+    if (supabase) {
+      await saveSyzygyReplySystemPrompt(user.id, nextPrompt)
+    }
+    setUserSettings(nextSettings)
+  }, [user])
+
 
   return (
     <div className="app-shell">
@@ -1129,6 +1169,8 @@ const App = () => {
                 ready={settingsReady}
                 onSaveSettings={handleSaveSettings}
                 onSaveSnackSystemPrompt={handleSaveSnackSystemPrompt}
+                onSaveSyzygyPostPrompt={handleSaveSyzygyPostSystemPrompt}
+                onSaveSyzygyReplyPrompt={handleSaveSyzygyReplySystemPrompt}
               />
             </RequireAuth>
           }

--- a/src/constants/aiOverlays.ts
+++ b/src/constants/aiOverlays.ts
@@ -5,7 +5,27 @@ export const DEFAULT_SNACK_SYSTEM_OVERLAY = `你正在以“朋友圈/社交平�
 - 不要长篇分析、不要分点罗列、不要复述整段动态。
 - 可以轻轻回应情绪、夸一句或关心一句；时间戳只在确实有意义时顺带提到。`
 
+export const DEFAULT_SYZYGY_POST_PROMPT = `中文，1–2 句，总字数尽量不超过 90 字。
+第一句：温柔、落地地观察“串串/小窝的一天”（不要编造可核验的具体事实）。
+第二句：Syzygy 的随想（允许轻微想象性表达，但不要捏造具体事件）。
+不要分点，不要长分析，不要表情符号。`
+
+export const DEFAULT_SYZYGY_REPLY_PROMPT = `中文，像社交平台下的简短回复。
+1–3 句为主，总字数尽量不超过 80 字。
+不要长分析，不要分点，不要复述整段内容。
+语气亲近自然，轻轻回应情绪即可。`
+
 export const resolveSnackSystemOverlay = (overlay: string | null | undefined) => {
   const trimmed = overlay?.trim()
   return trimmed && trimmed.length > 0 ? overlay ?? '' : DEFAULT_SNACK_SYSTEM_OVERLAY
+}
+
+export const resolveSyzygyPostPrompt = (prompt: string | null | undefined) => {
+  const trimmed = prompt?.trim()
+  return trimmed && trimmed.length > 0 ? prompt ?? '' : DEFAULT_SYZYGY_POST_PROMPT
+}
+
+export const resolveSyzygyReplyPrompt = (prompt: string | null | undefined) => {
+  const trimmed = prompt?.trim()
+  return trimmed && trimmed.length > 0 ? prompt ?? '' : DEFAULT_SYZYGY_REPLY_PROMPT
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export type UserSettings = {
   maxTokens: number
   systemPrompt: string
   snackSystemOverlay: string
+  syzygyPostSystemPrompt: string
+  syzygyReplySystemPrompt: string
   enableReasoning: boolean
   updatedAt: string
 }


### PR DESCRIPTION
### Motivation
- Allow users to edit the “仓鼠观察日志” (Syzygy) post and reply system prompts via `user_settings` and have runtime generation use those values instead of hard-coded text. 

### Description
- Added default templates and resolvers: `DEFAULT_SYZYGY_POST_PROMPT`, `DEFAULT_SYZYGY_REPLY_PROMPT`, `resolveSyzygyPostPrompt`, and `resolveSyzygyReplyPrompt` in `src/constants/aiOverlays.ts` to provide fallbacks when DB values are empty. 
- Extended types and settings storage: added `syzygyPostSystemPrompt` and `syzygyReplySystemPrompt` to `UserSettings` and the Supabase mapping, and implemented one-column save helpers `saveSyzygyPostSystemPrompt` and `saveSyzygyReplySystemPrompt` in `src/storage/userSettings.ts` to update prompts without overwriting other fields. 
- Settings UI: added two new textarea sections in `SettingsPage` for “仓鼠观察日志 - 发帖风格（Syzygy Post Prompt）” and “仓鼠观察日志 - 回复风格（Syzygy Reply Prompt）”, each with explicit Save and Reset-to-default buttons, mount-time loading from `user_settings` with fallback to defaults, and unsaved-state handling integrated with existing leave-page guards (`src/pages/SettingsPage.tsx`). 
- App wiring: exposed new save callbacks from `App` to `SettingsPage` that persist single-column updates and update local `userSettings` state (`src/App.tsx`). 
- Snacks runtime: added a 🤖 generate-post button and generation path that builds messages using `BASE system prompt` + saved/fallback `syzygy_post_system_prompt` and a small local timestamp/user context; updated AI reply generation to use `BASE system prompt` + saved/fallback `syzygy_reply_system_prompt` and include the original post, a short list of recent replies, and the latest user comment; responses are persisted to replies via `createSnackReply` (`src/pages/SnacksPage.tsx`). 
- Preserved existing behavior for model selection, generation params and snack overlay; all Supabase updates use `update({...}).eq('user_id', ...)` pattern to avoid overwriting unrelated fields. 

### Testing
- Ran `npm run -s lint` and it passed successfully. 
- Ran full build `npm run -s build` (`tsc -b && vite build`) and it completed successfully. 
- Started the dev server and captured a UI screenshot to validate the new Settings UI (developer-run automated screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981cdd4d708330b02a72fd2d494dcc)