### PR TITLE
Fix Home customization reset: persist settings to localStorage and images to IndexedDB

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,10 +8,10 @@ import {
 } from '../storage/supabaseSync'
 import {
   createImageKey,
-  loadHomeLayout,
+  loadHomeSettings,
   loadImageBlob,
   removeImageBlob,
-  saveHomeLayout,
+  saveHomeSettings,
   saveImageBlob,
   type AppIconConfig,
   type DecorativeWidget,
@@ -213,7 +213,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
   }, [])
 
   useEffect(() => {
-    const cached = loadHomeLayout()
+    const cached = loadHomeSettings()
     if (!cached) {
       setAppIconConfigs(defaultAppIconConfigs)
       return
@@ -241,7 +241,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
   }, [defaultAppIconConfigs])
 
   useEffect(() => {
-    saveHomeLayout({
+    saveHomeSettings({
       iconOrder,
       widgetOrder,
       widgets,


### PR DESCRIPTION
### Motivation
- Home launcher customizations were lost on page refresh because settings and image assets were not persisted under a stable, dedicated store.
- The goal is local-only persistence: non-image config in `localStorage` and image blobs in `IndexedDB`, with no export/import or cloud behavior.

### Description
- Introduced a dedicated settings type `HomeSettingsState` and a stable storage key `hamster_home_settings_v1`, plus a migration from the legacy key `hamster.home.layout.v1` via `loadHomeSettings`/`saveHomeSettings`.
- Changed the IndexedDB object store name to `home_assets` and kept existing blob helpers `saveImageBlob`, `loadImageBlob`, and `removeImageBlob` to store image `Blob`s by generated `imageKey`.
- Added `parseHomeSettings` helper and preserved backward-compatible aliases `loadHomeLayout`/`saveHomeLayout` that forward to the new settings API.
- Updated `HomePage` to import and use `loadHomeSettings`/`saveHomeSettings` so hydration and saves use the new stable keys and migration logic.

### Testing
- Ran `npm run lint` which completed (there is one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`).
- Ran `npm run build` (which runs `tsc -b && vite build`) and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cfda13c5c8330bc56da6426cdefd1)