### PR TITLE
Fix RP popover layering and restore Dashboard as page view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 :root {
+  --z-popover: 5000;
   line-height: 1.5;
   font-weight: 400;
   color: var(--text-main, #0f172a);

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -341,6 +341,13 @@
   z-index: 40;
 }
 
+.actions-menu-portal {
+  position: fixed;
+  top: auto;
+  right: auto;
+  z-index: var(--z-popover);
+}
+
 .actions-menu button {
   border: none;
   background: transparent;

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -126,29 +126,25 @@
   padding: 10px 16px calc(14px + env(safe-area-inset-bottom));
 }
 
-.rp-dashboard-overlay {
-  width: 100%;
-  min-height: 100%;
-  display: flex;
-  justify-content: flex-end;
-}
-
-.rp-dashboard-drawer {
+.rp-dashboard-page {
   position: relative;
-  width: min(500px, 92vw);
-  height: 100%;
-  margin-left: auto;
-  border-left: 1px solid color-mix(in srgb, var(--glass-border) 75%, #e5e7eb 25%);
-  border-radius: 28px 0 0 28px;
+  width: min(780px, 100%);
+  min-height: 100%;
+  margin: 0 auto;
+  border: 1px solid color-mix(in srgb, var(--glass-border) 75%, #e5e7eb 25%);
+  border-radius: 28px;
   padding: 14px;
   background: rgba(255, 255, 255, 0.72);
   box-shadow: var(--shadow-soft);
   overflow: hidden;
   backdrop-filter: blur(var(--blur));
   -webkit-backdrop-filter: blur(var(--blur));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.rp-dashboard-drawer::before {
+.rp-dashboard-page::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -159,15 +155,9 @@
   opacity: 0.62;
 }
 
-.rp-dashboard-drawer-content {
+.rp-dashboard-page > * {
   position: relative;
   z-index: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  height: 100%;
-  overflow: auto;
-  padding: 2px;
 }
 
 .rp-dashboard-page h2 {
@@ -354,10 +344,9 @@
     padding: 8px 8px calc(10px + env(safe-area-inset-bottom));
   }
 
-  .rp-dashboard-drawer {
+  .rp-dashboard-page {
     width: 92vw;
     border-radius: 22px;
-    border: 1px solid color-mix(in srgb, var(--glass-border) 75%, #e5e7eb 25%);
     margin-inline: auto;
   }
 

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -170,9 +170,7 @@
 }
 
 .rp-actions-popover {
-  position: absolute;
-  top: 34px;
-  right: 0;
+  position: fixed;
   border: 1px solid rgba(229, 231, 235, 0.95);
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.96);
@@ -194,7 +192,11 @@
 }
 
 .rp-color-popover-portal {
-  z-index: 2200;
+  z-index: var(--z-popover);
+}
+
+.rp-actions-popover-portal {
+  z-index: var(--z-popover);
 }
 
 .rp-color-swatch {


### PR DESCRIPTION
### Motivation

- Dropdowns in RP rooms and RP room chat were being clipped or rendered under other UI layers due to stacking contexts, overflow and transform-created clipping, causing actions like rename/archive/delete to be partially hidden. 
- The RP Dashboard was implemented as a right-side drawer overlay which caused layering/UX inconsistencies; it should be navigated to as a full page while preserving the same visuals.

### Description

- Portaled the room-tile actions popover to `document.body` and switched it to fixed positioning with trigger-based `getBoundingClientRect()` placement, viewport clamping (flip/shift), and a portal z-index so the menu is never clipped by tiles or scroll containers (changes in `src/pages/RpRoomsPage.tsx` and `src/pages/RpRoomsPage.css`).
- Portaled the assistant/message actions menu in the RP room chat to `document.body` with fixed positioning, the same positioning/clamping logic, and outside-click handling that respects both trigger and menu nodes (changes in `src/pages/RpRoomPage.tsx` and `src/pages/ChatPage.css`).
- Introduced a global popover stacking token `--z-popover: 5000` and applied portal-specific CSS classes so popovers consistently render above drawers/overlays (change in `src/index.css` and updated CSS files).
- Restored the Dashboard as a routed full page by rendering the existing Dashboard component as main page content instead of a right-side drawer, while keeping the same glass/dot visuals and responsive styling (changes in `src/pages/RpRoomPage.tsx` and `src/pages/RpRoomPage.css`).

### Testing

- Ran `npm run build` which completed successfully and produced a production bundle. 
- Ran `npm run lint` which completed successfully (one unrelated existing warning remains in `src/pages/CheckinPage.tsx`).
- Launched the dev server and captured a runtime UI screenshot using Playwright to validate popover and dashboard rendering; the screenshot artifact was produced from the running app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699edef35cac83309960b0a1bfe8e7ae)