### PR TITLE
Add Chitchat session archive drawer with cross-device persistence

### DIFF
--- a/src/components/SessionsDrawer.css
+++ b/src/components/SessionsDrawer.css
@@ -57,6 +57,32 @@
   font-size: 18px;
 }
 
+
+.drawer-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  background: #e2e8f0;
+  border-radius: 10px;
+  padding: 4px;
+}
+
+.drawer-tabs button {
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 13px;
+  color: #334155;
+  cursor: pointer;
+}
+
+.drawer-tabs button.active {
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
 .search-input {
   border: 1px solid #e2e8f0;
   border-radius: 10px;
@@ -107,6 +133,7 @@
 .session-actions {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .rename-row {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ export type ChatSession = {
   title: string
   createdAt: string
   updatedAt: string
+  isArchived: boolean
+  archivedAt: string | null
   overrideModel?: string | null
   overrideReasoning?: boolean | null
 }


### PR DESCRIPTION
### Motivation
- Provide an in-app archive/drawer (“收纳/抽屉”) for Chitchat so users can hide unused conversations without deleting data and have that state persist across devices.

### Description
- Added archive metadata to `ChatSession` (`isArchived`, `archivedAt`) and normalized local snapshots so older data defaults to `isArchived=false` / `archivedAt=null`.
- Local storage: added `ensureSessionFields`, backfilled session defaults, initialized new sessions as unarchived, and added `setSessionArchiveState` to toggle archive state locally (`src/storage/chatStorage.ts`).
- Remote sync: included `is_archived`/`archived_at` in Supabase selects/mapping and added `updateRemoteSessionArchiveState` which updates the authenticated user’s session row only (`src/storage/supabaseSync.ts`).
- App wiring: added `handleSessionArchiveStateChange` in `App` that updates remote first with a local fallback, and passed `onArchiveSession` through `ChatRoute` into `SessionsDrawer` (`src/App.tsx`).
- UI: implemented drawer tabs `进行中 | 抽屉`, tab-based filtering by `isArchived`, per-session action button `收纳 / 移出抽屉`, and added styling for the tab switcher and action layout (`src/components/SessionsDrawer.tsx`, `src/components/SessionsDrawer.css`).

### Testing
- Built the project with `npm run build` which runs `tsc -b && vite build`, and the build completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served; a browser screenshot was captured via Playwright for verification.
- No automated test failures occurred during build/dev steps; note the drawer interaction could not be captured in the artifact because the environment landed on the auth page (no authenticated session).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69999a01ea608330958fd226934e2ad6)