### PR TITLE
RP Room Page — Timeline MVP (rp_messages): list + send + delete

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -1,13 +1,34 @@
 .rp-room-page {
-  max-width: 880px;
+  max-width: 960px;
   margin: 0 auto;
   padding: 1rem;
   display: grid;
-  gap: 0.9rem;
+  gap: 0.75rem;
+  min-height: 100dvh;
 }
 
 .rp-room-header {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+}
+
+.rp-room-header h1 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.rp-room-timeline {
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 14px;
+  padding: 1rem;
+  overflow: auto;
+  min-height: 0;
 }
 
 .rp-room-card {
@@ -17,20 +38,13 @@
   padding: 1rem;
 }
 
-.rp-room-card h1,
-.rp-room-card h2 {
+.rp-room-card h1 {
   margin: 0;
 }
 
 .rp-room-card p {
-  color: #4b5563;
-  margin: 0.55rem 0 0;
+  margin: 0.5rem 0 0;
 }
-
-.rp-room-card.placeholder {
-  background: #fafafa;
-}
-
 
 .rp-room-page button {
   border: 1px solid #d1d5db;
@@ -40,6 +54,73 @@
   cursor: pointer;
 }
 
+.rp-message-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rp-message-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+  background: #fafafa;
+}
+
+.rp-message-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.rp-message-item p {
+  margin: 0.55rem 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.rp-composer {
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 14px;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.6rem;
+  position: sticky;
+  bottom: 0.75rem;
+}
+
+.rp-composer textarea {
+  width: 100%;
+  min-height: 88px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.6rem 0.7rem;
+  resize: vertical;
+}
+
+.rp-composer .primary {
+  justify-self: end;
+}
+
+.tips {
+  color: #4b5563;
+}
+
 .error {
   color: #b91c1c;
+}
+
+@media (max-width: 640px) {
+  .rp-room-page {
+    padding: 0.75rem;
+  }
+
+  .rp-composer {
+    bottom: 0;
+    border-radius: 12px 12px 0 0;
+  }
 }

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { useNavigate, useParams } from 'react-router-dom'
-import { fetchRpSessionById } from '../storage/supabaseSync'
-import type { RpSession } from '../types'
+import ConfirmDialog from '../components/ConfirmDialog'
+import {
+  createRpMessage,
+  deleteRpMessage,
+  fetchRpMessages,
+  fetchRpSessionById,
+} from '../storage/supabaseSync'
+import type { RpMessage, RpSession } from '../types'
 import './RpRoomPage.css'
 
 type RpRoomPageProps = {
@@ -15,6 +21,13 @@ const RpRoomPage = ({ user }: RpRoomPageProps) => {
   const [room, setRoom] = useState<RpSession | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [messages, setMessages] = useState<RpMessage[]>([])
+  const [messagesLoading, setMessagesLoading] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [sending, setSending] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<RpMessage | null>(null)
+  const [deletingMessageId, setDeletingMessageId] = useState<string | null>(null)
 
   useEffect(() => {
     const loadRoom = async () => {
@@ -43,6 +56,77 @@ const RpRoomPage = ({ user }: RpRoomPageProps) => {
     void loadRoom()
   }, [sessionId, user])
 
+  useEffect(() => {
+    const loadMessages = async () => {
+      if (!user || !room) {
+        setMessages([])
+        return
+      }
+      setMessagesLoading(true)
+      setError(null)
+      try {
+        const rows = await fetchRpMessages(room.id, user.id)
+        setMessages(rows)
+      } catch (loadError) {
+        console.warn('加载 RP 时间线失败', loadError)
+        setError('加载时间线失败，请稍后重试。')
+      } finally {
+        setMessagesLoading(false)
+      }
+    }
+
+    void loadMessages()
+  }, [room, user])
+
+  const handleSend = async () => {
+    if (!room || !user || sending) {
+      return
+    }
+    const content = draft.trim()
+    if (!content) {
+      return
+    }
+    setSending(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const message = await createRpMessage(
+        room.id,
+        user.id,
+        room.playerDisplayName?.trim() ? room.playerDisplayName : '串串',
+        content,
+      )
+      setMessages((current) => [...current, message])
+      setDraft('')
+      setNotice('发送成功')
+    } catch (sendError) {
+      console.warn('发送 RP 消息失败', sendError)
+      setError('发送失败，请稍后重试。')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!pendingDelete || deletingMessageId) {
+      return
+    }
+    setDeletingMessageId(pendingDelete.id)
+    setError(null)
+    setNotice(null)
+    try {
+      await deleteRpMessage(pendingDelete.id)
+      setMessages((current) => current.filter((item) => item.id !== pendingDelete.id))
+      setPendingDelete(null)
+      setNotice('消息已删除')
+    } catch (deleteError) {
+      console.warn('删除 RP 消息失败', deleteError)
+      setError('删除失败，请稍后重试。')
+    } finally {
+      setDeletingMessageId(null)
+    }
+  }
+
   if (loading) {
     return <div className="rp-room-page"><p className="tips">房间加载中…</p></div>
   }
@@ -52,7 +136,7 @@ const RpRoomPage = ({ user }: RpRoomPageProps) => {
       <div className="rp-room-page">
         <header className="rp-room-header">
           <button type="button" className="ghost" onClick={() => navigate('/rp')}>
-            返回房间列表
+            返回
           </button>
         </header>
         <div className="rp-room-card">
@@ -66,25 +150,72 @@ const RpRoomPage = ({ user }: RpRoomPageProps) => {
   return (
     <div className="rp-room-page">
       <header className="rp-room-header">
+        <div>
+          <h1>{room.title || '未命名房间'}</h1>
+        </div>
         <button type="button" className="ghost" onClick={() => navigate('/rp')}>
-          返回房间列表
+          返回
         </button>
       </header>
 
-      <section className="rp-room-card">
-        <h1>{room.title || '未命名房间'}</h1>
-        <p>房间 ID：{room.id}</p>
+      <section className="rp-room-timeline">
+        {notice ? <p className="tips">{notice}</p> : null}
+        {error ? <p className="error">{error}</p> : null}
+
+        {messagesLoading ? <p className="tips">时间线加载中…</p> : null}
+        {!messagesLoading && messages.length === 0 ? <p className="tips">还没有消息，先说点什么吧。</p> : null}
+
+        <ul className="rp-message-list">
+          {messages.map((message) => (
+            <li key={message.id} className="rp-message-item">
+              <div className="rp-message-top">
+                <strong>{message.role}</strong>
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={() => setPendingDelete(message)}
+                  disabled={Boolean(deletingMessageId)}
+                >
+                  删除
+                </button>
+              </div>
+              <p>{message.content}</p>
+            </li>
+          ))}
+        </ul>
       </section>
 
-      <section className="rp-room-card placeholder">
-        <h2>时间线（Phase 2）</h2>
-        <p>后续将在这里实现 rp_messages 的时间线与互动内容。</p>
+      <section className="rp-composer">
+        <textarea
+          placeholder="输入消息内容"
+          rows={3}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.nativeEvent.isComposing) {
+              return
+            }
+            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault()
+              void handleSend()
+            }
+          }}
+        />
+        <button type="button" className="primary" onClick={() => void handleSend()} disabled={sending}>
+          {sending ? '发送中…' : '发送'}
+        </button>
       </section>
 
-      <section className="rp-room-card placeholder">
-        <h2>房间仪表盘（Phase 2）</h2>
-        <p>后续将在这里配置角色、玩家信息与其他 RP 控件。</p>
-      </section>
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="确认删除？"
+        description="删除后无法恢复。"
+        cancelLabel="取消"
+        confirmLabel="删除"
+        confirmDisabled={Boolean(deletingMessageId)}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,3 +137,15 @@ export type RpSession = {
   playerDisplayName: string | null
   playerAvatarUrl: string | null
 }
+
+export type RpMessage = {
+  id: string
+  sessionId: string
+  userId: string
+  role: string
+  content: string
+  createdAt: string
+  clientId: string | null
+  clientCreatedAt: string | null
+  meta?: Record<string, unknown>
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, usable RP room timeline on `/rp/:sessionId` that shows the player's public messages and allows sending and hard-deleting messages with confirmation.
- Enforce room ownership so only the owning user can open a room and interact with its timeline.
- Keep data minimal (speaker + plain text) and follow existing Supabase patterns from the chat module.

### Description
- Added a new `RpMessage` type in `src/types.ts` to represent `rp_messages` rows. 
- Implemented Supabase helpers in `src/storage/supabaseSync.ts`: `fetchRpMessages(sessionId, userId)`, `createRpMessage(...)`, and `deleteRpMessage(messageId)`, mapping rows and ordering timeline by `created_at ASC`.
- Implemented timeline UI and interactions in `src/pages/RpRoomPage.tsx`: ownership check via `fetchRpSessionById`, message list rendering (`role` + `content`), multiline composer with send flow (uses `playerDisplayName` or falls back to `串串`), optimistic append after successful insert, and per-message hard-delete with a `ConfirmDialog` (`确认删除？` / `删除后无法恢复。`).
- Polished styles in `src/pages/RpRoomPage.css` to match room-list header styling and provide mobile-friendly behavior with a sticky composer; added UI loading/empty/error/notice states.

### Testing
- Ran `npm run lint`, which passed with one pre-existing unrelated warning in `src/pages/CheckinPage.tsx` (not introduced by this PR). 
- Ran `npm run build`, which completed successfully. 
- Started the dev server and captured a mobile viewport screenshot of `/rp/demo-room` via an automated Playwright script to validate layout and composer behavior (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ab66026b48330a9a78dd3405f938b)