### PR TITLE
Remove room-level default model selector from RP dashboard (UI cleanup)

### DIFF
--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -70,7 +70,6 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
   const [pendingDeleteNpc, setPendingDeleteNpc] = useState<RpNpcCard | null>(null)
   const [deletingNpcId, setDeletingNpcId] = useState<string | null>(null)
   const [selectedNpcId, setSelectedNpcId] = useState('')
-  const [roomDefaultModelInput, setRoomDefaultModelInput] = useState('')
   const { enabledModelIds, enabledModelOptions } = useEnabledModels(user)
   const playerName = room?.playerDisplayName?.trim() ? room.playerDisplayName.trim() : '串串'
   const isDashboardPage = mode === 'dashboard'
@@ -123,10 +122,6 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
     setPlayerDisplayNameInput(room.playerDisplayName?.trim() || '串串')
     setPlayerAvatarUrlInput(room.playerAvatarUrl ?? '')
     setWorldbookTextInput(room.worldbookText ?? '')
-    const rpDefaultModelId = typeof room.settings?.rp_default_model_id === 'string'
-      ? room.settings.rp_default_model_id
-      : ''
-    setRoomDefaultModelInput(rpDefaultModelId)
   }, [room])
 
   useEffect(() => {
@@ -218,15 +213,10 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
     setNotice(null)
     const normalizedDisplayName = playerDisplayNameInput.trim() || '串串'
     const normalizedAvatar = playerAvatarUrlInput.trim()
-    const mergedSettings = {
-      ...(room.settings ?? {}),
-      rp_default_model_id: roomDefaultModelInput.trim() || null,
-    }
     try {
       const updated = await updateRpSessionDashboard(room.id, {
         playerDisplayName: normalizedDisplayName,
         playerAvatarUrl: normalizedAvatar,
-        settings: mergedSettings,
       })
       setRoom(updated)
       setNotice('保存成功')
@@ -369,7 +359,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
           sessionId: room.id,
           userId: user.id,
           displayName,
-          systemPrompt: npcForm.systemPrompt.trim() || null,
+          systemPrompt: npcForm.systemPrompt,
           modelConfig,
           apiConfig,
           enabled: nextEnabled,
@@ -378,7 +368,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
       } else {
         const updated = await updateRpNpcCard(editingNpcId, {
           displayName,
-          systemPrompt: npcForm.systemPrompt.trim() || null,
+          systemPrompt: npcForm.systemPrompt,
           modelConfig,
           apiConfig,
           enabled: nextEnabled,
@@ -492,27 +482,6 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
             placeholder="https://example.com/avatar.png"
           />
         </label>
-        <label>
-          默认模型
-          <select
-            value={roomDefaultModelInput}
-            onChange={(event) => setRoomDefaultModelInput(event.target.value)}
-            disabled={enabledModelOptions.length === 0}
-          >
-            {enabledModelOptions.length === 0 ? <option value="">请先去模型库启用模型</option> : <option value="">跟随系统（未设置）</option>}
-            {enabledModelOptions.map((model) => (
-              <option key={model.id} value={model.id}>{model.label}</option>
-            ))}
-          </select>
-        </label>
-        {enabledModelOptions.length === 0 ? (
-          <div className="rp-model-empty-hint">
-            <p className="rp-dashboard-helper">请先去模型库启用模型</p>
-            <button type="button" className="ghost" onClick={() => navigate('/settings')}>
-              前往模型库
-            </button>
-          </div>
-        ) : null}
         <button type="button" className="primary" onClick={() => void handleSaveRoomSettings()} disabled={savingRoomSettings}>
           {savingRoomSettings ? '保存中…' : '保存'}
         </button>
@@ -577,7 +546,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
                 onChange={(event) => setNpcForm((current) => ({ ...current, model: event.target.value }))}
                 disabled={enabledModelOptions.length === 0}
               >
-                {enabledModelOptions.length === 0 ? <option value="">请先去模型库启用模型</option> : <option value="">继承房间默认模型</option>}
+                {enabledModelOptions.length === 0 ? <option value="">请先去模型库启用模型</option> : <option value="">未指定（按NPC调用时决定）</option>}
                 {enabledModelOptions.map((model) => (
                   <option key={model.id} value={model.id}>{model.label}</option>
                 ))}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -235,7 +235,7 @@ const mapRpNpcCardRow = (row: RpNpcCardRow): RpNpcCard => ({
   sessionId: row.session_id,
   userId: row.user_id,
   displayName: row.display_name,
-  systemPrompt: row.system_prompt,
+  systemPrompt: row.system_prompt ?? '',
   modelConfig: row.model_config ?? {},
   apiConfig: row.api_config ?? {},
   enabled: row.enabled ?? false,
@@ -590,7 +590,7 @@ export const createRpNpcCard = async (
     sessionId: string
     userId: string
     displayName: string
-    systemPrompt?: string | null
+    systemPrompt?: string
     modelConfig?: Record<string, unknown>
     apiConfig?: Record<string, unknown>
     enabled?: boolean
@@ -599,6 +599,9 @@ export const createRpNpcCard = async (
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
+  const normalizedSystemPrompt = payload.systemPrompt ?? ''
+  const normalizedModelConfig = payload.modelConfig ?? {}
+  const normalizedApiConfig = payload.apiConfig ?? {}
   const now = new Date().toISOString()
   const { data, error } = await supabase
     .from('rp_npc_cards')
@@ -606,9 +609,9 @@ export const createRpNpcCard = async (
       session_id: payload.sessionId,
       user_id: payload.userId,
       display_name: payload.displayName,
-      system_prompt: payload.systemPrompt ?? null,
-      model_config: payload.modelConfig ?? {},
-      api_config: payload.apiConfig ?? {},
+      system_prompt: normalizedSystemPrompt,
+      model_config: normalizedModelConfig,
+      api_config: normalizedApiConfig,
       enabled: payload.enabled ?? false,
       created_at: now,
       updated_at: now,
@@ -625,7 +628,7 @@ export const updateRpNpcCard = async (
   npcCardId: string,
   updates: {
     displayName?: string
-    systemPrompt?: string | null
+    systemPrompt?: string
     modelConfig?: Record<string, unknown>
     apiConfig?: Record<string, unknown>
     enabled?: boolean
@@ -638,7 +641,7 @@ export const updateRpNpcCard = async (
   const nextUpdates: {
     updated_at: string
     display_name?: string
-    system_prompt?: string | null
+    system_prompt?: string
     model_config?: Record<string, unknown>
     api_config?: Record<string, unknown>
     enabled?: boolean
@@ -649,13 +652,13 @@ export const updateRpNpcCard = async (
     nextUpdates.display_name = updates.displayName
   }
   if (typeof updates.systemPrompt !== 'undefined') {
-    nextUpdates.system_prompt = updates.systemPrompt
+    nextUpdates.system_prompt = updates.systemPrompt ?? ''
   }
   if (typeof updates.modelConfig !== 'undefined') {
-    nextUpdates.model_config = updates.modelConfig
+    nextUpdates.model_config = updates.modelConfig ?? {}
   }
   if (typeof updates.apiConfig !== 'undefined') {
-    nextUpdates.api_config = updates.apiConfig
+    nextUpdates.api_config = updates.apiConfig ?? {}
   }
   if (typeof updates.enabled !== 'undefined') {
     nextUpdates.enabled = updates.enabled

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,7 @@ export type RpNpcCard = {
   sessionId: string
   userId: string
   displayName: string
-  systemPrompt: string | null
+  systemPrompt: string
   modelConfig: Record<string, unknown>
   apiConfig: Record<string, unknown>
   enabled: boolean


### PR DESCRIPTION
### Motivation

- The room-level “默认模型” selector in 房间设置 is confusing because the player (串串) is not an AI endpoint and the field does not belong in player settings.  
- The UI should not mutate or overwrite stored `rp_default_model_id` from this section while keeping room/NPC model behavior unchanged.  
- Normalize NPC card payloads to avoid sending `null` for `system_prompt`/`model_config`/`api_config` and make `systemPrompt` non-null in types to prevent NOT NULL DB issues.

### Description

- Removed the `默认模型` label, dropdown, empty hint and associated `roomDefaultModelInput` state from `src/pages/RpRoomPage.tsx`, leaving 房间设置 with only `玩家显示名`, `玩家头像URL`, and the Save button.  
- Stopped including `rp_default_model_id` when saving room settings so the stored field is left untouched by this UI.  
- Changed NPC form saves to pass `systemPrompt` as a string directly (`npcForm.systemPrompt`) and adjusted option copy for NPC model select to read `未指定（按NPC调用时决定）`.  
- In `src/storage/supabaseSync.ts` normalized read/write mapping for NPC cards by returning `row.system_prompt ?? ''` and defaulting `model_config`/`api_config` to `{}` on create/update to ensure non-null payloads.  
- Tightened `RpNpcCard.systemPrompt` to `string` in `src/types.ts` to reflect normalized, non-null values.

### Testing

- Ran `npm run build` and the build completed successfully.  
- Started the dev server and captured a full-page screenshot via an automated Playwright script to validate the UI, both operations completed without errors.  
- Verified that saving room settings still sends `playerDisplayName` and `playerAvatarUrl` and that no console/build errors occurred during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acaa0bf7883309de6c2b7a81a3dc2)