### PR TITLE
Chat area styling: system fonts, solid user bubbles, control chips, and menu portal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,6 @@
   min-height: 100vh;
   background: #f1f5f9;
   color: #0f172a;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 button {

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,4 @@
 :root {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
   color: var(--text-main, #0f172a);
@@ -16,6 +15,13 @@
 body {
   margin: 0;
   min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Segoe UI',
+    Roboto, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans SC', Arial,
+    sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-variant-numeric: tabular-nums;
 }
 
 #root {

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -82,9 +82,8 @@
 }
 
 .header-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  position: fixed;
+  z-index: 1200;
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(229, 231, 235, 0.9);
   border-radius: 12px;
@@ -94,7 +93,6 @@
   flex-direction: column;
   gap: 4px;
   min-width: 140px;
-  z-index: 3;
 }
 
 .header-menu button {
@@ -160,14 +158,22 @@
   gap: 6px;
 }
 
-.message.out .bubble {
-  background: #1f2937;
-  color: #f9fafb;
-  border-color: rgba(31, 41, 55, 0.9);
+.message .bubble p {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.6;
 }
 
-.message.out .bubble p {
-  white-space: pre-wrap;
+.message.out .bubble {
+  background: #9fa2aa;
+  color: #ffffff;
+  border: none;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.1);
+}
+
+.message.out .bubble a {
+  color: #f8fafc;
+  text-decoration: underline;
 }
 
 .assistant-markdown {
@@ -349,26 +355,43 @@
 .composer-toolbar {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
   font-size: 12px;
   color: #4b5563;
 }
 
-.model-selector {
+.model-selector,
+.composer-toggle {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: rgba(255, 255, 255, 0.76);
-  border: 1px solid rgba(209, 213, 219, 0.9);
+  min-height: 30px;
   border-radius: 999px;
-  padding: 4px 10px;
+  padding: 0 11px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-main);
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.model-selector:hover,
+.composer-toggle:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.model-selector:focus-within,
+.composer-toggle:active {
+  background: rgba(255, 255, 255, 0.35);
 }
 
 .model-selector select {
   border: none;
   background: transparent;
   font-size: 12px;
+  font-weight: 500;
   color: var(--text-main);
   outline: none;
 }
@@ -378,19 +401,33 @@
   color: var(--text-subtle);
 }
 
-.composer-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
+.composer-toggle input {
+  appearance: none;
+  width: 14px;
+  height: 14px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.76);
-  border: 1px solid rgba(209, 213, 219, 0.9);
-  color: var(--text-main);
+  border: 1px solid rgba(107, 114, 128, 0.4);
+  background: rgba(255, 255, 255, 0.6);
+  margin: 0;
+  position: relative;
 }
 
-.composer-toggle input {
-  accent-color: #ec4899;
+.composer-toggle input:checked {
+  background: color-mix(in srgb, var(--accent) 28%, #ffffff 72%);
+  border-color: color-mix(in srgb, var(--accent) 40%, rgba(107, 114, 128, 0.3) 60%);
+}
+
+.composer-toggle input:checked::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-strong) 70%, #f472b6 30%);
+}
+
+.composer-toggle:has(input:checked) {
+  background: color-mix(in srgb, var(--glass-bg) 75%, var(--accent) 25%);
+  border-color: color-mix(in srgb, var(--glass-border) 70%, var(--accent) 30%);
 }
 
 .composer-toggle .toggle-hint {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { FormEvent } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { useNavigate } from 'react-router-dom'
@@ -47,9 +48,11 @@ const ChatPage = ({
   const [draft, setDraft] = useState('')
   const [openActionsId, setOpenActionsId] = useState<string | null>(null)
   const [openHeaderMenu, setOpenHeaderMenu] = useState(false)
+  const [headerMenuPosition, setHeaderMenuPosition] = useState({ top: 0, right: 0 })
   const [pendingDelete, setPendingDelete] = useState<ChatMessage | null>(null)
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const headerMenuRef = useRef<HTMLDivElement | null>(null)
+  const headerMenuButtonRef = useRef<HTMLButtonElement | null>(null)
   const navigate = useNavigate()
 
   const submitDraft = async () => {
@@ -124,6 +127,32 @@ const ChatPage = ({
     if (!openHeaderMenu) {
       return
     }
+
+    const updateHeaderMenuPosition = () => {
+      const triggerRect = headerMenuButtonRef.current?.getBoundingClientRect()
+      if (!triggerRect) {
+        return
+      }
+      setHeaderMenuPosition({
+        top: triggerRect.bottom + 6,
+        right: Math.max(window.innerWidth - triggerRect.right, 12),
+      })
+    }
+
+    updateHeaderMenuPosition()
+    window.addEventListener('resize', updateHeaderMenuPosition)
+    window.addEventListener('scroll', updateHeaderMenuPosition, true)
+
+    return () => {
+      window.removeEventListener('resize', updateHeaderMenuPosition)
+      window.removeEventListener('scroll', updateHeaderMenuPosition, true)
+    }
+  }, [openHeaderMenu])
+
+  useEffect(() => {
+    if (!openHeaderMenu) {
+      return
+    }
     const handleClick = (event: MouseEvent) => {
       if (!headerMenuRef.current) {
         return
@@ -151,6 +180,7 @@ const ChatPage = ({
         </div>
         <div className="header-actions" ref={headerMenuRef}>
           <button
+            ref={headerMenuButtonRef}
             type="button"
             className="ghost"
             onClick={(event) => {
@@ -160,74 +190,80 @@ const ChatPage = ({
           >
             聊天操作
           </button>
-          {openHeaderMenu ? (
-            <div className="header-menu">
-              <button
-                type="button"
-                onClick={() => {
-                  setOpenHeaderMenu(false)
-                  navigate('/snacks')
-                }}
-              >
-                零食罐罐
-              </button>
+          {openHeaderMenu
+            ? createPortal(
+                <div
+                  className="header-menu"
+                  style={{ top: `${headerMenuPosition.top}px`, right: `${headerMenuPosition.right}px` }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpenHeaderMenu(false)
+                      navigate('/snacks')
+                    }}
+                  >
+                    零食罐罐
+                  </button>
 
-              <button
-                type="button"
-                onClick={() => {
-                  setOpenHeaderMenu(false)
-                  navigate('/syzygy')
-                }}
-              >
-                仓鼠观察日志
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setOpenHeaderMenu(false)
-                  navigate('/memory-vault')
-                }}
-              >
-                囤囤库
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setOpenHeaderMenu(false)
-                  navigate('/checkin')
-                }}
-              >
-                打卡
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setOpenHeaderMenu(false)
-                  navigate('/rp')
-                }}
-              >
-                跑跑滚轮
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setOpenHeaderMenu(false)
-                  navigate('/settings')
-                }}
-              >
-                设置
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setOpenHeaderMenu(false)
-                  navigate('/export')
-                }}
-              >
-                数据导出
-              </button>
-            </div>
-          ) : null}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpenHeaderMenu(false)
+                      navigate('/syzygy')
+                    }}
+                  >
+                    仓鼠观察日志
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpenHeaderMenu(false)
+                      navigate('/memory-vault')
+                    }}
+                  >
+                    囤囤库
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpenHeaderMenu(false)
+                      navigate('/checkin')
+                    }}
+                  >
+                    打卡
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpenHeaderMenu(false)
+                      navigate('/rp')
+                    }}
+                  >
+                    跑跑滚轮
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpenHeaderMenu(false)
+                      navigate('/settings')
+                    }}
+                  >
+                    设置
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpenHeaderMenu(false)
+                      navigate('/export')
+                    }}
+                  >
+                    数据导出
+                  </button>
+                </div>,
+                document.body,
+              )
+            : null}
         </div>
       </header>
       <main className="chat-messages glass-panel">


### PR DESCRIPTION
### Motivation

- Improve visual polish of the chat UI to an iOS-like glass aesthetic while making the user's own messages a readable solid bubble and preserving existing layout and behavior.
- Use the system sans font stack and improved font rendering for consistent typography and better numeric layout across platforms.

### Description

- Set a system font stack and legibility settings on `body` and removed the previous `Inter` override to standardize typography across the app (`src/index.css`, `src/App.css`).
- Updated user message styling to a solid gray background `#9fa2aa` with white text, readable link styles, subtle shadow, and preserved corner radius while keeping assistant bubbles as the existing glass style (`src/pages/ChatPage.css`).
- Improved message content legibility by applying `line-height: 1.6` to bubble content and ensured paragraphs have no extra margins inside bubbles (`src/pages/ChatPage.css`).
- Restyled composer controls (model selector and thinking toggle) into unified iOS-like glass “chips” with pill radius, ~30px control height, font-weight `500`, subtle hover/active feedback, and a light tinted on-state for the thinking toggle (`src/pages/ChatPage.css`).
- Prevented the top-right header/menu from being clipped by rendering the header menu via a portal to `document.body`, anchoring it with viewport coordinates that update on resize/scroll, and giving the menu a high `z-index` so it renders above other panels (`src/pages/ChatPage.tsx`, `src/pages/ChatPage.css`).

### Testing

- Built the production bundle with `npm run build` which completed successfully.
- Started the dev server (`vite`) and captured a visual smoke-check screenshot using a Playwright script which produced a screenshot artifact confirming the layout and visual changes (artifact produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6e69e38883309c4b75fadeda6414)