### PR TITLE
RP — Add Narration (旁白) send mode (single input, extra button)

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -92,6 +92,10 @@
   justify-content: flex-end;
 }
 
+.rp-message.narration {
+  justify-content: center;
+}
+
 .rp-bubble {
   max-width: 75%;
   background: #fff;
@@ -103,6 +107,16 @@
 .rp-message.out .rp-bubble {
   background: #0f172a;
   color: #fff;
+}
+
+.rp-message.narration .rp-bubble {
+  width: min(100%, 640px);
+  max-width: 100%;
+  background: #f8fafc;
+  color: #475569;
+  text-align: center;
+  box-shadow: none;
+  border: 1px dashed #cbd5e1;
 }
 
 .rp-bubble p {
@@ -120,6 +134,10 @@
 
 .rp-message.out .rp-speaker {
   color: #cbd5e1;
+}
+
+.rp-message.narration .rp-speaker {
+  color: #64748b;
 }
 
 .rp-message-actions .ghost {
@@ -200,6 +218,22 @@
   font-size: 14px;
   cursor: pointer;
   align-self: flex-end;
+}
+
+.rp-composer-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.rp-composer-actions .ghost {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #334155;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-size: 14px;
+  cursor: pointer;
 }
 
 .rp-dashboard-page h2 {


### PR DESCRIPTION
### Motivation

- Allow players to send narration messages from the same composer input so narration can be stored and rendered distinctly from player dialogue.
- Ensure narration is included in NPC model context with a clear `【旁白】` speaker label without embedding labels into stored content.
- Keep existing player send behavior and export format unchanged while providing a separate UI affordance for narration.

### Description

- `handleSend` now accepts a mode parameter (`'player' | 'narration'`) and writes narration messages to `rp_messages` with `role = "旁白"` and `meta.kind = "narration"` while leaving `content` unchanged (`src/pages/RpRoomPage.tsx`).
- Composer UI updated to keep the single textarea and add a second button: `发送` (player) and `旁白` (narration) that both use the same input (`src/pages/RpRoomPage.tsx`).
- Message rendering detects narration via `role === '旁白'` or `meta.kind === 'narration'` and applies a centered/full-width, subtle bubble style and a dedicated `narration` class so narration is visually distinct and not treated as assistant markdown (`src/pages/RpRoomPage.tsx`, `src/pages/RpRoomPage.css`).
- NPC prompt assembly now marks narration lines as `【旁白】{content}` when building `messagesPayload`, while stored DB `content` remains plain text (no embedded label) (`src/pages/RpRoomPage.tsx`).

### Testing

- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and it passed (one pre-existing warning in `src/pages/CheckinPage.tsx`).
- Started the dev server and ran a headless Playwright script to capture a UI screenshot to validate the composer and narration rendering visually (screenshot captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af6170c44833099be7f591d1843b5)