### PR TITLE
Add permanent delete (hard delete) to Snack and Syzygy recycle bins

### DIFF
--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -529,6 +529,71 @@ export const softDeleteSnackReply = async (replyId: string): Promise<void> => {
   }
 }
 
+export const fetchDeletedSnackReplies = async (): Promise<SnackReply[]> => {
+  if (!supabase) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('snack_replies')
+    .select('id,user_id,post_id,role,content,meta,created_at,is_deleted')
+    .eq('is_deleted', true)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapSnackReplyRow(row as SnackReplyRow))
+}
+
+export const restoreSnackReply = async (replyId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('snack_replies')
+    .update({ is_deleted: false })
+    .eq('id', replyId)
+
+  if (error) {
+    throw error
+  }
+}
+
+export const permanentlyDeleteSnackPost = async (postId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error: repliesError } = await supabase.from('snack_replies').delete().eq('post_id', postId)
+  if (repliesError) {
+    throw repliesError
+  }
+
+  const { error: postError } = await supabase
+    .from('snack_posts')
+    .delete()
+    .eq('id', postId)
+    .eq('is_deleted', true)
+
+  if (postError) {
+    throw postError
+  }
+}
+
+export const permanentlyDeleteSnackReply = async (replyId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('snack_replies')
+    .delete()
+    .eq('id', replyId)
+    .eq('is_deleted', true)
+
+  if (error) {
+    throw error
+  }
+}
+
 
 export const fetchSyzygyPosts = async (): Promise<SyzygyPost[]> => {
   if (!supabase) {
@@ -708,6 +773,41 @@ export const restoreSyzygyReply = async (replyId: string): Promise<void> => {
     .from('syzygy_replies')
     .update({ is_deleted: false, deleted_at: null })
     .eq('id', replyId)
+
+  if (error) {
+    throw error
+  }
+}
+
+export const permanentlyDeleteSyzygyPost = async (postId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error: repliesError } = await supabase.from('syzygy_replies').delete().eq('post_id', postId)
+  if (repliesError) {
+    throw repliesError
+  }
+
+  const { error: postError } = await supabase
+    .from('syzygy_posts')
+    .delete()
+    .eq('id', postId)
+    .eq('is_deleted', true)
+
+  if (postError) {
+    throw postError
+  }
+}
+
+export const permanentlyDeleteSyzygyReply = async (replyId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('syzygy_replies')
+    .delete()
+    .eq('id', replyId)
+    .eq('is_deleted', true)
 
   if (error) {
     throw error


### PR DESCRIPTION
### Motivation

- Provide a safe, explicit way to permanently remove soft-deleted Snack and Syzygy posts/replies from the recycle bin with a second confirmation step.  
- Ensure permanent delete only affects items already soft-deleted and that post deletion cascades replies first to avoid orphaned rows.

### Description

- Added storage helpers in `src/storage/supabaseSync.ts` to fetch/restore deleted snack replies and to permanently delete snack/syzygy posts and replies, with cascade semantics for post deletion (`delete replies` then `delete post`) and checks that rows are `is_deleted = true`.  
- Extended Snack recycle-bin UI (`src/pages/SnacksPage.tsx`) to show deleted replies, add `彻底删除` buttons for deleted posts and replies, show a second-step `ConfirmDialog` for permanent deletes, and surface success notices after operations.  
- Extended Syzygy recycle-bin UI (`src/pages/SyzygyFeedPage.tsx`) to add `彻底删除` actions for deleted posts and replies, second-step confirmations, and success notices while keeping existing restore/soft-delete flows unchanged.  
- Kept existing soft-delete logic and main-list behavior intact (no accidental hard deletes from main lists).

### Testing

- Ran `npm run lint` and the linter completed successfully.  
- Ran full production build with `npm run build` and the build succeeded.  
- Started the dev server and captured a UI screenshot to validate recycle-bin flows visually (dev server started without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999b1bcaf1c83309f4833fa2be4489f)