### PR TITLE
Add Pixelify Sans display font and `.ui-title` heading style; apply to headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%vite.svg" />
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <link rel="apple-touch-icon" href="%BASE_URL%icons/pwa-180.png" />

--- a/src/components/SessionsDrawer.tsx
+++ b/src/components/SessionsDrawer.tsx
@@ -202,7 +202,7 @@ const SessionsDrawer = ({
       <aside className={`sessions-drawer ${open ? 'open' : ''}`}>
         <div className="sessions-drawer-content">
           <div className="drawer-header">
-            <h2>会话</h2>
+            <h2 className="ui-title">会话</h2>
             <div className="drawer-header-actions">
               {syncing ? <span className="syncing">同步中...</span> : null}
               <button type="button" className="ghost" onClick={onClose}>

--- a/src/index.css
+++ b/src/index.css
@@ -17,9 +17,7 @@ body {
   min-height: 100vh;
   min-height: 100dvh;
   background: var(--page-bg);
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Segoe UI',
-    Roboto, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans SC', Arial,
-    sans-serif;
+  font-family: var(--font-sans);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -109,7 +109,7 @@ const AuthPage = ({ user }: AuthPageProps) => {
   return (
     <div className="auth-page">
       <div className="auth-card">
-        <h1>邮箱验证码登录</h1>
+        <h1 className="ui-title">邮箱验证码登录</h1>
         <p className="subtitle">使用邮箱验证码登录后即可同步云端会话。</p>
         <label className="field">
           <span>邮箱地址</span>

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -175,7 +175,7 @@ const ChatPage = ({
           会话
         </button>
         <div className="header-title">
-          <h1>{session.title}</h1>
+          <h1 className="ui-title">{session.title}</h1>
           <span className="subtitle">单聊</span>
         </div>
         <div className="header-actions" ref={headerMenuRef}>

--- a/src/pages/CheckinPage.tsx
+++ b/src/pages/CheckinPage.tsx
@@ -98,7 +98,7 @@ const CheckinPage = ({ user }: CheckinPageProps) => {
   return (
     <div className="checkin-page">
       <header className="checkin-page-header">
-        <h1>打卡</h1>
+        <h1 className="ui-title">打卡</h1>
         <div className="checkin-nav-actions">
           <button type="button" className="ghost" onClick={() => navigate('/')}>
             聊天
@@ -123,7 +123,7 @@ const CheckinPage = ({ user }: CheckinPageProps) => {
 
       <section className="checkin-card standalone">
         <div className="checkin-header">
-          <h2>今日打卡</h2>
+          <h2 className="ui-title">今日打卡</h2>
           <span>{todayDisplay}</span>
         </div>
         <div className="checkin-status-row">

--- a/src/pages/ExportPage.tsx
+++ b/src/pages/ExportPage.tsx
@@ -458,14 +458,14 @@ const ExportPage = ({ user }: { user: User | null }) => {
         <button type="button" className="ghost" onClick={() => navigate(-1)}>
           返回
         </button>
-        <h1>数据导出</h1>
+        <h1 className="ui-title">数据导出</h1>
         <button type="button" className="ghost" onClick={() => navigate('/')}>
           聊天
         </button>
       </header>
 
       <section className="export-card">
-        <h2>导出格式</h2>
+        <h2 className="ui-title">导出格式</h2>
         <label>
           <input
             type="radio"
@@ -486,7 +486,7 @@ const ExportPage = ({ user }: { user: User | null }) => {
       </section>
 
       <section className="export-card">
-        <h2>导出模块</h2>
+        <h2 className="ui-title">导出模块</h2>
         <label>
           <input type="checkbox" checked={modules.chat} onChange={() => toggleModule('chat')} />
           吱吱吱区（sessions + messages）

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -679,7 +679,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
           <button type="button" className="edit-button" onClick={() => setEditMode((value) => !value)}>
             {editMode ? '完成' : '编辑'}
           </button>
-          <h1>{timeLabel}</h1>
+          <h1 className="ui-title">{timeLabel}</h1>
           <p>{dateLabel}</p>
         </header>
 
@@ -706,7 +706,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
 
         {editMode ? (
           <section className="glass-card appearance-toolbar">
-            <h2>外观</h2>
+            <h2 className="ui-title">外观</h2>
             <label>
               图标底色
               <input
@@ -776,7 +776,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
 
         {editMode ? (
           <section className="glass-card icon-editor-toolbar">
-            <h2>编辑图标</h2>
+            <h2 className="ui-title">编辑图标</h2>
             <label>
               应用
               <select value={editingIconId} onChange={(event) => setEditingIconId(event.target.value)}>

--- a/src/pages/MemoryVaultPage.tsx
+++ b/src/pages/MemoryVaultPage.tsx
@@ -217,14 +217,14 @@ const MemoryVaultPage = ({
         <button type="button" className="ghost" onClick={() => navigate(-1)}>
           返回
         </button>
-        <h1>囤囤库</h1>
+        <h1 className="ui-title">囤囤库</h1>
         <button type="button" className="ghost" onClick={() => navigate('/')}>
           聊天
         </button>
       </header>
 
       <section className="memory-section">
-        <h2>Confirmed</h2>
+        <h2 className="ui-title">Confirmed</h2>
         <textarea
           value={newMemory}
           onChange={(event) => setNewMemory(event.target.value)}
@@ -288,7 +288,7 @@ const MemoryVaultPage = ({
 
       <section className="memory-section">
         <div className="memory-section-heading">
-          <h2>Pending</h2>
+          <h2 className="ui-title">Pending</h2>
           <div className="memory-toggle-group">
             <button
               type="button"

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -938,7 +938,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
           </button>
         </header>
         <div className="rp-room-card">
-          <h1>无法进入房间</h1>
+          <h1 className="ui-title">无法进入房间</h1>
           <p className="error">{error ?? '未找到房间。'}</p>
         </div>
       </div>
@@ -947,9 +947,9 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
 
   const dashboardContent = (
     <>
-      <h2>仪表盘</h2>
+      <h2 className="ui-title">仪表盘</h2>
       <section className="rp-dashboard-section">
-        <h3>房间设置</h3>
+        <h3 className="ui-title">房间设置</h3>
         <label>
           玩家显示名
           <input
@@ -998,7 +998,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
       </section>
 
       <section className="rp-dashboard-section">
-        <h3>NPC 角色卡</h3>
+        <h3 className="ui-title">NPC 角色卡</h3>
         <p className="rp-dashboard-helper">已启用 {enabledNpcCount} / {NPC_MAX_ENABLED} 个 NPC</p>
         <button type="button" className="primary" onClick={startCreateNpc}>
           新增NPC
@@ -1129,7 +1129,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
       </section>
 
       <section className="rp-dashboard-section">
-        <h3>世界书（基础版）</h3>
+        <h3 className="ui-title">世界书（基础版）</h3>
         <p className="rp-dashboard-helper">房间级全量注入文本</p>
         <textarea
           value={worldbookTextInput}
@@ -1143,7 +1143,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
       </section>
 
       <section className="rp-dashboard-section">
-        <h3>导出</h3>
+        <h3 className="ui-title">导出</h3>
         <p className="rp-dashboard-helper">仅导出 speaker(role) + 纯文本内容。</p>
         <button type="button" className="primary" onClick={handleExportMessages}>
           导出
@@ -1162,7 +1162,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
         >
           返回
         </button>
-        <h1>{room.title?.trim() || '新房间'}</h1>
+        <h1 className="ui-title">{room.title?.trim() || '新房间'}</h1>
         <div className="rp-room-header-slot">
           {!isDashboardPage ? (
             <button

--- a/src/pages/RpRoomsPage.tsx
+++ b/src/pages/RpRoomsPage.tsx
@@ -229,7 +229,7 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
     <div className="rp-rooms-page">
       <header className="rp-rooms-header">
         <div>
-          <h1>跑跑滚轮区</h1>
+          <h1 className="ui-title">跑跑滚轮区</h1>
           <p>管理你的 RP 房间，进入后可继续搭建角色与剧情。</p>
         </div>
         <button type="button" className="ghost" onClick={() => navigate('/')}>
@@ -238,7 +238,7 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
       </header>
 
       <section className="rp-create-card">
-        <h2>新建房间</h2>
+        <h2 className="ui-title">新建房间</h2>
         <div className="rp-create-row">
           <input
             value={newTitle}
@@ -278,7 +278,7 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
         {notice ? <p className="tips">{notice}</p> : null}
         {error ? <p className="error">{error}</p> : null}
 
-        <h2>{tabTitle}</h2>
+        <h2 className="ui-title">{tabTitle}</h2>
         {loading ? <p className="tips">加载中…</p> : null}
         {!loading && rooms.length === 0 ? (
           <p className="tips">{isArchivedView ? '还没有归档房间。' : '还没有房间，先新建一个吧。'}</p>
@@ -312,7 +312,7 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
                     </div>
                   ) : (
                     <div className="rp-room-title-row">
-                      <h3>{room.title || '未命名房间'}</h3>
+                      <h3 className="ui-title">{room.title || '未命名房间'}</h3>
                       <span className="rp-room-count">
                         {countsLoading ? '… 条消息' : `${roomMessageCounts[room.id] ?? 0} 条消息`}
                       </span>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -706,7 +706,7 @@ const SettingsPage = ({
           >
             返回
           </button>
-          <h1>API设置</h1>
+          <h1 className="ui-title">API设置</h1>
           <span className="header-spacer" />
         </header>
         <div className="settings-loading">正在加载设置...</div>
@@ -724,7 +724,7 @@ const SettingsPage = ({
         >
           返回
         </button>
-        <h1>API设置</h1>
+        <h1 className="ui-title">API设置</h1>
         <span className="header-spacer" />
       </header>
 
@@ -736,7 +736,7 @@ const SettingsPage = ({
           aria-expanded={modelSectionExpanded}
         >
           <span className="section-title">
-            <h2>模型库</h2>
+            <h2 className="ui-title">模型库</h2>
             <p>管理已启用模型并设置默认模型。</p>
           </span>
           <span className="collapse-indicator">{modelSectionExpanded ? '收起' : '展开'}</span>
@@ -776,7 +776,7 @@ const SettingsPage = ({
             )}
 
             <div className="section-title nested-prompt-title">
-              <h2>OpenRouter 模型库</h2>
+              <h2 className="ui-title">OpenRouter 模型库</h2>
               <p>搜索并启用你想使用的模型。</p>
             </div>
             <input
@@ -856,7 +856,7 @@ const SettingsPage = ({
           aria-expanded={generationSectionExpanded}
         >
           <span className="section-title">
-            <h2>生成参数</h2>
+            <h2 className="ui-title">生成参数</h2>
             <p>调整生成行为与推理开关。</p>
           </span>
           <span className="collapse-indicator">{generationSectionExpanded ? '收起' : '展开'}</span>
@@ -908,7 +908,7 @@ const SettingsPage = ({
 
       <section className="settings-section">
         <div className="section-title">
-          <h2>思考链</h2>
+          <h2 className="ui-title">思考链</h2>
           <p>分别控制日常聊天与跑跑滚轮是否请求思考链。</p>
         </div>
         <div className="field-group">
@@ -945,7 +945,7 @@ const SettingsPage = ({
           aria-expanded={memorySectionExpanded}
         >
           <span className="section-title">
-            <h2>记忆相关</h2>
+            <h2 className="ui-title">记忆相关</h2>
             <p>配置记忆抽取模型；自动提取与归并可在囤囤库中设置。</p>
           </span>
           <span className="collapse-indicator">{memorySectionExpanded ? '收起' : '展开'}</span>
@@ -997,7 +997,7 @@ const SettingsPage = ({
           aria-expanded={compressionSectionExpanded}
         >
           <span className="section-title">
-            <h2>上下文压缩</h2>
+            <h2 className="ui-title">上下文压缩</h2>
             <p>配置压缩触发阈值、保留条数与摘要模型。</p>
           </span>
           <span className="collapse-indicator">{compressionSectionExpanded ? '收起' : '展开'}</span>
@@ -1077,7 +1077,7 @@ const SettingsPage = ({
 
       <section className="settings-section">
         <div className="section-title">
-          <h2>系统提示词</h2>
+          <h2 className="ui-title">系统提示词</h2>
           <p>用于引导模型的全局指令，仅对当前用户生效。</p>
         </div>
         <textarea
@@ -1109,7 +1109,7 @@ const SettingsPage = ({
           aria-expanded={snackSectionExpanded}
         >
           <span className="section-title">
-            <h2>Snack Feed</h2>
+            <h2 className="ui-title">Snack Feed</h2>
             <p>仅用于零食罐罐区；基础系统提示词保持不变。</p>
           </span>
           <span className="collapse-indicator">{snackSectionExpanded ? '收起' : '展开'}</span>
@@ -1149,7 +1149,7 @@ const SettingsPage = ({
           aria-expanded={syzygySectionExpanded}
         >
           <span className="section-title">
-            <h2>仓鼠观察日志</h2>
+            <h2 className="ui-title">仓鼠观察日志</h2>
             <p>控制发帖与回复时的提示词行为。</p>
           </span>
           <span className="collapse-indicator">{syzygySectionExpanded ? '收起' : '展开'}</span>
@@ -1157,7 +1157,7 @@ const SettingsPage = ({
         {syzygySectionExpanded ? (
           <>
             <div className="section-title">
-              <h2>发帖风格（Syzygy Post Prompt）</h2>
+              <h2 className="ui-title">发帖风格（Syzygy Post Prompt）</h2>
               <p>控制 🤖 发帖按钮的文风与输出约束。</p>
             </div>
             <textarea
@@ -1181,7 +1181,7 @@ const SettingsPage = ({
             </div>
 
             <div className="section-title nested-prompt-title">
-              <h2>回复风格（Syzygy Reply Prompt）</h2>
+              <h2 className="ui-title">回复风格（Syzygy Reply Prompt）</h2>
               <p>控制 🤖 AI 回复的语气与长度。</p>
             </div>
             <textarea

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -577,7 +577,7 @@ const SnacksPage = ({ user, snackAiConfig }: SnacksPageProps) => {
         <button type="button" className="ghost" onClick={() => navigate('/')}>
           返回聊天
         </button>
-        <h1>{showTrash ? '零食回收站' : '零食罐罐区'}</h1>
+        <h1 className="ui-title">{showTrash ? '零食回收站' : '零食罐罐区'}</h1>
         <button
           type="button"
           className="ghost compact-action"

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -610,7 +610,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
         <button type="button" className="ghost" onClick={() => navigate('/')}>
           返回聊天
         </button>
-        <h1>{showTrash ? '观察日志回收站' : '仓鼠观察日志'}</h1>
+        <h1 className="ui-title">{showTrash ? '观察日志回收站' : '仓鼠观察日志'}</h1>
         <button
           type="button"
           className="ghost compact-action"

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1,4 +1,8 @@
 :root {
+  --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Segoe UI',
+    Roboto, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans SC', Arial,
+    sans-serif;
+  --font-display: 'Pixelify Sans', var(--font-sans);
   --accent: #ffd6e7;
   --accent-strong: #f8bad4;
   --text-main: #111827;
@@ -14,6 +18,16 @@
     radial-gradient(circle at 12% 10%, rgba(255, 214, 231, 0.55), transparent 40%),
     radial-gradient(circle at 85% 0%, rgba(229, 231, 235, 0.48), transparent 35%),
     linear-gradient(180deg, #fdf2f8 0%, #f8fafc 52%, #f3f4f6 100%);
+}
+
+.ui-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  line-height: 1.15;
+  text-transform: none;
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
 }
 
 .glass-card,


### PR DESCRIPTION
### Motivation

- Introduce a dedicated display font and a reusable heading style to improve visual consistency for titles across the app.

### Description

- Add Google Fonts preconnect and `Pixelify Sans` stylesheet link to `index.html` and expose a display font via new CSS variables `--font-sans` and `--font-display` in `src/styles/ui.css`.
- Replace the hardcoded body `font-family` with `var(--font-sans)` in `src/index.css` to centralize font configuration.
- Add a new `.ui-title` rule in `src/styles/ui.css` that uses `var(--font-display)` and applied typographic tweaks for headings.
- Apply the `ui-title` class to numerous heading elements (`h1`, `h2`, `h3`, etc.) across multiple pages and components to opt them into the new display font and styling.

### Testing

- Ran type checking with `tsc` which completed successfully.
- Ran linter with `npm run lint` which reported no new errors.
- Built the production bundle with `npm run build` which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eaa9b97f88330b6fbb1a3810e7a8e)