### PR TITLE
feat: add iOS-style glass Home launcher with local widgets and drag-and-drop grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ import CheckinPage from './pages/CheckinPage'
 import ExportPage from './pages/ExportPage'
 import RpRoomsPage from './pages/RpRoomsPage'
 import RpRoomPage from './pages/RpRoomPage'
+import HomePage from './pages/HomePage'
 import {
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
@@ -166,6 +167,7 @@ const buildRecentExtractionMessages = (
 }
 
 const App = () => {
+  const navigate = useNavigate()
   const [sessions, setSessions] = useState<ChatSession[]>(initialSnapshot.sessions)
   const [messages, setMessages] = useState<ChatMessage[]>(initialSnapshot.messages)
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -1298,6 +1300,30 @@ const App = () => {
         <Route path="/auth" element={<AuthPage user={user} />} />
         <Route
           path="/"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <HomePage
+                user={user}
+                onOpenChat={() => {
+                  const latest = selectMostRecentSession(sessions)
+                  if (latest) {
+                    navigate(`/chat/${latest.id}`)
+                    return
+                  }
+                  void createSessionEntry().then((session) => {
+                    navigate(`/chat/${session.id}`)
+                  })
+                }}
+              />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/home"
+          element={<Navigate to="/" replace />}
+        />
+        <Route
+          path="/chat"
           element={
             <RequireAuth ready={authReady} user={user}>
               <NewSessionRedirect

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,0 +1,217 @@
+.home-page {
+  min-height: 100vh;
+  padding: max(env(safe-area-inset-top), 1rem) 1rem max(env(safe-area-inset-bottom), 1.25rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(125, 211, 252, 0.45), transparent 40%),
+    radial-gradient(circle at 80% 30%, rgba(167, 139, 250, 0.38), transparent 42%),
+    linear-gradient(180deg, #dbeafe 0%, #bfdbfe 45%, #dbeafe 100%);
+}
+
+.phone-shell {
+  width: min(420px, 100%);
+  min-height: min(880px, calc(100vh - 2rem));
+  border-radius: 36px;
+  padding: 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
+  backdrop-filter: blur(20px);
+  display: grid;
+  grid-template-rows: auto auto auto 1fr;
+  gap: 0.9rem;
+}
+
+.home-header {
+  text-align: center;
+  position: relative;
+}
+
+.home-header h1 {
+  margin: 0;
+  font-size: 3.5rem;
+  line-height: 1;
+  color: #0f172a;
+}
+
+.home-header p {
+  margin: 0.25rem 0 0;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+.edit-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.28);
+  color: #0f172a;
+  border-radius: 999px;
+  padding: 0.32rem 0.75rem;
+}
+
+.home-notice {
+  margin: 0;
+  text-align: center;
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.glass-card {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(12px);
+}
+
+.widget-toolbar {
+  padding: 0.6rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.widget-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.widget-slot {
+  min-height: 105px;
+}
+
+.widget-card {
+  height: 100%;
+  padding: 0.7rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.55rem;
+  position: relative;
+}
+
+.widget-placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 105px;
+  border-radius: 16px;
+  border: 1px dashed rgba(51, 65, 85, 0.4);
+  color: rgba(15, 23, 42, 0.45);
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+}
+
+.checkin-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.checkin-head .done {
+  color: #15803d;
+}
+
+.checkin-head .todo {
+  color: #b45309;
+}
+
+.checkin-metrics-mini {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.4rem;
+  color: #334155;
+  font-size: 0.78rem;
+}
+
+.widget-delete {
+  position: absolute;
+  top: 0.2rem;
+  right: 0.2rem;
+  border-radius: 999px;
+  border: none;
+  width: 1.45rem;
+  height: 1.45rem;
+  background: rgba(15, 23, 42, 0.7);
+  color: white;
+}
+
+.text-widget {
+  margin: 0;
+  color: #0f172a;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.image-widget {
+  width: 100%;
+  height: 100%;
+  min-height: 78px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.icons-grid {
+  margin-top: auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+  align-content: end;
+}
+
+.app-icon-button {
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  width: 100%;
+  border-radius: 22px;
+  padding: 0.85rem 0.6rem;
+  background: rgba(255, 255, 255, 0.24);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.14);
+  backdrop-filter: blur(10px);
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: #0f172a;
+}
+
+.icon-emoji {
+  display: inline-grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.icon-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.primary,
+.ghost {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 0.34rem 0.7rem;
+  color: #0f172a;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+@media (max-width: 420px) {
+  .phone-shell {
+    min-height: calc(100vh - 1rem);
+    border-radius: 28px;
+    padding: 0.85rem;
+  }
+
+  .home-header h1 {
+    font-size: 3rem;
+  }
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,491 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
+import {
+  createTodayCheckin,
+  fetchCheckinTotalCount,
+  fetchRecentCheckins,
+} from '../storage/supabaseSync'
+import {
+  loadHomeLayout,
+  loadImageBlob,
+  removeImageBlob,
+  saveHomeLayout,
+  saveImageBlob,
+  type DecorativeWidget,
+} from '../storage/homeLayout'
+import './HomePage.css'
+
+type HomePageProps = {
+  user: User | null
+  onOpenChat: () => void
+}
+
+type AppIcon = {
+  id: string
+  icon: string
+  label: string
+  route?: string
+  action?: () => void
+}
+
+const DEFAULT_ICON_ORDER = ['chat', 'checkin', 'memory', 'snacks', 'syzygy', 'rp', 'settings', 'export']
+const CORE_WIDGET_ID = 'widget-checkin'
+const MAX_WIDGETS = 6
+
+const formatDateKey = (date: Date) => {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const shiftDateKey = (dateKey: string, daysDelta: number) => {
+  const base = new Date(`${dateKey}T00:00:00`)
+  base.setDate(base.getDate() + daysDelta)
+  return formatDateKey(base)
+}
+
+const computeStreak = (dates: string[], todayKey: string) => {
+  const uniqueDates = Array.from(new Set(dates)).sort((a, b) => b.localeCompare(a))
+  const dateSet = new Set(uniqueDates)
+  const startDate = dateSet.has(todayKey) ? todayKey : shiftDateKey(todayKey, -1)
+  if (!dateSet.has(startDate)) {
+    return 0
+  }
+
+  let streak = 0
+  let cursor = startDate
+  while (dateSet.has(cursor)) {
+    streak += 1
+    cursor = shiftDateKey(cursor, -1)
+  }
+  return streak
+}
+
+const HomePage = ({ user, onOpenChat }: HomePageProps) => {
+  const navigate = useNavigate()
+  const [now, setNow] = useState(() => new Date())
+  const [checkinDates, setCheckinDates] = useState<string[]>([])
+  const [checkinTotal, setCheckinTotal] = useState(0)
+  const [checkinSubmitting, setCheckinSubmitting] = useState(false)
+  const [checkinLoading, setCheckinLoading] = useState(false)
+
+  const [editMode, setEditMode] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const [iconOrder, setIconOrder] = useState<string[]>(DEFAULT_ICON_ORDER)
+  const [widgetOrder, setWidgetOrder] = useState<string[]>([CORE_WIDGET_ID])
+  const [widgets, setWidgets] = useState<DecorativeWidget[]>([])
+  const [imageUrls, setImageUrls] = useState<Record<string, string>>({})
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const holdTimerRef = useRef<number | null>(null)
+
+  const appIcons = useMemo<AppIcon[]>(
+    () => [
+      { id: 'chat', icon: '💬', label: '聊天', action: onOpenChat },
+      { id: 'checkin', icon: '✅', label: '打卡', route: '/checkin' },
+      { id: 'memory', icon: '🧠', label: '囤囤库', route: '/memory-vault' },
+      { id: 'snacks', icon: '🍪', label: '零食罐罐', route: '/snacks' },
+      { id: 'syzygy', icon: '📘', label: '仓鼠日志', route: '/syzygy' },
+      { id: 'rp', icon: '🎭', label: 'RP 房间', route: '/rp' },
+      { id: 'settings', icon: '⚙️', label: '设置', route: '/settings' },
+      { id: 'export', icon: '📦', label: '导出', route: '/export' },
+    ],
+    [onOpenChat],
+  )
+
+  const iconMap = useMemo(() => new Map(appIcons.map((icon) => [icon.id, icon])), [appIcons])
+
+  const todayKey = useMemo(() => formatDateKey(now), [now])
+  const checkedToday = useMemo(() => checkinDates.includes(todayKey), [checkinDates, todayKey])
+  const streakDays = useMemo(() => computeStreak(checkinDates, todayKey), [checkinDates, todayKey])
+  const dateLabel = useMemo(
+    () =>
+      now.toLocaleDateString('zh-CN', {
+        month: 'long',
+        day: 'numeric',
+        weekday: 'short',
+      }),
+    [now],
+  )
+  const timeLabel = useMemo(
+    () =>
+      now.toLocaleTimeString('en-GB', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }),
+    [now],
+  )
+
+  const decoratedWidgetCount = useMemo(() => widgets.length + 1, [widgets.length])
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setNow(new Date())
+    }, 1000)
+    return () => window.clearInterval(intervalId)
+  }, [])
+
+  useEffect(() => {
+    const cached = loadHomeLayout()
+    if (!cached) {
+      return
+    }
+
+    const safeIconOrder = DEFAULT_ICON_ORDER.filter((id) => cached.iconOrder.includes(id))
+    const missing = DEFAULT_ICON_ORDER.filter((id) => !safeIconOrder.includes(id))
+    setIconOrder([...safeIconOrder, ...missing])
+
+    const safeWidgets = cached.widgets.filter((widget) => widget.type === 'image' || widget.type === 'text')
+    const widgetIds = safeWidgets.map((widget) => widget.id)
+    const restoredOrder = cached.widgetOrder.filter((id) => id === CORE_WIDGET_ID || widgetIds.includes(id))
+    setWidgets(safeWidgets)
+    setWidgetOrder(Array.from(new Set([CORE_WIDGET_ID, ...restoredOrder])))
+  }, [])
+
+  useEffect(() => {
+    saveHomeLayout({
+      iconOrder,
+      widgetOrder,
+      widgets,
+    })
+  }, [iconOrder, widgetOrder, widgets])
+
+  useEffect(() => {
+    const imageWidgets = widgets.filter((widget) => widget.type === 'image')
+    const disposed: string[] = []
+
+    void Promise.all(
+      imageWidgets.map(async (widget) => {
+        const blob = await loadImageBlob(widget.imageKey)
+        if (!blob) {
+          return null
+        }
+        return { id: widget.id, url: URL.createObjectURL(blob) }
+      }),
+    ).then((results) => {
+      setImageUrls((current) => {
+        Object.values(current).forEach((url) => {
+          if (!Object.values(current).includes(url)) {
+            URL.revokeObjectURL(url)
+          }
+        })
+        const next: Record<string, string> = {}
+        results.forEach((entry) => {
+          if (entry) {
+            next[entry.id] = entry.url
+          }
+        })
+        Object.entries(current).forEach(([id, url]) => {
+          if (!next[id]) {
+            disposed.push(url)
+          }
+        })
+        return next
+      })
+      disposed.forEach((url) => URL.revokeObjectURL(url))
+    })
+
+    return () => {
+      disposed.forEach((url) => URL.revokeObjectURL(url))
+    }
+  }, [widgets])
+
+  useEffect(
+    () => () => {
+      Object.values(imageUrls).forEach((url) => URL.revokeObjectURL(url))
+    },
+    [imageUrls],
+  )
+
+  const loadCheckinData = useCallback(async () => {
+    if (!user) {
+      return
+    }
+    setCheckinLoading(true)
+    try {
+      const [recent, total] = await Promise.all([fetchRecentCheckins(60), fetchCheckinTotalCount()])
+      setCheckinDates(recent.map((entry) => entry.checkinDate))
+      setCheckinTotal(total)
+    } catch (error) {
+      console.warn('加载打卡记录失败', error)
+      setNotice('加载打卡数据失败，请稍后重试')
+    } finally {
+      setCheckinLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    void loadCheckinData()
+  }, [loadCheckinData])
+
+  const handleCheckin = async () => {
+    if (!user || checkedToday || checkinSubmitting) {
+      return
+    }
+    setCheckinSubmitting(true)
+    try {
+      const result = await createTodayCheckin(todayKey)
+      setNotice(result === 'created' ? '打卡成功！' : '今日已打卡')
+      await loadCheckinData()
+    } catch (error) {
+      console.warn('打卡失败', error)
+      setNotice('打卡失败，请稍后重试')
+    } finally {
+      setCheckinSubmitting(false)
+    }
+  }
+
+  const moveInList = (list: string[], fromId: string, toIndex: number) => {
+    const fromIndex = list.indexOf(fromId)
+    if (fromIndex < 0 || toIndex < 0 || toIndex >= list.length) {
+      return list
+    }
+    const next = [...list]
+    const [item] = next.splice(fromIndex, 1)
+    next.splice(toIndex, 0, item)
+    return next
+  }
+
+  const handleIconDrop = (event: React.DragEvent<HTMLDivElement>, targetIndex: number) => {
+    event.preventDefault()
+    const sourceId = event.dataTransfer.getData('text/icon-id')
+    if (!sourceId) {
+      return
+    }
+    setIconOrder((current) => moveInList(current, sourceId, targetIndex))
+  }
+
+  const handleWidgetDrop = (event: React.DragEvent<HTMLDivElement>, targetIndex: number) => {
+    event.preventDefault()
+    const sourceId = event.dataTransfer.getData('text/widget-id')
+    if (!sourceId) {
+      return
+    }
+    setWidgetOrder((current) => moveInList(current, sourceId, targetIndex))
+  }
+
+  const triggerEditModeByHold = () => {
+    if (editMode) {
+      return
+    }
+    holdTimerRef.current = window.setTimeout(() => {
+      setEditMode(true)
+    }, 450)
+  }
+
+  const cancelHold = () => {
+    if (holdTimerRef.current) {
+      window.clearTimeout(holdTimerRef.current)
+      holdTimerRef.current = null
+    }
+  }
+
+  const canAddWidget = decoratedWidgetCount < MAX_WIDGETS
+
+  const handleAddTextWidget = () => {
+    if (!canAddWidget) {
+      setNotice(`最多只能放 ${MAX_WIDGETS} 个组件`) 
+      return
+    }
+    const id = `widget-text-${Date.now()}`
+    const text = window.prompt('输入文本组件内容', '今天也要开心撸仓鼠！')?.trim()
+    if (!text) {
+      return
+    }
+    setWidgets((current) => [...current, { id, type: 'text', text }])
+    setWidgetOrder((current) => [...current, id])
+  }
+
+  const handleAddImageWidget = () => {
+    if (!canAddWidget) {
+      setNotice(`最多只能放 ${MAX_WIDGETS} 个组件`)
+      return
+    }
+    fileInputRef.current?.click()
+  }
+
+  const handleImageSelected = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) {
+      return
+    }
+    if (!canAddWidget) {
+      setNotice(`最多只能放 ${MAX_WIDGETS} 个组件`)
+      return
+    }
+    const id = `widget-image-${Date.now()}`
+    try {
+      const imageKey = await saveImageBlob(file)
+      setWidgets((current) => [...current, { id, type: 'image', imageKey, fit: 'cover' }])
+      setWidgetOrder((current) => [...current, id])
+    } catch (error) {
+      console.warn('保存图片组件失败', error)
+      setNotice('保存图片失败，请稍后再试')
+    }
+  }
+
+  const removeWidget = async (id: string) => {
+    const target = widgets.find((widget) => widget.id === id)
+    if (!target) {
+      return
+    }
+    if (target.type === 'image') {
+      await removeImageBlob(target.imageKey)
+    }
+    setWidgets((current) => current.filter((widget) => widget.id !== id))
+    setWidgetOrder((current) => current.filter((widgetId) => widgetId !== id))
+  }
+
+  return (
+    <main className="home-page">
+      <div className="phone-shell">
+        <header className="home-header">
+          <button type="button" className="edit-button" onClick={() => setEditMode((value) => !value)}>
+            {editMode ? '完成' : '编辑'}
+          </button>
+          <h1>{timeLabel}</h1>
+          <p>{dateLabel}</p>
+        </header>
+
+        {notice ? <p className="home-notice">{notice}</p> : null}
+
+        {editMode ? (
+          <section className="glass-card widget-toolbar">
+            <button type="button" className="ghost" onClick={handleAddTextWidget}>+ 文本组件</button>
+            <button type="button" className="ghost" onClick={handleAddImageWidget}>+ 图片组件</button>
+            <span>{decoratedWidgetCount}/{MAX_WIDGETS} 组件</span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              hidden
+              onChange={(event) => void handleImageSelected(event)}
+            />
+          </section>
+        ) : null}
+
+        <section className="widget-grid" aria-label="Widgets">
+          {Array.from({ length: MAX_WIDGETS }).map((_, index) => {
+            const widgetId = widgetOrder[index]
+            const widget = widgets.find((entry) => entry.id === widgetId)
+            const isCheckin = widgetId === CORE_WIDGET_ID
+            return (
+              <div
+                key={`widget-slot-${index}`}
+                className="widget-slot"
+                onDragOver={(event) => editMode && event.preventDefault()}
+                onDrop={(event) => editMode && handleWidgetDrop(event, index)}
+              >
+                {!widgetId ? (
+                  <div className="widget-placeholder">空位</div>
+                ) : isCheckin ? (
+                  <article
+                    className="glass-card widget-card"
+                    draggable={editMode}
+                    onDragStart={(event) => event.dataTransfer.setData('text/widget-id', CORE_WIDGET_ID)}
+                    onPointerDown={triggerEditModeByHold}
+                    onPointerUp={cancelHold}
+                    onPointerLeave={cancelHold}
+                  >
+                    <div className="checkin-head">
+                      <strong>今日打卡</strong>
+                      <span className={checkedToday ? 'done' : 'todo'}>{checkedToday ? '已完成' : '未完成'}</span>
+                    </div>
+                    <div className="checkin-metrics-mini">
+                      <span>连续 {streakDays} 天</span>
+                      <span>累计 {checkinTotal} 次</span>
+                    </div>
+                    <button
+                      type="button"
+                      className="primary"
+                      disabled={checkedToday || checkinSubmitting || checkinLoading}
+                      onClick={() => void handleCheckin()}
+                    >
+                      {checkedToday ? '已打卡' : checkinSubmitting ? '打卡中…' : '立即打卡'}
+                    </button>
+                  </article>
+                ) : widget ? (
+                  <article
+                    className="glass-card widget-card"
+                    draggable={editMode}
+                    onDragStart={(event) => event.dataTransfer.setData('text/widget-id', widget.id)}
+                    onPointerDown={triggerEditModeByHold}
+                    onPointerUp={cancelHold}
+                    onPointerLeave={cancelHold}
+                  >
+                    {editMode ? (
+                      <button type="button" className="widget-delete" onClick={() => void removeWidget(widget.id)}>
+                        ×
+                      </button>
+                    ) : null}
+                    {widget.type === 'text' ? (
+                      <p className="text-widget">{widget.text}</p>
+                    ) : (
+                      <img
+                        className="image-widget"
+                        src={imageUrls[widget.id]}
+                        style={{ objectFit: widget.fit ?? 'cover' }}
+                        alt="本地图片组件"
+                      />
+                    )}
+                  </article>
+                ) : (
+                  <div className="widget-placeholder">空位</div>
+                )}
+              </div>
+            )
+          })}
+        </section>
+
+        <section className="icons-grid" aria-label="Apps">
+          {iconOrder.map((iconId, index) => {
+            const icon = iconMap.get(iconId)
+            if (!icon) {
+              return null
+            }
+            return (
+              <div
+                key={icon.id}
+                className="app-icon-slot"
+                onDragOver={(event) => editMode && event.preventDefault()}
+                onDrop={(event) => editMode && handleIconDrop(event, index)}
+              >
+                <button
+                  type="button"
+                  className="app-icon-button"
+                  draggable={editMode}
+                  onDragStart={(event) => event.dataTransfer.setData('text/icon-id', icon.id)}
+                  onPointerDown={triggerEditModeByHold}
+                  onPointerUp={cancelHold}
+                  onPointerLeave={cancelHold}
+                  onClick={() => {
+                    if (editMode) {
+                      return
+                    }
+                    if (icon.action) {
+                      icon.action()
+                      return
+                    }
+                    if (icon.route) {
+                      navigate(icon.route)
+                    }
+                  }}
+                >
+                  <span className="icon-emoji">{icon.icon}</span>
+                  <span className="icon-label">{icon.label}</span>
+                </button>
+              </div>
+            )
+          })}
+        </section>
+      </div>
+    </main>
+  )
+}
+
+export default HomePage

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -1,0 +1,86 @@
+export type DecorativeWidget =
+  | {
+      id: string
+      type: 'text'
+      text: string
+    }
+  | {
+      id: string
+      type: 'image'
+      imageKey: string
+      fit?: 'cover' | 'contain'
+    }
+
+export type HomeLayoutState = {
+  iconOrder: string[]
+  widgetOrder: string[]
+  widgets: DecorativeWidget[]
+}
+
+const HOME_LAYOUT_STORAGE_KEY = 'hamster.home.layout.v1'
+const IMAGE_DB_NAME = 'hamster-home-db'
+const IMAGE_STORE_NAME = 'images'
+
+const openImageDb = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(IMAGE_DB_NAME, 1)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(IMAGE_STORE_NAME)) {
+        db.createObjectStore(IMAGE_STORE_NAME)
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('打开 IndexedDB 失败'))
+  })
+
+const withImageStore = async <T>(
+  mode: IDBTransactionMode,
+  handler: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> => {
+  const db = await openImageDb()
+  return new Promise<T>((resolve, reject) => {
+    const transaction = db.transaction(IMAGE_STORE_NAME, mode)
+    const store = transaction.objectStore(IMAGE_STORE_NAME)
+    const request = handler(store)
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB 操作失败'))
+    transaction.oncomplete = () => db.close()
+    transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB 事务失败'))
+  })
+}
+
+export const loadHomeLayout = (): HomeLayoutState | null => {
+  const raw = localStorage.getItem(HOME_LAYOUT_STORAGE_KEY)
+  if (!raw) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(raw) as HomeLayoutState
+    return parsed
+  } catch (error) {
+    console.warn('解析 Home 布局失败', error)
+    return null
+  }
+}
+
+export const saveHomeLayout = (state: HomeLayoutState) => {
+  localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, JSON.stringify(state))
+}
+
+export const createImageKey = () =>
+  globalThis.crypto?.randomUUID?.() ?? `image-${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+export const saveImageBlob = async (blob: Blob, key = createImageKey()): Promise<string> => {
+  await withImageStore('readwrite', (store) => store.put(blob, key))
+  return key
+}
+
+export const loadImageBlob = async (key: string): Promise<Blob | null> => {
+  const result = await withImageStore<Blob | undefined>('readonly', (store) => store.get(key))
+  return result ?? null
+}
+
+export const removeImageBlob = async (key: string): Promise<void> => {
+  await withImageStore('readwrite', (store) => store.delete(key))
+}


### PR DESCRIPTION
### Motivation
- Provide a modern, phone-like launcher as the primary entry that surfaces live local time, check-in status, and quick app navigation without changing existing feature pages. 
- Keep all layout and widget data strictly local-only (no Supabase or export/import) while allowing decorative image/text widgets and ordering customization.

### Description
- Add a new `HomePage` (`src/pages/HomePage.tsx` + `src/pages/HomePage.css`) implementing a glassmorphism phone shell with a live `HH:mm` lock-screen style time, optional date, a functional check-in widget, and a 2×4 app icon grid for navigation. 
- Implement edit mode (header `编辑/完成` button + long-press trigger) with drag-and-drop slot snapping for both app icons and widgets and a per-session discrete slot reorder model. 
- Add a widget system with a required check-in widget and up to `MAX_WIDGETS` (6) total widgets, supporting decorative `text` and local `image` widgets and delete only for decorative widgets. 
- Persist layout and widget configs locally using `localStorage` for orders/configs and IndexedDB `Blob` store for image data via `src/storage/homeLayout.ts`, with helpers `saveImageBlob`, `loadImageBlob`, and `removeImageBlob`. 
- Wire `HomePage` into routing so `/` is the primary launcher, `/home` aliases to `/`, and `/chat` preserves the previous new-session redirect behavior; existing feature pages are otherwise unchanged. 

### Testing
- Ran `npm run build` and production build completed successfully. 
- Ran `npm run lint` and lint passed (one pre-existing warning remains in `CheckinPage.tsx` about hook deps). 
- Started the dev server and loaded the new home route automatically, and captured a Playwright screenshot verifying UI renders. 
- No unit tests were added or modified; manual/visual validation performed via the automated dev server + screenshot run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1036d1988330816ee969e34c7248)