### PR TITLE
Add RP room dashboard MVP with room settings, worldbook, and export

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -38,7 +38,12 @@
 }
 
 .rp-room-header-slot {
-  height: 1px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.rp-dashboard-open-btn {
+  display: inline-flex;
 }
 
 .rp-room-body {
@@ -168,7 +173,8 @@
   line-height: 1.5;
 }
 
-.rp-composer .primary {
+.rp-composer .primary,
+.rp-dashboard-section .primary {
   border: none;
   background: #0f172a;
   color: #fff;
@@ -185,17 +191,55 @@
   background: #f8fafc;
   padding: 16px;
   display: none;
+  overflow-y: auto;
 }
 
-.rp-dashboard-panel h2 {
+.rp-dashboard-panel h2,
+.rp-dashboard-mobile-head h2 {
   margin: 0;
   font-size: 15px;
 }
 
-.rp-dashboard-panel p {
-  margin: 8px 0 0;
+.rp-dashboard-section {
+  margin-top: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rp-dashboard-section h3 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.rp-dashboard-section label {
+  font-size: 12px;
+  color: #334155;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rp-dashboard-section input,
+.rp-dashboard-section textarea {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 8px 10px;
   font-size: 13px;
+}
+
+.rp-dashboard-helper {
+  margin: 0;
+  font-size: 12px;
   color: #64748b;
+}
+
+.rp-dashboard-mobile-modal {
+  display: none;
 }
 
 .rp-room-card {
@@ -216,8 +260,53 @@
   margin: 0;
 }
 
+@media (max-width: 1099px) {
+  .rp-dashboard-mobile-modal.open {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    display: block;
+  }
+
+  .rp-dashboard-mobile-scrim {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.5);
+  }
+
+  .rp-dashboard-mobile-sheet {
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: min(94vw, 420px);
+    background: #f8fafc;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .rp-dashboard-mobile-head {
+    padding: 14px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .rp-dashboard-mobile-body {
+    padding: 14px;
+    overflow-y: auto;
+  }
+}
+
 @media (min-width: 1100px) {
   .rp-dashboard-panel {
     display: block;
+  }
+
+  .rp-dashboard-open-btn,
+  .rp-dashboard-mobile-modal {
+    display: none;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,8 @@ export type RpSession = {
   archivedAt: string | null
   playerDisplayName: string | null
   playerAvatarUrl: string | null
+  worldbookText: string | null
+  settings: Record<string, unknown>
 }
 
 export type RpMessage = {

--- a/supabase/migrations/20260222100000_add_rp_dashboard_fields.sql
+++ b/supabase/migrations/20260222100000_add_rp_dashboard_fields.sql
@@ -1,0 +1,3 @@
+alter table public.rp_sessions
+  add column if not exists worldbook_text text,
+  add column if not exists settings jsonb not null default '{}'::jsonb;


### PR DESCRIPTION
### Motivation
- Provide a right-side RP 仪表盘 on `/rp/:sessionId` to manage room-level metadata and room-wide injection text as an MVP. 
- Persist player-level settings and room worldbook to the `rp_sessions` record so values survive reloads and can be consumed by room logic. 
- Offer a minimal export entry for room timelines (speaker + plain text) and make the dashboard accessible on desktop and mobile.

### Description
- Implemented the dashboard UI and mobile slide-over in `src/pages/RpRoomPage.tsx` and styles in `src/pages/RpRoomPage.css`, adding sections for 房间设置, 世界书 (multiline editor), and 导出. 
- Added `worldbookText` and `settings` to the `RpSession` type in `src/types.ts` and mapped new DB fields in `src/storage/supabaseSync.ts`. 
- Introduced `updateRpSessionDashboard` in `src/storage/supabaseSync.ts` and consolidated RP session select fields into `RP_SESSION_SELECT_FIELDS` to read/write dashboard columns. 
- Added a Supabase migration `supabase/migrations/20260222100000_add_rp_dashboard_fields.sql` to add `worldbook_text` and `settings` to `rp_sessions`, and implemented a simple export that downloads non-system messages as `role: content` plaintext.

### Testing
- Ran lint with `npm run lint` which completed (one pre-existing unrelated warning in `src/pages/CheckinPage.tsx`).
- Built the production bundle with `npm run build` which succeeded. 
- Launched the dev server and executed a Playwright script to load `/rp/test-room` and capture a screenshot of the RP room dashboard UI, confirming the panel renders.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699abc459fcc8330af1210d9ddf6595a)