### PR TITLE
Add auto memory extraction toggle and guardrails to prevent runaway cost

### DIFF
--- a/src/pages/MemoryVaultPage.css
+++ b/src/pages/MemoryVaultPage.css
@@ -77,6 +77,13 @@
   margin: 0;
 }
 
+.memory-toggle-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+}
+
 .merge-toggle {
   display: inline-flex;
   align-items: center;

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -673,6 +673,22 @@ export const listMemories = async (status: MemoryStatus): Promise<MemoryEntry[]>
   return (data ?? []).map((row) => mapMemoryEntryRow(row as MemoryEntryRow))
 }
 
+export const fetchPendingMemoryCount = async (userId: string): Promise<number> => {
+  if (!supabase) {
+    return 0
+  }
+  const { count, error } = await supabase
+    .from('memory_entries')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .eq('status', 'pending')
+    .eq('is_deleted', false)
+  if (error) {
+    throw error
+  }
+  return count ?? 0
+}
+
 export const createMemory = async (content: string): Promise<MemoryEntry> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type UserSettings = {
   summarizerModel: string | null
   memoryExtractModel: string | null
   memoryMergeEnabled: boolean
+  memoryAutoExtractEnabled: boolean
   temperature: number
   topP: number
   maxTokens: number


### PR DESCRIPTION
### Motivation
- Provide a user-controlled way to stop automatic extraction of pending memory candidates because auto-extraction may incur model costs and should be gated by user consent.
- Prevent runaway cost from automated extraction by adding simple guardrails (pending-cap + cooldown + existing cadence) while preserving the manual extraction flow.

### Description
- Added a new persisted user setting `memory_auto_extract_enabled` (default false) to `UserSettings` and wired it through `ensureUserSettings`, `updateUserSettings`, and the `user_settings` read/insert/update plumbing in `src/storage/userSettings.ts` and `src/types.ts`.
- Added a UI toggle in Memory Vault → Pending with label `自动提取候选记忆（会产生费用）` and an `onToggleAutoExtract` handler passed from `App` to `MemoryVaultPage`, with a small layout adjustment for stacked toggles in `src/pages/MemoryVaultPage.tsx` and `src/pages/MemoryVaultPage.css`.
- Persisted toggle changes with a new `saveMemoryAutoExtractEnabled` helper and exposed it via `handleToggleMemoryAutoExtract` in `App` so the toggle updates `user_settings.memory_auto_extract_enabled` in the database.
- Prevented automatic calls to `invokeMemoryExtraction` unless `memoryAutoExtractEnabled` is true, and added guardrails in the chat auto-extract pipeline to skip auto extraction when pending count >= 50 and to respect the existing cadence (every 12 user messages) and cooldown (10 minutes per session); added `fetchPendingMemoryCount` in `src/storage/supabaseSync.ts` and a new `AUTO_EXTRACT_PENDING_LIMIT` constant and control flow changes in `src/App.tsx`.
- Left manual `Extract suggestions` button behavior unchanged so users can trigger extraction anytime regardless of the auto toggle.

### Testing
- Ran `npm run build` successfully with a production bundle build completing without errors.
- Launched the dev server (`npm run dev`) and captured a visual verification screenshot of the Memory Vault page showing the new toggle.
- No automated unit tests were added; the change was validated via build and manual UI verification (screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69998da764208330a68281e2cc738499)