### PR TITLE
RP runtime context compression with shared summarizer and module-isolated cache

### DIFF
--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -231,6 +231,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
   }
 
   const requestNpcReply = async (payload: {
+    conversationId: string
     modelId: string
     temperature?: number
     topP?: number
@@ -249,6 +250,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
     }
 
     const requestBody: Record<string, unknown> = {
+      conversationId: payload.conversationId,
       model: payload.modelId,
       modelId: payload.modelId,
       module: 'rp-room',
@@ -448,6 +450,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
       let result: Awaited<ReturnType<typeof requestNpcReply>>
       try {
         result = await requestNpcReply({
+          conversationId: room.id,
           modelId: modelId.trim(),
           temperature,
           topP,
@@ -478,6 +481,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
       } catch (streamError) {
         console.warn('RP 流式回复失败，回退非流式请求', streamError)
         result = await requestNpcReply({
+          conversationId: room.id,
           modelId: modelId.trim(),
           temperature,
           topP,


### PR DESCRIPTION
### Motivation
- Prevent RP NPC prompts from exceeding model context by adding runtime-only compression for long RP timelines while keeping raw `rp_messages` unchanged.
- Reuse the existing, single-source Summarizer configuration used by Daily Chat so RP summarization follows the same policy and model selection.
- Ensure compression cache isolation so RP summaries never collide with Daily Chat summaries by scoping cache rows to `module = 'rp'`.

### Description
- Extended the edge function payload to accept `module: 'rp-room'` and `conversationId`, and introduced `resolveCompressionModule` to map incoming payloads to compression scopes (`'chat' | 'rp'`).
- Added `module` to the `CompressionCacheRow` shape and updated `fetchCompressionCache` and `upsertCompressionCache` to read/write using `module` and to use `onConflict: 'module,conversation_id,compressed_up_to_message_id'` for safe upserts.
- Implemented RP-specific timeline fetch `fetchRpConversationMessages` (reads `rp_messages`) and adapted the runtime compression flow to: reuse shared user compression settings and summarizer selection, estimate tokens with the existing estimator, summarize new windows, and inject an RP-specific system summary message `以下为截至目前的剧情摘要：{summary}` into the runtime prompt while keeping the most recent K messages uncompressed.
- Updated the RP frontend call-site (`src/pages/RpRoomPage.tsx`) to include `conversationId` when calling the openrouter edge function so server-side compression can load/cache summaries against `rp_sessions.id` without modifying stored RP history.

### Testing
- Built the client successfully with `npm run build` (production build completed).
- Ran linting with `npm run lint`; lint passed with a single pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to this change.
- Performed local TypeScript build during `npm run build` (no type errors) and validated the new server function compiles as part of the project build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699add57f43483308000239ceda031cc)