### PR TITLE
RP Zone Phase 1 — Rooms UI, archive support, and menu entry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,8 @@ import SyzygyFeedPage from './pages/SyzygyFeedPage'
 import MemoryVaultPage from './pages/MemoryVaultPage'
 import CheckinPage from './pages/CheckinPage'
 import ExportPage from './pages/ExportPage'
+import RpRoomsPage from './pages/RpRoomsPage'
+import RpRoomPage from './pages/RpRoomPage'
 import {
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
@@ -1339,6 +1341,22 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <ExportPage user={user} />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/rp"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <RpRoomsPage user={user} />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/rp/:sessionId"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <RpRoomPage user={user} />
             </RequireAuth>
           }
         />

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -196,6 +196,15 @@ const ChatPage = ({
                 type="button"
                 onClick={() => {
                   setOpenHeaderMenu(false)
+                  navigate('/rp')
+                }}
+              >
+                跑跑滚轮
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setOpenHeaderMenu(false)
                   navigate('/settings')
                 }}
               >

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -1,0 +1,45 @@
+.rp-room-page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.rp-room-header {
+  display: flex;
+}
+
+.rp-room-card {
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.rp-room-card h1,
+.rp-room-card h2 {
+  margin: 0;
+}
+
+.rp-room-card p {
+  color: #4b5563;
+  margin: 0.55rem 0 0;
+}
+
+.rp-room-card.placeholder {
+  background: #fafafa;
+}
+
+
+.rp-room-page button {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+.error {
+  color: #b91c1c;
+}

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate, useParams } from 'react-router-dom'
+import { fetchRpSessionById } from '../storage/supabaseSync'
+import type { RpSession } from '../types'
+import './RpRoomPage.css'
+
+type RpRoomPageProps = {
+  user: User | null
+}
+
+const RpRoomPage = ({ user }: RpRoomPageProps) => {
+  const { sessionId } = useParams()
+  const navigate = useNavigate()
+  const [room, setRoom] = useState<RpSession | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const loadRoom = async () => {
+      if (!user || !sessionId) {
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+      setError(null)
+      try {
+        const data = await fetchRpSessionById(sessionId, user.id)
+        if (!data) {
+          setError('房间不存在，或你无权访问该房间。')
+          setRoom(null)
+          return
+        }
+        setRoom(data)
+      } catch (loadError) {
+        console.warn('加载 RP 房间失败', loadError)
+        setError('加载房间失败，请稍后重试。')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void loadRoom()
+  }, [sessionId, user])
+
+  if (loading) {
+    return <div className="rp-room-page"><p className="tips">房间加载中…</p></div>
+  }
+
+  if (error || !room) {
+    return (
+      <div className="rp-room-page">
+        <header className="rp-room-header">
+          <button type="button" className="ghost" onClick={() => navigate('/rp')}>
+            返回房间列表
+          </button>
+        </header>
+        <div className="rp-room-card">
+          <h1>无法进入房间</h1>
+          <p className="error">{error ?? '未找到房间。'}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rp-room-page">
+      <header className="rp-room-header">
+        <button type="button" className="ghost" onClick={() => navigate('/rp')}>
+          返回房间列表
+        </button>
+      </header>
+
+      <section className="rp-room-card">
+        <h1>{room.title || '未命名房间'}</h1>
+        <p>房间 ID：{room.id}</p>
+      </section>
+
+      <section className="rp-room-card placeholder">
+        <h2>时间线（Phase 2）</h2>
+        <p>后续将在这里实现 rp_messages 的时间线与互动内容。</p>
+      </section>
+
+      <section className="rp-room-card placeholder">
+        <h2>房间仪表盘（Phase 2）</h2>
+        <p>后续将在这里配置角色、玩家信息与其他 RP 控件。</p>
+      </section>
+    </div>
+  )
+}
+
+export default RpRoomPage

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -1,0 +1,150 @@
+.rp-rooms-page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.rp-rooms-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.rp-rooms-header h1 {
+  margin: 0;
+}
+
+.rp-rooms-header p {
+  margin: 0.4rem 0 0;
+  color: #4b5563;
+}
+
+.rp-create-card,
+.rp-list-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  background: #fff;
+  padding: 1rem;
+}
+
+.rp-create-card h2,
+.rp-list-card h2 {
+  margin: 0 0 0.75rem;
+}
+
+.rp-create-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.6rem;
+}
+
+.rp-create-row input {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+}
+
+.rp-list-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.rp-tabs {
+  display: inline-flex;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  padding: 0.2rem;
+}
+
+.rp-tabs button {
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+}
+
+.rp-tabs button.active {
+  background: #111827;
+  color: #fff;
+}
+
+.rp-room-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.rp-room-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.rp-room-item h3 {
+  margin: 0;
+}
+
+.rp-room-item p {
+  margin: 0.35rem 0 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.rp-room-actions {
+  display: flex;
+  gap: 0.45rem;
+}
+
+@media (max-width: 640px) {
+  .rp-rooms-header,
+  .rp-room-item,
+  .rp-create-row {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .rp-room-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}
+
+
+.rp-rooms-page button {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+.rp-rooms-page button.primary {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
+}
+
+.rp-rooms-page button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #b91c1c;
+}
+
+.tips {
+  color: #4b5563;
+}

--- a/src/pages/RpRoomsPage.tsx
+++ b/src/pages/RpRoomsPage.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
+import ConfirmDialog from '../components/ConfirmDialog'
+import { createRpSession, fetchRpSessions, updateRpSessionArchiveState } from '../storage/supabaseSync'
+import type { RpSession } from '../types'
+import './RpRoomsPage.css'
+
+type RpRoomsPageProps = {
+  user: User | null
+}
+
+type ArchiveAction = {
+  sessionId: string
+  nextArchived: boolean
+  title: string
+}
+
+const formatRoomTime = (session: RpSession) => {
+  const timestamp = session.updatedAt ?? session.createdAt
+  return new Date(timestamp).toLocaleString([], {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
+  const navigate = useNavigate()
+  const [rooms, setRooms] = useState<RpSession[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [newTitle, setNewTitle] = useState('')
+  const [tab, setTab] = useState<'active' | 'archived'>('active')
+  const [pendingArchive, setPendingArchive] = useState<ArchiveAction | null>(null)
+  const [updatingArchive, setUpdatingArchive] = useState(false)
+
+  const isArchivedView = tab === 'archived'
+
+  const loadRooms = useCallback(async () => {
+    if (!user) {
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const next = await fetchRpSessions(user.id, isArchivedView)
+      setRooms(next)
+    } catch (loadError) {
+      console.warn('加载 RP 房间失败', loadError)
+      setError('加载房间失败，请稍后重试。')
+    } finally {
+      setLoading(false)
+    }
+  }, [isArchivedView, user])
+
+  useEffect(() => {
+    void loadRooms()
+  }, [loadRooms])
+
+  const handleCreateRoom = async () => {
+    if (!user || creating) {
+      return
+    }
+    setCreating(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const title = newTitle.trim().length > 0 ? newTitle.trim() : '新房间'
+      const room = await createRpSession(user.id, title)
+      setNotice('房间创建成功')
+      setNewTitle('')
+      navigate(`/rp/${room.id}`)
+    } catch (createError) {
+      console.warn('创建 RP 房间失败', createError)
+      setError('创建房间失败，请稍后重试。')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleToggleArchive = async () => {
+    if (!pendingArchive || updatingArchive) {
+      return
+    }
+    setUpdatingArchive(true)
+    setError(null)
+    setNotice(null)
+    try {
+      await updateRpSessionArchiveState(pendingArchive.sessionId, pendingArchive.nextArchived)
+      setNotice(pendingArchive.nextArchived ? '已归档房间' : '已取消归档')
+      setRooms((current) => current.filter((room) => room.id !== pendingArchive.sessionId))
+      setPendingArchive(null)
+    } catch (updateError) {
+      console.warn('更新 RP 房间归档状态失败', updateError)
+      setError('更新归档状态失败，请稍后重试。')
+    } finally {
+      setUpdatingArchive(false)
+    }
+  }
+
+  const tabTitle = useMemo(() => (isArchivedView ? '已归档房间' : '活跃房间'), [isArchivedView])
+
+  return (
+    <div className="rp-rooms-page">
+      <header className="rp-rooms-header">
+        <div>
+          <h1>跑跑滚轮区</h1>
+          <p>管理你的 RP 房间，进入后可继续搭建角色与剧情。</p>
+        </div>
+        <button type="button" className="ghost" onClick={() => navigate('/')}>
+          返回聊天
+        </button>
+      </header>
+
+      <section className="rp-create-card">
+        <h2>新建房间</h2>
+        <div className="rp-create-row">
+          <input
+            value={newTitle}
+            onChange={(event) => setNewTitle(event.target.value)}
+            placeholder="输入房间标题（可留空）"
+            maxLength={80}
+          />
+          <button type="button" className="primary" disabled={creating} onClick={handleCreateRoom}>
+            {creating ? '创建中…' : '新建房间'}
+          </button>
+        </div>
+      </section>
+
+      <section className="rp-list-card">
+        <div className="rp-list-head">
+          <div className="rp-tabs" role="tablist" aria-label="房间筛选">
+            <button
+              type="button"
+              className={!isArchivedView ? 'active' : ''}
+              onClick={() => setTab('active')}
+            >
+              活跃
+            </button>
+            <button
+              type="button"
+              className={isArchivedView ? 'active' : ''}
+              onClick={() => setTab('archived')}
+            >
+              已归档
+            </button>
+          </div>
+          <button type="button" className="ghost" onClick={() => void loadRooms()} disabled={loading}>
+            刷新
+          </button>
+        </div>
+
+        {notice ? <p className="tips">{notice}</p> : null}
+        {error ? <p className="error">{error}</p> : null}
+
+        <h2>{tabTitle}</h2>
+        {loading ? <p className="tips">加载中…</p> : null}
+        {!loading && rooms.length === 0 ? (
+          <p className="tips">{isArchivedView ? '还没有归档房间。' : '还没有房间，先新建一个吧。'}</p>
+        ) : null}
+
+        <ul className="rp-room-list">
+          {rooms.map((room) => (
+            <li key={room.id} className="rp-room-item">
+              <div>
+                <h3>{room.title || '未命名房间'}</h3>
+                <p>更新时间：{formatRoomTime(room)}</p>
+              </div>
+              <div className="rp-room-actions">
+                <button type="button" className="ghost" onClick={() => navigate(`/rp/${room.id}`)}>
+                  进入
+                </button>
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={() =>
+                    setPendingArchive({
+                      sessionId: room.id,
+                      nextArchived: !room.isArchived,
+                      title: room.title || '未命名房间',
+                    })
+                  }
+                >
+                  {room.isArchived ? '取消归档' : '归档'}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <ConfirmDialog
+        open={Boolean(pendingArchive)}
+        title={pendingArchive?.nextArchived ? '确认归档房间？' : '确认取消归档？'}
+        description={pendingArchive ? `房间：${pendingArchive.title}` : undefined}
+        confirmLabel={pendingArchive?.nextArchived ? '归档' : '取消归档'}
+        cancelLabel="取消"
+        onCancel={() => setPendingArchive(null)}
+        onConfirm={() => void handleToggleArchive()}
+      />
+    </div>
+  )
+}
+
+export default RpRoomsPage

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,3 +125,15 @@ export type CheckinEntry = {
   checkinDate: string
   createdAt: string
 }
+
+export type RpSession = {
+  id: string
+  userId: string
+  title: string
+  createdAt: string
+  updatedAt: string | null
+  isArchived: boolean
+  archivedAt: string | null
+  playerDisplayName: string | null
+  playerAvatarUrl: string | null
+}


### PR DESCRIPTION
### Motivation
- Provide the first usable layer of a new isolated RP Zone so users can create, list, enter, and archive RP rooms without touching other zones or shared tables.
- Surface the RP Zone in the app navigation so users can discover and open the new module (`跑跑滚轮`).

### Description
- Added routes and pages for RP rooms: `src/pages/RpRoomsPage.tsx` (rooms list / create / archive tabs) and `src/pages/RpRoomPage.tsx` (room shell), plus associated CSS files and imports in `src/App.tsx`.
- Added a new menu entry `跑跑滚轮` in the chat actions to navigate to `/rp` and wired two routes: `/rp` and `/rp/:sessionId`.
- Introduced `RpSession` type in `src/types.ts` and Supabase helpers in `src/storage/supabaseSync.ts` for `rp_sessions`: `fetchRpSessions`, `createRpSession`, `fetchRpSessionById`, and `updateRpSessionArchiveState` with proper `user_id` scoping and archive timestamp handling.
- Implemented UI behaviors: Active / Archived tabs (default active), create with fallback title `新房间`, enter action, archive/unarchive actions that reuse the existing `ConfirmDialog` pattern, ownership checks on room entry, and loading/empty/error/notice states; pages are responsive for mobile.

### Testing
- Built the project with `npm run build` and the build completed successfully.
- Ran lint via `npm run lint` which passed (the run reports one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`).
- Started a dev server and exercised the `/rp` route with an automated Playwright capture (screenshot produced) to validate navigation and page rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aaf9058ac8330b2d44385d0462657)