### PR TITLE
RP Rooms: show message count per room in active/archived lists

### DIFF
--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -96,6 +96,19 @@
   margin: 0;
 }
 
+.rp-room-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.rp-room-count {
+  color: #6b7280;
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
 .rp-room-item p {
   margin: 0.35rem 0 0;
   color: #6b7280;
@@ -137,6 +150,10 @@
 
   .rp-room-actions {
     justify-content: flex-start;
+  }
+
+  .rp-room-title-row {
+    flex-wrap: wrap;
   }
 
   .rp-rename-row input {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -526,6 +526,37 @@ export const fetchRpMessages = async (sessionId: string, userId: string): Promis
   return (data ?? []).map((row) => mapRpMessageRow(row as RpMessageRow))
 }
 
+export const fetchRpMessageCounts = async (
+  userId: string,
+  sessionIds: string[],
+): Promise<Record<string, number>> => {
+  if (!supabase || sessionIds.length === 0) {
+    return {}
+  }
+
+  const { data, error } = await supabase
+    .from('rp_messages')
+    .select('session_id')
+    .eq('user_id', userId)
+    .in('session_id', sessionIds)
+
+  if (error) {
+    throw error
+  }
+
+  const counts = sessionIds.reduce<Record<string, number>>((accumulator, sessionId) => {
+    accumulator[sessionId] = 0
+    return accumulator
+  }, {})
+
+  const rows = (data ?? []) as Array<{ session_id: string }>
+  rows.forEach((row) => {
+    counts[row.session_id] = (counts[row.session_id] ?? 0) + 1
+  })
+
+  return counts
+}
+
 export const createRpMessage = async (
   sessionId: string,
   userId: string,


### PR DESCRIPTION
### Motivation
- Let users quickly judge RP room size/activity by showing a per-room message count in the rooms list similar to Daily Chat sessions.  
- Avoid N+1 queries when loading counts for multiple visible rooms by batching the counts fetch into a single query.

### Description
- Added `fetchRpMessageCounts(userId, sessionIds)` in `src/storage/supabaseSync.ts` which queries `public.rp_messages` for the visible `session_id`s and aggregates counts by `session_id` in one request.  
- Updated `src/pages/RpRoomsPage.tsx` to load message counts asynchronously after rooms render, with state `roomMessageCounts` and `countsLoading`, a cancellation guard to avoid stale updates, and a non-blocking placeholder `… 条消息` while counts load.  
- Render `X 条消息` on each room card for both active and archived tabs and keep existing create/enter/rename/archive/delete flows unchanged.  
- Added layout styles in `src/pages/RpRoomsPage.css` (`.rp-room-title-row`, `.rp-room-count`) and responsive wrapping to preserve clean mobile/desktop layouts.

### Testing
- Ran `npm run lint` which completed successfully (one unrelated existing warning remains in `src/pages/CheckinPage.tsx`).  
- Ran `npm run build` which completed successfully.  
- Launched the dev server and ran an automated Playwright script to load `/rp` and capture a screenshot, which succeeded and produced an artifact showing the UI with message counts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b01046a4c833080011af4943e169d)