### PR TITLE
Add structured compression_cache upsert diagnostics, DB unique-key migration, and RP token ceiling enforcement

### DIFF
--- a/supabase/migrations/20260223133000_update_compression_cache_unique_constraint.sql
+++ b/supabase/migrations/20260223133000_update_compression_cache_unique_constraint.sql
@@ -1,0 +1,16 @@
+alter table public.compression_cache
+  drop constraint if exists compression_cache_module_conv_msg_key;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'compression_cache_module_conv_key'
+      and conrelid = 'public.compression_cache'::regclass
+  ) then
+    alter table public.compression_cache
+      add constraint compression_cache_module_conv_key unique (module, conversation_id);
+  end if;
+end
+$$;


### PR DESCRIPTION
### Motivation
- Prevent opaque/trimmed Supabase errors by logging full Postgres/Supabase error fields for `compression_cache` upserts. 
- Ensure upserts reliably overwrite a single per-conversation row by aligning the runtime `onConflict` target with the DB unique constraint. 
- Avoid oversized RP compression outputs by dynamically trimming recent messages until a hard floor while checking estimated token usage.

### Description
- Replace the previous `upsertCompressionCache` return-without-check by awaiting the result and logging a JSON payload with `message`, `code`, `details`, and `hint` when `result.error` is present, and returning the full result. 
- Change the runtime upsert conflict key to `onConflict: 'module,conversation_id'` and add a migration `supabase/migrations/20260223133000_update_compression_cache_unique_constraint.sql` that drops the old `(module, conversation_id, compressed_up_to_message_id)` constraint and ensures a unique constraint on `(module, conversation_id)`. 
- Store `cacheWriteErrorMessage` as a structured JSON string containing `message`, `code`, `details`, and `hint`, and log that same JSON string where cache upsert failures occur for easier inspection in edge logs/headers. 
- Centralize message formatting via `formatHistoryMessagesForCompression` and implement `buildSummarizedMessages` which applies a post-compression loop for `rp` that reduces `effectiveKeepRecentMessages` down to a floor (`MIN_DYNAMIC_KEEP_RECENT_MESSAGES_RP`) while comparing `estimateTotalTokens` against `rp_context_token_limit`, and emits a warning if the limit is still exceeded.

### Testing
- Ran `npm run lint`, which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx`. 
- Ran `npm run build`, which completed successfully and produced production artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf2f6df408330bc1ec87c5b470109)