### PR TITLE
Add Memory Vault V1 CRUD UI and first-message memory injection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import './App.css'
 import SettingsPage from './pages/SettingsPage'
 import SnacksPage from './pages/SnacksPage'
 import SyzygyFeedPage from './pages/SyzygyFeedPage'
+import MemoryVaultPage from './pages/MemoryVaultPage'
 import {
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
@@ -479,6 +480,12 @@ const App = () => {
         max_tokens: activeSettings.maxTokens,
       }
       const systemPrompt = activeSettings.systemPrompt
+      const isFirstMessageInSession = !messagesRef.current.some(
+        (message) =>
+          message.sessionId === sessionId &&
+          message.role === 'user' &&
+          message.content.trim().length > 0,
+      )
       const clientId = createClientId()
       const clientCreatedAt = new Date().toISOString()
       const optimisticMessage: ChatMessage = {
@@ -762,6 +769,7 @@ const App = () => {
             max_tokens: paramsSnapshot.max_tokens,
             reasoning: reasoningEnabled,
             stream: true,
+            isFirstMessage: isFirstMessageInSession,
           }
           if (reasoningEnabled && isClaudeModel(effectiveModel)) {
             const maxTokens = paramsSnapshot.max_tokens ?? 1024
@@ -1185,6 +1193,14 @@ const App = () => {
           }
         />
 
+        <Route
+          path="/memory-vault"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <MemoryVaultPage />
+            </RequireAuth>
+          }
+        />
         <Route
           path="/syzygy"
           element={

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -176,6 +176,15 @@ const ChatPage = ({
                 type="button"
                 onClick={() => {
                   setOpenHeaderMenu(false)
+                  navigate('/memory-vault')
+                }}
+              >
+                Memory Vault
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setOpenHeaderMenu(false)
                   navigate('/settings')
                 }}
               >

--- a/src/pages/MemoryVaultPage.css
+++ b/src/pages/MemoryVaultPage.css
@@ -1,0 +1,66 @@
+.memory-page {
+  min-height: 100vh;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.memory-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.memory-header h1 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.memory-section {
+  background: #fff;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
+}
+
+.memory-section h2 {
+  margin: 0 0 10px;
+  font-size: 16px;
+}
+
+.memory-section textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 8px;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.memory-list {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.memory-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.memory-card p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.memory-actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}

--- a/src/pages/MemoryVaultPage.tsx
+++ b/src/pages/MemoryVaultPage.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { MemoryEntry } from '../types'
+import {
+  confirmMemory,
+  createMemory,
+  discardMemory,
+  listMemories,
+  updateMemory,
+} from '../storage/supabaseSync'
+import './MemoryVaultPage.css'
+
+const MemoryVaultPage = () => {
+  const navigate = useNavigate()
+  const [confirmed, setConfirmed] = useState<MemoryEntry[]>([])
+  const [pending, setPending] = useState<MemoryEntry[]>([])
+  const [newMemory, setNewMemory] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingDraft, setEditingDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const loadMemories = useCallback(async () => {
+    try {
+      const [confirmedRows, pendingRows] = await Promise.all([
+        listMemories('confirmed'),
+        listMemories('pending'),
+      ])
+      setConfirmed(confirmedRows)
+      setPending(pendingRows)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载记忆失败', loadError)
+      setError('加载记忆失败，请稍后重试')
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadMemories()
+  }, [loadMemories])
+
+  const handleCreate = async () => {
+    const trimmed = newMemory.trim()
+    if (!trimmed) {
+      return
+    }
+    setSaving(true)
+    try {
+      await createMemory(trimmed)
+      setNewMemory('')
+      await loadMemories()
+    } catch (createError) {
+      console.warn('创建记忆失败', createError)
+      setError('创建记忆失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSaveEdit = async (id: string) => {
+    const trimmed = editingDraft.trim()
+    if (!trimmed) {
+      return
+    }
+    setSaving(true)
+    try {
+      await updateMemory(id, trimmed)
+      setEditingId(null)
+      setEditingDraft('')
+      await loadMemories()
+    } catch (updateError) {
+      console.warn('更新记忆失败', updateError)
+      setError('更新记忆失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleConfirm = async (entry: MemoryEntry, editedContent?: string) => {
+    setSaving(true)
+    try {
+      await confirmMemory(entry.id, editedContent)
+      if (editingId === entry.id) {
+        setEditingId(null)
+        setEditingDraft('')
+      }
+      await loadMemories()
+    } catch (confirmError) {
+      console.warn('确认记忆失败', confirmError)
+      setError('确认记忆失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDiscard = async (id: string) => {
+    setSaving(true)
+    try {
+      await discardMemory(id)
+      await loadMemories()
+    } catch (discardError) {
+      console.warn('删除记忆失败', discardError)
+      setError('删除记忆失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="memory-page">
+      <header className="memory-header">
+        <button type="button" className="ghost" onClick={() => navigate(-1)}>
+          返回
+        </button>
+        <h1>Memory Vault</h1>
+        <button type="button" className="ghost" onClick={() => navigate('/')}>
+          聊天
+        </button>
+      </header>
+
+      <section className="memory-section">
+        <h2>Confirmed</h2>
+        <textarea
+          value={newMemory}
+          onChange={(event) => setNewMemory(event.target.value)}
+          placeholder="新增一条确认记忆"
+          rows={3}
+        />
+        <button type="button" onClick={handleCreate} disabled={saving || !newMemory.trim()}>
+          保存
+        </button>
+        <div className="memory-list">
+          {confirmed.length === 0 ? <p className="tips">暂无 confirmed 记忆</p> : null}
+          {confirmed.map((entry) => (
+            <article key={entry.id} className="memory-card">
+              {editingId === entry.id ? (
+                <textarea
+                  rows={3}
+                  value={editingDraft}
+                  onChange={(event) => setEditingDraft(event.target.value)}
+                />
+              ) : (
+                <p>{entry.content}</p>
+              )}
+              <div className="memory-actions">
+                {editingId === entry.id ? (
+                  <>
+                    <button type="button" onClick={() => void handleSaveEdit(entry.id)} disabled={saving}>
+                      保存编辑
+                    </button>
+                    <button
+                      type="button"
+                      className="ghost"
+                      onClick={() => {
+                        setEditingId(null)
+                        setEditingDraft('')
+                      }}
+                    >
+                      取消
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingId(entry.id)
+                        setEditingDraft(entry.content)
+                      }}
+                    >
+                      编辑
+                    </button>
+                    <button type="button" className="danger" onClick={() => void handleDiscard(entry.id)}>
+                      删除
+                    </button>
+                  </>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="memory-section">
+        <h2>Pending</h2>
+        <div className="memory-list">
+          {pending.length === 0 ? <p className="tips">暂无 pending 记忆</p> : null}
+          {pending.map((entry) => (
+            <article key={entry.id} className="memory-card">
+              {editingId === entry.id ? (
+                <textarea
+                  rows={3}
+                  value={editingDraft}
+                  onChange={(event) => setEditingDraft(event.target.value)}
+                />
+              ) : (
+                <p>{entry.content}</p>
+              )}
+              <div className="memory-actions">
+                {editingId === entry.id ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => void handleConfirm(entry, editingDraft.trim())}
+                      disabled={saving || !editingDraft.trim()}
+                    >
+                      编辑并确认
+                    </button>
+                    <button
+                      type="button"
+                      className="ghost"
+                      onClick={() => {
+                        setEditingId(null)
+                        setEditingDraft('')
+                      }}
+                    >
+                      取消
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button type="button" onClick={() => void handleConfirm(entry)} disabled={saving}>
+                      确认
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingId(entry.id)
+                        setEditingDraft(entry.content)
+                      }}
+                    >
+                      编辑+确认
+                    </button>
+                    <button type="button" className="danger" onClick={() => void handleDiscard(entry.id)}>
+                      丢弃
+                    </button>
+                  </>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+      {error ? <p className="error">{error}</p> : null}
+    </div>
+  )
+}
+
+export default MemoryVaultPage

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,3 +91,16 @@ export type SyzygyReply = {
   isDeleted: boolean
   modelId?: string | null
 }
+
+export type MemoryStatus = 'confirmed' | 'pending'
+
+export type MemoryEntry = {
+  id: string
+  userId: string
+  content: string
+  source: string
+  status: MemoryStatus
+  createdAt: string
+  updatedAt: string
+  isDeleted: boolean
+}


### PR DESCRIPTION
### Motivation
- Provide a simple user-managed memory store backed by `memory_entries` so users can create/confirm/discard remembered facts. 
- Ensure confirmed memories are available to the model at the start of a new chat session only, improving system context without repeated fetches.

### Description
- Add domain types `MemoryStatus` and `MemoryEntry` to `src/types.ts` and map DB rows in `src/storage/supabaseSync.ts` with `mapMemoryEntryRow`.
- Implement Supabase helpers in `src/storage/supabaseSync.ts`: `listMemories(status)`, `createMemory(content)`, `updateMemory(id, content)`, `confirmMemory(id, content?)`, and `discardMemory(id)` (soft delete).
- Add a minimal `MemoryVaultPage` UI (`src/pages/MemoryVaultPage.tsx` + CSS) exposing two sections (`Confirmed` and `Pending`) supporting add/edit/delete for confirmed and confirm/edit+confirm/discard for pending.
- Wire the UI into the app by adding the `/memory-vault` route in `src/App.tsx` and a menu entry in `src/pages/ChatPage.tsx`.
- Add a first-message flag calculation in `src/App.tsx` (`isFirstMessageInSession`) and include it as `isFirstMessage` in the chat request payload to the Edge Function.
- Update the Edge Function `supabase/functions/openrouter-chat/index.ts` to authenticate the user, fetch up to 50 confirmed, non-deleted memories for the user via the REST endpoint, build a `MEMORY:
- ...` system block, and inject it after the base system prompt and before the first user message when `isFirstMessage === true` (graceful no-op on fetch failure).

### Testing
- Ran `npm run lint` and `eslint` with no reported errors (passed). 
- Built the app with `npm run build` and `vite build` successfully (passed). 
- Launched the dev server (`npm run dev`) and captured a screenshot of the `/memory-vault` route to verify UI render and routing (screenshot artifact saved during run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699864f817fc833090d72c90a6be0d09)