### PR TITLE
HOTFIX: use author_role column for syzygy_replies and align types/UI

### DIFF
--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -54,6 +54,10 @@ const formatChineseTime = (timestamp: string) =>
     minute: '2-digit',
   })
 
+
+const isAuthExpiredError = (value: unknown) =>
+  value instanceof Error && value.message.includes('登录状态异常')
+
 const getReplyPreview = (reply: SyzygyReply | undefined) => {
   if (!reply) {
     return '暂无回复'
@@ -168,12 +172,12 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
     setPublishing(true)
     setError(null)
     try {
-      const created = await createSyzygyPost(trimmed)
+      const created = await createSyzygyPost(trimmed, null)
       setPosts((current) => [created, ...current])
       setDraft('')
     } catch (publishError) {
       console.warn('发布观察日志失败', publishError)
-      setError('发布失败，请稍后重试。')
+      setError(isAuthExpiredError(publishError) ? '登录状态已过期，请重新登录。' : '发布失败，请稍后重试。')
     } finally {
       setPublishing(false)
     }
@@ -259,7 +263,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
     const pendingReply: SyzygyReply = {
       id: pendingId,
       postId,
-      role: 'user',
+      authorRole: 'user',
       content,
       createdAt: new Date().toISOString(),
       userId: user.id,
@@ -276,7 +280,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
     setReplyDrafts((current) => ({ ...current, [postId]: '' }))
 
     try {
-      const reply = await createSyzygyReply(postId, 'user', content, {})
+      const reply = await createSyzygyReply(postId, 'user', content, {}, null)
       setRepliesByPost((current) => ({
         ...current,
         [postId]: (current[postId] ?? []).map((item) => (item.id === pendingId ? reply : item)),
@@ -287,7 +291,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
         ...current,
         [postId]: (current[postId] ?? []).filter((item) => item.id !== pendingId),
       }))
-      setError('发送失败，请稍后重试。')
+      setError(isAuthExpiredError(submitError) ? '登录状态已过期，请重新登录。' : '发送失败，请稍后重试。')
     } finally {
       setSubmittingReplyPostId(null)
     }
@@ -397,11 +401,11 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
       messagesPayload.push({ role: 'user', content: `本地时间：${now}\nWrite a short post.` })
 
       const result = await requestOpenRouter(messagesPayload)
-      const created = await createSyzygyPost(result.content)
+      const created = await createSyzygyPost(result.content, snackAiConfig.model)
       setPosts((current) => [created, ...current])
     } catch (generateError) {
       console.warn('生成观察日志失败', generateError)
-      setError('生成失败，请稍后重试。')
+      setError(isAuthExpiredError(generateError) ? '登录状态已过期，请重新登录。' : '生成失败，请稍后重试。')
     } finally {
       setGeneratingPost(false)
     }
@@ -418,7 +422,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
     const pendingAssistantReply: SyzygyReply = {
       id: pendingAssistantId,
       postId: post.id,
-      role: 'assistant',
+      authorRole: 'ai',
       content: '生成中…',
       createdAt: new Date().toISOString(),
       userId: user.id,
@@ -453,11 +457,11 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
         messagesPayload.push({
           role: 'user',
           content: `最近回复：\n${lastReplies
-            .map((reply) => `${reply.role === 'assistant' ? 'Syzygy' : '串串'}：${reply.content}`)
+            .map((reply) => `${reply.authorRole === 'ai' ? 'Syzygy' : '串串'}：${reply.content}`)
             .join('\n')}`,
         })
       }
-      const latestUserComment = [...existingReplies].reverse().find((reply) => reply.role === 'user')
+      const latestUserComment = [...existingReplies].reverse().find((reply) => reply.authorRole === 'user')
       if (latestUserComment) {
         messagesPayload.push({ role: 'user', content: `串串最新留言：${latestUserComment.content}` })
       }
@@ -471,11 +475,11 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
         ),
       }))
 
-      await createSyzygyReply(post.id, 'assistant', result.content, {
+      await createSyzygyReply(post.id, 'ai', result.content, {
         provider: 'openrouter',
         model: result.model,
         reasoning_text: result.reasoningText,
-      })
+      }, result.model)
       const latestReplies = await fetchSyzygyRepliesByPost(post.id)
       setRepliesByPost((current) => ({
         ...current,
@@ -487,7 +491,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
         ...current,
         [post.id]: (current[post.id] ?? []).filter((item) => item.id !== pendingAssistantId),
       }))
-      setError('生成失败，请稍后重试。')
+      setError(isAuthExpiredError(generateError) ? '登录状态已过期，请重新登录。' : '生成失败，请稍后重试。')
     } finally {
       setGeneratingPostId(null)
     }
@@ -621,10 +625,10 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
                   {isExpanded ? (
                     <div className="reply-list">
                       {replies.map((reply) => (
-                        <div key={reply.id} className={`reply-bubble ${reply.role === 'assistant' ? 'assistant' : 'user'}`}>
+                        <div key={reply.id} className={`reply-bubble ${reply.authorRole === 'ai' ? 'assistant' : 'user'}`}>
                           <div className="reply-content-wrap">
                             <div className="reply-role">
-                              {reply.role === 'assistant' ? (
+                              {reply.authorRole === 'ai' ? (
                                 <>
                                   <span>Syzygy</span>
                                   <span className="reply-model-badge">{reply.meta?.model || '未知模型'}</span>
@@ -633,7 +637,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
                                 <span>串串</span>
                               )}
                             </div>
-                            {reply.role === 'assistant' ? (
+                            {reply.authorRole === 'ai' ? (
                               <div className="assistant-markdown">
                                 <ReactMarkdown remarkPlugins={[remarkGfm]}>{reply.content}</ReactMarkdown>
                               </div>

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -58,7 +58,7 @@ type SyzygyReplyRow = {
   id: string
   user_id: string
   post_id: string
-  role: SyzygyReply['role']
+  author_role: SyzygyReply['authorRole']
   content: string
   meta: SyzygyReply['meta'] | null
   created_at: string
@@ -99,7 +99,7 @@ const mapSyzygyReplyRow = (row: SyzygyReplyRow): SyzygyReply => ({
   id: row.id,
   userId: row.user_id,
   postId: row.post_id,
-  role: row.role,
+  authorRole: row.author_role,
   content: row.content,
   createdAt: row.created_at,
   isDeleted: row.is_deleted,
@@ -126,6 +126,23 @@ const mapMessageRow = (row: MessageRow): ChatMessage => ({
   meta: row.meta ?? undefined,
   pending: false,
 })
+
+const requireAuthenticatedUserId = async (): Promise<string> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  if (error) {
+    throw error
+  }
+  if (!user) {
+    throw new Error('登录状态异常，请重新登录')
+  }
+  return user.id
+}
 
 export const fetchRemoteSessions = async (userId: string): Promise<ChatSession[]> => {
   if (!supabase) {
@@ -482,13 +499,17 @@ export const fetchDeletedSyzygyPosts = async (): Promise<SyzygyPost[]> => {
   return (data ?? []).map((row) => mapSyzygyPostRow(row as SyzygyPostRow))
 }
 
-export const createSyzygyPost = async (content: string): Promise<SyzygyPost> => {
+export const createSyzygyPost = async (
+  content: string,
+  selectedModelId: string | null = null,
+): Promise<SyzygyPost> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
+  const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('syzygy_posts')
-    .insert({ content })
+    .insert({ user_id: userId, content, model_id: selectedModelId ?? null })
     .select('id,user_id,content,created_at,updated_at,is_deleted')
     .single()
 
@@ -532,9 +553,9 @@ export const fetchSyzygyReplies = async (postIds: string[]): Promise<SyzygyReply
   }
   const { data, error } = await supabase
     .from('syzygy_replies')
-    .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
+    .select('id,user_id,post_id,author_role,content,meta,created_at,is_deleted')
     .in('post_id', postIds)
-    .in('role', ['user', 'assistant'])
+    .in('author_role', ['user', 'ai'])
     .eq('is_deleted', false)
     .order('created_at', { ascending: true })
   if (error) {
@@ -549,7 +570,7 @@ export const fetchSyzygyRepliesByPost = async (postId: string): Promise<SyzygyRe
   }
   const { data, error } = await supabase
     .from('syzygy_replies')
-    .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
+    .select('id,user_id,post_id,author_role,content,meta,created_at,is_deleted')
     .eq('post_id', postId)
     .eq('is_deleted', false)
     .order('created_at', { ascending: true })
@@ -562,17 +583,26 @@ export const fetchSyzygyRepliesByPost = async (postId: string): Promise<SyzygyRe
 
 export const createSyzygyReply = async (
   postId: string,
-  role: SyzygyReply['role'],
+  authorRole: SyzygyReply['authorRole'],
   content: string,
   meta: SyzygyReply['meta'],
+  selectedModelId: string | null = null,
 ): Promise<SyzygyReply> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
+  const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('syzygy_replies')
-    .insert({ post_id: postId, role, content, meta: meta ?? {} })
-    .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
+    .insert({
+      user_id: userId,
+      post_id: postId,
+      author_role: authorRole,
+      content,
+      meta: meta ?? {},
+      model_id: selectedModelId ?? null,
+    })
+    .select('id,user_id,post_id,author_role,content,meta,created_at,is_deleted')
     .single()
   if (error || !data) {
     throw error ?? new Error('保存观察日志回复失败')

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export type SyzygyReply = {
   id: string
   userId: string
   postId: string
-  role: 'user' | 'assistant'
+  authorRole: 'user' | 'ai'
   content: string
   createdAt: string
   isDeleted: boolean


### PR DESCRIPTION
### Motivation
- Fix runtime 400 errors caused by queries and inserts referencing non-existent `role` column on `syzygy_replies` which uses `author_role` in the DB schema.
- Ensure the frontend writes `user_id` on post/reply inserts to satisfy RLS and avoid null-session inserts.

### Description
- Replaced `role` with `author_role` for all `syzygy_replies` selects, filters, and inserts and updated the row mapper to map `author_role` into `SyzygyReply.authorRole` (files changed: `src/storage/supabaseSync.ts`, `src/types.ts`).
- Updated the `SyzygyReply` type to use `authorRole: 'user' | 'ai'` and updated UI code to read/render `reply.authorRole` accordingly (file changed: `src/pages/SyzygyFeedPage.tsx`).
- Added `requireAuthenticatedUserId` to fetch authenticated user id and used it in `createSyzygyPost` and `createSyzygyReply` so inserts include `user_id` and optional `model_id` (file changed: `src/storage/supabaseSync.ts`).
- Adjusted create calls and pending-reply objects so AI replies are written as `author_role='ai'` and user replies as `author_role='user'`, and improved auth-expired error messages in the UI (file changed: `src/pages/SyzygyFeedPage.tsx`).

### Testing
- Ran `npm run build` (which runs `tsc -b && vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699825a9179c8330ad42a185d879530b)