### PR TITLE
RP Room: move dashboard to dedicated page and remove desktop sidebar

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -185,16 +185,6 @@
   align-self: flex-end;
 }
 
-.rp-dashboard-panel {
-  width: 320px;
-  border-left: 1px solid #e2e8f0;
-  background: #f8fafc;
-  padding: 16px;
-  display: none;
-  overflow-y: auto;
-}
-
-.rp-dashboard-panel h2,
 .rp-dashboard-page h2 {
   margin: 0;
   font-size: 15px;
@@ -264,24 +254,4 @@
 .error {
   color: #b91c1c;
   margin: 0;
-}
-
-@media (max-width: 1099px) {
-  .rp-dashboard-panel {
-    display: none;
-  }
-
-  .rp-dashboard-open-btn {
-    display: inline-flex;
-  }
-}
-
-@media (min-width: 1100px) {
-  .rp-dashboard-panel {
-    display: block;
-  }
-
-  .rp-dashboard-open-btn {
-    display: none;
-  }
 }

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -327,9 +327,8 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
             {dashboardContent}
           </main>
         ) : (
-          <>
-            <section className="rp-room-main">
-              <section className="rp-room-timeline">
+          <section className="rp-room-main">
+            <section className="rp-room-timeline">
                 {notice ? <p className="tips">{notice}</p> : null}
                 {error ? <p className="error">{error}</p> : null}
 
@@ -361,7 +360,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
                 </ul>
               </section>
 
-              <section className="rp-composer-wrap">
+            <section className="rp-composer-wrap">
                 <div className="rp-trigger-row" aria-label="NPC 触发按钮区域">
                   <span>NPC触发按钮（预留）</span>
                 </div>
@@ -386,13 +385,8 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
                     {sending ? '发送中…' : '发送'}
                   </button>
                 </section>
-              </section>
             </section>
-
-            <aside className="rp-dashboard-panel" aria-label="RP 仪表盘">
-              {dashboardContent}
-            </aside>
-          </>
+          </section>
         )}
       </div>
 


### PR DESCRIPTION
### Motivation
- Unify RP dashboard behavior so the dashboard is not a persistent right sidebar and instead opens as a dedicated page via the header button “仪表盘”.
- Keep the main RP chat view clean and full-width so timeline and composer remain the primary focus on all device sizes.

### Description
- Removed the desktop fixed right dashboard panel from the chat layout by deleting the aside panel render in `src/pages/RpRoomPage.tsx` and relying on the existing dashboard route mode (`mode="dashboard"`).
- Kept the header-level “仪表盘” button which navigates to the dedicated route `/rp/:sessionId/dashboard` and reused the same `dashboardContent` block for the separate dashboard page.
- Simplified CSS by removing the `.rp-dashboard-panel` styles and the desktop/mobile media-query toggles in `src/pages/RpRoomPage.css`, leaving a single consistent layout and a centered dashboard page view.
- Preserved all dashboard behaviors (房间设置, 世界书, 导出), save button labels (`保存`), and existing toasts/notifications without changing their logic.

### Testing
- Ran lint with `npm run lint` which completed successfully with an unrelated existing warning in `src/pages/CheckinPage.tsx`.
- Built the app with `npm run build` which completed successfully and produced the production bundle.
- Launched the dev server with `npm run dev` and captured a UI screenshot of `/rp/demo` using Playwright to validate the chat-first layout and dashboard navigation, and the screenshot artifact was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac163e7b0833084e6ae572e3cbdfc)