### PR TITLE
Fix Home widget clipping, icon dock placement, placeholder transparency, and mobile Settings scrolling

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -19,6 +19,8 @@
   flex: 1;
   display: grid;
   gap: 0.9rem;
+  min-height: 0;
+  overflow: visible;
 }
 
 .phone-shell {
@@ -29,13 +31,27 @@
   min-height: 0;
   border-radius: 36px;
   padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: relative;
+  overflow: visible;
+}
+
+.phone-shell__mask {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
   border: 1px solid rgba(255, 255, 255, 0.6);
   background: var(--page-overlay-bg);
   box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
   backdrop-filter: blur(20px);
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
+  z-index: 0;
+}
+
+.phone-shell > *:not(.phone-shell__mask) {
+  position: relative;
+  z-index: 1;
 }
 
 .home-header {
@@ -137,6 +153,11 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
   align-content: start;
+  overflow: visible;
+}
+
+.home-widget-stage {
+  overflow: visible;
 }
 
 .widget-card {
@@ -197,7 +218,13 @@
   width: 100%;
   min-height: 105px;
   border-radius: 16px;
-  border: 1px dashed rgba(51, 65, 85, 0.35);
+  border: 1px solid transparent !important;
+  background: transparent !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .checkin-inner {
@@ -261,12 +288,10 @@
 }
 
 .icons-grid {
-  margin-top: auto;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-rows: repeat(2, auto);
   gap: 0.9rem 0.65rem;
-  align-content: end;
 }
 
 .app-icon-slot {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -739,6 +739,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
       }
     >
       <div className="phone-shell">
+        <div className="phone-shell__mask" aria-hidden="true" />
         <div className="home-page__header app-shell__header">
           <header className="home-header">
             <button type="button" className="edit-button" onClick={() => setEditMode((value) => !value)}>
@@ -885,7 +886,7 @@ const HomePage = ({ user, onOpenChat }: HomePageProps) => {
         </div>
 
         <div className="home-page__content app-shell__content">
-          <section className="widget-grid" aria-label="Widgets">
+          <section className="widget-grid home-widget-stage" aria-label="Widgets">
             {orderedWidgetItems.map((item) => {
               const isCheckin = item.kind === 'checkin'
               const widget = item.widget

--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -1,17 +1,23 @@
-.settings-page {
+.settings-shell {
+  min-height: 100vh;
   min-height: 100dvh;
+}
+
+.settings-page {
+  min-height: 0;
   background: #f8fafc;
   display: flex;
   flex-direction: column;
   gap: 16px;
   padding-bottom: calc(24px + env(safe-area-inset-bottom));
+  overflow: visible;
 }
 
 .settings-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: calc(12px + env(safe-area-inset-top)) 16px 12px;
+  padding: 12px 16px;
   background: #fff;
   border-bottom: 1px solid #e2e8f0;
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -697,8 +697,8 @@ const SettingsPage = ({
 
   if (!ready || !settings) {
     return (
-      <div className="settings-page">
-        <header className="settings-header">
+      <div className="settings-shell app-shell">
+        <header className="settings-header app-shell__header">
           <button
             type="button"
             className="ghost"
@@ -709,14 +709,16 @@ const SettingsPage = ({
           <h1 className="ui-title">API设置</h1>
           <span className="header-spacer" />
         </header>
-        <div className="settings-loading">正在加载设置...</div>
+        <div className="settings-page app-shell__content">
+          <div className="settings-loading">正在加载设置...</div>
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="settings-page">
-      <header className="settings-header">
+    <div className="settings-shell app-shell">
+      <header className="settings-header app-shell__header">
         <button
           type="button"
           className="ghost"
@@ -728,6 +730,7 @@ const SettingsPage = ({
         <span className="header-spacer" />
       </header>
 
+      <div className="settings-page app-shell__content">
       <section className="settings-section">
         <button
           type="button"
@@ -1207,7 +1210,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-
+      </div>
 
       <ConfirmDialog
         open={pendingDisable !== null}


### PR DESCRIPTION
### Motivation
- Restore visual layout and UX regressions introduced by the global app-shell on mobile so widget borders/shadows, icon dock positioning, placeholders, and Settings scrolling behave as before.
- Keep changes strictly to CSS/layout without altering application logic.

### Description
- Split the Home phone-shell into a background mask and foreground content by adding a `.phone-shell__mask` layer and rendering content above it so rounded shell styling no longer clips widget shadows; set `.phone-shell` and related containers to `overflow: visible` to avoid clipping. (`src/pages/HomePage.tsx`, `src/pages/HomePage.css`)
- Ensure the widget stage is `overflow: visible` by adding `.home-widget-stage` and making `.home-page__content`/`.widget-grid` non-clipping so widgets can render full borders/shadows. (`src/pages/HomePage.css`, `src/pages/HomePage.tsx`)
- Restore icon dock flow by removing the `margin-top: auto` push so `.icons-grid` remains in normal document flow and visually attaches directly under the widget stage. (`src/pages/HomePage.css`)
- Force placeholder slots to be invisible by adding/overriding `.widget-placeholder` styles: `background: transparent !important`, `border-color: transparent !important`, `box-shadow: none !important`, `backdrop-filter: none !important`, `opacity: 0`, and `pointer-events: none`. (`src/pages/HomePage.css`)
- Move the Settings page into the shared `app-shell` layout by wrapping it in `settings-shell app-shell` and using `app-shell__header` and `app-shell__content` so there is exactly one scroll container on mobile; add `.settings-shell`/`.settings-page` CSS tweaks to avoid nested full-viewport sizing and restore mobile scrolling. (`src/pages/SettingsPage.tsx`, `src/pages/SettingsPage.css`)

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` and linting completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` (unrelated to these changes). 
- Attempted an automated mobile screenshot with Playwright to visually validate changes, but Chromium crashed in this environment (SIGSEGV) so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fa50caf108330908156450abc10b6)