### PR TITLE
Strip RP speaker prefixes in UI while keeping labeled model context

### DIFF
--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -5,6 +5,7 @@ import ConfirmDialog from '../components/ConfirmDialog'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import ReasoningPanel from '../components/ReasoningPanel'
 import { useEnabledModels } from '../hooks/useEnabledModels'
+import { stripSpeakerPrefix } from '../utils/rpMessage'
 import { supabase } from '../supabase/client'
 import {
   createRpMessage,
@@ -406,7 +407,8 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
     }
     messages.forEach((item) => {
       const role: 'user' | 'assistant' = item.role === playerName ? 'user' : 'assistant'
-      modelMessages.push({ role, content: `【${item.role}】${item.content}` })
+      const contentWithoutPrefix = stripSpeakerPrefix(item.content)
+      modelMessages.push({ role, content: `【${item.role}】${contentWithoutPrefix}` })
     })
     modelMessages.push({
       role: 'user',
@@ -487,7 +489,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
         )
       }
 
-      const persistedContent = result.content || '（空回复）'
+      const persistedContent = stripSpeakerPrefix(result.content || '（空回复）')
       const lastMessage = messagesRef.current.filter((item) => item.id !== tempId).at(-1)
       const createdAt = lastMessage
         ? new Date(new Date(lastMessage.createdAt).getTime() + 1).toISOString()
@@ -568,7 +570,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
     }
     const contentRows = messages
       .filter((item) => item.role.trim().toLowerCase() !== 'system')
-      .map((item) => `${item.role}: ${item.content}`)
+      .map((item) => `${item.role}: ${stripSpeakerPrefix(item.content)}`)
 
     const payload = contentRows.join('\n\n')
     const blob = new Blob([payload], { type: 'text/plain;charset=utf-8' })
@@ -1003,7 +1005,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
                       <div className="rp-bubble">
                         <p className="rp-speaker">{message.role}</p>
                         {isPlayer ? (
-                          <p>{message.content}</p>
+                          <p>{stripSpeakerPrefix(message.content)}</p>
                         ) : (
                           <>
                             {(() => {
@@ -1011,7 +1013,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
                               return reasoningText ? <ReasoningPanel reasoning={reasoningText} /> : null
                             })()}
                             <div className="rp-assistant-markdown">
-                              <MarkdownRenderer content={message.content} />
+                              <MarkdownRenderer content={stripSpeakerPrefix(message.content)} />
                             </div>
                           </>
                         )}

--- a/src/utils/rpMessage.ts
+++ b/src/utils/rpMessage.ts
@@ -1,0 +1,3 @@
+export const stripSpeakerPrefix = (content: string): string => {
+  return content.replace(/^【[^】\r\n]+】\s*/, '')
+}


### PR DESCRIPTION
### Motivation
- Keep RP timeline and exports free of legacy "【名字】" prefixes while preserving labeled speaker context when calling the model.
- Ensure the database stores and receives plain text for new messages and that historical prefixed messages render cleanly without schema changes.

### Description
- Added `stripSpeakerPrefix(content: string)` utility that conservatively removes a leading `【...】` label plus trailing whitespace/newline.  
- Use `stripSpeakerPrefix(...)` when assembling model context so the model still receives `【role】content` but only in-memory (messages sent to the model are `【role】${contentWithoutPrefix}`).
- Strip prefixes when rendering the RP timeline and when passing message text to `MarkdownRenderer`, while keeping `rp_messages.role` as the bubble header speaker source of truth.  
- Strip prefixes before persisting NPC replies (so `rp_messages.content` is saved as clean text) and when exporting RP messages to plain text.

### Testing
- Built the app with `npm run build` and the build succeeded.  
- Started the dev server (`npm run dev`) and captured a UI screenshot to validate the timeline renders stripped content.  
- Verified the app runs with the changes (dev server reachable and UI inspected); no automated unit tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad82e13d48330a0b713def2e31e93)