### PR TITLE
hotfix: expose Check-in via menu navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import SettingsPage from './pages/SettingsPage'
 import SnacksPage from './pages/SnacksPage'
 import SyzygyFeedPage from './pages/SyzygyFeedPage'
 import MemoryVaultPage from './pages/MemoryVaultPage'
+import CheckinPage from './pages/CheckinPage'
 import {
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
@@ -1321,6 +1322,14 @@ const App = () => {
                 onActiveSessionChange={setActiveChatSessionId}
                 user={user}
               />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/checkin"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <CheckinPage user={user} />
             </RequireAuth>
           }
         />

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -274,10 +274,19 @@ const ChatPage = ({
                 type="button"
                 onClick={() => {
                   setOpenHeaderMenu(false)
+                  navigate('/checkin')
+                }}
+              >
+                打卡
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setOpenHeaderMenu(false)
                   navigate('/settings')
                 }}
               >
-                API设置
+                设置
               </button>
             </div>
           ) : null}

--- a/src/pages/CheckinPage.css
+++ b/src/pages/CheckinPage.css
@@ -1,0 +1,85 @@
+.checkin-page {
+  min-height: 100vh;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 1.25rem 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.checkin-page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.checkin-page-header h1 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.checkin-nav-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.checkin-card.standalone {
+  width: min(680px, 100%);
+}
+
+.checkin-card {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.checkin-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.checkin-header h2 {
+  margin: 0;
+}
+
+.checkin-status-row {
+  margin-top: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.checkin-status.done { color: #22c55e; }
+.checkin-status.todo { color: #f59e0b; }
+
+.checkin-button { min-width: 5.5rem; }
+
+.checkin-metrics {
+  margin-top: 0.8rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.checkin-metrics p {
+  margin: 0;
+}
+
+.checkin-history {
+  margin: 0.8rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.checkin-tip {
+  margin: 0.6rem 0 0;
+  color: #cbd5e1;
+}

--- a/src/pages/CheckinPage.tsx
+++ b/src/pages/CheckinPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
+import type { CheckinEntry } from '../types'
+import { createTodayCheckin, fetchCheckinTotalCount, fetchRecentCheckins } from '../storage/supabaseSync'
+import './CheckinPage.css'
+
+export type CheckinPageProps = {
+  user: User | null
+}
+
+const formatDateKey = (date: Date) => {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const shiftDateKey = (dateKey: string, daysDelta: number) => {
+  const base = new Date(`${dateKey}T00:00:00`)
+  base.setDate(base.getDate() + daysDelta)
+  return formatDateKey(base)
+}
+
+const computeStreak = (dates: string[], todayKey: string) => {
+  const uniqueDates = Array.from(new Set(dates)).sort((a, b) => b.localeCompare(a))
+  const dateSet = new Set(uniqueDates)
+  const startDate = dateSet.has(todayKey) ? todayKey : shiftDateKey(todayKey, -1)
+  if (!dateSet.has(startDate)) {
+    return 0
+  }
+
+  let streak = 0
+  let cursor = startDate
+  while (dateSet.has(cursor)) {
+    streak += 1
+    cursor = shiftDateKey(cursor, -1)
+  }
+  return streak
+}
+
+const CheckinPage = ({ user }: CheckinPageProps) => {
+  const [recentCheckins, setRecentCheckins] = useState<CheckinEntry[]>([])
+  const [checkinTotal, setCheckinTotal] = useState(0)
+  const [checkinLoading, setCheckinLoading] = useState(false)
+  const [checkinSubmitting, setCheckinSubmitting] = useState(false)
+  const [checkinNotice, setCheckinNotice] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const todayKey = useMemo(() => formatDateKey(new Date()), [])
+  const todayDisplay = useMemo(
+    () => new Date().toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' }),
+    [],
+  )
+  const recentDateKeys = useMemo(() => recentCheckins.map((entry) => entry.checkinDate), [recentCheckins])
+  const checkedToday = useMemo(() => recentDateKeys.includes(todayKey), [recentDateKeys, todayKey])
+  const streakDays = useMemo(() => computeStreak(recentDateKeys, todayKey), [recentDateKeys, todayKey])
+
+  const loadCheckinData = async () => {
+    if (!user) {
+      return
+    }
+    setCheckinLoading(true)
+    try {
+      const [recent, total] = await Promise.all([fetchRecentCheckins(60), fetchCheckinTotalCount()])
+      setRecentCheckins(recent)
+      setCheckinTotal(total)
+      setCheckinNotice(null)
+    } catch (error) {
+      console.warn('加载打卡记录失败', error)
+      setCheckinNotice('加载打卡数据失败，请稍后重试。')
+    } finally {
+      setCheckinLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadCheckinData()
+  }, [user])
+
+  const handleCheckin = async () => {
+    if (!user || checkinSubmitting) {
+      return
+    }
+    setCheckinSubmitting(true)
+    try {
+      const result = await createTodayCheckin(todayKey)
+      setCheckinNotice(result === 'created' ? '打卡成功！' : '今日已打卡')
+      await loadCheckinData()
+    } catch (error) {
+      console.warn('打卡失败', error)
+      setCheckinNotice('打卡失败，请稍后重试。')
+    } finally {
+      setCheckinSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="checkin-page">
+      <header className="checkin-page-header">
+        <h1>打卡</h1>
+        <div className="checkin-nav-actions">
+          <button type="button" className="ghost" onClick={() => navigate('/')}>
+            聊天
+          </button>
+          <button type="button" className="ghost" onClick={() => navigate('/memory-vault')}>
+            囤囤库
+          </button>
+          <button type="button" className="ghost" onClick={() => navigate('/snacks')}>
+            零食罐罐
+          </button>
+          <button type="button" className="ghost" onClick={() => navigate('/syzygy')}>
+            仓鼠饲养日志
+          </button>
+          <button type="button" className="ghost" onClick={() => navigate('/settings')}>
+            设置
+          </button>
+        </div>
+      </header>
+
+      <section className="checkin-card standalone">
+        <div className="checkin-header">
+          <h2>今日打卡</h2>
+          <span>{todayDisplay}</span>
+        </div>
+        <div className="checkin-status-row">
+          <span className={`checkin-status ${checkedToday ? 'done' : 'todo'}`}>
+            {checkedToday ? '今日已打卡' : '今日未打卡'}
+          </span>
+          <button
+            type="button"
+            className="primary checkin-button"
+            onClick={() => void handleCheckin()}
+            disabled={!user || checkinSubmitting || checkedToday}
+          >
+            {checkedToday ? '已打卡' : checkinSubmitting ? '打卡中…' : '打卡'}
+          </button>
+        </div>
+        <div className="checkin-metrics">
+          <p>连续打卡：<strong>{streakDays}</strong> 天</p>
+          <p>累计打卡：<strong>{checkinTotal}</strong> 次</p>
+        </div>
+
+        <ul className="checkin-history">
+          {recentCheckins.length === 0 ? <li>暂无打卡记录</li> : recentCheckins.map((entry) => <li key={entry.id}>{entry.checkinDate}</li>)}
+        </ul>
+
+        {checkinLoading ? <p className="checkin-tip">打卡数据加载中…</p> : null}
+        {checkinNotice ? <p className="checkin-tip">{checkinNotice}</p> : null}
+      </section>
+    </div>
+  )
+}
+
+export default CheckinPage


### PR DESCRIPTION
### Motivation
- The Check-in feature exists but had no discoverable entry because the app opens into Chitchat and there is no dashboard/home UI, so users could not navigate to the Check-in page. 
- The change surfaces the feature immediately by adding a navigation entry so users can access Check-in without a dashboard.

### Description
- Added a new standalone `CheckinPage` (`src/pages/CheckinPage.tsx` + `src/pages/CheckinPage.css`) that reuses existing Supabase helpers and shows today status, a `打卡` button, current streak, total count, and history list. 
- Mounted the page behind a protected route at `"/checkin"` by importing and wiring `CheckinPage` into the app router in `src/App.tsx`.
- Added a `打卡` menu item to the chat header module menu in `src/pages/ChatPage.tsx` so the Check-in page is discoverable near other modules (囤囤库 / 零食罐罐 / 仓鼠饲养日志 / 设置). 
- Kept existing check-in behavior by calling the same storage APIs (`createTodayCheckin`, `fetchRecentCheckins`, `fetchCheckinTotalCount`) and preserved the original check-in UI/logic from `ChatPage`.

### Testing
- Ran a production build with `npm run build` and the build completed successfully. (passed)
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, opened `http://127.0.0.1:4173/checkin` and captured a screenshot to validate the page renders. (manual verification + screenshot captured)
- Changes were committed locally with a descriptive message `hotfix: add checkin route and navigation entry`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c4b07a44833086faa0a7b5db5b78)