### PR TITLE
Fix IndexedDB recovery for home image assets and restore RP dashboard scrolling

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -12,6 +12,13 @@
   background: var(--page-bg);
 }
 
+.rp-room-dashboard-page {
+  height: 100vh;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
 .rp-room-header {
   position: sticky;
   top: 0;

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -49,14 +49,90 @@ const HOME_SETTINGS_STORAGE_KEY = 'hamster_home_settings_v1'
 const LEGACY_HOME_LAYOUT_STORAGE_KEY = 'hamster.home.layout.v1'
 const IMAGE_DB_NAME = 'hamster-home-db'
 const IMAGE_STORE_NAME = 'home_assets'
+const IMAGE_DB_VERSION = 2
+const IMAGE_FALLBACK_STORAGE_KEY = 'hamster_home_assets_fallback_v1'
 
-const openImageDb = (): Promise<IDBDatabase> =>
+let schemaUpgradeLogged = false
+let activeImageDbVersion = IMAGE_DB_VERSION
+
+const getFallbackAssetMap = (): Record<string, string> => {
+  try {
+    const raw = localStorage.getItem(IMAGE_FALLBACK_STORAGE_KEY)
+    if (!raw) {
+      return {}
+    }
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, string>
+    }
+  } catch (error) {
+    console.warn('读取本地图片回退缓存失败', error)
+  }
+  return {}
+}
+
+const setFallbackAssetMap = (map: Record<string, string>) => {
+  localStorage.setItem(IMAGE_FALLBACK_STORAGE_KEY, JSON.stringify(map))
+}
+
+const blobToDataUrl = (blob: Blob): Promise<string> =>
   new Promise((resolve, reject) => {
-    const request = indexedDB.open(IMAGE_DB_NAME, 1)
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+      } else {
+        reject(new Error('读取 Blob 数据失败'))
+      }
+    }
+    reader.onerror = () => reject(reader.error ?? new Error('读取 Blob 数据失败'))
+    reader.readAsDataURL(blob)
+  })
+
+const dataUrlToBlob = async (dataUrl: string): Promise<Blob> => {
+  const response = await fetch(dataUrl)
+  return response.blob()
+}
+
+const saveImageBlobFallback = async (blob: Blob, key: string) => {
+  const map = getFallbackAssetMap()
+  map[key] = await blobToDataUrl(blob)
+  setFallbackAssetMap(map)
+}
+
+const loadImageBlobFallback = async (key: string): Promise<Blob | null> => {
+  const map = getFallbackAssetMap()
+  const dataUrl = map[key]
+  if (!dataUrl) {
+    return null
+  }
+  return dataUrlToBlob(dataUrl)
+}
+
+const removeImageBlobFallback = (key: string) => {
+  const map = getFallbackAssetMap()
+  if (!(key in map)) {
+    return
+  }
+  delete map[key]
+  setFallbackAssetMap(map)
+}
+
+const ensureImageStore = (db: IDBDatabase) => {
+  if (!db.objectStoreNames.contains(IMAGE_STORE_NAME)) {
+    db.createObjectStore(IMAGE_STORE_NAME)
+  }
+}
+
+const openImageDb = (version = activeImageDbVersion): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(IMAGE_DB_NAME, version)
     request.onupgradeneeded = () => {
       const db = request.result
-      if (!db.objectStoreNames.contains(IMAGE_STORE_NAME)) {
-        db.createObjectStore(IMAGE_STORE_NAME)
+      ensureImageStore(db)
+      if (!schemaUpgradeLogged) {
+        schemaUpgradeLogged = true
+        console.info('Home 本地图片缓存结构已升级')
       }
     }
     request.onsuccess = () => resolve(request.result)
@@ -67,16 +143,42 @@ const withImageStore = async <T>(
   mode: IDBTransactionMode,
   handler: (store: IDBObjectStore) => IDBRequest<T>,
 ): Promise<T> => {
-  const db = await openImageDb()
-  return new Promise<T>((resolve, reject) => {
-    const transaction = db.transaction(IMAGE_STORE_NAME, mode)
-    const store = transaction.objectStore(IMAGE_STORE_NAME)
-    const request = handler(store)
-    request.onsuccess = () => resolve(request.result)
-    request.onerror = () => reject(request.error ?? new Error('IndexedDB 操作失败'))
-    transaction.oncomplete = () => db.close()
-    transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB 事务失败'))
-  })
+  const runTransaction = async (allowRepairRetry: boolean): Promise<T> => {
+    const db = await openImageDb()
+
+    if (!db.objectStoreNames.contains(IMAGE_STORE_NAME)) {
+      db.close()
+      if (allowRepairRetry) {
+        activeImageDbVersion += 1
+        const repairedDb = await openImageDb(activeImageDbVersion)
+        repairedDb.close()
+        return runTransaction(false)
+      }
+      throw new Error(`IndexedDB 缺少对象仓库: ${IMAGE_STORE_NAME}`)
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const transaction = db.transaction(IMAGE_STORE_NAME, mode)
+      const store = transaction.objectStore(IMAGE_STORE_NAME)
+      const request = handler(store)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error ?? new Error('IndexedDB 操作失败'))
+      transaction.oncomplete = () => db.close()
+      transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB 事务失败'))
+    })
+  }
+
+  try {
+    return await runTransaction(true)
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'NotFoundError') {
+      activeImageDbVersion += 1
+      const repairedDb = await openImageDb(activeImageDbVersion)
+      repairedDb.close()
+      return runTransaction(false)
+    }
+    throw error
+  }
 }
 
 const parseHomeSettings = (raw: string | null): HomeSettingsState | null => {
@@ -122,15 +224,31 @@ export const createImageKey = () =>
   globalThis.crypto?.randomUUID?.() ?? `image-${Date.now()}-${Math.random().toString(16).slice(2)}`
 
 export const saveImageBlob = async (blob: Blob, key = createImageKey()): Promise<string> => {
-  await withImageStore('readwrite', (store) => store.put(blob, key))
+  try {
+    await withImageStore('readwrite', (store) => store.put(blob, key))
+  } catch (error) {
+    console.warn('IndexedDB 保存图片失败，已回退到 localStorage', error)
+    await saveImageBlobFallback(blob, key)
+  }
   return key
 }
 
 export const loadImageBlob = async (key: string): Promise<Blob | null> => {
-  const result = await withImageStore<Blob | undefined>('readonly', (store) => store.get(key))
-  return result ?? null
+  try {
+    const result = await withImageStore<Blob | undefined>('readonly', (store) => store.get(key))
+    return result ?? null
+  } catch (error) {
+    console.warn('IndexedDB 读取图片失败，尝试 localStorage 回退缓存', error)
+    return loadImageBlobFallback(key)
+  }
 }
 
 export const removeImageBlob = async (key: string): Promise<void> => {
-  await withImageStore('readwrite', (store) => store.delete(key))
+  try {
+    await withImageStore('readwrite', (store) => store.delete(key))
+  } catch (error) {
+    console.warn('IndexedDB 删除图片失败，清理 localStorage 回退缓存', error)
+  } finally {
+    removeImageBlobFallback(key)
+  }
 }


### PR DESCRIPTION
### Motivation
- Fix the `NotFoundError` when accessing the home image IndexedDB (used for local background/components) so local images continue to work for existing users without manual DB clearing.
- Restore RP Dashboard page scrolling by aligning the dashboard layout with the chat page scroll model while keeping existing UI/UX unchanged.

### Description
- Bumped the home image DB version via `IMAGE_DB_VERSION` and added guarded store creation in the upgrade handler using `db.objectStoreNames.contains(...)` so old/corrupt schemas are self-healed (`src/storage/homeLayout.ts`).
- Added a defensive runtime check before transactions that retries once by re-opening the DB at a higher `activeImageDbVersion` if the named object store is missing or a `NotFoundError` occurs, plus a one-time upgrade log message.
- Added a `localStorage` fallback for save/load/remove image-blob operations using data-URL encoding/decoding so image background/component features continue to work when IndexedDB operations fail (`IMAGE_FALLBACK_STORAGE_KEY` and helper functions in `src/storage/homeLayout.ts`).
- Restored dashboard scroll behavior by making the dashboard wrapper a full-height flex column (`.rp-room-dashboard-page { height: 100dvh; display:flex; flex-direction:column; }`) and ensuring the dashboard content area remains `flex:1; min-height:0; overflow:auto;` (`src/pages/RpRoomPage.css`).

### Testing
- Ran `npm run build` which completed successfully and produced the production build artifacts.
- Ran `npm run lint` which completed successfully (reports a pre-existing warning in `src/pages/CheckinPage.tsx`).
- Launched the dev server and executed a headless Playwright check that loaded `/rp/test/dashboard` and captured a screenshot to validate the dashboard scroll/layout, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee894cb288330b295bd6cdb52b853)