### PR TITLE
Global enabled model pool + RP room default & NPC model dropdown

### DIFF
--- a/src/hooks/useEnabledModels.ts
+++ b/src/hooks/useEnabledModels.ts
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { ensureUserSettings } from '../storage/userSettings'
+import { supabase } from '../supabase/client'
+
+type OpenRouterModel = {
+  id: string
+  name?: string
+}
+
+export type EnabledModelOption = {
+  id: string
+  label: string
+}
+
+export const useEnabledModels = (user: User | null) => {
+  const [enabledModelIds, setEnabledModelIds] = useState<string[]>([])
+  const [catalog, setCatalog] = useState<OpenRouterModel[]>([])
+
+  useEffect(() => {
+    let active = true
+    if (!user) {
+      return () => {
+        active = false
+      }
+    }
+
+    ensureUserSettings(user.id).then((settings) => {
+      if (!active) {
+        return
+      }
+      setEnabledModelIds(settings.enabledModels)
+    })
+
+    return () => {
+      active = false
+    }
+  }, [user])
+
+  useEffect(() => {
+    let active = true
+    if (!user || !supabase) {
+      return () => {
+        active = false
+      }
+    }
+
+    supabase.functions
+      .invoke<{ data?: OpenRouterModel[] }>('openrouter-models', { body: {} })
+      .then(({ data }) => {
+        if (!active) {
+          return
+        }
+        const models = Array.isArray(data?.data) ? data.data : []
+        setCatalog(models)
+      })
+      .catch(() => {
+        if (!active) {
+          return
+        }
+        setCatalog([])
+      })
+
+    return () => {
+      active = false
+    }
+  }, [user])
+
+  const catalogMap = useMemo(() => {
+    return new Map(catalog.map((model) => [model.id, model.name ?? model.id]))
+  }, [catalog])
+
+  const safeEnabledIds = useMemo(() => (user ? enabledModelIds : []), [enabledModelIds, user])
+
+  const enabledModelOptions = useMemo<EnabledModelOption[]>(() => {
+    return safeEnabledIds.map((id) => ({
+      id,
+      label: catalogMap.get(id) ?? id,
+    }))
+  }, [catalogMap, safeEnabledIds])
+
+  return {
+    enabledModelIds: safeEnabledIds,
+    enabledModelOptions,
+  }
+}

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -215,7 +215,8 @@
 }
 
 .rp-dashboard-section input,
-.rp-dashboard-section textarea {
+.rp-dashboard-section textarea,
+.rp-dashboard-section select {
   border: 1px solid #cbd5e1;
   border-radius: 10px;
   padding: 8px 10px;
@@ -333,6 +334,29 @@
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+}
+
+.rp-model-empty-hint {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.rp-model-empty-hint .ghost {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0f172a;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.rp-model-warning {
+  margin: 0;
+  font-size: 12px;
+  color: #b45309;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
### Motivation
- Provide a single global "enabled models" pool that all selectors can consume so enabled models are consistent across features. 
- Keep Daily Chat default model semantics unchanged while introducing a separate RP room default to avoid cross-module interference. 
- Restrict NPC role-card model choices to the global enabled pool while preserving existing card values and allowing per-card overrides.

### Description
- Add a shared hook `useEnabledModels(user)` that reads `user_settings.enabled_models` and fetches OpenRouter catalog labels for display, returning `enabledModelIds` and `enabledModelOptions` (`src/hooks/useEnabledModels.ts`).
- Update RP dashboard to show a room-scoped `默认模型` dropdown sourced from the enabled pool and persist it as `rp_default_model_id` inside `rp_sessions.settings` without touching Daily Chat defaults (`src/pages/RpRoomPage.tsx`).
- Replace free-form NPC model input with a dropdown of enabled models and add backward-compatible support for legacy `model_config.model` while writing new values as `model_config.model_id`, plus a non-destructive warning when an NPC's current model is not enabled (`src/pages/RpRoomPage.tsx`).
- Add styles and empty-state UI for the new selectors and guidance to navigate to Settings → 模型库 when the enabled pool is empty (`src/pages/RpRoomPage.css`).

### Testing
- Ran `npm run lint` which passed for changed files and reported one pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to this change.
- Ran `npm run build` which completed successfully and produced a production build.
- Launched the dev server with `npm run dev` and performed a visual smoke check, including an automated Playwright screenshot capture of the RP dashboard to validate UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac735d3288330b371d34767073bcb)