### PR TITLE
Unify Syzygy feed soft-delete and recycle bin behavior

### DIFF
--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -587,7 +587,7 @@ export const restoreSyzygyPost = async (postId: string): Promise<void> => {
   }
   const { error } = await supabase
     .from('syzygy_posts')
-    .update({ is_deleted: false })
+    .update({ is_deleted: false, deleted_at: null })
     .eq('id', postId)
 
   if (error) {
@@ -601,7 +601,7 @@ export const softDeleteSyzygyPost = async (postId: string): Promise<void> => {
   }
   const { error } = await supabase
     .from('syzygy_posts')
-    .update({ is_deleted: true })
+    .update({ is_deleted: true, deleted_at: new Date().toISOString() })
     .eq('id', postId)
 
   if (error) {
@@ -676,7 +676,37 @@ export const softDeleteSyzygyReply = async (replyId: string): Promise<void> => {
   }
   const { error } = await supabase
     .from('syzygy_replies')
-    .update({ is_deleted: true })
+    .update({ is_deleted: true, deleted_at: new Date().toISOString() })
+    .eq('id', replyId)
+
+  if (error) {
+    throw error
+  }
+}
+
+export const fetchDeletedSyzygyReplies = async (): Promise<SyzygyReply[]> => {
+  if (!supabase) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('syzygy_replies')
+    .select('id,user_id,post_id,author_role,content,model_id,created_at,is_deleted')
+    .eq('is_deleted', true)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapSyzygyReplyRow(row as SyzygyReplyRow))
+}
+
+export const restoreSyzygyReply = async (replyId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('syzygy_replies')
+    .update({ is_deleted: false, deleted_at: null })
     .eq('id', replyId)
 
   if (error) {


### PR DESCRIPTION
### Motivation
- Make Syzygy feed deletion behavior match Snacks: deletions should be soft (move to recycle bin) and support restore without removing rows from DB.
- Include replies in the recycle-bin flow so deleted replies can be viewed and restored alongside deleted posts.

### Description
- Update DB write behavior in `src/storage/supabaseSync.ts` so `softDeleteSyzygyPost`/`softDeleteSyzygyReply` set `is_deleted=true` and `deleted_at=now()`, and `restoreSyzygyPost`/`restoreSyzygyReply` clear `deleted_at` and set `is_deleted=false`.
- Add `fetchDeletedSyzygyReplies` and `restoreSyzygyReply` in `src/storage/supabaseSync.ts` to support querying and restoring deleted replies.
- Update `src/pages/SyzygyFeedPage.tsx` to load deleted replies into the recycle bin, render deleted replies with a restore button, restore replies back into the main reply list when applicable, and show deletion feedback copy `已移入回收站` and a snack-style empty-state `回收站空空如也，去记录点新观察吧。`.
- Ensure main listing queries still filter `is_deleted = false` so deleted items are excluded from the primary feed.

### Testing
- Ran a production build with `npm run build` which completed successfully (TypeScript compile + Vite build).
- Launched the dev server (`npm run dev`) and captured a UI screenshot via a Playwright script to validate the recycle-bin UI changes; the page rendered and screenshot artifact was produced.
- Files changed: `src/storage/supabaseSync.ts`, `src/pages/SyzygyFeedPage.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999aff067748330a626efaf5d3837db)