### PR TITLE
RP Room — Trigger NPC reply (OpenRouter) and persist ordered rp_messages

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -148,10 +148,27 @@
   border-radius: 10px;
   display: flex;
   align-items: center;
+  gap: 8px;
   padding: 0 10px;
   font-size: 12px;
   color: #64748b;
   background: #f8fafc;
+}
+
+.rp-trigger-row select {
+  flex: 1;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px 8px;
+}
+
+.rp-trigger-row .primary {
+  border: none;
+  background: #0f172a;
+  color: #fff;
+  border-radius: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
 }
 
 .rp-composer {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -531,11 +531,15 @@ export const createRpMessage = async (
   userId: string,
   role: string,
   content: string,
+  options?: {
+    createdAt?: string
+    meta?: Record<string, unknown>
+  },
 ): Promise<RpMessage> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
-  const now = new Date().toISOString()
+  const now = options?.createdAt ?? new Date().toISOString()
   const { data, error } = await supabase
     .from('rp_messages')
     .insert({
@@ -544,7 +548,7 @@ export const createRpMessage = async (
       role,
       content,
       created_at: now,
-      meta: {},
+      meta: options?.meta ?? {},
     })
     .select('id,session_id,user_id,role,content,created_at,client_id,client_created_at,meta')
     .single()


### PR DESCRIPTION
### Motivation
- Enable users to trigger an enabled NPC to speak from the RP room composer by calling the OpenRouter edge function.
- Ensure deterministic timeline ordering by inserting NPC replies with an explicit `created_at` equal to the last message's `created_at` plus 1 millisecond.
- Reuse the existing OpenRouter integration and inject room-level worldbook text as a system message to provide room context.

### Description
- Added a `触发发言` button next to the NPC dropdown and kept the dropdown to list enabled NPCs while disabling inputs/buttons during an in-flight trigger. 
- Implemented a deterministic request assembly that sends NPC `system_prompt`, a `世界书：{text}` system message when available, the room timeline mapped to `user`/`assistant` roles, and a final user instruction to the selected NPC, then calls the existing `openrouter-chat` edge function. 
- Extended `createRpMessage` to accept optional `createdAt` and `meta` so NPC replies can be inserted with explicit `created_at` ordering and metadata `{ source: "npc", npc_id, model }`. 
- Updated UI state handling to block triggers when no NPC or model is configured and added small CSS changes for the trigger-row layout.

### Testing
- Ran `npm run lint` which completed successfully (there is one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`).
- Ran `npm run build` which succeeded and produced a production build. 
- Started the dev server and captured a UI screenshot to verify the new dropdown + `触发发言` button and in-flight states.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aceb0cb84833089ab70320786c835)