### PR TITLE
iOS Safari zoom fix, RP room auto-scroll, and per-message actions dropdown

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,10 +24,10 @@ body {
 
 
 @media (max-width: 768px) {
-  input,
-  textarea,
-  select {
-    font-size: 16px;
+  #root input:not([type='checkbox']):not([type='radio']),
+  #root textarea,
+  #root select {
+    font-size: 16px !important;
   }
 
   body.chat-page-active {

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -148,6 +148,54 @@
   cursor: pointer;
 }
 
+
+.rp-message-actions-menu {
+  position: relative;
+}
+
+.rp-action-trigger {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.rp-actions-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  display: flex;
+  flex-direction: column;
+  min-width: 92px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  z-index: 8;
+}
+
+.rp-actions-menu button {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: #1e293b;
+  cursor: pointer;
+}
+
+.rp-actions-menu button:hover {
+  background: #f8fafc;
+}
+
+.rp-actions-menu .danger {
+  color: #b91c1c;
+}
+
 .rp-composer-wrap {
   position: sticky;
   bottom: 0;


### PR DESCRIPTION
### Motivation

- Prevent iOS Safari from auto-zooming on focus by ensuring form controls render at least 16px on mobile. 
- Improve RP room UX by opening a room at the latest message and keeping the timeline pinned when new messages arrive. 
- Make per-message actions consistent with Daily Chat by replacing the inline delete with a `•••` menu that includes `复制` and `删除`.

### Description

- Add a mobile-only global rule to enforce `font-size: 16px !important` for `input`, `textarea`, and `select` inside `#root` to stop iOS Safari auto-zoom behavior (file: `src/index.css`).
- Add a bottom sentinel and auto-scroll logic to the RP timeline so the view scrolls to the latest message after messages load and when message count changes (file: `src/pages/RpRoomPage.tsx`).
- Replace the inline RP message delete button with a `•••` dropdown per message that contains `复制` and `删除`, including a click-outside handler to close the menu, and copy-to-clipboard behavior that shows feedback via existing `notice`/`error` state (files: `src/pages/RpRoomPage.tsx`, `src/pages/RpRoomPage.css`).
- Keep existing delete confirmation modal and backend delete behavior unchanged; copy uses `stripSpeakerPrefix(message.content)` to copy plain text.

### Testing

- Ran `npm run lint` and it completed successfully (the run shows one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`).
- Built the app with `npm run build` and the production build completed successfully.
- Started the dev server and captured a mobile viewport screenshot using Playwright to visually validate the RP room layout and menu; the script ran and produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c085c9bc083309822db207d7e9b9c)