### PR TITLE
Fix RP room color picker clipping and update Enter button to glass style

### DIFF
--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -143,7 +143,6 @@
   cursor: pointer;
 }
 
-.rp-color-popover,
 .rp-actions-popover {
   position: absolute;
   top: 34px;
@@ -156,11 +155,20 @@
 }
 
 .rp-color-popover {
+  position: fixed;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
   width: 138px;
   padding: 8px;
+  border: 1px solid rgba(229, 231, 235, 0.95);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: var(--shadow-soft);
+}
+
+.rp-color-popover-portal {
+  z-index: 2200;
 }
 
 .rp-color-swatch {
@@ -216,6 +224,21 @@
 
 .rp-enter-btn {
   width: 100%;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.26);
+  color: #111827;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(6px);
+}
+
+.rp-enter-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.32);
+}
+
+.rp-enter-btn:active:not(:disabled) {
+  transform: translateY(1px);
+  background: rgba(255, 255, 255, 0.36);
 }
 
 .rp-rename-row {


### PR DESCRIPTION
### Motivation

- Prevent the room tile color palette from being clipped by tile/card overflow and ensure it is fully usable on mobile and desktop.
- Remove the pink filled appearance of the per-tile `进入` button so tile backgrounds can be more diverse and the action uses a neutral frosted-glass treatment.

### Description

- Render the color palette via a portal using `createPortal(..., document.body)` so the popover is not constrained by parent overflow and stays on top of other UI elements.
- Anchor and position the portal popover using the trigger button's `getBoundingClientRect()` and `position: fixed`, with viewport clamping and vertical flip when near the bottom edge; trigger refs are stored in `paletteTriggerRefs` and computed positions are stored in `palettePosition` state in `src/pages/RpRoomsPage.tsx`.
- Keep the existing click-outside close behavior intact by preserving the document click listener and using `event.stopPropagation()` within the popover.
- Update CSS for the popover to `position: fixed` and a high z-index (`.rp-color-popover-portal { z-index: 2200; }`) and restyle the tile `Enter` button (`.rp-enter-btn`) to a neutral glass appearance with translucent background, subtle border, blur, shadow, pill radius, and hover/active feedback in `src/pages/RpRoomsPage.css`.

### Testing

- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` which passed (reports one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`).
- Started the dev server (`vite`) and validated the updated RP rooms UI by capturing a screenshot via an automated Playwright script; the script completed and produced an artifact image."}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ebc421b3c8330bc9840903bae9240)