### PR TITLE
Always inject RP conversation history when compression is skipped

### DIFF
--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -577,6 +577,16 @@ const maybeCompressRuntimeContext = async (
         : await fetchConversationMessages(origin, authHeader, apiKeyHeader, conversationId)
     const totalHistoryMessages = fullHistory.length
     if (totalHistoryMessages <= keepRecentMessages + MIN_EXTRA_MESSAGES_FOR_COMPRESSION) {
+      if (compressionModule === 'rp') {
+        const historyAsMessages = formatHistoryMessagesForCompression(compressionModule, fullHistory)
+        return {
+          messages: [...systemMessages, ...historyAsMessages],
+          cacheWriteFailed,
+          cacheWriteSucceeded,
+          cacheWriteErrorMessage,
+        }
+      }
+
       return { messages, cacheWriteFailed, cacheWriteSucceeded, cacheWriteErrorMessage }
     }
 


### PR DESCRIPTION
### Motivation
- RP rooms with fewer than the compression trigger messages were not exposing their timeline to the model because the early-return skipped injecting `rp_messages`, leaving only system prompts in the outgoing payload. 

### Description
- Updated `maybeCompressRuntimeContext` in `supabase/functions/openrouter-chat/index.ts` so that when `compressionModule === 'rp'` and `totalHistoryMessages <= keepRecentMessages + MIN_EXTRA_MESSAGES_FOR_COMPRESSION`, the function formats the full RP history via `formatHistoryMessagesForCompression` and returns `messages: [...systemMessages, ...historyAsMessages]` instead of returning the original `messages` unchanged. 
- This preserves existing system messages while ensuring the full RP timeline is injected for short/new RP rooms without triggering compression. 
- Non-RP behavior and the rest of the compression flow remain unchanged. 

### Testing
- Attempted to run `deno check supabase/functions/openrouter-chat/index.ts`, but the environment does not have `deno` installed so the check could not be executed (failed to run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5f7cb5888330acb26edee8f7bf11)