### PR TITLE
Home: Use shared pink mist background

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -4,15 +4,14 @@
   --page-overlay-bg: rgba(255, 255, 255, 0.2);
   --home-background-image: none;
   min-height: 100vh;
+  min-height: 100dvh;
   padding: max(env(safe-area-inset-top), 1rem) 1rem max(env(safe-area-inset-bottom), 1.25rem);
   display: flex;
   align-items: center;
   justify-content: center;
   background:
     var(--home-background-image) center / cover no-repeat,
-    radial-gradient(circle at 20% 20%, rgba(125, 211, 252, 0.45), transparent 40%),
-    radial-gradient(circle at 80% 30%, rgba(167, 139, 250, 0.38), transparent 42%),
-    linear-gradient(180deg, #dbeafe 0%, #bfdbfe 45%, #dbeafe 100%);
+    var(--page-bg);
 }
 
 .phone-shell {


### PR DESCRIPTION
### Motivation
- Align the Home screen with the app-wide pink mist theme by removing the page-specific blue/purple gradient and using the shared background token.

### Description
- Replace the Home page custom gradient with `var(--page-bg)` and add `min-height: 100dvh` while preserving the optional `--home-background-image`; change applied to `src/pages/HomePage.css` only.

### Testing
- Ran `npm run build` (succeeded), `npm run lint` (succeeded with one pre-existing warning in `src/pages/CheckinPage.tsx`), and a headless browser navigation/screenshot which loaded the app and redirected to the auth gate as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efb3b2be883308b2aa174d4a8ceac)