### PR TITLE
RP Room — NPC Cards MVP: CRUD, 3‑NPC limit, and chat selector placeholder

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -255,3 +255,103 @@
   color: #b91c1c;
   margin: 0;
 }
+
+.rp-trigger-row label {
+  font-weight: 600;
+}
+
+.rp-trigger-row select {
+  margin-left: auto;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 4px 8px;
+  min-width: 180px;
+  font-size: 12px;
+  background: #fff;
+}
+
+.rp-npc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rp-npc-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.rp-npc-name {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.rp-npc-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.rp-dashboard-section .danger-text {
+  color: #b91c1c;
+}
+
+.rp-npc-form {
+  border-top: 1px dashed #cbd5e1;
+  padding-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rp-npc-form h4 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.rp-npc-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.rp-npc-enabled-toggle {
+  flex-direction: row !important;
+  align-items: center;
+}
+
+.rp-npc-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 640px) {
+  .rp-trigger-row {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .rp-trigger-row select {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .rp-npc-item {
+    flex-direction: column;
+  }
+
+  .rp-npc-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,3 +151,16 @@ export type RpMessage = {
   clientCreatedAt: string | null
   meta?: Record<string, unknown>
 }
+
+export type RpNpcCard = {
+  id: string
+  sessionId: string
+  userId: string
+  displayName: string
+  systemPrompt: string | null
+  modelConfig: Record<string, unknown>
+  apiConfig: Record<string, unknown>
+  enabled: boolean
+  createdAt: string
+  updatedAt: string | null
+}

--- a/supabase/migrations/20260222113000_add_rp_npc_cards.sql
+++ b/supabase/migrations/20260222113000_add_rp_npc_cards.sql
@@ -1,0 +1,31 @@
+create table if not exists public.rp_npc_cards (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.rp_sessions(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  display_name text not null,
+  system_prompt text,
+  model_config jsonb not null default '{}'::jsonb,
+  api_config jsonb not null default '{}'::jsonb,
+  enabled boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.rp_npc_cards enable row level security;
+
+create policy if not exists "Users can read own rp npc cards"
+  on public.rp_npc_cards for select
+  using (auth.uid() = user_id);
+
+create policy if not exists "Users can insert own rp npc cards"
+  on public.rp_npc_cards for insert
+  with check (auth.uid() = user_id);
+
+create policy if not exists "Users can update own rp npc cards"
+  on public.rp_npc_cards for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "Users can delete own rp npc cards"
+  on public.rp_npc_cards for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation
- Provide a first usable NPC management layer for RP rooms including room-scoped CRUD for NPC role cards and a chat-side selector placeholder for future NPC-triggered messages. 
- Keep runtime simple: no model calls, no automatic NPC messages inserted into `rp_messages`, and UI-level enforcement of enabled limits only. 

### Description
- Add a new Supabase migration `supabase/migrations/20260222113000_add_rp_npc_cards.sql` to create the `rp_npc_cards` table with `display_name`, `system_prompt`, `model_config`, `api_config`, `enabled`, timestamps, and owner RLS policies. 
- Introduce `RpNpcCard` type in `src/types.ts` and implement mapping plus full CRUD helpers (`fetchRpNpcCards`, `createRpNpcCard`, `updateRpNpcCard`, `deleteRpNpcCard`) in `src/storage/supabaseSync.ts` with a `RP_NPC_CARD_SELECT_FIELDS` constant. 
- Implement dashboard UI in `src/pages/RpRoomPage.tsx` to list/create/edit/delete NPC cards, show model summary, and enable/disable cards; enforce a UI-only `MAX = 3` enabled NPCs with a notice when the limit is hit. 
- Add a chat-composer adjacent dropdown selector (`选择NPC（预留）`) that lists only enabled NPCs (ordered by `created_at`) and stores the local selection state, plus CSS styles for the NPC list/form and responsive selector behavior in `src/pages/RpRoomPage.css`. 

### Testing
- Built the app successfully with `npm run build` and verified the dev server UI snapshot was captured. 
- Ran linting with `npm run lint`; lint runs completed successfully and yielded a pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to this change. 
- Manual UI checks on the dashboard and chat pages confirmed NPC listing, create/edit/delete flows, enable/disable behavior, and the dropdown selector rendering (no model or API calls were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac353428483308684f1e1f3f83d2e)