### PR TITLE
Add RP room reasoning toggle and send reasoning parameter for NPC requests

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -322,6 +322,19 @@
   background: #fff;
 }
 
+.rp-reasoning-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 4px;
+  color: #334155;
+  font-weight: 500;
+}
+
+.rp-reasoning-toggle input {
+  margin: 0;
+}
+
 .rp-npc-list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
### Motivation
- RP NPC replies were not requesting Claude/Anthropic reasoning because the RP UI never sent `reasoning: true` in the request payload, so thinking-chain content never arrived for the frontend to show.
- A room-level toggle is needed so reasoning can be enabled during active RP sessions and persisted per-room.

### Description
- Added a room-level reasoning toggle checkbox `思考链（房间）` to the RP trigger area and corresponding CSS styling in `src/pages/RpRoomPage.css`.
- Introduced `RP_ROOM_ENABLE_REASONING_KEY = 'enable_reasoning'` and initialized local toggle state from `room.settings` via `readRoomReasoningEnabled` in `src/pages/RpRoomPage.tsx`.
- Wired RPC request construction so NPC requests include `reasoning: true` when the room toggle is enabled and send a `thinking` config for Claude/Anthropic models (matching chitchat behavior). The request code is updated in `requestNpcReply` and callers in `handleTriggerNpcReply` now pass the `reasoning` flag.
- Persisted the per-room setting via `updateRpSessionDashboard(..., { settings })` and added `handleToggleRoomReasoning` to update room settings immediately when the toggle is changed.

### Testing
- Ran `npm run lint` which completed successfully (one unrelated warning remains in `src/pages/CheckinPage.tsx`).
- Ran `npm run build` which completed successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afe1443288330ac6cd426b62bab26)