### PR TITLE
feat(rp): move mobile dashboard to standalone page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1356,7 +1356,15 @@ const App = () => {
           path="/rp/:sessionId"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <RpRoomPage user={user} />
+              <RpRoomPage user={user} mode="chat" />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/rp/:sessionId/dashboard"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <RpRoomPage user={user} mode="dashboard" />
             </RequireAuth>
           }
         />

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -195,7 +195,7 @@
 }
 
 .rp-dashboard-panel h2,
-.rp-dashboard-mobile-head h2 {
+.rp-dashboard-page h2 {
   margin: 0;
   font-size: 15px;
 }
@@ -238,8 +238,14 @@
   color: #64748b;
 }
 
-.rp-dashboard-mobile-modal {
-  display: none;
+.rp-dashboard-page {
+  width: min(860px, 100%);
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.rp-room-body-dashboard {
+  justify-content: center;
 }
 
 .rp-room-card {
@@ -261,42 +267,12 @@
 }
 
 @media (max-width: 1099px) {
-  .rp-dashboard-mobile-modal.open {
-    position: fixed;
-    inset: 0;
-    z-index: 40;
-    display: block;
+  .rp-dashboard-panel {
+    display: none;
   }
 
-  .rp-dashboard-mobile-scrim {
-    position: absolute;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.5);
-  }
-
-  .rp-dashboard-mobile-sheet {
-    position: absolute;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    width: min(94vw, 420px);
-    background: #f8fafc;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .rp-dashboard-mobile-head {
-    padding: 14px;
-    border-bottom: 1px solid #e2e8f0;
-    background: #fff;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .rp-dashboard-mobile-body {
-    padding: 14px;
-    overflow-y: auto;
+  .rp-dashboard-open-btn {
+    display: inline-flex;
   }
 }
 
@@ -305,8 +281,7 @@
     display: block;
   }
 
-  .rp-dashboard-open-btn,
-  .rp-dashboard-mobile-modal {
+  .rp-dashboard-open-btn {
     display: none;
   }
 }


### PR DESCRIPTION
### Motivation
- On mobile the fixed right-side RP dashboard consumes too much screen space, so the dashboard should be hidden on small screens and reachable via a header entry that opens it as a separate page while keeping desktop behavior unchanged.

### Description
- Add a new route `/rp/:sessionId/dashboard` and render `RpRoomPage` in `dashboard` mode by passing `mode="dashboard"` from `src/App.tsx`.
- Refactor `RpRoomPage` to accept `mode?: 'chat' | 'dashboard'` and route-driven rendering so `chat` mode shows timeline + composer + desktop fixed sidebar, and `dashboard` mode shows a standalone dashboard page with a header back button that navigates back to the room chat page (keeps room title centered and header pattern).
- Remove the mobile modal flow and `dashboardOpen` state in favor of header navigation; the header now shows a `仪表盘` button (hidden on desktop) that navigates to the new dashboard route, and the back button navigates appropriately when on the dashboard page.
- Update CSS (`src/pages/RpRoomPage.css`) to add `.rp-dashboard-page` and `.rp-room-body-dashboard`, hide the fixed `.rp-dashboard-panel` on narrow screens and show the header entry, and preserve the fixed dashboard on wide screens so desktop layout is unchanged.
- Preserve all existing dashboard handlers and UX (房间设置 / 世界书 / 导出, `保存` labels and toast notifications) so persistence and feedback remain intact.

### Testing
- Ran `npm run build` which completed successfully (TypeScript build + `vite build`).
- Launched the dev server (`npm run dev`) and executed a Playwright script to open `/rp/demo` at a mobile viewport and captured a screenshot, but the app redirected to the auth screen in this environment so a fully authenticated RP page could not be validated; the screenshot artifact was produced.
- No automated test failures observed during the build step; TypeScript compilation passed as part of the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699abea807888330a8b1fb232d869730)