### PR TITLE
Home Launcher Polish v2 — overlay theming, spacer widget, per-app icon customization

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,5 +1,6 @@
 .home-page {
   --icon-tile-bg: rgba(255, 255, 255, 0.65);
+  --page-overlay-bg: rgba(255, 255, 255, 0.2);
   --home-background-image: none;
   min-height: 100vh;
   padding: max(env(safe-area-inset-top), 1rem) 1rem max(env(safe-area-inset-bottom), 1.25rem);
@@ -19,11 +20,11 @@
   border-radius: 36px;
   padding: 1.1rem;
   border: 1px solid rgba(255, 255, 255, 0.6);
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--page-overlay-bg);
   box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
   backdrop-filter: blur(20px);
   display: grid;
-  grid-template-rows: auto auto auto 1fr;
+  grid-template-rows: auto auto auto auto 1fr;
   gap: 0.9rem;
 }
 
@@ -79,19 +80,22 @@
   flex-wrap: wrap;
 }
 
-.appearance-toolbar {
+.appearance-toolbar,
+.icon-editor-toolbar {
   padding: 0.75rem;
   display: grid;
   gap: 0.6rem;
 }
 
-.appearance-toolbar h2 {
+.appearance-toolbar h2,
+.icon-editor-toolbar h2 {
   margin: 0;
   font-size: 0.95rem;
   color: #0f172a;
 }
 
-.appearance-toolbar label {
+.appearance-toolbar label,
+.icon-editor-toolbar label {
   display: grid;
   gap: 0.35rem;
   font-size: 0.85rem;
@@ -99,7 +103,9 @@
 }
 
 .appearance-toolbar input[type='color'],
-.appearance-toolbar input[type='range'] {
+.appearance-toolbar input[type='range'],
+.icon-editor-toolbar input,
+.icon-editor-toolbar select {
   width: 100%;
   font-size: 16px;
 }
@@ -137,6 +143,13 @@
   grid-column: span 2;
 }
 
+.spacer-card {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
 .widget-controls {
   display: flex;
   justify-content: space-between;
@@ -157,6 +170,17 @@
   border: 1px solid rgba(15, 23, 42, 0.2);
   background: rgba(255, 255, 255, 0.8);
   padding: 0.1rem 0.45rem;
+  font-size: 16px;
+}
+
+.spacer-editor {
+  min-height: 60px;
+  border-radius: 14px;
+  border: 1px dashed rgba(51, 65, 85, 0.35);
+  display: grid;
+  place-items: center;
+  color: #64748b;
+  font-size: 0.82rem;
 }
 
 .widget-placeholder {
@@ -261,6 +285,14 @@
   border: 1px solid rgba(255, 255, 255, 0.8);
   box-shadow: 0 10px 20px rgba(15, 23, 42, 0.14);
   font-size: clamp(1.35rem, 4.8vw, 1.8rem);
+  overflow: hidden;
+}
+
+.icon-image {
+  width: calc(100% - 12px);
+  height: calc(100% - 12px);
+  object-fit: contain;
+  border-radius: 12px;
 }
 
 .icon-label {

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -12,6 +12,21 @@ export type DecorativeWidget =
       fit?: 'cover' | 'contain'
       size?: '1x1' | '2x1'
     }
+  | {
+      id: string
+      type: 'spacer'
+      size?: '1x1' | '2x1'
+    }
+
+export type AppIconConfig =
+  | {
+      type: 'emoji'
+      emoji: string
+    }
+  | {
+      type: 'image'
+      imageKey: string
+    }
 
 export type HomeLayoutState = {
   iconOrder: string[]
@@ -21,7 +36,10 @@ export type HomeLayoutState = {
   showEmptySlots?: boolean
   iconTileBgColor?: string
   iconTileBgOpacity?: number
+  pageOverlayColor?: string
+  pageOverlayOpacity?: number
   homeBackgroundImageKey?: string | null
+  appIconConfigs?: Record<string, AppIconConfig>
 }
 
 const HOME_LAYOUT_STORAGE_KEY = 'hamster.home.layout.v1'


### PR DESCRIPTION
### Motivation
- Improve Home/Launcher local customization by making the big rounded glass panel themeable, add an invisible spacer for layout control, and allow per-app icons (emoji or local image) while keeping all assets local-only.
- Keep the UX confined to edit mode and avoid any cloud/export behavior for images or settings.

### Description
- Added new portable data models in `src/storage/homeLayout.ts`: `spacer` widget in `DecorativeWidget`, `AppIconConfig` union type, and `pageOverlayColor/pageOverlayOpacity` and `appIconConfigs` to `HomeLayoutState` for local persistence.
- Implemented overlay theming controls in the Home appearance toolbar by adding `pageOverlayColor`/`pageOverlayOpacity` state, persisting them via `saveHomeLayout`, and applying the CSS variable `--page-overlay-bg` to the phone shell so opacity `0%` shows only the background image.
- Implemented a new 1×1/2×1 `Spacer` widget that can be added from the edit toolbar, occupies grid slots and counts against the max widget limit, and renders as an invisible card outside edit mode with a dashed `占位` affordance while editing.
- Added per-app icon customization UI (an `编辑图标` toolbar) allowing emoji edits and local image uploads; images are saved to the existing IndexedDB store via `saveImageBlob`/`loadImageBlob` and referenced in `appIconConfigs` without any cloud/export behavior, and uploaded images render with `object-fit: contain` and padding inside the app tile.
- CSS updates in `src/pages/HomePage.css` include `--page-overlay-bg`, styles to hide the spacer in normal mode, editor affordances, and safe `font-size: 16px` for new inputs to address iOS font-size behavior.

### Testing
- Built the production bundle successfully with `npm run build` (TypeScript and Vite build passed).
- Ran static checks with `npm run lint` which completed successfully and reported one pre-existing lint warning in `src/pages/CheckinPage.tsx`.
- Launched the dev server and captured a UI screenshot to validate the edit controls and new visuals in-browser (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1c5df3c083309e0365ee98fc8c20)