### PR TITLE
Shift RP history assembly to server and add per-room RP context/keep settings

### DIFF
--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -110,6 +110,8 @@ type RpSessionRow = {
   player_display_name: string | null
   player_avatar_url: string | null
   worldbook_text: string | null
+  rp_context_token_limit: number | null
+  rp_keep_recent_messages: number | null
   settings: Record<string, unknown> | null
 }
 
@@ -209,11 +211,13 @@ const mapRpSessionRow = (row: RpSessionRow): RpSession => ({
   playerDisplayName: row.player_display_name,
   playerAvatarUrl: row.player_avatar_url,
   worldbookText: row.worldbook_text,
+  rpContextTokenLimit: row.rp_context_token_limit,
+  rpKeepRecentMessages: row.rp_keep_recent_messages,
   settings: row.settings ?? {},
 })
 
 const RP_SESSION_SELECT_FIELDS =
-  'id,user_id,title,created_at,updated_at,is_archived,archived_at,player_display_name,player_avatar_url,worldbook_text,settings'
+  'id,user_id,title,created_at,updated_at,is_archived,archived_at,player_display_name,player_avatar_url,worldbook_text,rp_context_token_limit,rp_keep_recent_messages,settings'
 
 const mapRpMessageRow = (row: RpMessageRow): RpMessage => ({
   id: row.id,
@@ -466,6 +470,8 @@ export const updateRpSessionDashboard = async (
     playerAvatarUrl?: string
     worldbookText?: string
     settings?: Record<string, unknown>
+    rpContextTokenLimit?: number
+    rpKeepRecentMessages?: number
   },
 ): Promise<RpSession> => {
   if (!supabase) {
@@ -478,6 +484,8 @@ export const updateRpSessionDashboard = async (
     player_avatar_url?: string
     worldbook_text?: string
     settings?: Record<string, unknown>
+    rp_context_token_limit?: number
+    rp_keep_recent_messages?: number
   } = {
     updated_at: new Date().toISOString(),
   }
@@ -493,6 +501,12 @@ export const updateRpSessionDashboard = async (
   }
   if (typeof updates.settings !== 'undefined') {
     nextUpdates.settings = updates.settings
+  }
+  if (typeof updates.rpContextTokenLimit !== 'undefined') {
+    nextUpdates.rp_context_token_limit = updates.rpContextTokenLimit
+  }
+  if (typeof updates.rpKeepRecentMessages !== 'undefined') {
+    nextUpdates.rp_keep_recent_messages = updates.rpKeepRecentMessages
   }
 
   const { data, error } = await supabase

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,8 @@ export type RpSession = {
   playerDisplayName: string | null
   playerAvatarUrl: string | null
   worldbookText: string | null
+  rpContextTokenLimit: number | null
+  rpKeepRecentMessages: number | null
   settings: Record<string, unknown>
 }
 

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -43,6 +43,12 @@ type UserCompressionSettings = {
   summarizer_model: string | null
 }
 
+type RpSessionCompressionSettingsRow = {
+  rp_context_token_limit: number | null
+  rp_keep_recent_messages: number | null
+  settings: Record<string, unknown> | null
+}
+
 type AuthUserResponse = {
   id: string
 }
@@ -126,12 +132,15 @@ const resolveCompressionModule = (payload: OpenRouterPayload): 'chat' | 'rp' | n
 }
 
 const DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_CHAT = 20
-const DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_RP = 12
-const MAX_RECENT_UNCOMPRESSED_MESSAGES_RP = 12
+const DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_RP = 10
+const MIN_RECENT_UNCOMPRESSED_MESSAGES_RP = 5
+const MAX_RECENT_UNCOMPRESSED_MESSAGES_RP = 20
 const MIN_EXTRA_MESSAGES_FOR_COMPRESSION = 10
-const MIN_NEW_MESSAGES_TO_REFRESH_SUMMARY = 8
+const MIN_NEW_MESSAGES_BEFORE_RESUMMARIZE = 5
 const DEFAULT_CONTEXT_TRIGGER_RATIO = 0.65
-const RP_UNIFIED_CONTEXT_WINDOW_TOKENS = 128000
+const DEFAULT_RP_CONTEXT_TOKEN_LIMIT = 32000
+const MIN_RP_CONTEXT_TOKEN_LIMIT = 8000
+const MAX_RP_CONTEXT_TOKEN_LIMIT = 128000
 const TOKEN_OVERHEAD_PER_MESSAGE = 8
 const CHAT_SUMMARY_MARKER = 'CHAT SUMMARY:'
 const RP_SUMMARY_MARKER = '以下为截至目前的剧情摘要：'
@@ -348,6 +357,40 @@ const fetchUserCompressionSettings = async (
   return rows[0] ?? null
 }
 
+const fetchRpSessionCompressionSettings = async (
+  origin: string,
+  authHeader: string,
+  apikey: string,
+  conversationId: string,
+): Promise<RpSessionCompressionSettingsRow | null> => {
+  const query = new URLSearchParams({
+    select: 'rp_context_token_limit,rp_keep_recent_messages,settings',
+    id: `eq.${conversationId}`,
+    limit: '1',
+  })
+  const response = await fetch(`${origin}/rest/v1/rp_sessions?${query.toString()}`, {
+    headers: {
+      apikey,
+      Authorization: authHeader,
+    },
+  })
+  if (!response.ok) {
+    throw new Error('load rp session settings failed')
+  }
+  const rows = (await response.json()) as Array<Record<string, unknown>>
+  const row = rows[0]
+  if (!row) {
+    return null
+  }
+  return {
+    rp_context_token_limit: typeof row.rp_context_token_limit === 'number' ? row.rp_context_token_limit : null,
+    rp_keep_recent_messages: typeof row.rp_keep_recent_messages === 'number' ? row.rp_keep_recent_messages : null,
+    settings: typeof row.settings === 'object' && row.settings
+      ? row.settings as Record<string, unknown>
+      : null,
+  }
+}
+
 const summarizeCompressedWindow = async (
   apiKey: string,
   summarizerModel: string,
@@ -427,14 +470,26 @@ const maybeCompressRuntimeContext = async (
     }
     const compressionTriggerRatio = userSettings?.compression_trigger_ratio ?? DEFAULT_CONTEXT_TRIGGER_RATIO
     const rawKeepRecentMessages = userSettings?.compression_keep_recent_messages
-    const defaultKeepRecentMessages =
+    const rpSessionCompressionSettings =
       compressionModule === 'rp'
-        ? DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_RP
-        : DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_CHAT
+        ? await fetchRpSessionCompressionSettings(origin, authHeader, apiKeyHeader, conversationId)
+        : null
+    const fallbackRpKeepRecentMessagesFromSettings =
+      rpSessionCompressionSettings?.settings && typeof rpSessionCompressionSettings.settings.compression_keep_recent_messages === 'number'
+        ? rpSessionCompressionSettings.settings.compression_keep_recent_messages
+        : null
+    const rpKeepRecentMessages =
+      rpSessionCompressionSettings?.rp_keep_recent_messages
+      ?? fallbackRpKeepRecentMessagesFromSettings
+      ?? rawKeepRecentMessages
+      ?? DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_RP
     const keepRecentMessages =
       compressionModule === 'rp'
-        ? Math.min(rawKeepRecentMessages ?? defaultKeepRecentMessages, MAX_RECENT_UNCOMPRESSED_MESSAGES_RP)
-        : (rawKeepRecentMessages ?? defaultKeepRecentMessages)
+        ? Math.min(
+            Math.max(rpKeepRecentMessages, MIN_RECENT_UNCOMPRESSED_MESSAGES_RP),
+            MAX_RECENT_UNCOMPRESSED_MESSAGES_RP,
+          )
+        : (rawKeepRecentMessages ?? DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_CHAT)
     const summarizerModel = userSettings?.summarizer_model?.trim()
       || userSettings?.default_model?.trim()
       || DEFAULT_SUMMARIZER_MODEL
@@ -455,9 +510,22 @@ const maybeCompressRuntimeContext = async (
         ? fullHistory.map((message) => ({ role: 'assistant', content: `【${message.role}】${message.content}` }))
         : fullHistory.map((message) => ({ role: message.role, content: message.content }))
     const contextEstimate = estimateTotalTokens([...systemMessages, ...fullAsMessages])
+    const fallbackRpContextLimitFromSettings =
+      rpSessionCompressionSettings?.settings && typeof rpSessionCompressionSettings.settings.rp_context_token_limit === 'number'
+        ? rpSessionCompressionSettings.settings.rp_context_token_limit
+        : null
+    const rpContextTokenLimit = Math.min(
+      Math.max(
+        rpSessionCompressionSettings?.rp_context_token_limit
+          ?? fallbackRpContextLimitFromSettings
+          ?? DEFAULT_RP_CONTEXT_TOKEN_LIMIT,
+        MIN_RP_CONTEXT_TOKEN_LIMIT,
+      ),
+      MAX_RP_CONTEXT_TOKEN_LIMIT,
+    )
     const baseContextLimit =
       compressionModule === 'rp'
-        ? RP_UNIFIED_CONTEXT_WINDOW_TOKENS
+        ? rpContextTokenLimit
         : estimateModelContextLimit(payload.model ?? 'openrouter/auto')
     const triggerLimit = Math.floor(baseContextLimit * compressionTriggerRatio)
     if (contextEstimate < triggerLimit) {
@@ -480,10 +548,45 @@ const maybeCompressRuntimeContext = async (
       summaryText = ''
     }
 
+    const hasValidCachedSummary = Boolean(cache?.summary_text?.trim())
+    const newMessagesCount = targetBoundaryIndex - cacheBoundaryIndex
+    if (hasValidCachedSummary && newMessagesCount < MIN_NEW_MESSAGES_BEFORE_RESUMMARIZE) {
+      const compressedUpToIndex = summaryText ? cacheBoundaryIndex : -1
+      const remainingMessages =
+        compressionModule === 'rp'
+          ? fullHistory.slice(compressedUpToIndex + 1).map((message) => ({
+              role: 'assistant',
+              content: `【${message.role}】${message.content}`,
+            }))
+          : fullHistory.slice(compressedUpToIndex + 1).map((message) => ({
+              role: message.role,
+              content: message.content,
+            }))
+
+      const summarizedMessages: OpenAiMessage[] = [
+        ...systemMessages,
+        {
+          role: 'system',
+          content:
+            compressionModule === 'rp'
+              ? `${RP_SUMMARY_MARKER}${summaryText}`
+              : `${CHAT_SUMMARY_MARKER}\n${summaryText}`,
+        },
+        ...remainingMessages,
+      ]
+
+      return {
+        messages: summarizedMessages,
+        cacheWriteFailed,
+        cacheWriteSucceeded,
+        cacheWriteErrorMessage,
+      }
+    }
+
     const uncachedCompressibleMessages = targetBoundaryIndex - cacheBoundaryIndex
     const shouldRefreshSummary =
       !summaryText
-      || uncachedCompressibleMessages >= MIN_NEW_MESSAGES_TO_REFRESH_SUMMARY
+      || uncachedCompressibleMessages >= MIN_NEW_MESSAGES_BEFORE_RESUMMARIZE
 
     if (shouldRefreshSummary && cacheBoundaryIndex < targetBoundaryIndex) {
       const newChunkStart = Math.max(cacheBoundaryIndex + 1, 0)

--- a/supabase/migrations/20260223120000_add_rp_compression_columns.sql
+++ b/supabase/migrations/20260223120000_add_rp_compression_columns.sql
@@ -1,0 +1,3 @@
+alter table public.rp_sessions
+  add column if not exists rp_context_token_limit integer not null default 32000,
+  add column if not exists rp_keep_recent_messages integer not null default 10;


### PR DESCRIPTION
### Motivation
- Ensure the Edge Function is authoritative for assembling and compressing RP conversation history so all NPCs in a room see identical summaries and recent messages. 
- Limit client-side payload size by stopping frontend full-history assembly and moving compression controls to server-side room settings. 
- Expose room-level controls for RP context size and keep-recent window so authors can tune compression/memory behavior per session.

### Description
- Frontend: updated `src/pages/RpRoomPage.tsx` to stop sending client-assembled full history and instead send `conversationId` plus system context and only the latest user-like input; removed `rpKeepRecentMessages` from the request body and added dashboard UI + validation inputs for `保留最近消息数` and `上下文 Token 上限` (defaults: `10` and `32000`, ranges `5–20` and `8000–128000`).
- Backend Edge Function: updated `supabase/functions/openrouter-chat/index.ts` to fetch RP session compression settings from `rp_sessions`, apply room-level `rp_context_token_limit` and `rp_keep_recent_messages` (with clamping and defaults), use the room token limit when deciding whether to trigger compression, and preserve re-summary throttling so summarizer refreshes only after >= `5` new messages (or on empty cache).
- Storage/types: extended mappings and types in `src/storage/supabaseSync.ts` and `src/types.ts` to include `rp_context_token_limit` and `rp_keep_recent_messages`, and wired `updateRpSessionDashboard` to persist the two new fields from the dashboard.
- Migration: added `supabase/migrations/20260223120000_add_rp_compression_columns.sql` to add `rp_context_token_limit integer not null default 32000` and `rp_keep_recent_messages integer not null default 10` to `rp_sessions`.

### Testing
- Ran `npm run build` and the production build completed successfully. (passed)
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app loads. (passed)
- Captured a Playwright screenshot of the RP dashboard to validate the new `保留最近消息数` and `上下文 Token 上限` fields. (artifact generated successfully)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699be53034308330b1d9577b51b61a9f)