### PR TITLE
Refactor phone shell to separate mask and content layers to prevent widget clipping

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -36,11 +36,10 @@
   margin: 0 auto;
   min-height: 0;
   border-radius: 36px;
-  padding: 1.1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
   position: relative;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
   overflow: visible;
 }
 
@@ -48,16 +47,21 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
+  overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.6);
   background: var(--page-overlay-bg);
-  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
   backdrop-filter: blur(20px);
   z-index: 0;
 }
 
-.phone-shell > *:not(.phone-shell__mask) {
+.phone-shell__content {
+  padding: 1.1rem clamp(18px, 4vw, 22px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
   position: relative;
   z-index: 1;
+  overflow: visible;
 }
 
 .home-header {
@@ -387,7 +391,10 @@
 @media (max-width: 420px) {
   .phone-shell {
     border-radius: 28px;
-    padding: 0.85rem;
+  }
+
+  .phone-shell__content {
+    padding: 0.85rem 18px;
   }
 
   .home-header h1 {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -172,7 +172,9 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
   const [checkinLoading, setCheckinLoading] = useState(false);
 
   const [editMode, setEditMode] = useState(false);
-  const [mobileTab, setMobileTab] = useState<"settings" | "preview">("settings");
+  const [mobileTab, setMobileTab] = useState<"settings" | "preview">(
+    "settings",
+  );
   const [notice, setNotice] = useState<string | null>(null);
 
   const [iconOrder, setIconOrder] = useState<string[]>(DEFAULT_ICON_ORDER);
@@ -201,7 +203,9 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
   >(null);
   const [backgroundUploading, setBackgroundUploading] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(() =>
-    typeof window !== "undefined" ? window.matchMedia("(max-width: 900px)").matches : true,
+    typeof window !== "undefined"
+      ? window.matchMedia("(max-width: 900px)").matches
+      : true,
   );
   const [appIconConfigs, setAppIconConfigs] = useState<AppIconState>({});
   const [appIconImageUrls, setAppIconImageUrls] = useState<
@@ -883,438 +887,461 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
         } as CSSProperties
       }
     >
-      <div className={`phone-shell ${isSettingsPage ? "phone-shell--settings" : ""}`}>
+      <div
+        className={`phone-shell ${isSettingsPage ? "phone-shell--settings" : ""}`}
+      >
         <div className="phone-shell__mask" aria-hidden="true" />
-        <div className="home-page__header app-shell__header">
-          <header className="home-header">
-            {isSettingsPage ? (
-              <>
-                <button
-                  type="button"
-                  className="edit-button edit-button-back"
-                  onClick={() => navigate(-1)}
-                >
-                  返回
-                </button>
-                <button
-                  type="button"
-                  className="edit-button"
-                  onClick={() => navigate("/")}
-                >
-                  完成
-                </button>
-                <h1 className="ui-title">主页布局</h1>
-                <p>编辑组件并实时预览</p>
-                {isMobileViewport ? (
-                  <div className="home-mode-toggle" role="tablist" aria-label="设置预览切换">
-                    <button
-                      type="button"
-                      className={mobileTab === "settings" ? "active" : ""}
-                      onClick={() => setMobileTab("settings")}
-                    >
-                      设置
-                    </button>
-                    <button
-                      type="button"
-                      className={mobileTab === "preview" ? "active" : ""}
-                      onClick={() => setMobileTab("preview")}
-                    >
-                      预览
-                    </button>
-                  </div>
-                ) : null}
-              </>
-            ) : (
-              <>
-                <button
-                  type="button"
-                  className="edit-button"
-                  onClick={() => navigate("/home-layout")}
-                >
-                  编辑
-                </button>
-                <h1 className="ui-title">{timeLabel}</h1>
-                <p>{dateLabel}</p>
-              </>
-            )}
-          </header>
-
-          {notice ? <p className="home-notice">{notice}</p> : null}
-
-          {showSettingsPanel ? (
-            <section className="glass-card widget-toolbar">
-              <button
-                type="button"
-                className="ghost"
-                onClick={handleAddTextWidget}
-              >
-                + 文本组件
-              </button>
-              <button
-                type="button"
-                className="ghost"
-                onClick={handleAddImageWidget}
-              >
-                + 图片组件
-              </button>
-              <button
-                type="button"
-                className="ghost"
-                onClick={handleAddSpacerWidget}
-              >
-                + 占位组件
-              </button>
-              <button
-                type="button"
-                className="ghost"
-                onClick={() => setShowEmptySlots((value) => !value)}
-              >
-                {showEmptySlots ? "隐藏空位" : "显示空位"}
-              </button>
-              <span>
-                {decoratedWidgetCount}/{MAX_WIDGETS} 组件
-              </span>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(event) => void handleImageSelected(event)}
-              />
-            </section>
-          ) : null}
-
-          {showSettingsPanel ? (
-            <section className="glass-card appearance-toolbar">
-              <h2 className="ui-title">外观</h2>
-              <label>
-                图标底色
-                <input
-                  type="color"
-                  value={iconTileBgColor}
-                  onChange={(event) => setIconTileBgColor(event.target.value)}
-                />
-              </label>
-              <label>
-                图标透明度 {Math.round(iconTileBgOpacity * 100)}%
-                <input
-                  type="range"
-                  min="0"
-                  max="100"
-                  step="1"
-                  value={Math.round(iconTileBgOpacity * 100)}
-                  onChange={(event) =>
-                    setIconTileBgOpacity(Number(event.target.value) / 100)
-                  }
-                />
-              </label>
-              <label>
-                面板颜色
-                <input
-                  type="color"
-                  value={pageOverlayColor}
-                  onChange={(event) => setPageOverlayColor(event.target.value)}
-                />
-              </label>
-              <label>
-                面板透明度 {Math.round(pageOverlayOpacity * 100)}%
-                <input
-                  type="range"
-                  min="0"
-                  max="100"
-                  step="1"
-                  value={Math.round(pageOverlayOpacity * 100)}
-                  onChange={(event) =>
-                    setPageOverlayOpacity(Number(event.target.value) / 100)
-                  }
-                />
-              </label>
-              <div className="background-controls">
-                <span>背景图</span>
-                <button
-                  type="button"
-                  className="ghost"
-                  onClick={() => homeBackgroundInputRef.current?.click()}
-                  disabled={backgroundUploading}
-                >
-                  {backgroundUploading ? "上传中…" : "上传背景图"}
-                </button>
-                <button
-                  type="button"
-                  className="ghost"
-                  onClick={() => void handleRemoveHomeBackground()}
-                  disabled={
-                    (!homeBackgroundImageKey && !homeBackgroundImageDataUrl) ||
-                    backgroundUploading
-                  }
-                >
-                  移除背景图
-                </button>
-              </div>
-              <input
-                ref={homeBackgroundInputRef}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(event) => void handleHomeBackgroundSelected(event)}
-              />
-            </section>
-          ) : null}
-
-          {showSettingsPanel ? (
-            <section className="glass-card icon-editor-toolbar">
-              <h2 className="ui-title">编辑图标</h2>
-              <label>
-                应用
-                <select
-                  value={editingIconId}
-                  onChange={(event) => setEditingIconId(event.target.value)}
-                >
-                  {iconOrder.map((iconId) => {
-                    const icon = iconMap.get(iconId);
-                    return icon ? (
-                      <option key={iconId} value={iconId}>
-                        {icon.label}
-                      </option>
-                    ) : null;
-                  })}
-                </select>
-              </label>
-              <label>
-                Emoji
-                <input
-                  type="text"
-                  value={
-                    appIconConfigs[editingIconId]?.type === "emoji"
-                      ? appIconConfigs[editingIconId].emoji
-                      : ""
-                  }
-                  onChange={(event) =>
-                    handleEmojiChange(editingIconId, event.target.value)
-                  }
-                  placeholder="输入 emoji"
-                  maxLength={4}
-                />
-              </label>
-              <div className="background-controls">
-                <button
-                  type="button"
-                  className="ghost"
-                  onClick={() => appIconInputRef.current?.click()}
-                >
-                  上传本地图标
-                </button>
-                <button
-                  type="button"
-                  className="ghost"
-                  onClick={() => void handleResetAppIcon(editingIconId)}
-                >
-                  恢复默认
-                </button>
-              </div>
-              <input
-                ref={appIconInputRef}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(event) => void handleAppIconImageSelected(event)}
-              />
-            </section>
-          ) : null}
-        </div>
-
-        {showPreviewPanel ? (<div className="home-page__content app-shell__content">
-          <div className="home-layout">
-            <section
-              className="widget-grid home-widget-stage"
-              aria-label="Widgets"
-            >
-              {orderedWidgetItems.map((item) => {
-                const isCheckin = item.kind === "checkin";
-                const widget = item.widget;
-                const isSpacer = widget?.type === "spacer";
-
-                return (
-                  <article
-                    key={item.id}
-                    className={`glass-card widget-card ${item.size === "2x1" ? "widget-card-wide" : ""} ${isSpacer ? "spacer-card" : ""}`}
-                    draggable={editMode}
-                    onDragStart={(event) =>
-                      event.dataTransfer.setData("text/widget-id", item.id)
-                    }
-                    onDragOver={(event) => editMode && event.preventDefault()}
-                    onDrop={(event) =>
-                      editMode && handleWidgetDropOnItem(event, item.id)
-                    }
-                    onPointerDown={triggerEditModeByHold}
-                    onPointerUp={cancelHold}
-                    onPointerLeave={cancelHold}
+        <div className="phone-shell__content">
+          <div className="home-page__header app-shell__header">
+            <header className="home-header">
+              {isSettingsPage ? (
+                <>
+                  <button
+                    type="button"
+                    className="edit-button edit-button-back"
+                    onClick={() => navigate(-1)}
                   >
-                    {editMode ? (
-                      <div className="widget-controls">
-                        <label>
-                          尺寸
-                          <select
-                            value={item.size}
-                            onChange={(event) =>
-                              handleWidgetSizeChange(
-                                item.id,
-                                event.target.value as WidgetSize,
-                              )
-                            }
-                          >
-                            <option value="1x1">小</option>
-                            <option value="2x1">大</option>
-                          </select>
-                        </label>
-                        {!isCheckin && widget ? (
-                          <button
-                            type="button"
-                            className="widget-delete"
-                            onClick={() => void removeWidget(widget.id)}
-                          >
-                            ×
-                          </button>
-                        ) : null}
-                      </div>
-                    ) : null}
-                    {isCheckin ? (
-                      <article
-                        className={`checkin-inner ${item.size === "2x1" ? "checkin-wide" : ""}`}
+                    返回
+                  </button>
+                  <button
+                    type="button"
+                    className="edit-button"
+                    onClick={() => navigate("/")}
+                  >
+                    完成
+                  </button>
+                  <h1 className="ui-title">主页布局</h1>
+                  <p>编辑组件并实时预览</p>
+                  {isMobileViewport ? (
+                    <div
+                      className="home-mode-toggle"
+                      role="tablist"
+                      aria-label="设置预览切换"
+                    >
+                      <button
+                        type="button"
+                        className={mobileTab === "settings" ? "active" : ""}
+                        onClick={() => setMobileTab("settings")}
                       >
-                        <div className="checkin-head">
-                          <strong>今日打卡</strong>
-                          <span className={checkedToday ? "done" : "todo"}>
-                            {checkedToday ? "已完成" : "未完成"}
-                          </span>
-                        </div>
-                        <div className="checkin-metrics-mini">
-                          <span>连续 {streakDays} 天</span>
-                          <span>累计 {checkinTotal} 次</span>
-                          {item.size === "2x1" ? (
-                            <span>
-                              {checkedToday ? "今天已打卡" : "今天还没打卡"}
-                            </span>
-                          ) : null}
-                        </div>
+                        设置
+                      </button>
+                      <button
+                        type="button"
+                        className={mobileTab === "preview" ? "active" : ""}
+                        onClick={() => setMobileTab("preview")}
+                      >
+                        预览
+                      </button>
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="edit-button"
+                    onClick={() => navigate("/home-layout")}
+                  >
+                    编辑
+                  </button>
+                  <h1 className="ui-title">{timeLabel}</h1>
+                  <p>{dateLabel}</p>
+                </>
+              )}
+            </header>
+
+            {notice ? <p className="home-notice">{notice}</p> : null}
+
+            {showSettingsPanel ? (
+              <section className="glass-card widget-toolbar">
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={handleAddTextWidget}
+                >
+                  + 文本组件
+                </button>
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={handleAddImageWidget}
+                >
+                  + 图片组件
+                </button>
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={handleAddSpacerWidget}
+                >
+                  + 占位组件
+                </button>
+                <button
+                  type="button"
+                  className="ghost"
+                  onClick={() => setShowEmptySlots((value) => !value)}
+                >
+                  {showEmptySlots ? "隐藏空位" : "显示空位"}
+                </button>
+                <span>
+                  {decoratedWidgetCount}/{MAX_WIDGETS} 组件
+                </span>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  onChange={(event) => void handleImageSelected(event)}
+                />
+              </section>
+            ) : null}
+
+            {showSettingsPanel ? (
+              <section className="glass-card appearance-toolbar">
+                <h2 className="ui-title">外观</h2>
+                <label>
+                  图标底色
+                  <input
+                    type="color"
+                    value={iconTileBgColor}
+                    onChange={(event) => setIconTileBgColor(event.target.value)}
+                  />
+                </label>
+                <label>
+                  图标透明度 {Math.round(iconTileBgOpacity * 100)}%
+                  <input
+                    type="range"
+                    min="0"
+                    max="100"
+                    step="1"
+                    value={Math.round(iconTileBgOpacity * 100)}
+                    onChange={(event) =>
+                      setIconTileBgOpacity(Number(event.target.value) / 100)
+                    }
+                  />
+                </label>
+                <label>
+                  面板颜色
+                  <input
+                    type="color"
+                    value={pageOverlayColor}
+                    onChange={(event) =>
+                      setPageOverlayColor(event.target.value)
+                    }
+                  />
+                </label>
+                <label>
+                  面板透明度 {Math.round(pageOverlayOpacity * 100)}%
+                  <input
+                    type="range"
+                    min="0"
+                    max="100"
+                    step="1"
+                    value={Math.round(pageOverlayOpacity * 100)}
+                    onChange={(event) =>
+                      setPageOverlayOpacity(Number(event.target.value) / 100)
+                    }
+                  />
+                </label>
+                <div className="background-controls">
+                  <span>背景图</span>
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() => homeBackgroundInputRef.current?.click()}
+                    disabled={backgroundUploading}
+                  >
+                    {backgroundUploading ? "上传中…" : "上传背景图"}
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() => void handleRemoveHomeBackground()}
+                    disabled={
+                      (!homeBackgroundImageKey &&
+                        !homeBackgroundImageDataUrl) ||
+                      backgroundUploading
+                    }
+                  >
+                    移除背景图
+                  </button>
+                </div>
+                <input
+                  ref={homeBackgroundInputRef}
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  onChange={(event) => void handleHomeBackgroundSelected(event)}
+                />
+              </section>
+            ) : null}
+
+            {showSettingsPanel ? (
+              <section className="glass-card icon-editor-toolbar">
+                <h2 className="ui-title">编辑图标</h2>
+                <label>
+                  应用
+                  <select
+                    value={editingIconId}
+                    onChange={(event) => setEditingIconId(event.target.value)}
+                  >
+                    {iconOrder.map((iconId) => {
+                      const icon = iconMap.get(iconId);
+                      return icon ? (
+                        <option key={iconId} value={iconId}>
+                          {icon.label}
+                        </option>
+                      ) : null;
+                    })}
+                  </select>
+                </label>
+                <label>
+                  Emoji
+                  <input
+                    type="text"
+                    value={
+                      appIconConfigs[editingIconId]?.type === "emoji"
+                        ? appIconConfigs[editingIconId].emoji
+                        : ""
+                    }
+                    onChange={(event) =>
+                      handleEmojiChange(editingIconId, event.target.value)
+                    }
+                    placeholder="输入 emoji"
+                    maxLength={4}
+                  />
+                </label>
+                <div className="background-controls">
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() => appIconInputRef.current?.click()}
+                  >
+                    上传本地图标
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() => void handleResetAppIcon(editingIconId)}
+                  >
+                    恢复默认
+                  </button>
+                </div>
+                <input
+                  ref={appIconInputRef}
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  onChange={(event) => void handleAppIconImageSelected(event)}
+                />
+              </section>
+            ) : null}
+          </div>
+
+          {showPreviewPanel ? (
+            <div className="home-page__content app-shell__content">
+              <div className="home-layout">
+                <section
+                  className="widget-grid home-widget-stage"
+                  aria-label="Widgets"
+                >
+                  {orderedWidgetItems.map((item) => {
+                    const isCheckin = item.kind === "checkin";
+                    const widget = item.widget;
+                    const isSpacer = widget?.type === "spacer";
+
+                    return (
+                      <article
+                        key={item.id}
+                        className={`glass-card widget-card ${item.size === "2x1" ? "widget-card-wide" : ""} ${isSpacer ? "spacer-card" : ""}`}
+                        draggable={editMode}
+                        onDragStart={(event) =>
+                          event.dataTransfer.setData("text/widget-id", item.id)
+                        }
+                        onDragOver={(event) =>
+                          editMode && event.preventDefault()
+                        }
+                        onDrop={(event) =>
+                          editMode && handleWidgetDropOnItem(event, item.id)
+                        }
+                        onPointerDown={triggerEditModeByHold}
+                        onPointerUp={cancelHold}
+                        onPointerLeave={cancelHold}
+                      >
+                        {editMode ? (
+                          <div className="widget-controls">
+                            <label>
+                              尺寸
+                              <select
+                                value={item.size}
+                                onChange={(event) =>
+                                  handleWidgetSizeChange(
+                                    item.id,
+                                    event.target.value as WidgetSize,
+                                  )
+                                }
+                              >
+                                <option value="1x1">小</option>
+                                <option value="2x1">大</option>
+                              </select>
+                            </label>
+                            {!isCheckin && widget ? (
+                              <button
+                                type="button"
+                                className="widget-delete"
+                                onClick={() => void removeWidget(widget.id)}
+                              >
+                                ×
+                              </button>
+                            ) : null}
+                          </div>
+                        ) : null}
+                        {isCheckin ? (
+                          <article
+                            className={`checkin-inner ${item.size === "2x1" ? "checkin-wide" : ""}`}
+                          >
+                            <div className="checkin-head">
+                              <strong>今日打卡</strong>
+                              <span className={checkedToday ? "done" : "todo"}>
+                                {checkedToday ? "已完成" : "未完成"}
+                              </span>
+                            </div>
+                            <div className="checkin-metrics-mini">
+                              <span>连续 {streakDays} 天</span>
+                              <span>累计 {checkinTotal} 次</span>
+                              {item.size === "2x1" ? (
+                                <span>
+                                  {checkedToday ? "今天已打卡" : "今天还没打卡"}
+                                </span>
+                              ) : null}
+                            </div>
+                            <button
+                              type="button"
+                              className="primary"
+                              disabled={
+                                checkedToday ||
+                                checkinSubmitting ||
+                                checkinLoading
+                              }
+                              onClick={() => void handleCheckin()}
+                            >
+                              {checkedToday
+                                ? "已打卡"
+                                : checkinSubmitting
+                                  ? "打卡中…"
+                                  : "立即打卡"}
+                            </button>
+                          </article>
+                        ) : widget ? (
+                          widget.type === "text" ? (
+                            <p className="text-widget">{widget.text}</p>
+                          ) : widget.type === "spacer" ? (
+                            editMode ? (
+                              <div className="spacer-editor">占位</div>
+                            ) : null
+                          ) : (
+                            <img
+                              className="image-widget"
+                              src={imageUrls[widget.id]}
+                              style={{ objectFit: widget.fit ?? "cover" }}
+                              alt="本地图片组件"
+                            />
+                          )
+                        ) : null}
+                      </article>
+                    );
+                  })}
+                  {editMode && showEmptySlots
+                    ? Array.from({
+                        length: Math.max(
+                          MAX_WIDGETS - orderedWidgetItems.length,
+                          0,
+                        ),
+                      }).map((_, index) => (
+                        <div
+                          key={`empty-${index}`}
+                          className="widget-placeholder"
+                          aria-hidden="true"
+                        />
+                      ))
+                    : null}
+                </section>
+
+                <section className="home-dock" aria-label="Apps">
+                  {iconOrder.map((iconId, index) => {
+                    const icon = iconMap.get(iconId);
+                    if (!icon) {
+                      return null;
+                    }
+
+                    const configured = appIconConfigs[iconId] ?? {
+                      type: "emoji",
+                      emoji: icon.defaultEmoji,
+                    };
+                    const iconImageUrl =
+                      configured.type === "image"
+                        ? appIconImageUrls[iconId]
+                        : null;
+                    const emojiValue =
+                      configured.type === "emoji"
+                        ? configured.emoji
+                        : icon.defaultEmoji;
+
+                    return (
+                      <div
+                        key={icon.id}
+                        className="app-icon-slot"
+                        onDragOver={(event) =>
+                          editMode && event.preventDefault()
+                        }
+                        onDrop={(event) =>
+                          editMode && handleIconDrop(event, index)
+                        }
+                      >
                         <button
                           type="button"
-                          className="primary"
-                          disabled={
-                            checkedToday || checkinSubmitting || checkinLoading
+                          className="app-icon-button"
+                          draggable={editMode}
+                          onDragStart={(event) =>
+                            event.dataTransfer.setData("text/icon-id", icon.id)
                           }
-                          onClick={() => void handleCheckin()}
+                          onPointerDown={triggerEditModeByHold}
+                          onPointerUp={cancelHold}
+                          onPointerLeave={cancelHold}
+                          onClick={() => {
+                            if (editMode) {
+                              setEditingIconId(icon.id);
+                              return;
+                            }
+                            if (icon.action) {
+                              icon.action();
+                              return;
+                            }
+                            if (icon.route) {
+                              navigate(icon.route);
+                            }
+                          }}
                         >
-                          {checkedToday
-                            ? "已打卡"
-                            : checkinSubmitting
-                              ? "打卡中…"
-                              : "立即打卡"}
+                          <span className="icon-emoji">
+                            {iconImageUrl ? (
+                              <img
+                                src={iconImageUrl}
+                                alt={`${icon.label} 图标`}
+                                className="icon-image"
+                              />
+                            ) : (
+                              <span>{emojiValue}</span>
+                            )}
+                          </span>
+                          <span className="icon-label">{icon.label}</span>
                         </button>
-                      </article>
-                    ) : widget ? (
-                      widget.type === "text" ? (
-                        <p className="text-widget">{widget.text}</p>
-                      ) : widget.type === "spacer" ? (
-                        editMode ? (
-                          <div className="spacer-editor">占位</div>
-                        ) : null
-                      ) : (
-                        <img
-                          className="image-widget"
-                          src={imageUrls[widget.id]}
-                          style={{ objectFit: widget.fit ?? "cover" }}
-                          alt="本地图片组件"
-                        />
-                      )
-                    ) : null}
-                  </article>
-                );
-              })}
-              {editMode && showEmptySlots
-                ? Array.from({
-                    length: Math.max(
-                      MAX_WIDGETS - orderedWidgetItems.length,
-                      0,
-                    ),
-                  }).map((_, index) => (
-                    <div
-                      key={`empty-${index}`}
-                      className="widget-placeholder"
-                      aria-hidden="true"
-                    />
-                  ))
-                : null}
-            </section>
-
-            <section className="home-dock" aria-label="Apps">
-              {iconOrder.map((iconId, index) => {
-                const icon = iconMap.get(iconId);
-                if (!icon) {
-                  return null;
-                }
-
-                const configured = appIconConfigs[iconId] ?? {
-                  type: "emoji",
-                  emoji: icon.defaultEmoji,
-                };
-                const iconImageUrl =
-                  configured.type === "image" ? appIconImageUrls[iconId] : null;
-                const emojiValue =
-                  configured.type === "emoji"
-                    ? configured.emoji
-                    : icon.defaultEmoji;
-
-                return (
-                  <div
-                    key={icon.id}
-                    className="app-icon-slot"
-                    onDragOver={(event) => editMode && event.preventDefault()}
-                    onDrop={(event) => editMode && handleIconDrop(event, index)}
-                  >
-                    <button
-                      type="button"
-                      className="app-icon-button"
-                      draggable={editMode}
-                      onDragStart={(event) =>
-                        event.dataTransfer.setData("text/icon-id", icon.id)
-                      }
-                      onPointerDown={triggerEditModeByHold}
-                      onPointerUp={cancelHold}
-                      onPointerLeave={cancelHold}
-                      onClick={() => {
-                        if (editMode) {
-                          setEditingIconId(icon.id);
-                          return;
-                        }
-                        if (icon.action) {
-                          icon.action();
-                          return;
-                        }
-                        if (icon.route) {
-                          navigate(icon.route);
-                        }
-                      }}
-                    >
-                      <span className="icon-emoji">
-                        {iconImageUrl ? (
-                          <img
-                            src={iconImageUrl}
-                            alt={`${icon.label} 图标`}
-                            className="icon-image"
-                          />
-                        ) : (
-                          <span>{emojiValue}</span>
-                        )}
-                      </span>
-                      <span className="icon-label">{icon.label}</span>
-                    </button>
-                  </div>
-                );
-              })}
-            </section>
-          </div>
-        </div>) : null}
+                      </div>
+                    );
+                  })}
+                </section>
+              </div>
+            </div>
+          ) : null}
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
### Motivation
- The Home preview/editor had persistent widget clipping and overflow issues because rounded-corner masking and content lived on the same element, causing shadows/popovers and long content to be cut off.
- The change isolates rounded-corner clipping to a background mask while allowing the content layer to remain overflow-visible so UI elements are not truncated.

### Description
- Split the phone shell markup to add a dedicated `.phone-shell__content` wrapper that sits above the existing `.phone-shell__mask` so the mask only affects background visuals and not content (`src/pages/HomePage.tsx`).
- Moved the outer shadow to the `.phone-shell` container and applied `overflow: hidden` to `.phone-shell__mask` while keeping `.phone-shell` and `.phone-shell__content` `overflow: visible` so content can extend beyond the rounded background (`src/pages/HomePage.css`).
- Added safe horizontal padding to `.phone-shell__content` (`padding: 1.1rem clamp(18px, 4vw, 22px)`) and mobile-specific lateral padding to avoid shadows touching the shell edges, and updated related layout spacing rules.
- No behavioral or data logic changes; only markup and CSS adjustments to the Home preview/editor phone shell.

### Testing
- Built the production bundle with `npm run build` which completed successfully.
- Ran lint via `npm run lint` which passed with one pre-existing warning in `src/pages/CheckinPage.tsx` and no new errors.
- Started the dev server and captured a visual verification screenshot with Playwright to confirm the preview renders and overflow is preserved (artifact produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fae273f3083309ef3def27b95b017)