### PR TITLE
Fix iOS Safari chat input zoom and keyboard layout stability

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -21,3 +21,19 @@ body {
 #root {
   min-height: 100vh;
 }
+
+
+@media (max-width: 768px) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+
+  body.chat-page-active {
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+}

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -1,8 +1,17 @@
 .chat-page {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  height: 100vh;
+  min-height: 100vh;
   min-height: 100dvh;
   background: #f1f5f9;
+  overflow: hidden;
+}
+
+@supports (height: 100dvh) {
+  .chat-page {
+    height: 100dvh;
+  }
 }
 
 .chat-header {
@@ -79,8 +88,11 @@
 }
 
 .chat-messages {
-  flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -277,6 +289,22 @@
   position: sticky;
   bottom: 0;
   z-index: 3;
+}
+
+@media (max-width: 768px) {
+  .chat-header {
+    position: sticky;
+    top: 0;
+  }
+
+  .chat-messages {
+    padding-bottom: calc(16px + env(safe-area-inset-bottom));
+  }
+
+  .chat-composer textarea,
+  .model-selector select {
+    font-size: 16px;
+  }
 }
 
 .streaming-status {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -114,6 +114,13 @@ const ChatPage = ({
   }, [messages.length])
 
   useEffect(() => {
+    document.body.classList.add('chat-page-active')
+    return () => {
+      document.body.classList.remove('chat-page-active')
+    }
+  }, [])
+
+  useEffect(() => {
     if (!openHeaderMenu) {
       return
     }


### PR DESCRIPTION
### Motivation
- iPhone Safari was auto-zooming when focusing form controls and causing layout jumps when the keyboard opened, breaking the chat composer/timeline UX.
- The goal is to prevent auto-zoom and keep the header fixed, timeline scrollable, and composer pinned without changing messaging logic.

### Description
- Enforce a mobile baseline of `font-size: 16px` for all `input`, `textarea`, and `select` via `src/index.css` under `@media (max-width: 768px)` to prevent iOS Safari auto-zoom.
- Convert the chat container to a bounded viewport layout in `src/pages/ChatPage.css` using a grid (`grid-template-rows: auto minmax(0, 1fr) auto`) and add `height: 100vh` with `100dvh` support and `overflow: hidden` to keep the page stable while allowing the message list to scroll internally.
- Harden the message scroller with `min-height: 0`, `overflow-y: auto`, `overscroll-behavior-y: contain`, and `-webkit-overflow-scrolling: touch` so the timeline retains touch momentum and prevents page bounce.
- Ensure composer textarea and model `select` render at `16px` on mobile and respect `env(safe-area-inset-bottom)` padding to remain visible above the keyboard.
- Add a mount/unmount effect in `src/pages/ChatPage.tsx` that toggles `body.chat-page-active` to lock body scroll while the chat is active (CSS handles `overflow: hidden`), keeping scroll inside the timeline.
- No messaging/send logic was modified; changes are CSS + one small lifecycle effect only.

### Testing
- Ran `npm run build` which completed successfully and produced a production build.
- Ran `npm run lint` which passed (a pre-existing unrelated warning remains in `src/pages/CheckinPage.tsx`).
- Launched the dev server and captured a mobile WebKit screenshot via Playwright (390×844) to visually validate the layout and keyboard-safe composer; screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c00c112408330af9ee3b203cd55f4)