### PR TITLE
Enforce per-module model resolution to prevent feed model leakage

### DIFF
--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -293,6 +293,7 @@ const SnacksPage = ({ user, snackAiConfig }: SnacksPageProps) => {
   const buildRequestBody = (messagesPayload: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>) => {
     const requestBody: Record<string, unknown> = {
       model: snackAiConfig.model,
+      modelId: snackAiConfig.model,
       module: 'snack-feed',
       messages: messagesPayload,
       temperature: snackAiConfig.temperature,

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -300,6 +300,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
   const buildRequestBody = (messagesPayload: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>) => {
     const requestBody: Record<string, unknown> = {
       model: snackAiConfig.model,
+      modelId: snackAiConfig.model,
       module: 'syzygy-feed',
       messages: messagesPayload,
       temperature: snackAiConfig.temperature,

--- a/src/utils/modelResolver.ts
+++ b/src/utils/modelResolver.ts
@@ -1,0 +1,34 @@
+export type ModelModule = 'chitchat' | 'snack' | 'syzygy'
+
+type ResolveModelContext = {
+  defaultModelId: string
+  chitchatSelectedModelId?: string | null
+}
+
+type ResolveModelOverrides = {
+  modelId?: string | null
+}
+
+const normalizeModelId = (modelId: string | null | undefined) => {
+  const normalized = modelId?.trim()
+  return normalized && normalized.length > 0 ? normalized : null
+}
+
+export const resolveModelId = (
+  module: ModelModule,
+  context: ResolveModelContext,
+  overrides?: ResolveModelOverrides,
+) => {
+  const overrideModelId = normalizeModelId(overrides?.modelId)
+  if (overrideModelId) {
+    return overrideModelId
+  }
+
+  const defaultModelId = normalizeModelId(context.defaultModelId) ?? 'openrouter/auto'
+
+  if (module === 'chitchat') {
+    return normalizeModelId(context.chitchatSelectedModelId) ?? defaultModelId
+  }
+
+  return defaultModelId
+}


### PR DESCRIPTION
### Motivation
- Feed modules (`snack`/`syzygy`) were unintentionally inheriting the currently-selected Chitchat model, causing Snack/Syzygy to change when the chat model was switched.
- Introduce an explicit, centralized model resolution policy so each module deterministically selects its model source and API calls include an explicit `modelId`.

### Description
- Added a centralized resolver `resolveModelId(module, context, overrides?)` in `src/utils/modelResolver.ts` to pick models per-module: `chitchat` uses the session-selected model with fallback to `default_model`, while `snack`/`syzygy` always use `default_model` unless explicitly overridden.
- Updated app wiring in `src/App.tsx` to use the resolver for feeds and chat: created `feedAiConfigBase`, introduced separate `snackAiConfig` and `syzygyAiConfig`, and updated `resolveSessionModel` to call `resolveModelId('chitchat', ...)`.
- Made client payloads explicit by adding `modelId` (and `module: 'chitchat'` for chat) to OpenRouter request bodies from `src/App.tsx`, `src/pages/SnacksPage.tsx`, and `src/pages/SyzygyFeedPage.tsx` so the server receives the intended model source.
- Hardened the edge function `supabase/functions/openrouter-chat/index.ts` by allowing optional `model`/`modelId` in the request, adding `resolveRequestModelId` helper that prefers `payload.modelId` then `payload.model` then `user_settings.default_model` (then `openrouter/auto`), and using the resolved model consistently for upstream calls and compression estimation.

### Testing
- Ran full TypeScript + Vite production build with `npm run build`, which completed successfully.
- Ran project lint with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699993a6f7008330b6e3ff1190e5843e)