### PR TITLE
Home: iOS-style app icons, hide empty slots, and widget 1x1/2x1 sizing

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -80,14 +80,11 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
-}
-
-.widget-slot {
-  min-height: 105px;
+  align-content: start;
 }
 
 .widget-card {
-  height: 100%;
+  min-height: 105px;
   padding: 0.7rem;
   display: flex;
   flex-direction: column;
@@ -96,16 +93,47 @@
   position: relative;
 }
 
+.widget-card-wide {
+  grid-column: span 2;
+}
+
+.widget-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.widget-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+  color: #334155;
+}
+
+.widget-controls select {
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  background: rgba(255, 255, 255, 0.8);
+  padding: 0.1rem 0.45rem;
+}
+
 .widget-placeholder {
   width: 100%;
-  height: 100%;
   min-height: 105px;
   border-radius: 16px;
-  border: 1px dashed rgba(51, 65, 85, 0.4);
-  color: rgba(15, 23, 42, 0.45);
-  display: grid;
-  place-items: center;
-  font-size: 0.85rem;
+  border: 1px dashed rgba(51, 65, 85, 0.35);
+}
+
+.checkin-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.checkin-wide .checkin-metrics-mini {
+  gap: 0.8rem;
 }
 
 .checkin-head {
@@ -130,18 +158,17 @@
   gap: 0.4rem;
   color: #334155;
   font-size: 0.78rem;
+  flex-wrap: wrap;
 }
 
 .widget-delete {
-  position: absolute;
-  top: 0.2rem;
-  right: 0.2rem;
   border-radius: 999px;
   border: none;
   width: 1.45rem;
   height: 1.45rem;
   background: rgba(15, 23, 42, 0.7);
   color: white;
+  line-height: 1;
 }
 
 .text-widget {
@@ -163,36 +190,43 @@
   margin-top: auto;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.7rem;
+  grid-template-rows: repeat(4, auto);
+  gap: 0.9rem 1rem;
   align-content: end;
 }
 
-.app-icon-button {
-  border: 1px solid rgba(255, 255, 255, 0.55);
-  width: 100%;
-  border-radius: 22px;
-  padding: 0.85rem 0.6rem;
-  background: rgba(255, 255, 255, 0.24);
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.14);
-  backdrop-filter: blur(10px);
+.app-icon-slot {
   display: flex;
+  justify-content: center;
+}
+
+.app-icon-button {
+  border: none;
+  background: transparent;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.4rem;
   color: #0f172a;
 }
 
 .icon-emoji {
   display: inline-grid;
   place-items: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.6);
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.14);
+  font-size: 1.8rem;
 }
 
 .icon-label {
-  font-size: 0.9rem;
+  font-size: 0.82rem;
   font-weight: 600;
+  text-align: center;
 }
 
 .primary,

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -3,18 +3,22 @@ export type DecorativeWidget =
       id: string
       type: 'text'
       text: string
+      size?: '1x1' | '2x1'
     }
   | {
       id: string
       type: 'image'
       imageKey: string
       fit?: 'cover' | 'contain'
+      size?: '1x1' | '2x1'
     }
 
 export type HomeLayoutState = {
   iconOrder: string[]
   widgetOrder: string[]
   widgets: DecorativeWidget[]
+  checkinSize?: '1x1' | '2x1'
+  showEmptySlots?: boolean
 }
 
 const HOME_LAYOUT_STORAGE_KEY = 'hamster.home.layout.v1'


### PR DESCRIPTION
### Motivation
- Make the Home launcher feel closer to iOS by using rounded-square app icon tiles with labels and a clean widget area without forced placeholders. 
- Add simple local-only widget sizing (1×1 / 2×1) and a toggle to hide/show empty widget slots to improve layout flexibility and let the Check-in widget expand to a wide card.

### Description
- Add `size?: '1x1' | '2x1'` to `DecorativeWidget` and extend `HomeLayoutState` with `checkinSize` and `showEmptySlots` so sizes and the empty-slot preference are persisted to `localStorage` (`src/storage/homeLayout.ts`).
- Replace pill-style app list with rounded-square icon tiles and labels under the emoji, keep 2×4 grid and preserve drag/navigation behavior (`src/pages/HomePage.tsx`, `src/pages/HomePage.css`).
- Rework widget rendering to only render real widgets outside edit mode and optionally show empty-slot outlines in edit mode via a toolbar toggle (`显示空位/隐藏空位`), defaulting to hidden (`src/pages/HomePage.tsx`).
- Add edit-mode size controls (`小` / `大`) for each widget (including Check-in), implement wide `2x1` widgets using CSS grid column span, and make the Check-in widget support both compact and wide presentations (`src/pages/HomePage.tsx`, `src/pages/HomePage.css`).

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm run lint` which completed successfully but reported one existing warning in `CheckinPage.tsx` (no new errors introduced).
- Launched a dev server and captured a headless browser screenshot via Playwright (Firefox run produced the artifact `artifacts/home-launcher-polish.png`) as visual validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c13b695fc8330855d3c0c16349e25)