### PR TITLE
Home layout editing → dedicated /home-layout page with mobile Settings/Preview toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import ExportPage from './pages/ExportPage'
 import RpRoomsPage from './pages/RpRoomsPage'
 import RpRoomPage from './pages/RpRoomPage'
 import HomePage from './pages/HomePage'
+import HomeLayoutSettingsPage from './pages/HomeLayoutSettingsPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1366,6 +1367,26 @@ const App = () => {
         <Route
           path="/home"
           element={<Navigate to="/" replace />}
+        />
+        <Route
+          path="/home-layout"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <HomeLayoutSettingsPage
+                user={user}
+                onOpenChat={() => {
+                  const latest = selectMostRecentSession(sessions)
+                  if (latest) {
+                    navigate(`/chat/${latest.id}`)
+                    return
+                  }
+                  void createSessionEntry().then((session) => {
+                    navigate(`/chat/${session.id}`)
+                  })
+                }}
+              />
+            </RequireAuth>
+          }
         />
         <Route
           path="/chat"

--- a/src/pages/HomeLayoutSettingsPage.tsx
+++ b/src/pages/HomeLayoutSettingsPage.tsx
@@ -1,0 +1,16 @@
+import type { User } from "@supabase/supabase-js";
+import HomePage from "./HomePage";
+
+type HomeLayoutSettingsPageProps = {
+  user: User | null;
+  onOpenChat: () => void;
+};
+
+const HomeLayoutSettingsPage = ({
+  user,
+  onOpenChat,
+}: HomeLayoutSettingsPageProps) => (
+  <HomePage user={user} onOpenChat={onOpenChat} mode="settings" />
+);
+
+export default HomeLayoutSettingsPage;

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -65,6 +65,28 @@
   position: relative;
 }
 
+.home-mode-toggle {
+  margin-top: 0.7rem;
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 0.22rem;
+  border: 1px solid rgba(255, 255, 255, 0.58);
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.home-mode-toggle button {
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  padding: 0.3rem 0.85rem;
+  color: #334155;
+}
+
+.home-mode-toggle button.active {
+  background: #ffd6e7;
+  color: #0f172a;
+}
+
 .home-header h1 {
   margin: 0;
   font-size: 3.5rem;
@@ -86,6 +108,11 @@
   color: #0f172a;
   border-radius: 999px;
   padding: 0.32rem 0.75rem;
+}
+
+.edit-button-back {
+  right: auto;
+  left: 0;
 }
 
 .home-notice {
@@ -369,5 +396,32 @@
 
   .home-dock {
     gap: 0.78rem 0.45rem;
+  }
+}
+
+@media (min-width: 901px) {
+  .home-page--settings .phone-shell--settings {
+    width: min(1120px, 100%);
+    max-width: 1120px;
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(340px, 0.9fr);
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+      "preview settings"
+      "preview settings";
+    align-items: start;
+    gap: 1rem;
+  }
+
+  .home-page--settings .home-page__header {
+    grid-area: settings;
+    max-height: calc(100dvh - 4rem);
+    overflow: auto;
+    padding-right: 0.25rem;
+  }
+
+  .home-page--settings .home-page__content {
+    grid-area: preview;
+    height: calc(100dvh - 4rem);
   }
 }


### PR DESCRIPTION
### Motivation
- The in-place overlay used for Home edit/settings caused clipping and broken mobile scrolling, so the editing UI needs a dedicated page route to avoid overlay side-effects. 
- Keep the existing settings form, visual style (glass, dots, pink primary), and persistence logic while changing only routing and interaction. 
- Provide a comfortable mobile experience with a full‑screen preview toggle and a desktop split preview/settings layout.

### Description
- Added a new `HomeLayoutSettingsPage` that renders `HomePage` in `mode="settings"` and registered the `/home-layout` route in the app router so editing has a dedicated page (new file `src/pages/HomeLayoutSettingsPage.tsx` and `src/App.tsx` updates). 
- Extended `HomePage` to support `mode` (default | settings) and implemented settings-mode behavior: top-left `返回` and top-right `完成` actions, mobile segmented control (`设置` / `预览`) with instant switching, and desktop split layout showing preview + settings side-by-side (`src/pages/HomePage.tsx`). 
- Rewired the Home page header `编辑` entry to navigate to `/home-layout` instead of toggling an overlay, and adapted the existing settings form, widget controls, image handlers and save logic to work unchanged in the new page context (`src/pages/HomePage.css` styling added for toggle, back button, and desktop layout). 

### Testing
- Built the app with `npm run build` which completed successfully (build produced a size warning but artifacts were generated). 
- Started the dev server with `npm run dev` and verified the new route loads. 
- Automated browser snapshots were captured via Playwright for mobile and desktop at `/home-layout` to validate the mobile Settings/Preview toggle and desktop split layout (artifacts produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fabe4a6e08330999c7ebb069aaff2)