### PR TITLE
RP Rooms — add rename and hard-delete with confirmation

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -8,6 +8,9 @@ export type ConfirmDialogProps = {
   confirmLabel?: string
   cancelLabel?: string
   neutralLabel?: string
+  confirmDisabled?: boolean
+  cancelDisabled?: boolean
+  neutralDisabled?: boolean
   onConfirm: () => void
   onCancel: () => void
   onNeutral?: () => void
@@ -20,6 +23,9 @@ const ConfirmDialog = ({
   confirmLabel = '确认',
   cancelLabel = '取消',
   neutralLabel,
+  confirmDisabled = false,
+  cancelDisabled = false,
+  neutralDisabled = false,
   onConfirm,
   onCancel,
   onNeutral,
@@ -34,15 +40,15 @@ const ConfirmDialog = ({
         <h2>{title}</h2>
         {description ? <p>{description}</p> : null}
         <div className="confirm-actions">
-          <button type="button" className="secondary" onClick={onCancel}>
+          <button type="button" className="secondary" onClick={onCancel} disabled={cancelDisabled}>
             {cancelLabel}
           </button>
           {neutralLabel && onNeutral ? (
-            <button type="button" className="tertiary" onClick={onNeutral}>
+            <button type="button" className="tertiary" onClick={onNeutral} disabled={neutralDisabled}>
               {neutralLabel}
             </button>
           ) : null}
-          <button type="button" className="primary" onClick={onConfirm}>
+          <button type="button" className="primary" onClick={onConfirm} disabled={confirmDisabled}>
             {confirmLabel}
           </button>
         </div>

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -102,9 +102,29 @@
   font-size: 0.9rem;
 }
 
+
+.rp-room-main {
+  min-width: 0;
+}
+
+.rp-rename-row {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.rp-rename-row input {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.45rem 0.65rem;
+  min-width: 200px;
+  flex: 1;
+}
 .rp-room-actions {
   display: flex;
   gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 @media (max-width: 640px) {
@@ -117,7 +137,11 @@
 
   .rp-room-actions {
     justify-content: flex-start;
-    flex-wrap: wrap;
+  }
+
+  .rp-rename-row input {
+    min-width: 0;
+    width: 100%;
   }
 }
 
@@ -134,6 +158,11 @@
   background: #111827;
   color: #fff;
   border-color: #111827;
+}
+
+.rp-rooms-page button.danger {
+  color: #b91c1c;
+  border-color: #fca5a5;
 }
 
 .rp-rooms-page button:disabled {

--- a/src/pages/RpRoomsPage.tsx
+++ b/src/pages/RpRoomsPage.tsx
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { useNavigate } from 'react-router-dom'
 import ConfirmDialog from '../components/ConfirmDialog'
-import { createRpSession, fetchRpSessions, updateRpSessionArchiveState } from '../storage/supabaseSync'
+import {
+  createRpSession,
+  deleteRpSession,
+  fetchRpSessions,
+  renameRpSession,
+  updateRpSessionArchiveState,
+} from '../storage/supabaseSync'
 import type { RpSession } from '../types'
 import './RpRoomsPage.css'
 
@@ -14,6 +20,10 @@ type ArchiveAction = {
   sessionId: string
   nextArchived: boolean
   title: string
+}
+
+type DeleteAction = {
+  sessionId: string
 }
 
 const formatRoomTime = (session: RpSession) => {
@@ -37,8 +47,14 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
   const [tab, setTab] = useState<'active' | 'archived'>('active')
   const [pendingArchive, setPendingArchive] = useState<ArchiveAction | null>(null)
   const [updatingArchive, setUpdatingArchive] = useState(false)
+  const [editingRoomId, setEditingRoomId] = useState<string | null>(null)
+  const [editingTitle, setEditingTitle] = useState('')
+  const [savingRoomId, setSavingRoomId] = useState<string | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<DeleteAction | null>(null)
+  const [deletingRoomId, setDeletingRoomId] = useState<string | null>(null)
 
   const isArchivedView = tab === 'archived'
+  const isMutating = Boolean(savingRoomId || deletingRoomId || updatingArchive)
 
   const loadRooms = useCallback(async () => {
     if (!user) {
@@ -102,6 +118,72 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
     }
   }
 
+
+
+  const startRename = (room: RpSession) => {
+    if (isMutating) {
+      return
+    }
+    setEditingRoomId(room.id)
+    setEditingTitle(room.title ?? '')
+    setError(null)
+    setNotice(null)
+  }
+
+  const cancelRename = () => {
+    if (savingRoomId) {
+      return
+    }
+    setEditingRoomId(null)
+    setEditingTitle('')
+  }
+
+  const handleRenameRoom = async (roomId: string) => {
+    if (!user || isMutating) {
+      return
+    }
+    setSavingRoomId(roomId)
+    setError(null)
+    setNotice(null)
+    try {
+      const title = editingTitle.trim().length > 0 ? editingTitle.trim() : '新房间'
+      const updatedRoom = await renameRpSession(roomId, title)
+      setRooms((current) => current.map((room) => (room.id === roomId ? updatedRoom : room)))
+      setNotice('房间名称已更新')
+      setEditingRoomId(null)
+      setEditingTitle('')
+    } catch (renameError) {
+      console.warn('更新 RP 房间名称失败', renameError)
+      setError('更新房间名称失败，请稍后重试。')
+    } finally {
+      setSavingRoomId(null)
+    }
+  }
+
+  const handleDeleteRoom = async () => {
+    if (!pendingDelete || isMutating) {
+      return
+    }
+    setDeletingRoomId(pendingDelete.sessionId)
+    setError(null)
+    setNotice(null)
+    try {
+      await deleteRpSession(pendingDelete.sessionId)
+      setNotice('房间已删除')
+      setPendingDelete(null)
+      setEditingRoomId((current) => (current === pendingDelete.sessionId ? null : current))
+      if (editingRoomId === pendingDelete.sessionId) {
+        setEditingTitle('')
+      }
+      await loadRooms()
+    } catch (deleteError) {
+      console.warn('删除 RP 房间失败', deleteError)
+      setError('删除房间失败，请稍后重试。')
+    } finally {
+      setDeletingRoomId(null)
+    }
+  }
+
   const tabTitle = useMemo(() => (isArchivedView ? '已归档房间' : '活跃房间'), [isArchivedView])
 
   return (
@@ -149,7 +231,7 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
               已归档
             </button>
           </div>
-          <button type="button" className="ghost" onClick={() => void loadRooms()} disabled={loading}>
+          <button type="button" className="ghost" onClick={() => void loadRooms()} disabled={loading || isMutating}>
             刷新
           </button>
         </div>
@@ -164,32 +246,69 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
         ) : null}
 
         <ul className="rp-room-list">
-          {rooms.map((room) => (
-            <li key={room.id} className="rp-room-item">
-              <div>
-                <h3>{room.title || '未命名房间'}</h3>
-                <p>更新时间：{formatRoomTime(room)}</p>
-              </div>
-              <div className="rp-room-actions">
-                <button type="button" className="ghost" onClick={() => navigate(`/rp/${room.id}`)}>
-                  进入
-                </button>
-                <button
-                  type="button"
-                  className="ghost"
-                  onClick={() =>
-                    setPendingArchive({
-                      sessionId: room.id,
-                      nextArchived: !room.isArchived,
-                      title: room.title || '未命名房间',
-                    })
-                  }
-                >
-                  {room.isArchived ? '取消归档' : '归档'}
-                </button>
-              </div>
-            </li>
-          ))}
+          {rooms.map((room) => {
+            const isRenaming = editingRoomId === room.id
+            const isSaving = savingRoomId === room.id
+            const isDeleting = deletingRoomId === room.id
+            const isBusy = isMutating || isSaving || isDeleting
+
+            return (
+              <li key={room.id} className="rp-room-item">
+                <div className="rp-room-main">
+                  {isRenaming ? (
+                    <div className="rp-rename-row">
+                      <input
+                        value={editingTitle}
+                        onChange={(event) => setEditingTitle(event.target.value)}
+                        placeholder="输入房间标题（可留空）"
+                        maxLength={80}
+                        disabled={isBusy}
+                      />
+                      <button type="button" className="primary" disabled={isBusy} onClick={() => void handleRenameRoom(room.id)}>
+                        {isSaving ? '保存中…' : '保存'}
+                      </button>
+                      <button type="button" className="ghost" disabled={isSaving} onClick={cancelRename}>
+                        取消
+                      </button>
+                    </div>
+                  ) : (
+                    <h3>{room.title || '未命名房间'}</h3>
+                  )}
+                  <p>更新时间：{formatRoomTime(room)}</p>
+                </div>
+                <div className="rp-room-actions">
+                  <button type="button" className="ghost" onClick={() => navigate(`/rp/${room.id}`)} disabled={isBusy}>
+                    进入
+                  </button>
+                  <button type="button" className="ghost" onClick={() => startRename(room)} disabled={isBusy || Boolean(editingRoomId && !isRenaming)}>
+                    改名
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() =>
+                      setPendingArchive({
+                        sessionId: room.id,
+                        nextArchived: !room.isArchived,
+                        title: room.title || '未命名房间',
+                      })
+                    }
+                    disabled={isBusy || Boolean(editingRoomId && !isRenaming)}
+                  >
+                    {room.isArchived ? '取消归档' : '归档'}
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost danger"
+                    onClick={() => setPendingDelete({ sessionId: room.id })}
+                    disabled={isBusy || Boolean(editingRoomId && !isRenaming)}
+                  >
+                    {isDeleting ? '删除中…' : '删除'}
+                  </button>
+                </div>
+              </li>
+            )
+          })}
         </ul>
       </section>
 
@@ -197,10 +316,25 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
         open={Boolean(pendingArchive)}
         title={pendingArchive?.nextArchived ? '确认归档房间？' : '确认取消归档？'}
         description={pendingArchive ? `房间：${pendingArchive.title}` : undefined}
-        confirmLabel={pendingArchive?.nextArchived ? '归档' : '取消归档'}
+        confirmLabel={updatingArchive ? '处理中…' : pendingArchive?.nextArchived ? '归档' : '取消归档'}
         cancelLabel="取消"
+        confirmDisabled={updatingArchive}
+        cancelDisabled={updatingArchive}
         onCancel={() => setPendingArchive(null)}
         onConfirm={() => void handleToggleArchive()}
+      />
+
+
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        title="确认删除？"
+        description="删除后无法恢复。"
+        confirmLabel={deletingRoomId ? '删除中…' : '删除'}
+        cancelLabel="取消"
+        confirmDisabled={Boolean(deletingRoomId)}
+        cancelDisabled={Boolean(deletingRoomId)}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => void handleDeleteRoom()}
       />
     </div>
   )

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -368,6 +368,45 @@ export const updateRpSessionArchiveState = async (
   return mapRpSessionRow(data as RpSessionRow)
 }
 
+export const renameRpSession = async (
+  sessionId: string,
+  title: string,
+): Promise<RpSession> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('rp_sessions')
+    .update({ title, updated_at: now })
+    .eq('id', sessionId)
+    .eq('user_id', userId)
+    .select(
+      'id,user_id,title,created_at,updated_at,is_archived,archived_at,player_display_name,player_avatar_url',
+    )
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('更新 RP 房间名称失败')
+  }
+  return mapRpSessionRow(data as RpSessionRow)
+}
+
+export const deleteRpSession = async (sessionId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('rp_sessions')
+    .delete()
+    .eq('id', sessionId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
 export const renameRemoteSession = async (
   sessionId: string,
   title: string,


### PR DESCRIPTION
### Motivation
- Provide users the ability to rename RP rooms inline and to hard-delete rooms with a confirmation step so room management is complete in the RP Rooms list. 
- Ensure deletes are hard (no soft delete) and rely on existing DB FK `ON DELETE CASCADE` to remove related RP records. 
- Prevent duplicate or conflicting mutations by disabling actions while async operations run and keep mobile layout usable.

### Description
- Added data-layer helpers `renameRpSession` and `deleteRpSession` to `src/storage/supabaseSync.ts`, where `renameRpSession` updates `title` and `updated_at`, and `deleteRpSession` removes the `rp_sessions` row scoped to the authenticated `user_id`.
- Extended `src/pages/RpRoomsPage.tsx` to add an inline rename flow (`改名`) with save/cancel and empty-title fallback to `新房间`, and a hard-delete action (`删除`) that opens a second-step `ConfirmDialog` titled `确认删除？` with message `删除后无法恢复。`.
- Kept archive/unarchive behaviour unchanged and added loading/disabled guards (`isMutating`, `savingRoomId`, `deletingRoomId`, `updatingArchive`) so actions are disabled while requests are in-flight; renames update the list in-place and deletes reload the list after success.
- Extended `ConfirmDialog` (`src/components/ConfirmDialog.tsx`) with optional `confirmDisabled`, `cancelDisabled`, and `neutralDisabled` props, and updated styles in `src/pages/RpRoomsPage.css` to support inline rename layout, action wrapping on small screens, and a danger style for the delete button.

### Testing
- Built the app with `npm run build` and the production build completed successfully.
- Ran the linter with `npm run lint`, which completed successfully (it reported a pre-existing warning in `src/pages/CheckinPage.tsx`).
- Launched the dev server and captured a Playwright screenshot of the `/rp` page to validate the UI; the script completed and produced an artifact image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab28e70148330b1980f2f9933a296)