### PR TITLE
Add module-specific reasoning toggles (Chat & RP) and RP 402 auto-fallback

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -62,7 +62,8 @@ const SettingsPage = ({
   const [compressionSectionExpanded, setCompressionSectionExpanded] = useState(false)
   const [draftEnabledModels, setDraftEnabledModels] = useState<string[]>([])
   const [draftDefaultModel, setDraftDefaultModel] = useState(defaultModelId)
-  const [draftReasoning, setDraftReasoning] = useState(false)
+  const [draftChatReasoning, setDraftChatReasoning] = useState(true)
+  const [draftRpReasoning, setDraftRpReasoning] = useState(false)
   const [draftMemoryExtractModel, setDraftMemoryExtractModel] = useState<string | null>(null)
   const [modelStatus, setModelStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [modelError, setModelError] = useState<string | null>(null)
@@ -101,7 +102,8 @@ const SettingsPage = ({
       setCompressionKeepRecentInput(settings.compressionKeepRecentMessages.toString())
       setDraftSummarizerModel(settings.summarizerModel)
       setDraftMemoryExtractModel(settings.memoryExtractModel)
-      setDraftReasoning(settings.enableReasoning)
+      setDraftChatReasoning(settings.chatReasoningEnabled)
+      setDraftRpReasoning(settings.rpReasoningEnabled)
     }, 0)
     return () => {
       window.clearTimeout(timer)
@@ -269,7 +271,8 @@ const SettingsPage = ({
       settings.compressionTriggerRatio !== parsedCompressionRatio ||
       settings.compressionKeepRecentMessages !== parsedCompressionKeepRecent ||
       (settings.summarizerModel ?? '') !== (draftSummarizerModel ?? '') ||
-      settings.enableReasoning !== draftReasoning
+      settings.chatReasoningEnabled !== draftChatReasoning ||
+      settings.rpReasoningEnabled !== draftRpReasoning
     : false
   const hasUnsavedSystemPrompt = settings ? draftSystemPrompt !== settings.systemPrompt : false
   const hasUnsavedSnackOverlay = settings
@@ -414,8 +417,13 @@ const SettingsPage = ({
     setGenerationStatus('idle')
   }
 
-  const handleReasoningToggle = (enabled: boolean) => {
-    setDraftReasoning(enabled)
+  const handleChatReasoningToggle = (enabled: boolean) => {
+    setDraftChatReasoning(enabled)
+    setGenerationStatus('idle')
+  }
+
+  const handleRpReasoningToggle = (enabled: boolean) => {
+    setDraftRpReasoning(enabled)
     setGenerationStatus('idle')
   }
 
@@ -481,7 +489,8 @@ const SettingsPage = ({
       compressionTriggerRatio: parsedCompressionRatio,
       compressionKeepRecentMessages: parsedCompressionKeepRecent,
       summarizerModel: draftSummarizerModel,
-      enableReasoning: draftReasoning,
+      chatReasoningEnabled: draftChatReasoning,
+      rpReasoningEnabled: draftRpReasoning,
     })
     if (!nextSettings) {
       return
@@ -631,7 +640,8 @@ const SettingsPage = ({
       setDraftEnabledModels(settings.enabledModels)
       setDraftDefaultModel(settings.defaultModel)
       setDraftMemoryExtractModel(settings.memoryExtractModel)
-      setDraftReasoning(settings.enableReasoning)
+      setDraftChatReasoning(settings.chatReasoningEnabled)
+      setDraftRpReasoning(settings.rpReasoningEnabled)
       setModelStatus('idle')
       setModelError(null)
       setDraftSystemPrompt(settings.systemPrompt)
@@ -892,20 +902,39 @@ const SettingsPage = ({
               />
               {errors.maxTokens ? <span className="field-error">{errors.maxTokens}</span> : null}
             </div>
-            <div className="field-group">
-              <label htmlFor="enableReasoning">思考链（默认）</label>
-              <label className="toggle-control">
-                <input
-                  id="enableReasoning"
-                  type="checkbox"
-                  checked={draftReasoning}
-                  onChange={(event) => handleReasoningToggle(event.target.checked)}
-                />
-                <span>{draftReasoning ? '已开启' : '已关闭'}</span>
-              </label>
-            </div>
           </>
         ) : null}
+      </section>
+
+      <section className="settings-section">
+        <div className="section-title">
+          <h2>思考链</h2>
+          <p>分别控制日常聊天与跑跑滚轮是否请求思考链。</p>
+        </div>
+        <div className="field-group">
+          <label htmlFor="chatReasoningEnabled">日常聊天思考链</label>
+          <label className="toggle-control">
+            <input
+              id="chatReasoningEnabled"
+              type="checkbox"
+              checked={draftChatReasoning}
+              onChange={(event) => handleChatReasoningToggle(event.target.checked)}
+            />
+            <span>{draftChatReasoning ? '已开启' : '已关闭'}</span>
+          </label>
+        </div>
+        <div className="field-group">
+          <label htmlFor="rpReasoningEnabled">跑跑滚轮思考链</label>
+          <label className="toggle-control">
+            <input
+              id="rpReasoningEnabled"
+              type="checkbox"
+              checked={draftRpReasoning}
+              onChange={(event) => handleRpReasoningToggle(event.target.checked)}
+            />
+            <span>{draftRpReasoning ? '已开启' : '已关闭'}</span>
+          </label>
+        </div>
       </section>
 
       <section className="settings-section">

--- a/src/storage/userSettings.ts
+++ b/src/storage/userSettings.ts
@@ -28,6 +28,8 @@ type UserSettingsRow = {
   syzygy_post_system_prompt: string | null
   syzygy_reply_system_prompt: string | null
   enable_reasoning: boolean | null
+  chat_reasoning_enabled: boolean | null
+  rp_reasoning_enabled: boolean | null
   updated_at: string
 }
 
@@ -51,7 +53,8 @@ export const createDefaultSettings = (userId: string): UserSettings => ({
   snackSystemOverlay: DEFAULT_SNACK_SYSTEM_OVERLAY,
   syzygyPostSystemPrompt: DEFAULT_SYZYGY_POST_PROMPT,
   syzygyReplySystemPrompt: DEFAULT_SYZYGY_REPLY_PROMPT,
-  enableReasoning: false,
+  chatReasoningEnabled: true,
+  rpReasoningEnabled: false,
   updatedAt: new Date().toISOString(),
 })
 
@@ -73,7 +76,8 @@ const mapSettingsRow = (row: UserSettingsRow): UserSettings => ({
   snackSystemOverlay: resolveSnackSystemOverlay(row.snack_system_prompt),
   syzygyPostSystemPrompt: resolveSyzygyPostPrompt(row.syzygy_post_system_prompt),
   syzygyReplySystemPrompt: resolveSyzygyReplyPrompt(row.syzygy_reply_system_prompt),
-  enableReasoning: row.enable_reasoning ?? false,
+  chatReasoningEnabled: row.chat_reasoning_enabled ?? row.enable_reasoning ?? true,
+  rpReasoningEnabled: row.rp_reasoning_enabled ?? false,
   updatedAt: row.updated_at,
 })
 
@@ -84,7 +88,7 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
   const { data, error } = await supabase
     .from('user_settings')
     .select(
-      'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,enable_reasoning,updated_at',
+      'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
     )
     .eq('user_id', userId)
     .maybeSingle()
@@ -114,11 +118,13 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
         snack_system_prompt: defaults.snackSystemOverlay,
         syzygy_post_system_prompt: defaults.syzygyPostSystemPrompt,
         syzygy_reply_system_prompt: defaults.syzygyReplySystemPrompt,
-        enable_reasoning: defaults.enableReasoning,
+        enable_reasoning: defaults.chatReasoningEnabled,
+        chat_reasoning_enabled: defaults.chatReasoningEnabled,
+        rp_reasoning_enabled: defaults.rpReasoningEnabled,
         updated_at: now,
       })
       .select(
-        'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,enable_reasoning,updated_at',
+        'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
       )
       .single()
     if (insertError || !inserted) {
@@ -153,7 +159,9 @@ export const updateUserSettings = async (settings: UserSettings): Promise<void> 
       snack_system_prompt: settings.snackSystemOverlay,
       syzygy_post_system_prompt: settings.syzygyPostSystemPrompt,
       syzygy_reply_system_prompt: settings.syzygyReplySystemPrompt,
-      enable_reasoning: settings.enableReasoning,
+      enable_reasoning: settings.chatReasoningEnabled,
+      chat_reasoning_enabled: settings.chatReasoningEnabled,
+      rp_reasoning_enabled: settings.rpReasoningEnabled,
       updated_at: now,
     })
     .eq('user_id', settings.userId)

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,8 @@ export type UserSettings = {
   snackSystemOverlay: string
   syzygyPostSystemPrompt: string
   syzygyReplySystemPrompt: string
-  enableReasoning: boolean
+  chatReasoningEnabled: boolean
+  rpReasoningEnabled: boolean
   updatedAt: string
 }
 


### PR DESCRIPTION
### Motivation
- Separate thinking/reasoning control per module so Daily Chat can keep reasoning while RP can opt-out to reduce cost and avoid 402 errors.
- Make Global Settings the single source of truth for request-time reasoning flags and remove ambiguity from per-room toggles.

### Description
- Split the single `enableReasoning` setting into two persisted flags on `UserSettings`: `chatReasoningEnabled` (default true) and `rpReasoningEnabled` (default false), and map to DB columns `chat_reasoning_enabled` and `rp_reasoning_enabled` with a fallback from the legacy `enable_reasoning`. (types + storage)【src/types.ts】【src/storage/userSettings.ts】
- Added a new "思考链" card in Global Settings with two independent switches: “日常聊天思考链” and “跑跑滚轮思考链”, wired to the new fields and save logic. (UI)【src/pages/SettingsPage.tsx】
- Chat request builder now includes `reasoning`/`thinking` fields only when chat reasoning is enabled and omits them entirely otherwise. (request wiring)【src/App.tsx】
- RP request builder now uses the global `rpReasoningEnabled` passed from `App` as the source of truth; per-room toggle that affected request params was removed from request logic and replaced by a read-only global status indicator in the room UI. (RP UI + request wiring)【src/pages/RpRoomPage.tsx】【src/App.tsx】
- Implemented RP-only 402 fallback: when an RP call returns 402, the code retries once with reasoning omitted, displays the toast `余额不足以启用思考链，已自动关闭以继续回复`, and attempts to persistently disable `rpReasoningEnabled` to avoid repeated failures. (retry + persistence)【src/pages/RpRoomPage.tsx】【src/App.tsx】

### Testing
- Ran `npm run lint`; result: passed (one unrelated warning remains in `CheckinPage.tsx`).
- Built the production bundle with `npm run build`; result: success.
- Launched dev server and captured a screenshot of the updated Settings page to validate the new UI; dev server started and page loaded successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db6d70f408330bb424a770ef7e87e)