### PR TITLE
Fix RP color picker interactions, enable dashboard scrolling, and restore local image uploads

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,8 @@
 .app-shell {
   min-height: 100vh;
-  background: #f1f5f9;
+  background:
+    var(--app-background-image, none) center / cover no-repeat fixed,
+    #f1f5f9;
   color: #0f172a;
 }
 

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -1,11 +1,11 @@
 .rp-room-page {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   min-height: 100dvh;
   height: 100vh;
   height: 100dvh;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .rp-room-chat-page {
@@ -52,6 +52,7 @@
 }
 
 .rp-room-body {
+  flex: 1;
   min-height: 0;
   display: flex;
 }
@@ -122,8 +123,11 @@
 }
 
 .rp-room-body-dashboard {
+  flex: 1;
+  min-height: 0;
   overflow: auto;
   padding: 10px 16px calc(14px + env(safe-area-inset-bottom));
+  -webkit-overflow-scrolling: touch;
 }
 
 .rp-dashboard-page {
@@ -136,7 +140,7 @@
   padding: 14px;
   background: rgba(255, 255, 255, 0.72);
   box-shadow: var(--shadow-soft);
-  overflow: hidden;
+  overflow: visible;
   backdrop-filter: blur(var(--blur));
   -webkit-backdrop-filter: blur(var(--blur));
   display: flex;

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -235,6 +235,17 @@
   color: #374151;
 }
 
+
+.rp-color-close-btn {
+  grid-column: 1 / -1;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 6px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
 .rp-actions-popover {
   display: grid;
   gap: 4px;

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -8,7 +8,8 @@ export type DecorativeWidget =
   | {
       id: string
       type: 'image'
-      imageKey: string
+      imageKey?: string
+      imageDataUrl?: string
       fit?: 'cover' | 'contain'
       size?: '1x1' | '2x1'
     }
@@ -25,7 +26,8 @@ export type AppIconConfig =
     }
   | {
       type: 'image'
-      imageKey: string
+      imageKey?: string
+      imageDataUrl?: string
     }
 
 export type HomeSettingsState = {
@@ -39,6 +41,7 @@ export type HomeSettingsState = {
   pageOverlayColor?: string
   pageOverlayOpacity?: number
   homeBackgroundImageKey?: string | null
+  homeBackgroundImageDataUrl?: string | null
   appIconConfigs?: Record<string, AppIconConfig>
 }
 
@@ -104,6 +107,7 @@ export const loadHomeSettings = (): HomeSettingsState | null => {
 
 export const saveHomeSettings = (state: HomeSettingsState) => {
   localStorage.setItem(HOME_SETTINGS_STORAGE_KEY, JSON.stringify(state))
+  window.dispatchEvent(new Event('hamster-home-settings-changed'))
 }
 
 export const loadHomeLayout = (): HomeSettingsState | null => {


### PR DESCRIPTION
### Motivation
- Fix three UI regressions: color picker popover closing during drag, dashboard page not scrolling, and local image/background uploads not updating the UI.
- Keep existing business logic and Supabase schema unchanged while restoring expected UX for color selection and local image persistence.

### Description
- RP color popover: added popover refs and guarded outside-click logic using a `pointerdown` listener and `onPointerDownCapture` to stop propagation inside the popover, enabled live updates using both `onInput` and `onChange` on the `<input type="color">`, removed automatic close on color change, and added an explicit `完成` close button; updated `src/pages/RpRoomsPage.tsx` and `src/pages/RpRoomsPage.css`.
- Dashboard scrolling: converted the RP room page wrapper to a column flex model and made the dashboard content area flexible and scrollable (`flex: 1; min-height: 0; overflow: auto`), and adjusted overflow visibility for the dashboard card so the page scrolls on mobile/desktop; updated `src/pages/RpRoomPage.css`.
- Local image/background persistence: added `readFileAsDataUrl` and stored Data URLs in home settings so selected local files update immediately and persist across navigation, preserved existing IndexedDB blob-key storage as a fallback, updated loaders to prefer Data URLs and only revoke blob URLs when appropriate, and emit a `hamster-home-settings-changed` event when home settings change so the app shell applies the background immediately; changes in `src/pages/HomePage.tsx`, `src/storage/homeLayout.ts`, `src/App.tsx`, and `src/App.css`.
- Misc: small CSS for the color popover close button and safe handling when removing stored blob keys (only remove if key exists).

### Testing
- Ran the full frontend production build with `npm run build`, which completed successfully.
- Started the dev server and captured a Playwright screenshot of the running app to validate layout and background application, which succeeded.
- No automated test failures were observed during the build and manual smoke checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee3d16fcc8330a45c0ee8a56346a5)