### PR TITLE
Fix RP area UX: sticky top regions, full tile color picker, and glass dashboard drawer

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -1,17 +1,15 @@
 .rp-room-page {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 100vh;
   min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
 }
 
 .rp-room-chat-page {
   background: var(--page-bg);
-}
-
-.rp-room-chat-page.rp-room-page {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-  overflow: hidden;
 }
 
 .rp-room-header {
@@ -23,6 +21,10 @@
   align-items: center;
   gap: 8px;
   padding: calc(10px + env(safe-area-inset-top)) 14px 10px;
+}
+
+.rp-room-header-dashboard {
+  background: rgba(255, 255, 255, 0.56);
 }
 
 .rp-room-header h1 {
@@ -50,7 +52,6 @@
 }
 
 .rp-room-body {
-  flex: 1;
   min-height: 0;
   display: flex;
 }
@@ -120,16 +121,65 @@
   position: relative;
 }
 
+.rp-room-body-dashboard {
+  overflow: auto;
+  padding: 10px 16px calc(14px + env(safe-area-inset-bottom));
+}
+
+.rp-dashboard-overlay {
+  width: 100%;
+  min-height: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.rp-dashboard-drawer {
+  position: relative;
+  width: min(500px, 92vw);
+  height: 100%;
+  margin-left: auto;
+  border-left: 1px solid color-mix(in srgb, var(--glass-border) 75%, #e5e7eb 25%);
+  border-radius: 28px 0 0 28px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  backdrop-filter: blur(var(--blur));
+  -webkit-backdrop-filter: blur(var(--blur));
+}
+
+.rp-dashboard-drawer::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: radial-gradient(circle, rgba(225, 224, 227, 0.95) 1.8px, transparent 2px);
+  background-size: 14px 14px;
+  opacity: 0.62;
+}
+
+.rp-dashboard-drawer-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  overflow: auto;
+  padding: 2px;
+}
+
 .rp-dashboard-page h2 {
   margin: 0;
   font-size: 15px;
 }
 
 .rp-dashboard-section {
-  margin-top: 12px;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  background: #fff;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.68);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.06);
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -152,10 +202,20 @@
 .rp-dashboard-section input,
 .rp-dashboard-section textarea,
 .rp-dashboard-section select {
-  border: 1px solid #cbd5e1;
-  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
+  border-radius: 12px;
   padding: 8px 10px;
   font-size: 13px;
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--text-main);
+}
+
+.rp-dashboard-section input:focus,
+.rp-dashboard-section textarea:focus,
+.rp-dashboard-section select:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 62%, #fda4af 38%);
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.3);
 }
 
 .rp-dashboard-helper {
@@ -164,14 +224,28 @@
   color: #64748b;
 }
 
-.rp-dashboard-page {
-  width: min(860px, 100%);
-  margin: 0 auto;
-  padding: 16px;
+.rp-dashboard-page button.primary,
+.rp-dashboard-page .rp-npc-form-actions .primary {
+  border: none;
+  background: var(--accent);
+  color: var(--text-main);
+  border-radius: 999px;
+  padding: 9px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 14px rgba(249, 168, 212, 0.34);
 }
 
-.rp-room-body-dashboard {
-  justify-content: center;
+.rp-dashboard-page button.ghost,
+.rp-dashboard-page .rp-model-empty-hint .ghost {
+  border: 1px solid color-mix(in srgb, var(--glass-border) 70%, #d1d5db 30%);
+  background: rgba(255, 255, 255, 0.74);
+  color: #334155;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
 }
 
 .rp-room-card {
@@ -202,9 +276,10 @@
 }
 
 .rp-npc-item {
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
+  border-radius: 12px;
   padding: 10px;
+  background: rgba(255, 255, 255, 0.66);
   display: flex;
   justify-content: space-between;
   gap: 10px;
@@ -264,16 +339,6 @@
   gap: 8px;
 }
 
-.rp-model-empty-hint .ghost {
-  border: 1px solid #cbd5e1;
-  background: #fff;
-  color: #0f172a;
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 12px;
-  cursor: pointer;
-}
-
 .rp-model-warning {
   margin: 0;
   font-size: 12px;
@@ -281,6 +346,21 @@
 }
 
 @media (max-width: 640px) {
+  .rp-room-header {
+    padding-inline: 10px;
+  }
+
+  .rp-room-body-dashboard {
+    padding: 8px 8px calc(10px + env(safe-area-inset-bottom));
+  }
+
+  .rp-dashboard-drawer {
+    width: 92vw;
+    border-radius: 22px;
+    border: 1px solid color-mix(in srgb, var(--glass-border) 75%, #e5e7eb 25%);
+    margin-inline: auto;
+  }
+
   .rp-trigger-row {
     flex-wrap: wrap;
     gap: 6px;

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -1161,8 +1161,8 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
   )
 
   return (
-    <div className={`rp-room-page ${!isDashboardPage ? 'rp-room-chat-page chat-polka-dots' : ''}`}>
-      <header className={`rp-room-header ${!isDashboardPage ? 'chat-header top-nav' : ''}`}>
+    <div className={`rp-room-page ${isDashboardPage ? 'rp-room-dashboard-page chat-polka-dots' : 'rp-room-chat-page chat-polka-dots'}`}>
+      <header className={`rp-room-header ${!isDashboardPage ? 'chat-header top-nav' : 'top-nav rp-room-header-dashboard'}`}>
         <button
           type="button"
           className="ghost"
@@ -1186,11 +1186,15 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
 
       <div className={`rp-room-body ${isDashboardPage ? 'rp-room-body-dashboard' : ''}`}>
         {isDashboardPage ? (
-          <main className="rp-dashboard-page" aria-label="RP 仪表盘页面">
-            {notice ? <p className="tips">{notice}</p> : null}
-            {error ? <p className="error">{error}</p> : null}
-            {dashboardContent}
-          </main>
+          <div className="rp-dashboard-overlay" aria-label="RP 仪表盘页面">
+            <main className="rp-dashboard-page rp-dashboard-drawer">
+              <div className="rp-dashboard-drawer-content">
+                {notice ? <p className="tips">{notice}</p> : null}
+                {error ? <p className="error">{error}</p> : null}
+                {dashboardContent}
+              </div>
+            </main>
+          </div>
         ) : (
           <section className="rp-room-main">
             <section className="chat-messages glass-panel rp-room-timeline">

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -1,11 +1,37 @@
 .rp-rooms-page {
   position: relative;
-  max-width: 1080px;
-  margin: 0 auto;
-  padding: 16px;
-  display: grid;
-  gap: 14px;
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
   isolation: isolate;
+}
+
+.rp-rooms-shell {
+  max-width: 1080px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 12px 16px 16px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 12px;
+}
+
+.rp-rooms-top {
+  position: sticky;
+  top: 0;
+  z-index: 12;
+  display: grid;
+  gap: 12px;
+  padding-top: calc(4px + env(safe-area-inset-top));
+}
+
+.rp-rooms-scroll {
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding-bottom: calc(16px + env(safe-area-inset-bottom));
 }
 
 .rp-rooms-page::before {
@@ -157,9 +183,9 @@
 .rp-color-popover {
   position: fixed;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 6px;
-  width: 138px;
+  width: 196px;
   padding: 8px;
   border: 1px solid rgba(229, 231, 235, 0.95);
   border-radius: 12px;
@@ -177,6 +203,34 @@
   width: 100%;
   aspect-ratio: 1;
   cursor: pointer;
+}
+
+.rp-color-custom {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(209, 213, 219, 0.8);
+  font-size: 12px;
+  color: var(--text-subtle);
+}
+
+.rp-color-custom input[type='color'] {
+  width: 34px;
+  height: 30px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 10px;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.rp-color-custom span {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  color: #374151;
 }
 
 .rp-actions-popover {
@@ -262,8 +316,12 @@
 }
 
 @media (max-width: 680px) {
-  .rp-rooms-page {
-    padding: 10px;
+  .rp-rooms-shell {
+    padding: 8px 10px 12px;
+    gap: 10px;
+  }
+
+  .rp-rooms-top {
     gap: 10px;
   }
 


### PR DESCRIPTION
### Motivation
- Make RP pages match the Chat page scroll model so the top navigation and create controls remain visible while only the content area scrolls. 
- Allow picking any color for room tiles (full palette) while keeping quick swatches and preserving existing DB format. 
- Restyle the RP dashboard so it visually matches the Sessions Drawer (glass + polka-dot background + pink primary buttons). 

### Description
- Reworked the RP rooms page into a fixed-height shell with a sticky top region and an internal scrolling region using the new structure and classes `rp-rooms-shell`, `rp-rooms-top`, and `rp-rooms-scroll`, (files: `src/pages/RpRoomsPage.tsx`, `src/pages/RpRoomsPage.css`).
- Upgraded the color popover to include a native full-spectrum picker via `<input type="color">` and a small hex preview, added `normalizeHexColor` to ensure `#RRGGBB` format, and continued to persist using `updateRpSessionTileColor` (no DB field change). (file: `src/pages/RpRoomsPage.tsx`)
- Restyled the RP dashboard into a right-side glass drawer with polka-dot texture, glass inputs/cards, internal scrolling, and accent pink primary buttons by adding `rp-dashboard-drawer`, `rp-dashboard-drawer-content`, and related CSS that reuse tokens from `ui.css` and the sessions drawer. (files: `src/pages/RpRoomPage.tsx`, `src/pages/RpRoomPage.css`)
- Kept all RP data-flow and Supabase calls unchanged; color writes still go through the same `updateRpSessionTileColor` call and persist a normalized `#RRGGBB` value.

### Testing
- Ran lint with `npm run lint` and it passed (one unrelated warning remains in `src/pages/CheckinPage.tsx`).
- Built the app with `npm run build` and the production build completed successfully.
- Started the dev server with `npm run dev` and captured a visual snapshot of the updated RP page via Playwright for visual verification (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eda84f58c8330a353d99e0e5b9993)