### PR TITLE
Fix iOS first-open flicker by reducing expensive paint effects

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 .app-shell {
   min-height: 100vh;
   background:
-    var(--app-background-image, none) center / cover no-repeat fixed,
+    var(--app-background-image, none) center / cover no-repeat,
     #f1f5f9;
   color: #0f172a;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,27 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+html.no-fx,
+html.no-fx body {
+  background: #f8fafc !important;
+}
+
+html.no-fx,
+html.no-fx *,
+html.no-fx *::before,
+html.no-fx *::after {
+  animation: none !important;
+  transition: none !important;
+  filter: none !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+html.no-fx {
+  --blur: 0px;
+  --page-bg: #f8fafc;
+}
+
 #root {
   min-height: 100vh;
   min-height: 100dvh;
@@ -49,4 +70,25 @@ body {
     overflow: hidden;
     overscroll-behavior: none;
   }
+}
+
+
+html.no-fx .app-shell {
+  background: #f8fafc !important;
+}
+
+html.no-fx .chat-page,
+html.no-fx .rp-room-dashboard-page,
+html.no-fx .rp-rooms-page {
+  background: #f8fafc !important;
+}
+
+html.no-fx .chat-page::before,
+html.no-fx .rp-room-dashboard-page::before,
+html.no-fx .rp-rooms-page::before,
+html.no-fx .rp-rooms-page::after,
+html.no-fx .sessions-overlay,
+html.no-fx .sessions-drawer::before {
+  background: none !important;
+  opacity: 0 !important;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,14 @@ import './index.css'
 import './styles/ui.css'
 import App from './App.tsx'
 
+const noFxEnabled =
+  new URLSearchParams(window.location.search).get('noFx') === '1' ||
+  import.meta.env.VITE_NO_FX === '1'
+
+if (noFxEnabled) {
+  document.documentElement.classList.add('no-fx')
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <HashRouter>

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -24,7 +24,7 @@
 
 .rp-room-dashboard-page::before {
   content: '';
-  position: fixed;
+  position: absolute;
   inset: 0;
   pointer-events: none;
   z-index: 0;
@@ -377,5 +377,12 @@
 
   .rp-chat-composer {
     margin: 0 8px 8px;
+  }
+}
+
+
+@media (max-width: 560px) {
+  .rp-room-dashboard-page::before {
+    background-image: none;
   }
 }

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -36,7 +36,7 @@
 
 .rp-rooms-page::before {
   content: '';
-  position: fixed;
+  position: absolute;
   inset: 0;
   z-index: -1;
   background:
@@ -47,7 +47,7 @@
 
 .rp-rooms-page::after {
   content: '';
-  position: fixed;
+  position: absolute;
   inset: 0;
   pointer-events: none;
   z-index: -1;
@@ -352,5 +352,16 @@
   .rp-room-tile {
     min-height: 148px;
     border-radius: 18px;
+  }
+}
+
+
+@media (max-width: 560px) {
+  .rp-rooms-page::before {
+    background: linear-gradient(180deg, #fdf8fb 0%, #f4f4f6 100%);
+  }
+
+  .rp-rooms-page::after {
+    opacity: 0.16;
   }
 }

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -14,10 +14,7 @@
   --radius-tile: 20px;
   --radius-btn: 16px;
   --blur: 16px;
-  --page-bg:
-    radial-gradient(circle at 12% 10%, rgba(255, 214, 231, 0.55), transparent 40%),
-    radial-gradient(circle at 85% 0%, rgba(229, 231, 235, 0.48), transparent 35%),
-    linear-gradient(180deg, #fdf2f8 0%, #f8fafc 52%, #f3f4f6 100%);
+  --page-bg: linear-gradient(180deg, #fdf2f8 0%, #f8fafc 52%, #f3f4f6 100%);
 }
 
 .ui-title {
@@ -123,5 +120,28 @@
   .input-glass,
   .textarea-glass {
     font-size: 16px;
+  }
+}
+
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .glass-card,
+  .glass-panel,
+  .top-nav {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgba(255, 255, 255, 0.76);
+  }
+}
+
+@media (max-width: 560px) {
+  .glass-card,
+  .glass-panel,
+  .top-nav,
+  .input-glass,
+  .textarea-glass {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgba(255, 255, 255, 0.35);
   }
 }


### PR DESCRIPTION
### Motivation

- Cold-open UI on iOS/mobile showed a severe flicker on first load consistent with paint/compositor instability caused by full-viewport blur/filters, fixed background layers, and global transitions.
- Provide a quick isolation path to confirm the cause and allow switching heavy visual effects off without code changes at runtime.
- Apply conservative, non-functional style changes to reduce compositor pressure while keeping visual appearance close to the original.

### Description

- Added a runtime visual-effects debug toggle that enables a global `no-fx` class when `?noFx=1` or `VITE_NO_FX=1` is present, implemented in `src/main.tsx`.
- Implemented `no-fx` CSS overrides in `src/index.css` to globally disable `backdrop-filter`, `filter: blur(...)`, `animation`, and `transition`, and force a flat page background via a `.no-fx` class and CSS variables.
- Simplified and stabilized background and glass styling in `src/styles/ui.css` by reducing the multi-layer radial gradients to a single gradient, adding an `@supports` fallback for `backdrop-filter`, and adding a mobile fallback (`@media (max-width: 560px)`) that disables backdrop blur on glass surfaces.
- Avoided full-viewport repaint churn by removing `background-attachment: fixed` from the app shell in `src/App.css` and converted full-screen decorative pseudo-elements from `position: fixed` to `position: absolute` in `src/pages/RpRoomPage.css` and `src/pages/RpRoomsPage.css`, plus added mobile simplifications for those backgrounds.

### Testing

- Built the production bundle with `npm run build` which completed successfully and produced the app artifacts.
- Started the dev server with `npm run dev` and confirmed it booted and served the app for localhost testing.
- Ran an automated Playwright script that opened the mobile viewport at `http://127.0.0.1:4173/?noFx=1#/auth` and captured a screenshot to validate the `no-fx` toggle path; the script executed and produced the artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef2b90d408330a3e0c4216b811979)