### PR TITLE
Mobile responsive chat UI, unified model chip, and glass sessions drawer

### DIFF
--- a/src/components/SessionsDrawer.css
+++ b/src/components/SessionsDrawer.css
@@ -1,11 +1,13 @@
 .drawer-scrim {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.35);
+  background: rgba(248, 250, 252, 0.42);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
-  z-index: 20;
+  z-index: 1600;
 }
 
 .drawer-scrim.open {
@@ -18,17 +20,23 @@
   top: 0;
   left: 0;
   bottom: 0;
-  width: min(320px, 85vw);
-  background: #f8fafc;
-  padding: 20px;
-  padding-top: calc(20px + env(safe-area-inset-top));
-  transform: translateX(-100%);
+  width: min(360px, 90vw);
+  background: rgba(255, 255, 255, 0.72);
+  border-right: 1px solid var(--glass-border);
+  border-top-right-radius: 28px;
+  border-bottom-right-radius: 28px;
+  padding: 16px;
+  padding-top: calc(16px + env(safe-area-inset-top));
+  padding-bottom: calc(16px + env(safe-area-inset-bottom));
+  transform: translateX(-102%);
   transition: transform 0.25s ease;
-  z-index: 30;
+  z-index: 1650;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  box-shadow: 16px 0 30px rgba(15, 23, 42, 0.15);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(var(--blur));
+  -webkit-backdrop-filter: blur(var(--blur));
 }
 
 .sessions-drawer.open {
@@ -44,12 +52,12 @@
 .drawer-header-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
 .syncing {
   font-size: 12px;
-  color: #64748b;
+  color: var(--text-subtle);
 }
 
 .drawer-header h2 {
@@ -57,20 +65,20 @@
   font-size: 18px;
 }
 
-
 .drawer-tabs {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px;
-  background: #e2e8f0;
-  border-radius: 10px;
+  background: color-mix(in srgb, var(--glass-bg) 70%, #ffffff 30%);
+  border: 1px solid color-mix(in srgb, var(--glass-border) 75%, #e5e7eb 25%);
+  border-radius: 999px;
   padding: 4px;
 }
 
 .drawer-tabs button {
-  border: none;
+  border: 1px solid transparent;
   background: transparent;
-  border-radius: 8px;
+  border-radius: 999px;
   padding: 6px 10px;
   font-size: 13px;
   color: #334155;
@@ -78,16 +86,27 @@
 }
 
 .drawer-tabs button.active {
-  background: #ffffff;
+  background: rgba(255, 255, 255, 0.85);
   color: #0f172a;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  border-color: rgba(209, 213, 219, 0.7);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
 }
 
-.search-input {
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 8px 12px;
+.search-input,
+.rename-row input {
+  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
+  background: rgba(255, 255, 255, 0.76);
+  border-radius: 12px;
+  padding: 9px 12px;
   font-size: 14px;
+  color: var(--text-main);
+  outline: none;
+}
+
+.search-input:focus,
+.rename-row input:focus {
+  border-color: color-mix(in srgb, var(--accent) 62%, #fda4af 38%);
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.3);
 }
 
 .sessions-list {
@@ -95,21 +114,23 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+  padding-right: 2px;
 }
 
 .session-row {
-  background: #fff;
-  border-radius: 12px;
-  padding: 12px;
-  border: 1px solid transparent;
+  background: color-mix(in srgb, #ffffff 80%, var(--glass-bg) 20%);
+  border-radius: 14px;
+  padding: 10px;
+  border: 1px solid rgba(226, 232, 240, 0.9);
   display: flex;
   flex-direction: column;
   gap: 10px;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.06);
 }
 
 .session-row.active {
-  border-color: #0f172a;
+  border-color: color-mix(in srgb, var(--accent-strong) 42%, #94a3b8 58%);
 }
 
 .session-select {
@@ -118,6 +139,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 10px;
   font-size: 14px;
   padding: 0;
   cursor: pointer;
@@ -125,12 +147,20 @@
   color: #0f172a;
 }
 
-.session-select .count {
-  font-size: 12px;
-  color: #64748b;
+.session-select span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.session-actions {
+.session-select .count {
+  font-size: 12px;
+  color: var(--text-subtle);
+  flex-shrink: 0;
+}
+
+.session-actions,
+.inline-actions {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
@@ -142,44 +172,55 @@
   gap: 8px;
 }
 
-.rename-row input {
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  padding: 6px 10px;
-}
-
-.inline-actions {
-  display: flex;
-  gap: 8px;
-}
-
 .sessions-drawer button.primary {
   border: none;
-  background: #0f172a;
-  color: #fff;
+  background: var(--accent);
+  color: var(--text-main);
   border-radius: 999px;
-  padding: 8px 16px;
+  padding: 9px 14px;
   font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 6px 14px rgba(249, 168, 212, 0.34);
 }
 
-.sessions-drawer button.ghost {
-  border: none;
-  background: transparent;
-  color: #0f172a;
+.sessions-drawer button.ghost,
+.sessions-drawer button.danger,
+.sessions-drawer .inline-actions button {
+  border: 1px solid color-mix(in srgb, var(--glass-border) 70%, #d1d5db 30%);
+  background: rgba(255, 255, 255, 0.74);
+  color: #334155;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
   cursor: pointer;
 }
 
 .sessions-drawer button.danger {
-  border: none;
-  background: #fee2e2;
   color: #991b1b;
-  border-radius: 999px;
-  padding: 6px 12px;
-  cursor: pointer;
+  background: rgba(254, 226, 226, 0.75);
 }
 
 .sessions-drawer .empty {
   color: #94a3b8;
   font-size: 14px;
+  text-align: center;
+  padding: 18px 8px;
+}
+
+@media (max-width: 560px) {
+  .sessions-drawer {
+    width: 92vw;
+    padding: 14px 12px;
+    padding-top: calc(14px + env(safe-area-inset-top));
+    padding-bottom: calc(14px + env(safe-area-inset-bottom));
+    border-top-right-radius: 22px;
+    border-bottom-right-radius: 22px;
+  }
+
+  .session-select {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
 }

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -83,7 +83,7 @@
 
 .header-menu {
   position: fixed;
-  z-index: 1200;
+  z-index: 1500;
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(229, 231, 235, 0.9);
   border-radius: 12px;
@@ -116,6 +116,7 @@
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   margin: 8px 16px;
+  padding: 2px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -291,7 +292,7 @@
   flex-direction: column;
   gap: 4px;
   min-width: 140px;
-  z-index: 2;
+  z-index: 40;
 }
 
 .actions-menu button {
@@ -356,9 +357,15 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
   font-size: 12px;
   color: #4b5563;
+}
+
+.composer-toolbar::-webkit-scrollbar {
+  display: none;
 }
 
 .model-selector,
@@ -366,6 +373,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  flex-shrink: 0;
   min-height: 30px;
   border-radius: 999px;
   padding: 0 11px;
@@ -375,6 +383,7 @@
   font-weight: 500;
   color: var(--text-main);
   transition: background-color 120ms ease, border-color 120ms ease;
+  position: relative;
 }
 
 .model-selector:hover,
@@ -388,6 +397,13 @@
 }
 
 .model-selector select {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  appearance: none;
   border: none;
   background: transparent;
   font-size: 12px;
@@ -397,7 +413,29 @@
 }
 
 .model-hint {
-  font-size: 12px;
+  font-size: 11px;
+  line-height: 1.2;
+  color: var(--text-subtle);
+  opacity: 0.82;
+  margin-left: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chip-label {
+  color: var(--text-subtle);
+}
+
+.chip-value {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chip-chevron {
+  font-size: 10px;
   color: var(--text-subtle);
 }
 
@@ -437,12 +475,81 @@
 .composer-row {
   display: flex;
   gap: 8px;
+  align-items: flex-end;
 }
 
 .chat-composer textarea {
   flex: 1;
   resize: none;
   min-height: 42px;
+}
+
+@media (max-width: 560px) {
+  .chat-page {
+    grid-template-rows: auto minmax(0, 1fr) auto;
+  }
+
+  .chat-header {
+    padding: calc(10px + env(safe-area-inset-top)) 10px 8px;
+    gap: 6px;
+  }
+
+  .chat-header .ghost {
+    padding: 5px 8px;
+    font-size: 13px;
+  }
+
+  .header-title h1 {
+    font-size: 15px;
+    max-width: 42vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chat-messages {
+    margin: 6px 8px;
+    border-radius: 20px;
+    padding: 10px;
+    gap: 10px;
+  }
+
+  .message .bubble {
+    max-width: 86%;
+    border-radius: 14px;
+    padding: 9px 10px;
+  }
+
+  .chat-composer {
+    margin: 0 8px 8px;
+    padding: 10px 10px calc(10px + env(safe-area-inset-bottom));
+    border-radius: 20px;
+    gap: 6px;
+  }
+
+  .model-selector,
+  .composer-toggle {
+    min-height: 28px;
+    font-size: 12px;
+    padding: 0 10px;
+  }
+
+  .chip-value {
+    max-width: 104px;
+  }
+
+  .composer-row {
+    width: 100%;
+  }
+
+  .chat-composer textarea {
+    min-height: 40px;
+  }
+
+  .chat-composer .btn-primary {
+    min-width: 64px;
+    padding: 10px 12px;
+  }
 }
 
 .checkin-card {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -345,8 +345,15 @@ const ChatPage = ({
         ) : null}
         <div className="composer-toolbar">
           <label className="model-selector">
-            <span>模型</span>
+            <span className="chip-label">模型</span>
+            <span className="chip-value" title={selectedModel}>
+              {selectedModel}
+            </span>
+            <span className="chip-chevron" aria-hidden="true">
+              ˅
+            </span>
             <select
+              aria-label="选择模型"
               value={selectedModel}
               onChange={(event) => {
                 const next = event.target.value
@@ -360,10 +367,6 @@ const ChatPage = ({
               ))}
             </select>
           </label>
-          <span className="model-hint">
-            当前：{selectedModel}
-            {hasOverride ? '（会话覆盖）' : '（默认）'}
-          </span>
           <label className="composer-toggle">
             <input
               type="checkbox"
@@ -374,6 +377,10 @@ const ChatPage = ({
             <span className="toggle-hint">{reasoningHint}</span>
           </label>
         </div>
+        <span className="model-hint">
+          当前模型：{selectedModel}
+          {hasOverride ? '（会话覆盖）' : '（默认）'}
+        </span>
         <div className="composer-row">
           <textarea
             className="textarea-glass"


### PR DESCRIPTION
### Motivation
- Improve mobile layout so the chat page and composer feel native on small screens without changing any behavior or app logic. 
- Make the model selector visually consistent with the existing thinking-toggle chip and reduce the visual weight of the current-model info. 
- Restyle the sessions drawer to match the app's glass/grid visual language and fix layering so menus/drawers don't clip.

### Description
- Render the model selector as a compact chip containing the label, truncated model name, and chevron while keeping the existing `<select>` for accessibility and behavior; move the full `当前模型` text into a subtle caption beneath the chip row. (modified `src/pages/ChatPage.tsx`, `src/pages/ChatPage.css`).
- Make composer toolbar chip row horizontally scrollable on small widths, prevent large wrapping, tighten paddings/margins, add safe-area bottom padding, and reduce bubble/card radii/padding for mobile breakpoints (`@media (max-width: 560px)`). (modified `src/pages/ChatPage.css`).
- Convert the sessions drawer into a glass-style panel with softened scrim/backdrop, glass background/border, rounded right corners, segmented tab styling, glass inputs, pill buttons, and responsive mobile width (92vw) while preserving existing drawer behavior and controls. (replaced/updated `src/components/SessionsDrawer.css`).
- Adjust z-indexing for header menus, actions menus, and drawer scrim so overlays stack predictably and floating menus are not clipped. (modified `src/pages/ChatPage.css`, `src/components/SessionsDrawer.css`).
- Visual-only changes only: no routing, state, Supabase sync/auth, message flow, or component logic changes were introduced.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully. 
- Launched the dev server and captured a mobile viewport screenshot using Playwright (390x844) after opening the app and attempting to open the sessions drawer, confirming layout and drawer visuals; the capture completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e731b1cb48330b4f602c7c7e759da)