### PR TITLE
Apply shared mobile full-height app shell to Home and RP Rooms pages

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -3,28 +3,38 @@
   --icon-tile-bg: rgba(255, 255, 255, 0.65);
   --page-overlay-bg: rgba(255, 255, 255, 0.2);
   --home-background-image: none;
-  min-height: 100vh;
-  min-height: 100dvh;
-  padding: max(env(safe-area-inset-top), 1rem) 1rem max(env(safe-area-inset-bottom), 1.25rem);
-  display: flex;
+  padding: 1rem;
   align-items: center;
-  justify-content: center;
   background:
     var(--home-background-image) center / cover no-repeat,
     var(--page-bg);
 }
 
+.home-page__header {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.home-page__content {
+  flex: 1;
+  display: grid;
+  gap: 0.9rem;
+}
+
 .phone-shell {
   width: min(420px, 100%);
-  min-height: min(880px, calc(100vh - 2rem));
+  height: 100%;
+  max-height: 100%;
+  margin: 0 auto;
+  min-height: 0;
   border-radius: 36px;
   padding: 1.1rem;
   border: 1px solid rgba(255, 255, 255, 0.6);
   background: var(--page-overlay-bg);
   box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
   backdrop-filter: blur(20px);
-  display: grid;
-  grid-template-rows: auto auto auto auto 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 0.9rem;
 }
 
@@ -312,7 +322,6 @@
 
 @media (max-width: 420px) {
   .phone-shell {
-    min-height: calc(100vh - 1rem);
     border-radius: 28px;
     padding: 0.85rem;
   }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -729,7 +729,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
 
   return (
     <main
-      className="home-page"
+      className="home-page app-shell"
       style={
         {
           '--home-background-image': homeBackgroundImageDataUrl ? `url(${homeBackgroundImageDataUrl})` : 'none',
@@ -739,283 +739,287 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
       }
     >
       <div className="phone-shell">
-        <header className="home-header">
-          <button type="button" className="edit-button" onClick={() => setEditMode((value) => !value)}>
-            {editMode ? '完成' : '编辑'}
-          </button>
-          <h1 className="ui-title">{timeLabel}</h1>
-          <p>{dateLabel}</p>
-        </header>
-
-        {notice ? <p className="home-notice">{notice}</p> : null}
-
-        {editMode ? (
-          <section className="glass-card widget-toolbar">
-            <button type="button" className="ghost" onClick={handleAddTextWidget}>+ 文本组件</button>
-            <button type="button" className="ghost" onClick={handleAddImageWidget}>+ 图片组件</button>
-            <button type="button" className="ghost" onClick={handleAddSpacerWidget}>+ 占位组件</button>
-            <button type="button" className="ghost" onClick={() => setShowEmptySlots((value) => !value)}>
-              {showEmptySlots ? '隐藏空位' : '显示空位'}
+        <div className="home-page__header app-shell__header">
+          <header className="home-header">
+            <button type="button" className="edit-button" onClick={() => setEditMode((value) => !value)}>
+              {editMode ? '完成' : '编辑'}
             </button>
-            <span>{decoratedWidgetCount}/{MAX_WIDGETS} 组件</span>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              hidden
-              onChange={(event) => void handleImageSelected(event)}
-            />
-          </section>
-        ) : null}
+            <h1 className="ui-title">{timeLabel}</h1>
+            <p>{dateLabel}</p>
+          </header>
 
-        {editMode ? (
-          <section className="glass-card appearance-toolbar">
-            <h2 className="ui-title">外观</h2>
-            <label>
-              图标底色
-              <input
-                type="color"
-                value={iconTileBgColor}
-                onChange={(event) => setIconTileBgColor(event.target.value)}
-              />
-            </label>
-            <label>
-              图标透明度 {Math.round(iconTileBgOpacity * 100)}%
-              <input
-                type="range"
-                min="0"
-                max="100"
-                step="1"
-                value={Math.round(iconTileBgOpacity * 100)}
-                onChange={(event) => setIconTileBgOpacity(Number(event.target.value) / 100)}
-              />
-            </label>
-            <label>
-              面板颜色
-              <input
-                type="color"
-                value={pageOverlayColor}
-                onChange={(event) => setPageOverlayColor(event.target.value)}
-              />
-            </label>
-            <label>
-              面板透明度 {Math.round(pageOverlayOpacity * 100)}%
-              <input
-                type="range"
-                min="0"
-                max="100"
-                step="1"
-                value={Math.round(pageOverlayOpacity * 100)}
-                onChange={(event) => setPageOverlayOpacity(Number(event.target.value) / 100)}
-              />
-            </label>
-            <div className="background-controls">
-              <span>背景图</span>
-              <button
-                type="button"
-                className="ghost"
-                onClick={() => homeBackgroundInputRef.current?.click()}
-                disabled={backgroundUploading}
-              >
-                {backgroundUploading ? '上传中…' : '上传背景图'}
+          {notice ? <p className="home-notice">{notice}</p> : null}
+
+          {editMode ? (
+            <section className="glass-card widget-toolbar">
+              <button type="button" className="ghost" onClick={handleAddTextWidget}>+ 文本组件</button>
+              <button type="button" className="ghost" onClick={handleAddImageWidget}>+ 图片组件</button>
+              <button type="button" className="ghost" onClick={handleAddSpacerWidget}>+ 占位组件</button>
+              <button type="button" className="ghost" onClick={() => setShowEmptySlots((value) => !value)}>
+                {showEmptySlots ? '隐藏空位' : '显示空位'}
               </button>
-              <button
-                type="button"
-                className="ghost"
-                onClick={() => void handleRemoveHomeBackground()}
-                disabled={(!homeBackgroundImageKey && !homeBackgroundImageDataUrl) || backgroundUploading}
-              >
-                移除背景图
-              </button>
-            </div>
-            <input
-              ref={homeBackgroundInputRef}
-              type="file"
-              accept="image/*"
-              hidden
-              onChange={(event) => void handleHomeBackgroundSelected(event)}
-            />
-          </section>
-        ) : null}
-
-        {editMode ? (
-          <section className="glass-card icon-editor-toolbar">
-            <h2 className="ui-title">编辑图标</h2>
-            <label>
-              应用
-              <select value={editingIconId} onChange={(event) => setEditingIconId(event.target.value)}>
-                {iconOrder.map((iconId) => {
-                  const icon = iconMap.get(iconId)
-                  return icon ? (
-                    <option key={iconId} value={iconId}>
-                      {icon.label}
-                    </option>
-                  ) : null
-                })}
-              </select>
-            </label>
-            <label>
-              Emoji
+              <span>{decoratedWidgetCount}/{MAX_WIDGETS} 组件</span>
               <input
-                type="text"
-                value={appIconConfigs[editingIconId]?.type === 'emoji' ? appIconConfigs[editingIconId].emoji : ''}
-                onChange={(event) => handleEmojiChange(editingIconId, event.target.value)}
-                placeholder="输入 emoji"
-                maxLength={4}
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={(event) => void handleImageSelected(event)}
               />
-            </label>
-            <div className="background-controls">
-              <button type="button" className="ghost" onClick={() => appIconInputRef.current?.click()}>
-                上传本地图标
-              </button>
-              <button type="button" className="ghost" onClick={() => void handleResetAppIcon(editingIconId)}>
-                恢复默认
-              </button>
-            </div>
-            <input
-              ref={appIconInputRef}
-              type="file"
-              accept="image/*"
-              hidden
-              onChange={(event) => void handleAppIconImageSelected(event)}
-            />
-          </section>
-        ) : null}
+            </section>
+          ) : null}
 
-        <section className="widget-grid" aria-label="Widgets">
-          {orderedWidgetItems.map((item) => {
-            const isCheckin = item.kind === 'checkin'
-            const widget = item.widget
-            const isSpacer = widget?.type === 'spacer'
-
-            return (
-              <article
-                key={item.id}
-                className={`glass-card widget-card ${item.size === '2x1' ? 'widget-card-wide' : ''} ${isSpacer ? 'spacer-card' : ''}`}
-                draggable={editMode}
-                onDragStart={(event) => event.dataTransfer.setData('text/widget-id', item.id)}
-                onDragOver={(event) => editMode && event.preventDefault()}
-                onDrop={(event) => editMode && handleWidgetDropOnItem(event, item.id)}
-                onPointerDown={triggerEditModeByHold}
-                onPointerUp={cancelHold}
-                onPointerLeave={cancelHold}
-              >
-                {editMode ? (
-                  <div className="widget-controls">
-                    <label>
-                      尺寸
-                      <select
-                        value={item.size}
-                        onChange={(event) => handleWidgetSizeChange(item.id, event.target.value as WidgetSize)}
-                      >
-                        <option value="1x1">小</option>
-                        <option value="2x1">大</option>
-                      </select>
-                    </label>
-                    {!isCheckin && widget ? (
-                      <button type="button" className="widget-delete" onClick={() => void removeWidget(widget.id)}>
-                        ×
-                      </button>
-                    ) : null}
-                  </div>
-                ) : null}
-                {isCheckin ? (
-                  <article className={`checkin-inner ${item.size === '2x1' ? 'checkin-wide' : ''}`}>
-                    <div className="checkin-head">
-                      <strong>今日打卡</strong>
-                      <span className={checkedToday ? 'done' : 'todo'}>{checkedToday ? '已完成' : '未完成'}</span>
-                    </div>
-                    <div className="checkin-metrics-mini">
-                      <span>连续 {streakDays} 天</span>
-                      <span>累计 {checkinTotal} 次</span>
-                      {item.size === '2x1' ? <span>{checkedToday ? '今天已打卡' : '今天还没打卡'}</span> : null}
-                    </div>
-                    <button
-                      type="button"
-                      className="primary"
-                      disabled={checkedToday || checkinSubmitting || checkinLoading}
-                      onClick={() => void handleCheckin()}
-                    >
-                      {checkedToday ? '已打卡' : checkinSubmitting ? '打卡中…' : '立即打卡'}
-                    </button>
-                  </article>
-                ) : widget ? (
-                  widget.type === 'text' ? (
-                    <p className="text-widget">{widget.text}</p>
-                  ) : widget.type === 'spacer' ? (
-                    editMode ? <div className="spacer-editor">占位</div> : null
-                  ) : (
-                    <img
-                      className="image-widget"
-                      src={imageUrls[widget.id]}
-                      style={{ objectFit: widget.fit ?? 'cover' }}
-                      alt="本地图片组件"
-                    />
-                  )
-                ) : null}
-              </article>
-            )
-          })}
-          {editMode && showEmptySlots
-            ? Array.from({ length: Math.max(MAX_WIDGETS - orderedWidgetItems.length, 0) }).map((_, index) => (
-                <div key={`empty-${index}`} className="widget-placeholder" aria-hidden="true" />
-              ))
-            : null}
-        </section>
-
-        <section className="icons-grid" aria-label="Apps">
-          {iconOrder.map((iconId, index) => {
-            const icon = iconMap.get(iconId)
-            if (!icon) {
-              return null
-            }
-
-            const configured = appIconConfigs[iconId] ?? { type: 'emoji', emoji: icon.defaultEmoji }
-            const iconImageUrl = configured.type === 'image' ? appIconImageUrls[iconId] : null
-            const emojiValue = configured.type === 'emoji' ? configured.emoji : icon.defaultEmoji
-
-            return (
-              <div
-                key={icon.id}
-                className="app-icon-slot"
-                onDragOver={(event) => editMode && event.preventDefault()}
-                onDrop={(event) => editMode && handleIconDrop(event, index)}
-              >
+          {editMode ? (
+            <section className="glass-card appearance-toolbar">
+              <h2 className="ui-title">外观</h2>
+              <label>
+                图标底色
+                <input
+                  type="color"
+                  value={iconTileBgColor}
+                  onChange={(event) => setIconTileBgColor(event.target.value)}
+                />
+              </label>
+              <label>
+                图标透明度 {Math.round(iconTileBgOpacity * 100)}%
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  step="1"
+                  value={Math.round(iconTileBgOpacity * 100)}
+                  onChange={(event) => setIconTileBgOpacity(Number(event.target.value) / 100)}
+                />
+              </label>
+              <label>
+                面板颜色
+                <input
+                  type="color"
+                  value={pageOverlayColor}
+                  onChange={(event) => setPageOverlayColor(event.target.value)}
+                />
+              </label>
+              <label>
+                面板透明度 {Math.round(pageOverlayOpacity * 100)}%
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  step="1"
+                  value={Math.round(pageOverlayOpacity * 100)}
+                  onChange={(event) => setPageOverlayOpacity(Number(event.target.value) / 100)}
+                />
+              </label>
+              <div className="background-controls">
+                <span>背景图</span>
                 <button
                   type="button"
-                  className="app-icon-button"
+                  className="ghost"
+                  onClick={() => homeBackgroundInputRef.current?.click()}
+                  disabled={backgroundUploading}
+                >
+                  {backgroundUploading ? '上传中…' : '上传背景图'}
+                </button>
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={() => void handleRemoveHomeBackground()}
+                  disabled={(!homeBackgroundImageKey && !homeBackgroundImageDataUrl) || backgroundUploading}
+                >
+                  移除背景图
+                </button>
+              </div>
+              <input
+                ref={homeBackgroundInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={(event) => void handleHomeBackgroundSelected(event)}
+              />
+            </section>
+          ) : null}
+
+          {editMode ? (
+            <section className="glass-card icon-editor-toolbar">
+              <h2 className="ui-title">编辑图标</h2>
+              <label>
+                应用
+                <select value={editingIconId} onChange={(event) => setEditingIconId(event.target.value)}>
+                  {iconOrder.map((iconId) => {
+                    const icon = iconMap.get(iconId)
+                    return icon ? (
+                      <option key={iconId} value={iconId}>
+                        {icon.label}
+                      </option>
+                    ) : null
+                  })}
+                </select>
+              </label>
+              <label>
+                Emoji
+                <input
+                  type="text"
+                  value={appIconConfigs[editingIconId]?.type === 'emoji' ? appIconConfigs[editingIconId].emoji : ''}
+                  onChange={(event) => handleEmojiChange(editingIconId, event.target.value)}
+                  placeholder="输入 emoji"
+                  maxLength={4}
+                />
+              </label>
+              <div className="background-controls">
+                <button type="button" className="ghost" onClick={() => appIconInputRef.current?.click()}>
+                  上传本地图标
+                </button>
+                <button type="button" className="ghost" onClick={() => void handleResetAppIcon(editingIconId)}>
+                  恢复默认
+                </button>
+              </div>
+              <input
+                ref={appIconInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={(event) => void handleAppIconImageSelected(event)}
+              />
+            </section>
+          ) : null}
+        </div>
+
+        <div className="home-page__content app-shell__content">
+          <section className="widget-grid" aria-label="Widgets">
+            {orderedWidgetItems.map((item) => {
+              const isCheckin = item.kind === 'checkin'
+              const widget = item.widget
+              const isSpacer = widget?.type === 'spacer'
+
+              return (
+                <article
+                  key={item.id}
+                  className={`glass-card widget-card ${item.size === '2x1' ? 'widget-card-wide' : ''} ${isSpacer ? 'spacer-card' : ''}`}
                   draggable={editMode}
-                  onDragStart={(event) => event.dataTransfer.setData('text/icon-id', icon.id)}
+                  onDragStart={(event) => event.dataTransfer.setData('text/widget-id', item.id)}
+                  onDragOver={(event) => editMode && event.preventDefault()}
+                  onDrop={(event) => editMode && handleWidgetDropOnItem(event, item.id)}
                   onPointerDown={triggerEditModeByHold}
                   onPointerUp={cancelHold}
                   onPointerLeave={cancelHold}
-                  onClick={() => {
-                    if (editMode) {
-                      setEditingIconId(icon.id)
-                      return
-                    }
-                    if (icon.action) {
-                      icon.action()
-                      return
-                    }
-                    if (icon.route) {
-                      navigate(icon.route)
-                    }
-                  }}
                 >
-                  <span className="icon-emoji">
-                    {iconImageUrl ? (
-                      <img src={iconImageUrl} alt={`${icon.label} 图标`} className="icon-image" />
+                  {editMode ? (
+                    <div className="widget-controls">
+                      <label>
+                        尺寸
+                        <select
+                          value={item.size}
+                          onChange={(event) => handleWidgetSizeChange(item.id, event.target.value as WidgetSize)}
+                        >
+                          <option value="1x1">小</option>
+                          <option value="2x1">大</option>
+                        </select>
+                      </label>
+                      {!isCheckin && widget ? (
+                        <button type="button" className="widget-delete" onClick={() => void removeWidget(widget.id)}>
+                          ×
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : null}
+                  {isCheckin ? (
+                    <article className={`checkin-inner ${item.size === '2x1' ? 'checkin-wide' : ''}`}>
+                      <div className="checkin-head">
+                        <strong>今日打卡</strong>
+                        <span className={checkedToday ? 'done' : 'todo'}>{checkedToday ? '已完成' : '未完成'}</span>
+                      </div>
+                      <div className="checkin-metrics-mini">
+                        <span>连续 {streakDays} 天</span>
+                        <span>累计 {checkinTotal} 次</span>
+                        {item.size === '2x1' ? <span>{checkedToday ? '今天已打卡' : '今天还没打卡'}</span> : null}
+                      </div>
+                      <button
+                        type="button"
+                        className="primary"
+                        disabled={checkedToday || checkinSubmitting || checkinLoading}
+                        onClick={() => void handleCheckin()}
+                      >
+                        {checkedToday ? '已打卡' : checkinSubmitting ? '打卡中…' : '立即打卡'}
+                      </button>
+                    </article>
+                  ) : widget ? (
+                    widget.type === 'text' ? (
+                      <p className="text-widget">{widget.text}</p>
+                    ) : widget.type === 'spacer' ? (
+                      editMode ? <div className="spacer-editor">占位</div> : null
                     ) : (
-                      <span>{emojiValue}</span>
-                    )}
-                  </span>
-                  <span className="icon-label">{icon.label}</span>
-                </button>
-              </div>
-            )
-          })}
-        </section>
+                      <img
+                        className="image-widget"
+                        src={imageUrls[widget.id]}
+                        style={{ objectFit: widget.fit ?? 'cover' }}
+                        alt="本地图片组件"
+                      />
+                    )
+                  ) : null}
+                </article>
+              )
+            })}
+            {editMode && showEmptySlots
+              ? Array.from({ length: Math.max(MAX_WIDGETS - orderedWidgetItems.length, 0) }).map((_, index) => (
+                  <div key={`empty-${index}`} className="widget-placeholder" aria-hidden="true" />
+                ))
+              : null}
+          </section>
+
+          <section className="icons-grid" aria-label="Apps">
+            {iconOrder.map((iconId, index) => {
+              const icon = iconMap.get(iconId)
+              if (!icon) {
+                return null
+              }
+
+              const configured = appIconConfigs[iconId] ?? { type: 'emoji', emoji: icon.defaultEmoji }
+              const iconImageUrl = configured.type === 'image' ? appIconImageUrls[iconId] : null
+              const emojiValue = configured.type === 'emoji' ? configured.emoji : icon.defaultEmoji
+
+              return (
+                <div
+                  key={icon.id}
+                  className="app-icon-slot"
+                  onDragOver={(event) => editMode && event.preventDefault()}
+                  onDrop={(event) => editMode && handleIconDrop(event, index)}
+                >
+                  <button
+                    type="button"
+                    className="app-icon-button"
+                    draggable={editMode}
+                    onDragStart={(event) => event.dataTransfer.setData('text/icon-id', icon.id)}
+                    onPointerDown={triggerEditModeByHold}
+                    onPointerUp={cancelHold}
+                    onPointerLeave={cancelHold}
+                    onClick={() => {
+                      if (editMode) {
+                        setEditingIconId(icon.id)
+                        return
+                      }
+                      if (icon.action) {
+                        icon.action()
+                        return
+                      }
+                      if (icon.route) {
+                        navigate(icon.route)
+                      }
+                    }}
+                  >
+                    <span className="icon-emoji">
+                      {iconImageUrl ? (
+                        <img src={iconImageUrl} alt={`${icon.label} 图标`} className="icon-image" />
+                      ) : (
+                        <span>{emojiValue}</span>
+                      )}
+                    </span>
+                    <span className="icon-label">{icon.label}</span>
+                  </button>
+                </div>
+              )
+            })}
+          </section>
+        </div>
       </div>
     </main>
   )

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -1,9 +1,5 @@
 .rp-rooms-page {
   position: relative;
-  min-height: 100vh;
-  min-height: 100dvh;
-  height: 100vh;
-  height: 100dvh;
   overflow: hidden;
   isolation: isolate;
 }
@@ -19,19 +15,16 @@
 }
 
 .rp-rooms-top {
-  position: sticky;
-  top: 0;
   z-index: 12;
   display: grid;
   gap: 12px;
-  padding-top: calc(4px + env(safe-area-inset-top));
+  padding-top: 4px;
 }
 
 .rp-rooms-scroll {
   min-height: 0;
-  overflow: auto;
   overscroll-behavior: contain;
-  padding-bottom: calc(16px + env(safe-area-inset-bottom));
+  padding-bottom: 16px;
 }
 
 .rp-rooms-page::before {

--- a/src/pages/RpRoomsPage.tsx
+++ b/src/pages/RpRoomsPage.tsx
@@ -470,9 +470,9 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
   }, [openPaletteRoomId, rooms])
 
   return (
-    <div className="rp-rooms-page">
+    <div className="rp-rooms-page app-shell">
       <div className="rp-rooms-shell">
-        <section className="rp-rooms-top">
+        <section className="rp-rooms-top app-shell__header">
           <header className="rp-rooms-header glass-panel">
             <div>
               <h1 className="ui-title">跑跑滚轮区</h1>
@@ -499,7 +499,7 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
           </section>
         </section>
 
-        <section className="rp-rooms-scroll">
+        <section className="rp-rooms-scroll app-shell__content">
           <section className="rp-list-card glass-panel">
             <div className="rp-list-head">
               <div className="rp-tabs" role="tablist" aria-label="房间筛选">

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -113,6 +113,32 @@
   -webkit-backdrop-filter: blur(var(--blur));
 }
 
+.app-shell {
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--page-bg);
+}
+
+.app-shell__header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding-top: env(safe-area-inset-top);
+  background: inherit;
+}
+
+.app-shell__content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
 @media (max-width: 768px) {
   .btn-primary,
   .btn-secondary,


### PR DESCRIPTION
### Motivation
- Ensure mobile pages other than the chat fill the full viewport so the themed background (`--page-bg`) covers the entire screen and header areas remain stable under the status bar.
- Create a reusable shell primitive to keep layout consistent across top-level pages and avoid page-specific viewport-height hacks.

### Description
- Added shared shell CSS primitives in `src/styles/ui.css`: `.app-shell`, `.app-shell__header`, and `.app-shell__content` to provide 100dvh height, safe-area header handling, and a scrollable content area.
- Updated `HomePage` (`src/pages/HomePage.tsx` and `src/pages/HomePage.css`) to apply `app-shell` and to split the page into `app-shell__header` (sticky header and controls) and `app-shell__content` (scrollable widgets and icons), and removed conflicting viewport-height hacks from the Home styles.
- Updated `RpRoomsPage` (`src/pages/RpRoomsPage.tsx` and `src/pages/RpRoomsPage.css`) to adopt `app-shell` with the top region inside `app-shell__header` and the rooms list inside `app-shell__content`, and simplified height/scroll CSS to rely on the shared shell.
- Kept the same theme token (`--page-bg`) and avoided logic changes; adjustments are purely markup/CSS to centralize full-height behavior.

### Testing
- `npm run build` completed successfully (production build produced assets).
- Dev server started with `npm run dev` and the app was served locally for validation.
- Automated browser screenshot validation: Chromium headless run crashed in this environment (SIGSEGV) but a Firefox-based run succeeded and produced screenshots for the Home and RP Rooms mobile routes.
- All applied changes compile and the build/dev verification steps passed after the updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f9e2c605c83308340438e09b30744)