### PR TITLE
Add runtime context compression with compression_cache for chitchat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -786,6 +786,7 @@ const App = () => {
           const isClaudeModel = (model: string) => /claude|anthropic/i.test(model)
           const requestBody: Record<string, unknown> = {
             model: effectiveModel,
+            conversationId: sessionId,
             messages: messagesPayload,
             temperature: paramsSnapshot.temperature,
             top_p: paramsSnapshot.top_p,


### PR DESCRIPTION
### Motivation
- Prevent long chitchat conversations from exceeding model context and avoid repeated summarizer calls by caching incremental summaries.
- Perform compression at request time so original `messages` rows remain unchanged while keeping the runtime flow responsive.
- Reuse a DB-backed `compression_cache` to avoid summarizing the same history repeatedly.

### Description
- Added `conversationId` to the chat request payload so the edge function can load full conversation history and decide whether to compress earlier messages.
- Implemented runtime compression in `supabase/functions/openrouter-chat/index.ts` with rough token estimation heuristics, a conservative trigger ratio, and a retained recent window of the last 20 messages.
- Integrated `compression_cache` read/reuse/upsert logic to reuse existing `summary_text` when it already covers the compressible boundary and to incrementally summarize only newly compressible messages using a hardcoded summarizer model (`openai/gpt-4o-mini`).
- Preserved existing behavior by keeping memory injection and falling back to the original payload on any errors, and avoided modifying stored `messages` rows (only `compression_cache` is written/merged).

### Testing
- Ran `npm run build` which completed successfully and produced the client build without errors.
- Ran `npm run lint` which completed successfully with no lint failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699971144a2c8330bc2f238c7a5000d6)