### PR TITLE
RP NPC context: add speaker labels and identity guardrail

### DIFF
--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -291,13 +291,22 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
 
     const normalizedWorldbook = room.worldbookText?.trim() ?? ''
     const modelMessages = [] as Array<{ role: 'system' | 'user' | 'assistant'; content: string }>
+    modelMessages.push({
+      role: 'system',
+      content: [
+        '你将收到格式为“【名字】内容”的对话记录。',
+        '这些标签是唯一且真实的说话者归属依据。',
+        `你必须且只能以【${selectedNpcCard.displayName}】身份回复。`,
+        '不要为其他角色补写、改写或伪造带标签台词。',
+      ].join(''),
+    })
     modelMessages.push({ role: 'system', content: selectedNpcCard.systemPrompt?.trim() ?? '' })
     if (normalizedWorldbook) {
       modelMessages.push({ role: 'system', content: `世界书：${normalizedWorldbook}` })
     }
     messages.forEach((item) => {
       const role: 'user' | 'assistant' = item.role === playerName ? 'user' : 'assistant'
-      modelMessages.push({ role, content: item.content })
+      modelMessages.push({ role, content: `【${item.role}】${item.content}` })
     })
     modelMessages.push({
       role: 'user',


### PR DESCRIPTION
### Motivation

- Multi-speaker RP timelines caused attribution ambiguity and occasional NPCs replying out-of-character or speaking for other roles.

### Description

- Prepend a concise system instruction to NPC trigger context that declares the `【名字】内容` labels as ground-truth attribution and requires the model to reply only as the selected NPC and not fabricate labeled lines. 
- Transform each timeline message before sending to the model into the format `【${role}】${content}` using `rp_messages.role` (`item.role`) as the displayed speaker name for both player and NPC messages. 
- These changes only affect model prompt assembly in `src/pages/RpRoomPage.tsx` and do not change database storage or export formats (stored/exported messages remain `role + plain text`).

### Testing

- Ran `npm run lint` which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to this change. 
- Ran `npm run build` which completed successfully and produced the production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad398b28c8330a54a6a11dd671712)