### PR TITLE
Move message actions into metadata row and boost drawer polka-dot visibility

### DIFF
--- a/src/components/SessionsDrawer.css
+++ b/src/components/SessionsDrawer.css
@@ -43,10 +43,10 @@
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  background-image: radial-gradient(circle, rgba(107, 114, 128, 0.18) 1px, transparent 1.2px);
-  background-size: 16px 16px;
+  background-image: radial-gradient(circle, rgba(241, 241, 241, 0.9) 1.6px, transparent 1.8px);
+  background-size: 14px 14px;
   background-position: 0 0;
-  opacity: 0.14;
+  opacity: 0.45;
   filter: blur(0.2px);
 }
 

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -152,7 +152,7 @@
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid rgba(255, 255, 255, 0.65);
   border-radius: 18px;
-  padding: 12px 40px 10px 12px;
+  padding: 12px 12px 10px;
   position: relative;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
   display: flex;
@@ -245,13 +245,22 @@
   justify-content: space-between;
 }
 
-.message-footer .timestamp {
-  font-size: 11px;
-  color: rgba(107, 114, 128, 0.9);
+.message-metadata {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 7px;
+  margin-left: auto;
+  color: var(--text-subtle);
 }
 
-.message.out .message-footer .timestamp {
-  color: rgba(229, 231, 235, 0.9);
+.message-footer .timestamp {
+  font-size: 11px;
+  color: currentColor;
+}
+
+.message.out .message-metadata {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .model-tag {
@@ -271,30 +280,36 @@
 }
 
 .message-actions {
-  position: absolute;
-  top: 11px;
-  right: 11px;
+  position: relative;
 }
 
 .action-trigger {
-  width: 32px;
-  height: 32px;
+  min-width: 24px;
+  min-height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  border-radius: 999px;
+  padding: 4px 6px;
+  border-radius: 8px;
   border: 1px solid transparent;
   background: transparent;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 700;
-  color: inherit;
+  color: currentColor;
   line-height: 1;
 }
 
 .message.out .action-trigger {
-  opacity: 0;
-  transition: opacity 150ms ease, background-color 150ms ease, border-color 150ms ease;
+  opacity: 0.82;
+  transition: background-color 150ms ease, border-color 150ms ease, opacity 150ms ease;
+}
+
+.message .bubble:hover .action-trigger,
+.message .bubble:active .action-trigger,
+.message .bubble:focus-within .action-trigger,
+.message .bubble .action-trigger[aria-expanded='true'] {
+  background: rgba(15, 23, 42, 0.08);
+  border-color: rgba(15, 23, 42, 0.12);
 }
 
 .message.out .bubble:hover .action-trigger,
@@ -303,7 +318,7 @@
 .message.out .bubble .action-trigger[aria-expanded='true'] {
   opacity: 1;
   background: rgba(255, 255, 255, 0.16);
-  border-color: rgba(255, 255, 255, 0.28);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 .actions-menu {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -278,36 +278,6 @@ const ChatPage = ({
               className={`message ${message.role === 'user' ? 'out' : 'in'}`}
             >
               <div className="bubble">
-                <div className="message-actions">
-                  <button
-                    type="button"
-                    className="ghost action-trigger"
-                    aria-expanded={openActionsId === message.id}
-                    aria-label={actionsLabel}
-                    onClick={() =>
-                      setOpenActionsId((current) =>
-                        current === message.id ? null : message.id,
-                      )
-                    }
-                  >
-                    •••
-                  </button>
-                  {openActionsId === message.id ? (
-                    <div className="actions-menu" role="menu">
-                      <button type="button" role="menuitem" onClick={() => handleCopy(message)}>
-                        复制
-                      </button>
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className="danger"
-                        onClick={() => handleDelete(message)}
-                      >
-                        删除
-                      </button>
-                    </div>
-                  ) : null}
-                </div>
                 {(() => {
                   const reasoningText =
                     message.meta?.reasoning_text?.trim() ?? message.meta?.reasoning?.trim()
@@ -326,7 +296,39 @@ const ChatPage = ({
                       {message.meta.model === 'mock-model' ? '模拟模型' : message.meta.model}
                     </span>
                   ) : null}
-                  <span className="timestamp">{formatTime(message.createdAt)}</span>
+                  <div className="message-metadata">
+                    <span className="timestamp">{formatTime(message.createdAt)}</span>
+                    <div className="message-actions">
+                      <button
+                        type="button"
+                        className="ghost action-trigger"
+                        aria-expanded={openActionsId === message.id}
+                        aria-label={actionsLabel}
+                        onClick={() =>
+                          setOpenActionsId((current) =>
+                            current === message.id ? null : message.id,
+                          )
+                        }
+                      >
+                        •••
+                      </button>
+                      {openActionsId === message.id ? (
+                        <div className="actions-menu" role="menu">
+                          <button type="button" role="menuitem" onClick={() => handleCopy(message)}>
+                            复制
+                          </button>
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className="danger"
+                            onClick={() => handleDelete(message)}
+                          >
+                            删除
+                          </button>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Reduce the reserved top-right bubble space that squeezed message text by relocating the per-message actions trigger into the bubble's bottom metadata row next to the timestamp. 
- Make the sessions drawer polka-dot pattern noticeably visible while keeping it decorative and behind content. 
- Keep message action logic (`copy` / `delete`) and menu behavior unchanged while only adjusting markup and styles.

### Description
- Moved the `•••` action trigger markup from the bubble top-right into a new right-aligned metadata container next to the timestamp in `src/pages/ChatPage.tsx` so it no longer reserves corner padding. 
- Removed the extra right padding from the bubble and added a `.message-metadata` flex row in `src/pages/ChatPage.css` with smaller font, subtle colors (`--text-subtle` for assistant, semi-transparent white for user), compact trigger sizing, and hover-only visual affordance. 
- Adjusted `.actions-menu` placement to remain absolute within the metadata container so the dropdown still opens correctly and retains its `z-index` layering. 
- Increased the drawer polka-dot visibility by updating `src/components/SessionsDrawer.css` to use dot color `#f1f1f1` (`rgba(241,241,241,0.9)`), tighter spacing, larger dot size, and higher opacity while keeping the pattern in the `::before` pseudo-element behind content (`z-index: 0`).

### Testing
- Ran `npm run lint` which completed (project contains one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`).
- Built the app with `npm run build` which succeeded. 
- Launched dev server and captured a Playwright screenshot to validate styles; the app landing required auth in this environment so interactive verification of protected chat state was limited but static styling changes were exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9f492968833092f7afac7405a9fb)