### PR TITLE
Separate 仓鼠观察日志 (Syzygy) into its own page and data layer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { supabase } from './supabase/client'
 import './App.css'
 import SettingsPage from './pages/SettingsPage'
 import SnacksPage from './pages/SnacksPage'
+import SyzygyFeedPage from './pages/SyzygyFeedPage'
 import {
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
@@ -1180,6 +1181,15 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <SnacksPage user={user} snackAiConfig={snackAiConfig} />
+            </RequireAuth>
+          }
+        />
+
+        <Route
+          path="/syzygy"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <SyzygyFeedPage user={user} snackAiConfig={snackAiConfig} />
             </RequireAuth>
           }
         />

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -163,6 +163,16 @@ const ChatPage = ({
               >
                 零食罐
               </button>
+
+              <button
+                type="button"
+                onClick={() => {
+                  setOpenHeaderMenu(false)
+                  navigate('/syzygy')
+                }}
+              >
+                仓鼠观察日志
+              </button>
               <button
                 type="button"
                 onClick={() => {

--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -236,3 +236,19 @@
   margin: 0 0 8px;
   padding-left: 20px;
 }
+
+
+.post-header {
+  margin-bottom: 8px;
+}
+
+.feed-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  color: #475569;
+  font-size: 11px;
+  line-height: 1.4;
+  background: #f8fafc;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,3 +69,28 @@ export type SnackReply = {
     reasoning_text?: string
   }
 }
+
+
+export type SyzygyPost = {
+  id: string
+  userId: string
+  content: string
+  createdAt: string
+  updatedAt: string
+  isDeleted: boolean
+}
+
+export type SyzygyReply = {
+  id: string
+  userId: string
+  postId: string
+  role: 'user' | 'assistant'
+  content: string
+  createdAt: string
+  isDeleted: boolean
+  meta?: {
+    provider?: string
+    model?: string
+    reasoning_text?: string
+  }
+}


### PR DESCRIPTION
### Motivation
- The Snack Feed mixed Syzygy-generated posts and user snack posts, making them hard to distinguish; feeds must be separated at the module boundary. 
- Provide a clear route and UI affordance for 仓鼠观察日志 so it can be managed independently from `snack_posts`.
- Keep existing reply flows and AI reply/post generation working while avoiding merged queries across feeds.

### Description
- Added a new page component `SyzygyFeedPage` and route `/syzygy`, and wired it into the app router so 仓鼠观察日志 is a standalone module. 
- Added a new chat header menu item that navigates to `/syzygy`, and kept the existing `/snacks` route for the snack feed. 
- Implemented Syzygy-specific Supabase helpers and types (`syzygy_posts` / `syzygy_replies`) in `src/storage/supabaseSync.ts` and added `SyzygyPost` / `SyzygyReply` to `src/types.ts` to isolate data sources. 
- Updated `SnacksPage` to only use snack APIs (removed the AI post-generation button) and added a small identity badge `串串动态` to snack post cards while `SyzygyFeedPage` shows a `Syzygy动态` badge. 
- Added minimal shared CSS for the feed badge and preserved existing reply/publish/AI-reply flows on both pages.

### Testing
- Built the project with `npm run build` and the build completed successfully. 
- Launched the dev server with `npm run dev` and performed an automated Playwright capture of `http://127.0.0.1:4173/snacks` to validate the UI change (screenshot artifact generated). 
- Re-ran the production build again after edits to verify no regressions and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998223d1fa08330b1ab8e18d4dd8403)