### PR TITLE
RP output UX: markdown rendering, streaming NPC replies, and reasoning panel

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -396,3 +396,27 @@
     justify-content: flex-end;
   }
 }
+
+.rp-assistant-markdown > *:first-child {
+  margin-top: 0;
+}
+
+.rp-assistant-markdown > *:last-child {
+  margin-bottom: 0;
+}
+
+.rp-assistant-markdown pre {
+  overflow-x: auto;
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.rp-assistant-markdown code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.rp-message.out .reasoning-panel__toggle {
+  background: rgba(255, 255, 255, 0.15);
+  color: #e2e8f0;
+}


### PR DESCRIPTION
### Motivation
- Improve RP NPC reply UX so NPC messages render rich Markdown, stream progressively, and optionally show internal reasoning without changing export formats.
- Avoid NPC attribution issues by preserving explicit `【名字】内容` labels when assembling model prompts and ensuring replies are produced only as the selected NPC.
- Keep the client responsive during generation and provide a safe fallback when streaming is unavailable.

### Description
- Reworked the NPC trigger flow to request streaming responses from the OpenRouter function and added an `onDelta` handler to append streamed content and reasoning into a temporary in-UI message.【F:src/pages/RpRoomPage.tsx】
- Added a fallback retry to a non-streaming request if the streaming call fails, and persist the final NPC reply exactly once with existing +1ms ordering logic.【F:src/pages/RpRoomPage.tsx】
- Changed prompt assembly so timeline messages are transformed into `【${role}】${content}` labels for model input to preserve speaker attribution without altering stored/exported records.【F:src/pages/RpRoomPage.tsx】
- Render NPC (left-side) messages with GFM Markdown using the reusable `MarkdownRenderer` and show conditional, collapsible reasoning content via `ReasoningPanel`; player messages remain plain text, and RP-specific CSS was added for Markdown styling and reasoning toggle contrast.【F:src/pages/RpRoomPage.tsx】【F:src/pages/RpRoomPage.css】

### Testing
- Ran `npm run lint` which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx`.
- Ran `npm run build` which completed successfully and produced the production build.
- Started a dev server and attempted an automated Playwright UI capture which failed to navigate in this environment with `ERR_EMPTY_RESPONSE`, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad398b28c8330a54a6a11dd671712)