### PR TITLE
Normalize NPC card fields before save to avoid 400 on system_prompt NOT NULL

### DIFF
--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -369,7 +369,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
           sessionId: room.id,
           userId: user.id,
           displayName,
-          systemPrompt: npcForm.systemPrompt.trim() || null,
+          systemPrompt: npcForm.systemPrompt,
           modelConfig,
           apiConfig,
           enabled: nextEnabled,
@@ -378,7 +378,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
       } else {
         const updated = await updateRpNpcCard(editingNpcId, {
           displayName,
-          systemPrompt: npcForm.systemPrompt.trim() || null,
+          systemPrompt: npcForm.systemPrompt,
           modelConfig,
           apiConfig,
           enabled: nextEnabled,

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -235,7 +235,7 @@ const mapRpNpcCardRow = (row: RpNpcCardRow): RpNpcCard => ({
   sessionId: row.session_id,
   userId: row.user_id,
   displayName: row.display_name,
-  systemPrompt: row.system_prompt,
+  systemPrompt: row.system_prompt ?? '',
   modelConfig: row.model_config ?? {},
   apiConfig: row.api_config ?? {},
   enabled: row.enabled ?? false,
@@ -590,7 +590,7 @@ export const createRpNpcCard = async (
     sessionId: string
     userId: string
     displayName: string
-    systemPrompt?: string | null
+    systemPrompt?: string
     modelConfig?: Record<string, unknown>
     apiConfig?: Record<string, unknown>
     enabled?: boolean
@@ -599,6 +599,9 @@ export const createRpNpcCard = async (
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
+  const normalizedSystemPrompt = payload.systemPrompt ?? ''
+  const normalizedModelConfig = payload.modelConfig ?? {}
+  const normalizedApiConfig = payload.apiConfig ?? {}
   const now = new Date().toISOString()
   const { data, error } = await supabase
     .from('rp_npc_cards')
@@ -606,9 +609,9 @@ export const createRpNpcCard = async (
       session_id: payload.sessionId,
       user_id: payload.userId,
       display_name: payload.displayName,
-      system_prompt: payload.systemPrompt ?? null,
-      model_config: payload.modelConfig ?? {},
-      api_config: payload.apiConfig ?? {},
+      system_prompt: normalizedSystemPrompt,
+      model_config: normalizedModelConfig,
+      api_config: normalizedApiConfig,
       enabled: payload.enabled ?? false,
       created_at: now,
       updated_at: now,
@@ -625,7 +628,7 @@ export const updateRpNpcCard = async (
   npcCardId: string,
   updates: {
     displayName?: string
-    systemPrompt?: string | null
+    systemPrompt?: string
     modelConfig?: Record<string, unknown>
     apiConfig?: Record<string, unknown>
     enabled?: boolean
@@ -638,7 +641,7 @@ export const updateRpNpcCard = async (
   const nextUpdates: {
     updated_at: string
     display_name?: string
-    system_prompt?: string | null
+    system_prompt?: string
     model_config?: Record<string, unknown>
     api_config?: Record<string, unknown>
     enabled?: boolean
@@ -649,13 +652,13 @@ export const updateRpNpcCard = async (
     nextUpdates.display_name = updates.displayName
   }
   if (typeof updates.systemPrompt !== 'undefined') {
-    nextUpdates.system_prompt = updates.systemPrompt
+    nextUpdates.system_prompt = updates.systemPrompt ?? ''
   }
   if (typeof updates.modelConfig !== 'undefined') {
-    nextUpdates.model_config = updates.modelConfig
+    nextUpdates.model_config = updates.modelConfig ?? {}
   }
   if (typeof updates.apiConfig !== 'undefined') {
-    nextUpdates.api_config = updates.apiConfig
+    nextUpdates.api_config = updates.apiConfig ?? {}
   }
   if (typeof updates.enabled !== 'undefined') {
     nextUpdates.enabled = updates.enabled

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,7 @@ export type RpNpcCard = {
   sessionId: string
   userId: string
   displayName: string
-  systemPrompt: string | null
+  systemPrompt: string
   modelConfig: Record<string, unknown>
   apiConfig: Record<string, unknown>
   enabled: boolean


### PR DESCRIPTION
### Motivation
- Creating or editing an NPC could send `system_prompt: null` to Postgres, which violates the `NOT NULL` constraint and causes a 400 error. 
- The intent is to normalize payloads/read mappings so the app never writes explicit `null` for fields that must be non-null and to keep `model_config`/`api_config` as objects.

### Description
- Normalize read mapping so `systemPrompt` is always a string by returning `row.system_prompt ?? ''` in `mapRpNpcCardRow` and tighten `RpNpcCard.systemPrompt` to `string` in `src/types.ts`.
- Normalize create payloads in `createRpNpcCard` by computing `normalizedSystemPrompt`, `normalizedModelConfig`, and `normalizedApiConfig` and insert those instead of possibly sending `null`.
- Normalize update payloads in `updateRpNpcCard` by setting `nextUpdates.system_prompt = updates.systemPrompt ?? ''` and defaulting `model_config`/`api_config` to `{}` when provided as undefined/null.
- Stop coercing cleared system prompts to `null` in the UI save flow by sending the form string directly from `RpRoomPage` (`systemPrompt: npcForm.systemPrompt`).
- Files changed: `src/storage/supabaseSync.ts`, `src/pages/RpRoomPage.tsx`, `src/types.ts`.

### Testing
- Ran `npm run build` (which runs `tsc -b && vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acaa0bf7883309de6c2b7a81a3dc2)