### PR TITLE
style: apply RP dashboard dots as full-page background

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -13,10 +13,28 @@
 }
 
 .rp-room-dashboard-page {
+  position: relative;
   height: 100vh;
   height: 100dvh;
   display: flex;
   flex-direction: column;
+  background: var(--page-bg);
+  isolation: isolate;
+}
+
+.rp-room-dashboard-page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: radial-gradient(circle, rgba(107, 114, 128, 0.08) 1.15px, transparent 1.2px);
+  background-size: 18px 18px;
+}
+
+.rp-room-dashboard-page > * {
+  position: relative;
+  z-index: 1;
 }
 
 .rp-room-header {
@@ -138,37 +156,14 @@
 }
 
 .rp-dashboard-page {
-  position: relative;
   width: min(780px, 100%);
   min-height: 100%;
   margin: 0 auto;
-  border: 1px solid color-mix(in srgb, var(--glass-border) 75%, #e5e7eb 25%);
-  border-radius: 28px;
   padding: 14px;
-  background: rgba(255, 255, 255, 0.72);
-  box-shadow: var(--shadow-soft);
   overflow: visible;
-  backdrop-filter: blur(var(--blur));
-  -webkit-backdrop-filter: blur(var(--blur));
   display: flex;
   flex-direction: column;
   gap: 12px;
-}
-
-.rp-dashboard-page::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background-image: radial-gradient(circle, rgba(225, 224, 227, 0.95) 1.8px, transparent 2px);
-  background-size: 14px 14px;
-  opacity: 0.62;
-}
-
-.rp-dashboard-page > * {
-  position: relative;
-  z-index: 1;
 }
 
 .rp-dashboard-page h2 {


### PR DESCRIPTION
### Motivation
- The dashboard previously rendered the dot pattern inside an inner rounded, filled container which produced a dotted “frame” effect instead of a single full-page background layer. 
- The goal is to make the dot pattern a single persistent page background while keeping dashboard cards/panels as glass-only surfaces.

### Description
- Moved the dot pattern from the inner container to the outer page wrapper by adding a fixed pseudo-element on `.rp-room-dashboard-page` and applying the dot `radial-gradient` there. 
- Ensured the page-level wrapper uses `background: var(--page-bg)` and `isolation: isolate` and added `.rp-room-dashboard-page > * { position: relative; z-index: 1; }` so content stacks above the fixed background. 
- Removed the dotted pseudo-element and the rounded framed styling (border, radius, inner background, blur/box-shadow) from `.rp-dashboard-page` so it becomes a plain layout container while ` .rp-dashboard-section` remains a glass-style card. 
- All changes are contained in `src/pages/RpRoomPage.css` and affect only dashboard layout/visuals (CSS only, no logic changes). 

### Testing
- Ran `npm run lint` which completed successfully with one pre-existing non-critical warning in `src/pages/CheckinPage.tsx`. 
- Booted the dev server and captured an automated Playwright screenshot of `http://127.0.0.1:4173/rp/demo/dashboard`, saved at `browser:/tmp/codex_browser_invocations/.../artifacts/rp-dashboard-fullpage-dots.png`, confirming the full-page dot background renders behind content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eead933608330ac9f838b4be02d5d)