### PR TITLE
Add configurable Memory Vault extraction pipeline with manual and auto triggers

### DIFF
--- a/src/storage/memoryExtraction.ts
+++ b/src/storage/memoryExtraction.ts
@@ -1,0 +1,41 @@
+import type { ExtractMessageInput } from '../types'
+import { supabase } from '../supabase/client'
+
+type ExtractMemoriesResult = {
+  insertedCount: number
+  skippedCount: number
+}
+
+type InvokeResponse = {
+  insertedCount?: unknown
+  skippedCount?: unknown
+}
+
+export const invokeMemoryExtraction = async (
+  recentMessages: ExtractMessageInput[],
+  timezone?: string,
+): Promise<ExtractMemoriesResult> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const sanitized = recentMessages
+    .map((message) => ({ role: message.role, content: message.content.trim() }))
+    .filter((message) => message.content.length > 0)
+  if (sanitized.length === 0) {
+    return { insertedCount: 0, skippedCount: 0 }
+  }
+  const { data, error } = await supabase.functions.invoke('memory-extract', {
+    body: {
+      recentMessages: sanitized,
+      timezone,
+    },
+  })
+  if (error) {
+    throw error
+  }
+  const payload = (data ?? {}) as InvokeResponse
+  return {
+    insertedCount: Number(payload.insertedCount ?? 0),
+    skippedCount: Number(payload.skippedCount ?? 0),
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export type UserSettings = {
   userId: string
   enabledModels: string[]
   defaultModel: string
+  memoryExtractModel: string | null
   temperature: number
   topP: number
   maxTokens: number
@@ -44,6 +45,11 @@ export type UserSettings = {
   syzygyReplySystemPrompt: string
   enableReasoning: boolean
   updatedAt: string
+}
+
+export type ExtractMessageInput = {
+  role: 'user' | 'assistant' | 'system'
+  content: string
 }
 
 export type SnackPost = {

--- a/supabase/functions/memory-extract/index.ts
+++ b/supabase/functions/memory-extract/index.ts
@@ -1,0 +1,269 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
+
+type MessageInput = {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+type RequestPayload = {
+  recentMessages?: MessageInput[]
+  timezone?: string
+}
+
+type AuthUserResponse = {
+  id: string
+}
+
+type UserSettingsRow = {
+  memory_extract_model?: string | null
+  default_model?: string | null
+}
+
+const allowedOrigins = ['https://chuan-101.github.io', /^http:\/\/localhost:\d+$/]
+const MIN_MEMORY_LENGTH = 8
+const MAX_INSERT_COUNT = 10
+
+const EXTRACTION_PROMPT = `You are a memory extraction assistant.
+Task: extract candidate long-term memories from the provided recent conversation.
+Only extract:
+1) stable user preferences/habits
+2) project progress & technical decisions/changes
+3) important factual info
+4) repeatedly emphasized items
+Exclude:
+- casual small talk
+- temporary ideas
+- emotional fluctuations unless repeatedly emphasized
+Output format MUST be valid JSON:
+{"items": ["...", "..."]}
+Each item must be concise, 1-2 sentences, with no numbering prefixes or commentary.`
+
+const isAllowedOrigin = (origin: string | null) => {
+  if (!origin) {
+    return true
+  }
+  return allowedOrigins.some((pattern) =>
+    typeof pattern === 'string' ? pattern === origin : pattern.test(origin),
+  )
+}
+
+const buildCorsHeaders = (origin: string | null) => ({
+  'Access-Control-Allow-Origin': origin ?? '*',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Max-Age': '86400',
+})
+
+const jsonResponse = (origin: string | null, payload: Record<string, unknown>, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      ...buildCorsHeaders(origin),
+      'Content-Type': 'application/json',
+    },
+  })
+
+const normalizeContent = (value: string) => value.trim().replace(/\s+/g, ' ')
+
+const parseItems = (content: string): string[] => {
+  const start = content.indexOf('{')
+  const end = content.lastIndexOf('}')
+  if (start < 0 || end < start) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(content.slice(start, end + 1)) as { items?: unknown }
+    if (!Array.isArray(parsed.items)) {
+      return []
+    }
+    return parsed.items
+      .map((item) => {
+        if (typeof item === 'string') {
+          return normalizeContent(item)
+        }
+        if (item && typeof item === 'object' && 'content' in item) {
+          const value = (item as { content?: unknown }).content
+          return typeof value === 'string' ? normalizeContent(value) : ''
+        }
+        return ''
+      })
+      .filter((item) => item.length >= MIN_MEMORY_LENGTH)
+  } catch {
+    return []
+  }
+}
+
+serve(async (req) => {
+  const origin = req.headers.get('origin')
+  if (!isAllowedOrigin(origin)) {
+    return jsonResponse(origin, { error: '不允许的来源' }, 403)
+  }
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: buildCorsHeaders(origin) })
+  }
+
+  const authHeader = req.headers.get('authorization')
+  const apiKeyHeader = req.headers.get('apikey')
+  if (!authHeader || !apiKeyHeader) {
+    return jsonResponse(origin, { error: '缺少身份令牌' }, 401)
+  }
+
+  const baseOrigin = new URL(req.url).origin
+  let userId: string
+  try {
+    const authUrl = new URL('/auth/v1/user', baseOrigin)
+    const authResponse = await fetch(authUrl, {
+      headers: { apikey: apiKeyHeader, Authorization: authHeader },
+    })
+    if (!authResponse.ok) {
+      return jsonResponse(origin, { error: '身份令牌无效' }, 401)
+    }
+    const authData = (await authResponse.json()) as AuthUserResponse
+    userId = authData.id
+  } catch {
+    return jsonResponse(origin, { error: '身份令牌无效' }, 401)
+  }
+
+  let payload: RequestPayload
+  try {
+    payload = await req.json()
+  } catch {
+    return jsonResponse(origin, { error: '请求体格式错误' }, 400)
+  }
+
+  const apiKey = Deno.env.get('OPENROUTER_API_KEY')
+  if (!apiKey) {
+    return jsonResponse(origin, { error: '服务未配置' }, 500)
+  }
+
+  const recentMessages = (payload.recentMessages ?? [])
+    .map((message) => ({ role: message.role, content: normalizeContent(message.content ?? '') }))
+    .filter((message) => message.content.length > 0)
+  if (recentMessages.length === 0) {
+    return jsonResponse(origin, { insertedCount: 0, skippedCount: 0 })
+  }
+
+  const settingsQuery = new URLSearchParams({
+    select: 'memory_extract_model,default_model',
+    user_id: `eq.${userId}`,
+    limit: '1',
+  })
+  const settingsResponse = await fetch(`${baseOrigin}/rest/v1/user_settings?${settingsQuery.toString()}`, {
+    headers: { apikey: apiKeyHeader, Authorization: authHeader },
+  })
+  if (!settingsResponse.ok) {
+    return jsonResponse(origin, { error: '读取用户设置失败' }, 500)
+  }
+  const settingsRows = (await settingsResponse.json()) as UserSettingsRow[]
+  const settings = settingsRows[0] ?? {}
+  const extractorModel =
+    settings.memory_extract_model?.trim() || settings.default_model?.trim() || 'openrouter/auto'
+
+  const conversationBlock = recentMessages
+    .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+    .join('\n')
+
+  const modelResponse = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: extractorModel,
+      temperature: 0.2,
+      max_tokens: 700,
+      messages: [
+        { role: 'system', content: EXTRACTION_PROMPT },
+        {
+          role: 'user',
+          content: `timezone=${payload.timezone ?? 'unknown'}\nconversation:\n${conversationBlock}`,
+        },
+      ],
+      stream: false,
+    }),
+  })
+
+  if (!modelResponse.ok) {
+    const errorText = await modelResponse.text()
+    return jsonResponse(origin, { error: errorText || '抽取模型调用失败' }, modelResponse.status)
+  }
+
+  const modelData = (await modelResponse.json()) as {
+    choices?: Array<{ message?: { content?: string } }>
+  }
+  const outputText = modelData.choices?.[0]?.message?.content ?? ''
+  const extractedItems = parseItems(outputText)
+
+  if (extractedItems.length === 0) {
+    return jsonResponse(origin, { insertedCount: 0, skippedCount: 0 })
+  }
+
+  const existingQuery = new URLSearchParams({
+    select: 'content',
+    user_id: `eq.${userId}`,
+    is_deleted: 'eq.false',
+    limit: '5000',
+  })
+  const existingResponse = await fetch(`${baseOrigin}/rest/v1/memory_entries?${existingQuery.toString()}`, {
+    headers: { apikey: apiKeyHeader, Authorization: authHeader },
+  })
+  if (!existingResponse.ok) {
+    return jsonResponse(origin, { error: '读取已有记忆失败' }, 500)
+  }
+  const existingRows = (await existingResponse.json()) as Array<{ content?: unknown }>
+  const knownContent = new Set(
+    existingRows
+      .map((row) => (typeof row.content === 'string' ? normalizeContent(row.content).toLowerCase() : ''))
+      .filter((item) => item.length > 0),
+  )
+
+  const inserts: Array<{ user_id: string; content: string; source: string; status: string }> = []
+  let skippedCount = 0
+  for (const candidate of extractedItems) {
+    if (inserts.length >= MAX_INSERT_COUNT) {
+      break
+    }
+    const normalized = normalizeContent(candidate)
+    if (normalized.length < MIN_MEMORY_LENGTH) {
+      skippedCount += 1
+      continue
+    }
+    const key = normalized.toLowerCase()
+    if (knownContent.has(key)) {
+      skippedCount += 1
+      continue
+    }
+    knownContent.add(key)
+    inserts.push({
+      user_id: userId,
+      content: normalized,
+      source: 'ai_suggested',
+      status: 'pending',
+    })
+  }
+
+  if (inserts.length > 0) {
+    const insertResponse = await fetch(`${baseOrigin}/rest/v1/memory_entries`, {
+      method: 'POST',
+      headers: {
+        apikey: apiKeyHeader,
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(inserts),
+    })
+    if (!insertResponse.ok) {
+      const errorText = await insertResponse.text()
+      return jsonResponse(origin, { error: errorText || '写入记忆失败' }, 500)
+    }
+  }
+
+  return jsonResponse(origin, {
+    insertedCount: inserts.length,
+    skippedCount,
+    model: extractorModel,
+  })
+})


### PR DESCRIPTION
### Motivation
- Introduce an automated pipeline to surface candidate long-term memories from recent chat context using a lightweight extractor model that is configurable per-user. 
- Provide a manual UI trigger and a conservative automatic trigger to create pending suggestions without changing the current confirmed-only injection behavior.

### Description
- Add a Supabase Edge Function `memory-extract` that resolves `memory_extract_model` (fallback to `default_model`), calls OpenRouter with a strict JSON extraction prompt, parses output, de-duplicates against existing non-deleted memories, filters short items (<8 chars), caps inserts at 10, and inserts new rows into `memory_entries` with `source='ai_suggested'` and `status='pending'`.
- Add a frontend helper `invokeMemoryExtraction` (`src/storage/memoryExtraction.ts`) and wire a manual "Extract suggestions" button on the Memory Vault page that calls the edge function, shows progress, and refreshes pending items.
- Extend settings and storage to support `memoryExtractModel` (`src/types.ts`, `src/storage/userSettings.ts`) and add a dedicated single-column saver `saveMemoryExtractModel` with a Settings UI dropdown to select the extractor model from `enabled_models`, including validation and a separate save flow.
- Implement a minimal automatic trigger in the chat runtime (`src/App.tsx`) that invokes extraction every 12 user messages per session with a per-session cooldown (10 minutes) and per-session state to avoid spam, and pass recent chat context into Memory Vault for extraction.
- Ensure existing confirmed-memory injection logic in `openrouter-chat` remains unchanged so pending suggestions are not auto-injected.

### Testing
- Ran a full production build via `npm run build` (TypeScript compile + `vite build`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986a3b8ec08330869e10c484dcd908)