### PR TITLE
HOTFIX: remove syzygy_replies.meta and use model_id

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -84,13 +84,9 @@ export type SyzygyReply = {
   id: string
   userId: string
   postId: string
-  role: 'user' | 'assistant'
+  authorRole: 'user' | 'ai'
   content: string
   createdAt: string
   isDeleted: boolean
-  meta?: {
-    provider?: string
-    model?: string
-    reasoning_text?: string
-  }
+  modelId?: string | null
 }


### PR DESCRIPTION
### Motivation
- Fix Supabase 400 errors caused by selecting/inserting non-existent `syzygy_replies.meta` column by switching to the existing `model_id` and `author_role` columns. 
- Ensure writes include an authenticated `user_id` to satisfy RLS and prevent failed/anonymous inserts.

### Description
- Removed all `meta` reads/writes for `syzygy_replies` and updated DB queries/inserts to use `model_id` instead and filter by `author_role`. (changes in `src/storage/supabaseSync.ts`).
- Mapped `SyzygyReplyRow.model_id` → frontend `SyzygyReply.modelId` and replaced the previous `meta`-based shape in `src/types.ts`.
- Simplified `createSyzygyReply`/`createSyzygyPost` signatures to accept `selectedModelId` (and no `meta`) and added `requireAuthenticatedUserId` to include `user_id` on inserts.
- Updated UI and rendering logic in `src/pages/SyzygyFeedPage.tsx` to use `authorRole` and `modelId` for pending and persisted AI replies and badges.

### Testing
- Ran `npm run build` (which runs `tsc -b && vite build`) and the build completed successfully. 
- Verified via repository search that `syzygy_replies.meta` is no longer referenced and related queries now select/insert `model_id`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699825a9179c8330ad42a185d879530b)