### PR TITLE
Ensure RP compression_cache upsert runs and expose dev write errors

### DIFF
--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -254,6 +254,7 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
       model: payload.modelId,
       modelId: payload.modelId,
       module: 'rp-room',
+      debug: import.meta.env.DEV,
       messages: payload.messagesPayload,
       stream: payload.stream ?? true,
     }
@@ -276,6 +277,18 @@ const RpRoomPage = ({ user, mode = 'chat' }: RpRoomPageProps) => {
 
     if (!response.ok) {
       throw new Error(await response.text())
+    }
+
+    if (import.meta.env.DEV) {
+      const cacheWriteStatus = response.headers.get('x-rp-compression-cache-write')
+      if (cacheWriteStatus === 'failed') {
+        const encodedError = response.headers.get('x-rp-compression-cache-error') ?? ''
+        const errorMessage = encodedError ? decodeURIComponent(encodedError) : '未知错误'
+        console.error('RP compression_cache upsert failed', errorMessage)
+        setNotice(`RP压缩缓存写入失败：${errorMessage}`)
+      } else if (cacheWriteStatus === 'success') {
+        setNotice('RP压缩缓存写入成功')
+      }
     }
 
     const collectReasoning = (source: Record<string, unknown> | null | undefined): string => {


### PR DESCRIPTION
### Motivation
- RP summarization produced summaries but no `compression_cache` rows for module `rp`, and errors were not visible in dev, so we must always attempt server-side upsert and surface failures for debugging.

### Description
- Make RP compression upserts use the same service-role Supabase client and include explicit `module`, `conversation_id`, `compressed_up_to_message_id`, and `summary_text` fields when writing to `compression_cache` in the edge function (`supabase/functions/openrouter-chat/index.ts`).
- Capture the full upsert result (`{ data, error }`) instead of throwing directly, record success/failure and error message, and log the outcome to the function logs.
- Expose RP write outcome to clients in dev via CORS-exposed response headers (`x-rp-compression-cache-write` and `x-rp-compression-cache-error`) and include debug info in non-streaming JSON payloads when appropriate.
- Client-side RP request now sends a `debug` flag when `import.meta.env.DEV` and displays clear dev notices (`RP压缩缓存写入成功` or `RP压缩缓存写入失败：{error.message}`) based on response headers (`src/pages/RpRoomPage.tsx`).

### Testing
- Ran `npm run lint` which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to this change. (success)
- Ran `npm run build` and produced a successful production build. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aeb3ca9148330afe4736a72b39677)