### PR TITLE
Stabilize mobile viewport height, safe-area header, and single scroll container

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="apple-touch-icon" href="%BASE_URL%icons/pwa-180.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#fdf2f8" />
     <title>ham</title>
   </head>

--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,16 @@
 .app-shell {
   transition: none;
   min-height: 100vh;
+  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
   background:
     var(--app-background-image, none) center / cover no-repeat,
     #f1f5f9;
   color: #0f172a;
+  overscroll-behavior: none;
 }
 
 button {
@@ -13,6 +19,7 @@ button {
 
 .loading-state {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,12 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+html,
+body,
+#root {
+  height: 100%;
+}
+
 html.no-fx,
 html.no-fx body {
   background: #f8fafc !important;
@@ -69,6 +75,10 @@ html.no-fx {
     height: 100dvh;
     overflow: hidden;
     overscroll-behavior: none;
+  }
+
+  body.chat-page-active #root {
+    height: 100dvh;
   }
 }
 

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -1,13 +1,14 @@
 .chat-page {
   position: relative;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   height: 100vh;
+  height: 100dvh;
   min-height: 100vh;
   min-height: 100dvh;
-  padding-top: env(safe-area-inset-top);
   background: var(--page-bg);
   overflow: hidden;
+  overscroll-behavior: none;
   color: var(--text-main);
   isolation: isolate;
 }
@@ -32,18 +33,16 @@
   z-index: 1;
 }
 
-@supports (height: 100dvh) {
-  .chat-page {
-    height: 100dvh;
-  }
-}
-
 .chat-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: calc(12px + env(safe-area-inset-top)) 16px 12px;
   gap: 8px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--page-bg);
 }
 
 .chat-header .ghost {
@@ -111,13 +110,14 @@
 }
 
 .chat-messages {
+  flex: 1;
   min-height: 0;
-  overflow-y: auto;
+  overflow: auto;
   overflow-x: hidden;
-  overscroll-behavior-y: contain;
+  overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   margin: 8px 16px;
-  padding: 2px;
+  padding: 2px 2px calc(16px + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -378,15 +378,6 @@
 }
 
 @media (max-width: 768px) {
-  .chat-header {
-    position: sticky;
-    top: 0;
-  }
-
-  .chat-messages {
-    padding-bottom: calc(16px + env(safe-area-inset-bottom));
-  }
-
   .chat-composer textarea,
   .model-selector select {
     font-size: 16px;


### PR DESCRIPTION
### Motivation
- Prevent the app UI from drifting on mobile due to dynamic address-bar/viewport changes and ensure the background always fills the screen.  
- Keep the top navigation pinned directly under the system status-bar safe area and avoid competing scroll regions that destabilize layout.  
- Apply minimal CSS/layout-only changes (no JS logic) to make the viewport stable while preserving user zoom/accessibility.

### Description
- Convert the root shell to a full-height dynamic viewport with fallbacks by adding `min-height: 100dvh` / `height: 100dvh` alongside `100vh`, make the shell a column flex root, and add `overscroll-behavior: none` to contain overscroll (`src/App.css`).
- Add root sizing stabilization by setting `html`, `body`, `#root` height and ensuring `body.chat-page-active #root` uses `100dvh` to anchor the app while browser chrome animates (`src/index.css`).
- Refactor chat page layout to a fixed header + single scrollable content model by switching the page to `display: flex; flex-direction: column; height: 100dvh`, making the header sticky with `padding: calc(12px + env(safe-area-inset-top))`, stable `z-index` and background, and making `.chat-messages` the only scrolling region with `flex: 1; min-height: 0; overflow: auto; -webkit-overflow-scrolling: touch; padding-bottom: calc(16px + env(safe-area-inset-bottom))` (`src/pages/ChatPage.css`).
- Constrain overscroll and remove competing scroll behaviors by using `overscroll-behavior` on the app shell and scroll container and avoiding `overflow: hidden` on `body` except for the chat UI root handling (`src/App.css`, `src/pages/ChatPage.css`, `src/index.css`).
- Normalize the viewport meta tag to `initial-scale=1` while keeping `viewport-fit=cover` and preserving zoom accessibility (`index.html`).

### Testing
- `npm run build` completed successfully (production build succeeded).  
- Dev server was started (`vite`) and a mobile viewport screenshot was captured automatically using Playwright to validate layout rendering.  
- No unit tests were changed or required; all verification was via the build and automated visual check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f993c756c8330b9d1b6732edca672)