### PR TITLE
Add Pending merge-pass toggle persisted in user settings

### DIFF
--- a/src/pages/MemoryVaultPage.css
+++ b/src/pages/MemoryVaultPage.css
@@ -64,3 +64,48 @@
   display: flex;
   gap: 8px;
 }
+
+.memory-section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.memory-section-heading h2 {
+  margin: 0;
+}
+
+.merge-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 6px 10px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  font-size: 13px;
+}
+
+.merge-toggle.is-on {
+  border-color: #16a34a;
+  background: #f0fdf4;
+}
+
+.merge-toggle.is-off {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.merge-toggle-state {
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: #e2e8f0;
+  font-weight: 700;
+}
+
+.merge-toggle.is-on .merge-toggle-state {
+  background: #16a34a;
+  color: #fff;
+}

--- a/src/storage/memoryExtraction.ts
+++ b/src/storage/memoryExtraction.ts
@@ -15,6 +15,7 @@ type InvokeResponse = {
 
 export const invokeMemoryExtraction = async (
   recentMessages: ExtractMessageInput[],
+  mergeEnabled?: boolean,
 ): Promise<ExtractMemoriesResult> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
@@ -42,7 +43,7 @@ export const invokeMemoryExtraction = async (
         apikey: anonKey,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ recentMessages: sanitized }),
+      body: JSON.stringify({ recentMessages: sanitized, mergeEnabled }),
     },
   )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type UserSettings = {
   enabledModels: string[]
   defaultModel: string
   memoryExtractModel: string | null
+  memoryMergeEnabled: boolean
   temperature: number
   topP: number
   maxTokens: number


### PR DESCRIPTION
### Motivation
- Provide a convenient toggle in the Memory Vault Pending section to enable/disable the lightweight “merge pass” model call when extracting suggestions and persist the choice per user. 
- Ensure the extractor edge function respects the toggle while keeping existing cleaning, dedupe and caps behavior intact.

### Description
- Add `memoryMergeEnabled` to `UserSettings` and wire it through `createDefaultSettings`, `ensureUserSettings`, mapping, and `updateUserSettings` in `src/storage/userSettings.ts` so the value persists in the `user_settings.memory_merge_enabled` column. 
- Add focused helpers `loadMemoryMergeEnabled` and `saveMemoryMergeEnabled` for single-column read/update and default-to-true behavior when DB value is null. 
- Add a toggle UI in the Memory Vault Pending header (`自动归并同类项（额外模型调用）`) with immediate UI state update and styling in `src/pages/MemoryVaultPage.tsx` and `src/pages/MemoryVaultPage.css`, and load/save logic that persists the setting to Supabase. 
- Pass `mergeEnabled` from the client extraction call (`invokeMemoryExtraction`) through `src/storage/memoryExtraction.ts` into the `memory-extract` Edge Function, and update `supabase/functions/memory-extract/index.ts` to accept `mergeEnabled` (fallback to `user_settings.memory_merge_enabled ?? true`); when false skip the merge-model pass and use raw extracted items while preserving cleaning/dedupe/insert caps and pending-cap enforcement.

### Testing
- Ran `npm run build` (TypeScript + Vite) and the build completed successfully. 
- Attempted an automated Playwright screenshot to validate the UI change but Chromium crashed with a `SIGSEGV` in this environment, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996a8d9f348330ab45d798bfa78d10)