### PR TITLE
PWA Setup — Wire up manifest, iOS metadata, and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%vite.svg" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="%BASE_URL%icons/pwa-180.png" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1f2937" />
     <title>ham</title>
   </head>
   <body>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "Hamster Nest",
+  "short_name": "HamNest",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "theme_color": "#1f2937",
+  "background_color": "#111827",
+  "icons": [
+    {
+      "src": "icons/pwa-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/pwa-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,74 @@
+const APP_SHELL_CACHE = 'hamster-nest-app-shell-v1'
+const RUNTIME_CACHE = 'hamster-nest-runtime-v1'
+
+const APP_SHELL_URLS = ['./', './index.html', './manifest.webmanifest']
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(APP_SHELL_CACHE)
+      .then((cache) => cache.addAll(APP_SHELL_URLS))
+      .then(() => self.skipWaiting()),
+  )
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => ![APP_SHELL_CACHE, RUNTIME_CACHE].includes(key))
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request
+
+  if (request.method !== 'GET') {
+    return
+  }
+
+  const url = new URL(request.url)
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(async () => {
+        const cache = await caches.open(APP_SHELL_CACHE)
+        return cache.match('./')
+      }),
+    )
+    return
+  }
+
+  if (url.origin !== self.location.origin) {
+    return
+  }
+
+  const isStaticAsset = ['style', 'script', 'worker', 'font', 'image'].includes(request.destination)
+
+  if (!isStaticAsset) {
+    return
+  }
+
+  event.respondWith(
+    caches.open(RUNTIME_CACHE).then(async (cache) => {
+      const cached = await cache.match(request)
+      const networkFetch = fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            cache.put(request, response.clone())
+          }
+          return response
+        })
+        .catch(() => cached)
+
+      return cached ?? networkFetch
+    }),
+  )
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,3 +11,11 @@ createRoot(document.getElementById('root')!).render(
     </HashRouter>
   </StrictMode>,
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch((error) => {
+      console.error('Service worker registration failed:', error)
+    })
+  })
+}


### PR DESCRIPTION
### Motivation
- Make the app installable as a Progressive Web App (desktop install + iOS “Add to Home Screen”) and provide a conservative app-shell caching strategy for faster reloads while avoiding caching API/user data.
- Ensure PWA assets and routes resolve correctly when deployed under the GitHub Pages repo base path used by the project.

### Description
- Added `public/manifest.webmanifest` with `name`, `short_name`, `start_url`, `scope`, `display: "standalone"`, colors, and `icons` entries that reference the existing `icons/pwa-192.png` and `icons/pwa-512.png` files.
- Updated `index.html` to include a manifest link, an iOS `apple-touch-icon` referencing the existing `icons/pwa-180.png`, `apple-mobile-web-app-capable` metadata, and a `theme-color` while preserving the existing viewport behavior.
- Added a minimal `public/sw.js` service worker that precaches the app shell (`./`, `./index.html`, `./manifest.webmanifest`), provides a navigation fallback to the cached shell when offline, and runtime-caches same-origin static assets (scripts/styles/fonts/images) while explicitly avoiding API/data caching.
- Registered the service worker in `src/main.tsx` using `import.meta.env.BASE_URL` so the SW and manifest paths resolve correctly for both local development and GitHub Pages production builds.

### Testing
- Ran `npm run build` which completed successfully and produced a production `dist/` with `dist/manifest.webmanifest`, `dist/sw.js`, and the existing `dist/icons/*` files.
- Verified build artifact listing via `find dist -maxdepth 3 -type f | sort` showing the manifest, service worker, and icons; the build step and artifact checks passed.
- No automated unit tests were present/modified; no API/data caching tests were run as the SW intentionally avoids caching non-static requests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c04f30b548330ad7b15364f303e86)