### PR TITLE
Enforce RP compression token ceiling by dynamically trimming recent messages and improve cache upsert diagnostics

### DIFF
--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -135,6 +135,7 @@ const resolveCompressionModule = (payload: OpenRouterPayload): 'chat' | 'rp' | n
 const DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_CHAT = 20
 const DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_RP = 10
 const MIN_RECENT_UNCOMPRESSED_MESSAGES_RP = 5
+const MIN_DYNAMIC_KEEP_RECENT_MESSAGES_RP = 3
 const MAX_RECENT_UNCOMPRESSED_MESSAGES_RP = 20
 const MIN_EXTRA_MESSAGES_FOR_COMPRESSION = 10
 const MIN_NEW_MESSAGES_BEFORE_RESUMMARIZE = 5
@@ -293,14 +294,75 @@ const upsertCompressionCache = async (
     .from('compression_cache')
     .upsert(
       {
-      module,
-      conversation_id: conversationId,
-      compressed_up_to_message_id: compressedUpToMessageId,
-      summary_text: summaryText,
-      updated_at: new Date().toISOString(),
+        module,
+        conversation_id: conversationId,
+        compressed_up_to_message_id: compressedUpToMessageId,
+        summary_text: summaryText,
+        updated_at: new Date().toISOString(),
       },
-      { onConflict: 'module,conversation_id,compressed_up_to_message_id' },
+      { onConflict: 'module,conversation_id' },
     )
+}
+
+const formatHistoryMessagesForCompression = (
+  compressionModule: 'chat' | 'rp',
+  fullHistory: StoredMessageRow[],
+): OpenAiMessage[] => (compressionModule === 'rp'
+  ? fullHistory.map((message) => ({ role: 'assistant', content: `【${message.role}】${message.content}` }))
+  : fullHistory.map((message) => ({ role: message.role, content: message.content })))
+
+const buildSummarizedMessages = (
+  compressionModule: 'chat' | 'rp',
+  systemMessages: OpenAiMessage[],
+  summaryText: string,
+  fullHistory: StoredMessageRow[],
+  compressedUpToIndex: number,
+  keepRecentMessages: number,
+  rpContextTokenLimit: number,
+  conversationId: string,
+): { summarizedMessages: OpenAiMessage[]; effectiveKeepRecentMessages: number } => {
+  const summaryMessage: OpenAiMessage = {
+    role: 'system',
+    content:
+      compressionModule === 'rp'
+        ? `${RP_SUMMARY_MARKER}${summaryText}`
+        : `${CHAT_SUMMARY_MARKER}\n${summaryText}`,
+  }
+  const fullRecentHistory = fullHistory.slice(compressedUpToIndex + 1)
+  let effectiveKeepRecentMessages = keepRecentMessages
+  let recentHistorySlice =
+    compressionModule === 'rp' ? fullRecentHistory.slice(-effectiveKeepRecentMessages) : fullRecentHistory
+  let summarizedMessages: OpenAiMessage[] = [
+    ...systemMessages,
+    summaryMessage,
+    ...formatHistoryMessagesForCompression(compressionModule, recentHistorySlice),
+  ]
+
+  if (compressionModule === 'rp' && rpContextTokenLimit > 0) {
+    while (
+      estimateTotalTokens(summarizedMessages) > rpContextTokenLimit
+      && effectiveKeepRecentMessages > MIN_DYNAMIC_KEEP_RECENT_MESSAGES_RP
+    ) {
+      effectiveKeepRecentMessages -= 1
+      recentHistorySlice = fullRecentHistory.slice(-effectiveKeepRecentMessages)
+      summarizedMessages = [
+        ...systemMessages,
+        summaryMessage,
+        ...formatHistoryMessagesForCompression(compressionModule, recentHistorySlice),
+      ]
+    }
+
+    if (estimateTotalTokens(summarizedMessages) > rpContextTokenLimit) {
+      console.warn('rp compression output still exceeds context token limit', {
+        conversationId,
+        rpContextTokenLimit,
+        finalTokens: estimateTotalTokens(summarizedMessages),
+        effectiveKeepRecentMessages,
+      })
+    }
+  }
+
+  return { summarizedMessages, effectiveKeepRecentMessages }
 }
 
 const fetchRpConversationMessages = async (
@@ -506,10 +568,7 @@ const maybeCompressRuntimeContext = async (
 
     const preCompressionTokens = estimateTotalTokens(messages)
 
-    const fullAsMessages: OpenAiMessage[] =
-      compressionModule === 'rp'
-        ? fullHistory.map((message) => ({ role: 'assistant', content: `【${message.role}】${message.content}` }))
-        : fullHistory.map((message) => ({ role: message.role, content: message.content }))
+    const fullAsMessages: OpenAiMessage[] = formatHistoryMessagesForCompression(compressionModule, fullHistory)
     const contextEstimate = estimateTotalTokens([...systemMessages, ...fullAsMessages])
     const fallbackRpContextLimitFromSettings =
       rpSessionCompressionSettings?.settings && typeof rpSessionCompressionSettings.settings.rp_context_token_limit === 'number'
@@ -553,28 +612,16 @@ const maybeCompressRuntimeContext = async (
     const newMessagesCount = targetBoundaryIndex - cacheBoundaryIndex
     if (hasValidCachedSummary && newMessagesCount < MIN_NEW_MESSAGES_BEFORE_RESUMMARIZE) {
       const compressedUpToIndex = summaryText ? cacheBoundaryIndex : -1
-      const remainingMessages =
-        compressionModule === 'rp'
-          ? fullHistory.slice(compressedUpToIndex + 1).map((message) => ({
-              role: 'assistant',
-              content: `【${message.role}】${message.content}`,
-            }))
-          : fullHistory.slice(compressedUpToIndex + 1).map((message) => ({
-              role: message.role,
-              content: message.content,
-            }))
-
-      const summarizedMessages: OpenAiMessage[] = [
-        ...systemMessages,
-        {
-          role: 'system',
-          content:
-            compressionModule === 'rp'
-              ? `${RP_SUMMARY_MARKER}${summaryText}`
-              : `${CHAT_SUMMARY_MARKER}\n${summaryText}`,
-        },
-        ...remainingMessages,
-      ]
+      const { summarizedMessages } = buildSummarizedMessages(
+        compressionModule,
+        systemMessages,
+        summaryText,
+        fullHistory,
+        compressedUpToIndex,
+        keepRecentMessages,
+        rpContextTokenLimit,
+        conversationId,
+      )
 
       return {
         messages: summarizedMessages,
@@ -617,10 +664,13 @@ const maybeCompressRuntimeContext = async (
           )
           if (error) {
             cacheWriteFailed = true
-            cacheWriteErrorMessage = error.message
+            cacheWriteErrorMessage = [error.code, error.message, error.details, error.hint]
+              .filter((field) => typeof field === 'string' && field.trim().length > 0)
+              .join(' | ')
             console.error('compression_cache upsert failed', {
               module: compressionModule,
               conversationId,
+              compressedUpToMessageId: refreshBoundaryId,
               error,
             })
           } else {
@@ -637,32 +687,20 @@ const maybeCompressRuntimeContext = async (
       }
     }
 
-    const compressedUpToIndex = summaryText ? cacheBoundaryIndex : -1
-    const remainingMessages =
-      compressionModule === 'rp'
-        ? fullHistory.slice(compressedUpToIndex + 1).map((message) => ({
-            role: 'assistant',
-            content: `【${message.role}】${message.content}`,
-          }))
-        : fullHistory.slice(compressedUpToIndex + 1).map((message) => ({
-            role: message.role,
-            content: message.content,
-          }))
-
     if (!summaryText) {
       return { messages, cacheWriteFailed, cacheWriteSucceeded, cacheWriteErrorMessage }
     }
-    const summarizedMessages: OpenAiMessage[] = [
-      ...systemMessages,
-      {
-        role: 'system',
-        content:
-          compressionModule === 'rp'
-            ? `${RP_SUMMARY_MARKER}${summaryText}`
-            : `${CHAT_SUMMARY_MARKER}\n${summaryText}`,
-      },
-      ...remainingMessages,
-    ]
+    const compressedUpToIndex = summaryText ? cacheBoundaryIndex : -1
+    const { summarizedMessages, effectiveKeepRecentMessages } = buildSummarizedMessages(
+      compressionModule,
+      systemMessages,
+      summaryText,
+      fullHistory,
+      compressedUpToIndex,
+      keepRecentMessages,
+      rpContextTokenLimit,
+      conversationId,
+    )
 
     const finalTokens = estimateTotalTokens(summarizedMessages)
     const reductionRatio = preCompressionTokens > 0
@@ -675,7 +713,7 @@ const maybeCompressRuntimeContext = async (
         preCompressionTokens,
         finalTokens,
         reductionRatio,
-        keepRecentMessages,
+        keepRecentMessages: effectiveKeepRecentMessages,
       })
     }
 


### PR DESCRIPTION
### Motivation
- RP conversations can contain very long messages so a fixed `keepRecentMessages` still allowed compressed context to exceed `rp_context_token_limit`, causing oversized requests.
- Compression cache upserts were brittle because the conflict key included `compressed_up_to_message_id`, and reported errors lacked actionable details for debugging.

### Description
- Add `MIN_DYNAMIC_KEEP_RECENT_MESSAGES_RP` and implement a post-compression loop in `buildSummarizedMessages` that reduces the retained recent RP messages down to a hard floor (3) while checking `estimateTotalTokens` against `rp_context_token_limit`, with a warning if the limit is still exceeded.
- Centralize message formatting and summarized-context assembly with `formatHistoryMessagesForCompression` and `buildSummarizedMessages` so both cache-hit and refreshed-summary paths use the same token-fitting logic.
- Change `upsertCompressionCache` conflict key to `module,conversation_id` to match single-row-per-conversation semantics and avoid upsert conflicts.
- Improve cache upsert failure diagnostics by composing `cacheWriteErrorMessage` from `error.code`, `error.message`, `error.details`, and `error.hint`, and include `compressedUpToMessageId` in failure logs.
- All changes are contained in `supabase/functions/openrouter-chat/index.ts` and preserve existing warning behavior when compression reduction is below expectation.

### Testing
- Ran `npm run lint` which completed successfully (one pre-existing warning in `src/pages/CheckinPage.tsx`).
- Ran `npm run build` which completed successfully and produced the production build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf2f6df408330bc1ec87c5b470109)