### PR TITLE
Fix memory-extract CORS headers across all POST/OPTIONS responses

### DIFF
--- a/supabase/functions/memory-extract/index.ts
+++ b/supabase/functions/memory-extract/index.ts
@@ -18,6 +18,12 @@ type UserSettingsRow = {
 const SERVER_RECENT_LIMIT = 30
 const MIN_MEMORY_LENGTH = 8
 const MAX_INSERT_COUNT = 10
+const corsHeaders = {
+  'Access-Control-Allow-Origin': 'https://chuan-101.github.io',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  Vary: 'Origin',
+}
 
 const EXTRACTION_PROMPT = `You extract long-term memory suggestions from a chat.
 Return ONLY valid JSON (no markdown): {"items":["...", "..."]}
@@ -27,17 +33,11 @@ Rules:
 - Exclude: small talk, temporary chatter, one-off emotional fluctuations.
 - Each item must be concise and 1-2 sentences.`
 
-const buildCorsHeaders = (origin: string | null) => ({
-  'Access-Control-Allow-Origin': origin ?? '*',
-  'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-})
-
-const jsonResponse = (origin: string | null, payload: Record<string, unknown>, status = 200) =>
+const jsonResponse = (payload: Record<string, unknown>, status = 200) =>
   new Response(JSON.stringify(payload), {
     status,
     headers: {
-      ...buildCorsHeaders(origin),
+      ...corsHeaders,
       'Content-Type': 'application/json',
     },
   })
@@ -65,171 +65,173 @@ const parseItems = (output: string): string[] => {
 }
 
 serve(async (req) => {
-  const origin = req.headers.get('origin')
-
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: buildCorsHeaders(origin) })
-  }
-
-  const supabaseUrl = Deno.env.get('SUPABASE_URL')
-  const anonKey = Deno.env.get('SUPABASE_ANON_KEY')
-  if (!supabaseUrl || !anonKey) {
-    return jsonResponse(origin, { error: 'Supabase 环境变量未配置' }, 500)
-  }
-
-  const authHeader = req.headers.get('authorization')
-  const apikey = req.headers.get('apikey')
-  if (!authHeader || !apikey) {
-    return jsonResponse(origin, { error: '缺少身份令牌' }, 401)
-  }
-
-  const supabase = createClient(supabaseUrl, anonKey, {
-    global: {
-      headers: {
-        Authorization: authHeader,
-        apikey,
-      },
-    },
-  })
-
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser()
-  if (userError || !user) {
-    return jsonResponse(origin, { error: '身份令牌无效' }, 401)
-  }
-
-  let payload: RequestPayload
   try {
-    payload = await req.json()
-  } catch {
-    return jsonResponse(origin, { error: '请求体格式错误' }, 400)
-  }
-
-  const recentMessages = (payload.recentMessages ?? [])
-    .slice(-SERVER_RECENT_LIMIT)
-    .map((message) => ({
-      role: message.role,
-      content: normalizeContent(message.content ?? ''),
-    }))
-    .filter((message) => message.content.length > 0)
-
-  if (recentMessages.length === 0) {
-    return jsonResponse(origin, { inserted: 0, skipped: 0, items: [] })
-  }
-
-  const { data: settings, error: settingsError } = await supabase
-    .from('user_settings')
-    .select('memory_extract_model, default_model')
-    .eq('user_id', user.id)
-    .maybeSingle<UserSettingsRow>()
-
-  if (settingsError) {
-    return jsonResponse(origin, { error: '读取用户设置失败' }, 500)
-  }
-
-  const modelId = settings?.memory_extract_model?.trim() || settings?.default_model?.trim() || ''
-  if (!modelId) {
-    return jsonResponse(origin, { error: '请先在设置中配置默认模型或抽取模型' }, 400)
-  }
-
-  const openRouterApiKey = Deno.env.get('OPENROUTER_API_KEY')
-  if (!openRouterApiKey) {
-    return jsonResponse(origin, { error: '服务未配置 OPENROUTER_API_KEY' }, 500)
-  }
-
-  const conversation = recentMessages
-    .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
-    .join('\n')
-
-  const upstream = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${openRouterApiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: modelId,
-      temperature: 0.2,
-      max_tokens: 700,
-      stream: false,
-      messages: [
-        { role: 'system', content: EXTRACTION_PROMPT },
-        { role: 'user', content: `Conversation:\n${conversation}` },
-      ],
-    }),
-  })
-
-  if (!upstream.ok) {
-    const errorText = await upstream.text()
-    return jsonResponse(origin, { error: errorText || '抽取模型调用失败' }, upstream.status)
-  }
-
-  const completion = (await upstream.json()) as {
-    choices?: Array<{ message?: { content?: string } }>
-  }
-  const rawOutput = completion.choices?.[0]?.message?.content ?? ''
-  const extracted = parseItems(rawOutput)
-
-  const { data: existingRows, error: existingError } = await supabase
-    .from('memory_entries')
-    .select('content')
-    .eq('user_id', user.id)
-    .eq('is_deleted', false)
-
-  if (existingError) {
-    return jsonResponse(origin, { error: '读取已有记忆失败' }, 500)
-  }
-
-  const seen = new Set(
-    (existingRows ?? [])
-      .map((row) => (typeof row.content === 'string' ? normalizeContent(row.content).toLowerCase() : ''))
-      .filter((value) => value.length > 0),
-  )
-
-  const acceptedItems: string[] = []
-  let skipped = 0
-
-  for (const item of extracted) {
-    if (acceptedItems.length >= MAX_INSERT_COUNT) {
-      break
+    if (req.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders })
     }
 
-    const normalized = normalizeContent(item)
-    if (normalized.length < MIN_MEMORY_LENGTH) {
-      skipped += 1
-      continue
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')
+    const anonKey = Deno.env.get('SUPABASE_ANON_KEY')
+    if (!supabaseUrl || !anonKey) {
+      return jsonResponse({ error: 'Supabase 环境变量未配置' }, 500)
     }
 
-    const key = normalized.toLowerCase()
-    if (seen.has(key)) {
-      skipped += 1
-      continue
+    const authHeader = req.headers.get('authorization')
+    const apikey = req.headers.get('apikey')
+    if (!authHeader || !apikey) {
+      return jsonResponse({ error: '缺少身份令牌' }, 401)
     }
 
-    seen.add(key)
-    acceptedItems.push(normalized)
-  }
+    const supabase = createClient(supabaseUrl, anonKey, {
+      global: {
+        headers: {
+          Authorization: authHeader,
+          apikey,
+        },
+      },
+    })
 
-  if (acceptedItems.length > 0) {
-    const { error: insertError } = await supabase.from('memory_entries').insert(
-      acceptedItems.map((content) => ({
-        user_id: user.id,
-        content,
-        source: 'ai_suggested',
-        status: 'pending',
-      })),
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return jsonResponse({ error: '身份令牌无效' }, 401)
+    }
+
+    let payload: RequestPayload
+    try {
+      payload = await req.json()
+    } catch {
+      return jsonResponse({ error: '请求体格式错误' }, 400)
+    }
+
+    const recentMessages = (payload.recentMessages ?? [])
+      .slice(-SERVER_RECENT_LIMIT)
+      .map((message) => ({
+        role: message.role,
+        content: normalizeContent(message.content ?? ''),
+      }))
+      .filter((message) => message.content.length > 0)
+
+    if (recentMessages.length === 0) {
+      return jsonResponse({ inserted: 0, skipped: 0, items: [] })
+    }
+
+    const { data: settings, error: settingsError } = await supabase
+      .from('user_settings')
+      .select('memory_extract_model, default_model')
+      .eq('user_id', user.id)
+      .maybeSingle<UserSettingsRow>()
+
+    if (settingsError) {
+      return jsonResponse({ error: '读取用户设置失败' }, 500)
+    }
+
+    const modelId = settings?.memory_extract_model?.trim() || settings?.default_model?.trim() || ''
+    if (!modelId) {
+      return jsonResponse({ error: '请先在设置中配置默认模型或抽取模型' }, 400)
+    }
+
+    const openRouterApiKey = Deno.env.get('OPENROUTER_API_KEY')
+    if (!openRouterApiKey) {
+      return jsonResponse({ error: '服务未配置 OPENROUTER_API_KEY' }, 500)
+    }
+
+    const conversation = recentMessages
+      .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+      .join('\n')
+
+    const upstream = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${openRouterApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: modelId,
+        temperature: 0.2,
+        max_tokens: 700,
+        stream: false,
+        messages: [
+          { role: 'system', content: EXTRACTION_PROMPT },
+          { role: 'user', content: `Conversation:\n${conversation}` },
+        ],
+      }),
+    })
+
+    if (!upstream.ok) {
+      const errorText = await upstream.text()
+      return jsonResponse({ error: errorText || '抽取模型调用失败' }, upstream.status)
+    }
+
+    const completion = (await upstream.json()) as {
+      choices?: Array<{ message?: { content?: string } }>
+    }
+    const rawOutput = completion.choices?.[0]?.message?.content ?? ''
+    const extracted = parseItems(rawOutput)
+
+    const { data: existingRows, error: existingError } = await supabase
+      .from('memory_entries')
+      .select('content')
+      .eq('user_id', user.id)
+      .eq('is_deleted', false)
+
+    if (existingError) {
+      return jsonResponse({ error: '读取已有记忆失败' }, 500)
+    }
+
+    const seen = new Set(
+      (existingRows ?? [])
+        .map((row) => (typeof row.content === 'string' ? normalizeContent(row.content).toLowerCase() : ''))
+        .filter((value) => value.length > 0),
     )
 
-    if (insertError) {
-      return jsonResponse(origin, { error: '写入记忆失败' }, 500)
-    }
-  }
+    const acceptedItems: string[] = []
+    let skipped = 0
 
-  return jsonResponse(origin, {
-    inserted: acceptedItems.length,
-    skipped,
-    items: acceptedItems,
-  })
+    for (const item of extracted) {
+      if (acceptedItems.length >= MAX_INSERT_COUNT) {
+        break
+      }
+
+      const normalized = normalizeContent(item)
+      if (normalized.length < MIN_MEMORY_LENGTH) {
+        skipped += 1
+        continue
+      }
+
+      const key = normalized.toLowerCase()
+      if (seen.has(key)) {
+        skipped += 1
+        continue
+      }
+
+      seen.add(key)
+      acceptedItems.push(normalized)
+    }
+
+    if (acceptedItems.length > 0) {
+      const { error: insertError } = await supabase.from('memory_entries').insert(
+        acceptedItems.map((content) => ({
+          user_id: user.id,
+          content,
+          source: 'ai_suggested',
+          status: 'pending',
+        })),
+      )
+
+      if (insertError) {
+        return jsonResponse({ error: '写入记忆失败' }, 500)
+      }
+    }
+
+    return jsonResponse({
+      inserted: acceptedItems.length,
+      skipped,
+      items: acceptedItems,
+    })
+  } catch {
+    return jsonResponse({ error: '服务内部错误' }, 500)
+  }
 })


### PR DESCRIPTION
### Motivation
- POST responses from the `memory-extract` Edge Function were missing CORS headers causing browser CORS errors even though OPTIONS preflight succeeded.
- Ensure every response path (OPTIONS, success, validation/auth errors, and unexpected exceptions) includes the required CORS headers so GitHub Pages can interact with the function.
- Preserve all existing logic for model selection, OpenRouter calls, Supabase reads/inserts, and secrets usage.

### Description
- Added a single `corsHeaders` constant near the top with the fixed origin `https://chuan-101.github.io` and the required allow headers/methods plus `Vary: Origin`.
- Replaced the previous header-building approach with a unified `jsonResponse` helper that always includes `{ ...corsHeaders, "Content-Type": "application/json" }`.
- Updated the `OPTIONS` branch to return `new Response(null, { status: 204, headers: corsHeaders })` and ensured all other returns use `jsonResponse(...)` so CORS headers are present on every response path.
- Wrapped the main handler in a top-level `try/catch` so unexpected exceptions also return JSON with the CORS headers, without changing the extraction/auth/model/insert logic.

### Testing
- Ran `npm run build` (TypeScript compilation and Vite build); the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987b7da06883309ba0b0484e3d970f)