### PR TITLE
UI Design System v1: pink glass tokens + Daily Chat styling refresh

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #0f172a;
+  color: var(--text-main, #0f172a);
   background-color: #f1f5f9;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -22,6 +22,11 @@ body {
   min-height: 100vh;
 }
 
+#root input:not([type='checkbox']):not([type='radio']),
+#root textarea,
+#root select {
+  font-size: 16px;
+}
 
 @media (max-width: 768px) {
   #root input:not([type='checkbox']):not([type='radio']),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
 import './index.css'
+import './styles/ui.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -1,11 +1,34 @@
 .chat-page {
+  position: relative;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   height: 100vh;
   min-height: 100vh;
   min-height: 100dvh;
-  background: #f1f5f9;
+  background: var(--page-bg);
   overflow: hidden;
+  color: var(--text-main);
+  isolation: isolate;
+}
+
+.chat-page::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0;
+}
+
+.chat-page.chat-polka-dots::before {
+  opacity: 1;
+  background-image: radial-gradient(circle, rgba(107, 114, 128, 0.08) 1.15px, transparent 1.2px);
+  background-size: 18px 18px;
+}
+
+.chat-page > * {
+  position: relative;
+  z-index: 1;
 }
 
 @supports (height: 100dvh) {
@@ -15,26 +38,26 @@
 }
 
 .chat-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: calc(12px + env(safe-area-inset-top)) 16px 12px;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04);
   gap: 8px;
 }
 
 .chat-header .ghost {
-  border: none;
+  border: 1px solid transparent;
   background: transparent;
-  color: #0f172a;
+  color: var(--text-main);
   font-weight: 600;
   font-size: 14px;
   cursor: pointer;
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+.chat-header .ghost:hover {
+  background: rgba(255, 255, 255, 0.45);
 }
 
 .header-title {
@@ -51,7 +74,7 @@
 
 .header-title .subtitle {
   font-size: 12px;
-  color: #94a3b8;
+  color: var(--text-subtle);
 }
 
 .header-actions {
@@ -62,9 +85,10 @@
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  background: #fff;
-  border-radius: 10px;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(229, 231, 235, 0.9);
+  border-radius: 12px;
+  box-shadow: var(--shadow-soft);
   padding: 6px;
   display: flex;
   flex-direction: column;
@@ -84,7 +108,7 @@
 }
 
 .header-menu button:hover {
-  background: #f1f5f9;
+  background: #f3f4f6;
 }
 
 .chat-messages {
@@ -93,7 +117,7 @@
   overflow-x: hidden;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
-  padding: 16px;
+  margin: 8px 16px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -104,7 +128,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #64748b;
+  color: var(--text-subtle);
   font-size: 14px;
   text-align: center;
   padding: 24px;
@@ -126,18 +150,20 @@
 
 .message .bubble {
   max-width: 75%;
-  background: #fff;
-  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  border-radius: 18px;
   padding: 10px 12px;
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
 .message.out .bubble {
-  background: #0f172a;
-  color: #fff;
+  background: #1f2937;
+  color: #f9fafb;
+  border-color: rgba(31, 41, 55, 0.9);
 }
 
 .message.out .bubble p {
@@ -147,7 +173,7 @@
 .assistant-markdown {
   font-size: 14px;
   line-height: 1.6;
-  color: #0f172a;
+  color: #1f2937;
   word-break: break-word;
 }
 
@@ -213,11 +239,11 @@
 
 .message-footer .timestamp {
   font-size: 11px;
-  color: rgba(148, 163, 184, 0.8);
+  color: rgba(107, 114, 128, 0.9);
 }
 
 .message.out .message-footer .timestamp {
-  color: rgba(226, 232, 240, 0.8);
+  color: rgba(229, 231, 235, 0.9);
 }
 
 .model-tag {
@@ -225,15 +251,15 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #475569;
-  background: rgba(148, 163, 184, 0.2);
+  color: #374151;
+  background: rgba(209, 213, 219, 0.4);
   padding: 2px 6px;
   border-radius: 999px;
 }
 
 .message.out .model-tag {
-  color: #cbd5f5;
-  background: rgba(226, 232, 240, 0.2);
+  color: #fbcfe8;
+  background: rgba(251, 207, 232, 0.2);
 }
 
 .message-actions {
@@ -250,9 +276,10 @@
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  background: #fff;
+  background: rgba(255, 255, 255, 0.93);
+  border: 1px solid rgba(229, 231, 235, 0.9);
   border-radius: 10px;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+  box-shadow: var(--shadow-soft);
   padding: 6px;
   display: flex;
   flex-direction: column;
@@ -272,7 +299,7 @@
 }
 
 .actions-menu button:hover {
-  background: #f1f5f9;
+  background: #f3f4f6;
 }
 
 .actions-menu .danger {
@@ -280,12 +307,11 @@
 }
 
 .chat-composer {
-  padding: 12px 16px calc(20px + env(safe-area-inset-bottom));
+  margin: 0 16px 12px;
+  padding: 12px 14px calc(16px + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: #fff;
-  border-top: 1px solid #e2e8f0;
   position: sticky;
   bottom: 0;
   z-index: 3;
@@ -312,7 +338,7 @@
   align-items: center;
   justify-content: space-between;
   font-size: 12px;
-  color: #64748b;
+  color: var(--text-subtle);
 }
 
 .streaming-status .stop-button {
@@ -326,15 +352,15 @@
   gap: 12px;
   flex-wrap: wrap;
   font-size: 12px;
-  color: #475569;
+  color: #4b5563;
 }
 
 .model-selector {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(209, 213, 219, 0.9);
   border-radius: 999px;
   padding: 4px 10px;
 }
@@ -343,13 +369,13 @@
   border: none;
   background: transparent;
   font-size: 12px;
-  color: #0f172a;
+  color: var(--text-main);
   outline: none;
 }
 
 .model-hint {
   font-size: 12px;
-  color: #64748b;
+  color: var(--text-subtle);
 }
 
 .composer-toggle {
@@ -358,17 +384,17 @@
   gap: 6px;
   padding: 4px 10px;
   border-radius: 999px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  color: #0f172a;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(209, 213, 219, 0.9);
+  color: var(--text-main);
 }
 
 .composer-toggle input {
-  accent-color: #0f172a;
+  accent-color: #ec4899;
 }
 
 .composer-toggle .toggle-hint {
-  color: #64748b;
+  color: var(--text-subtle);
 }
 
 .composer-row {
@@ -379,20 +405,7 @@
 .chat-composer textarea {
   flex: 1;
   resize: none;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 10px 12px;
-  font-size: 14px;
-}
-
-.chat-composer .primary {
-  border: none;
-  background: #0f172a;
-  color: #fff;
-  border-radius: 12px;
-  padding: 10px 16px;
-  font-size: 14px;
-  cursor: pointer;
+  min-height: 42px;
 }
 
 .checkin-card {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -140,8 +140,8 @@ const ChatPage = ({
   }, [openHeaderMenu])
 
   return (
-    <div className="chat-page">
-      <header className="chat-header">
+    <div className="chat-page chat-polka-dots">
+      <header className="chat-header top-nav">
         <button type="button" className="ghost" onClick={onOpenDrawer}>
           会话
         </button>
@@ -230,7 +230,7 @@ const ChatPage = ({
           ) : null}
         </div>
       </header>
-      <main className="chat-messages">
+      <main className="chat-messages glass-panel">
         {messages.length === 0 ? (
           <div className="empty-state">
             <p>暂无消息，开始聊点什么吧。</p>
@@ -298,7 +298,7 @@ const ChatPage = ({
         )}
         <div ref={bottomRef} />
       </main>
-      <form className="chat-composer" onSubmit={handleSubmit}>
+      <form className="chat-composer glass-card" onSubmit={handleSubmit}>
         {isStreaming ? (
           <div className="streaming-status">
             <span>生成中…</span>
@@ -340,6 +340,7 @@ const ChatPage = ({
         </div>
         <div className="composer-row">
           <textarea
+            className="textarea-glass"
             placeholder="输入你的消息"
             rows={2}
             value={draft}
@@ -354,7 +355,7 @@ const ChatPage = ({
               }
             }}
           />
-          <button type="submit" className="primary">
+          <button type="submit" className="btn-primary">
             发送
           </button>
         </div>

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -63,7 +63,7 @@
   font-size: 0.9rem;
 }
 
-.glass-card {
+.home-page .glass-card {
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.5);
   background: rgba(255, 255, 255, 0.28);

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1,0 +1,113 @@
+:root {
+  --accent: #ffd6e7;
+  --accent-strong: #f8bad4;
+  --text-main: #111827;
+  --text-subtle: #6b7280;
+  --glass-bg: rgba(255, 255, 255, 0.22);
+  --glass-border: rgba(255, 255, 255, 0.35);
+  --shadow-soft: 0 12px 30px rgba(0, 0, 0, 0.08);
+  --radius-card: 28px;
+  --radius-tile: 20px;
+  --radius-btn: 16px;
+  --blur: 16px;
+  --page-bg:
+    radial-gradient(circle at 12% 10%, rgba(255, 214, 231, 0.55), transparent 40%),
+    radial-gradient(circle at 85% 0%, rgba(229, 231, 235, 0.48), transparent 35%),
+    linear-gradient(180deg, #fdf2f8 0%, #f8fafc 52%, #f3f4f6 100%);
+}
+
+.glass-card,
+.glass-panel {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(var(--blur));
+  -webkit-backdrop-filter: blur(var(--blur));
+}
+
+.glass-card {
+  border-radius: var(--radius-card);
+  padding: 1rem;
+}
+
+.glass-panel {
+  border-radius: calc(var(--radius-card) + 4px);
+  padding: 1rem;
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+  border: none;
+  border-radius: var(--radius-btn);
+  min-height: 42px;
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  transition: background-color 160ms ease, transform 120ms ease, box-shadow 160ms ease;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--text-main);
+  box-shadow: 0 6px 14px rgba(249, 168, 212, 0.34);
+}
+
+.btn-primary:hover {
+  background: color-mix(in srgb, var(--accent) 86%, #fff 14%);
+}
+
+.btn-primary:active {
+  background: var(--accent-strong);
+  transform: translateY(1px);
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-main);
+  border: 1px solid rgba(209, 213, 219, 0.9);
+}
+
+.btn-danger {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.input-glass,
+.textarea-glass {
+  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-main);
+  border-radius: var(--radius-tile);
+  padding: 10px 14px;
+  font-size: 16px;
+  line-height: 1.45;
+  outline: none;
+}
+
+.input-glass:focus,
+.textarea-glass:focus {
+  border-color: color-mix(in srgb, var(--accent) 62%, #fda4af 38%);
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.36);
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.42);
+  border-bottom: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--blur));
+  -webkit-backdrop-filter: blur(var(--blur));
+}
+
+@media (max-width: 768px) {
+  .btn-primary,
+  .btn-secondary,
+  .btn-danger,
+  .input-glass,
+  .textarea-glass {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a global pink iOS-style glassmorphism design system and palette without changing application logic.
- Standardize reusable tokens and utility classes for glass modules, buttons, inputs, and top navigation to make future restyling incremental.
- Apply the new look to the Daily Chat page as a reference and add a subtle polka-dot chat background option while keeping iOS input sizing to avoid Safari auto-zoom.

### Description
- Added a global design tokens and base UI stylesheet at `src/styles/ui.css` which defines color tokens (including `--accent: #ffd6e7`), glass surfaces, button variants (`.btn-primary`, `.btn-secondary`, `.btn-danger`), input variants (`.input-glass`, `.textarea-glass`), top nav (`.top-nav`), and the soft page background gradient and shadows.
- Imported the new stylesheet in the app entry by updating `src/main.tsx` and adjusted `src/index.css` to use `var(--text-main)` and enforce `16px` font sizing for form controls to prevent iOS zoom.
- Updated the Daily Chat implementation to opt-in to the new system by adding `.chat-polka-dots` class to the page root, converting the messages area to use `.glass-panel`, applying `.glass-card` to the composer, swapping the composer textarea to `.textarea-glass`, and replacing the old send button with `.btn-primary`; no behavioral or data changes were made to the page logic.
- Scoped existing Home launcher glass rules to `.home-page .glass-card` to avoid regressions from the new global `.glass-card` styles.

### Testing
- Ran `npm run build` which completed successfully and produced the production bundle.
- Ran `npm run lint` which completed successfully and reported one pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to these changes.
- Started the dev server and generated a headless screenshot of the Daily Chat page via an automated Playwright script to validate the new styling (artifact saved at `artifacts/chat-design-system.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e5dc801308330a656c06a49e21f38)