### PR TITLE
Fix HomePage settings layout and overflow across breakpoints

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -55,7 +55,7 @@
 }
 
 .phone-shell__content {
-  padding: 1.1rem clamp(18px, 4vw, 22px);
+  padding: 1.1rem clamp(22px, 5vw, 28px);
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
@@ -390,11 +390,11 @@
 
 @media (max-width: 420px) {
   .phone-shell {
-    border-radius: 28px;
+    border-radius: 22px;
   }
 
   .phone-shell__content {
-    padding: 0.85rem 18px;
+    padding: 0.85rem 22px;
   }
 
   .home-header h1 {
@@ -406,10 +406,22 @@
   }
 }
 
+@media (max-width: 900px) {
+  .home-page--settings .home-page__header {
+    max-height: calc(100dvh - 10rem);
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
 @media (min-width: 901px) {
-  .home-page--settings .phone-shell--settings {
+  .home-page--settings .phone-shell {
     width: min(1120px, 100%);
     max-width: 1120px;
+    border-radius: 24px;
+  }
+
+  .home-page--settings .phone-shell__content {
     display: grid;
     grid-template-columns: minmax(0, 1.1fr) minmax(340px, 0.9fr);
     grid-template-rows: auto minmax(0, 1fr);
@@ -423,7 +435,7 @@
   .home-page--settings .home-page__header {
     grid-area: settings;
     max-height: calc(100dvh - 4rem);
-    overflow: auto;
+    overflow-y: auto;
     padding-right: 0.25rem;
   }
 


### PR DESCRIPTION
### Motivation
- Desktop settings were rendering in a single column because the grid was applied to `.phone-shell--settings` instead of the actual parent of `.home-page__header` and `.home-page__content` so `grid-area` never took effect.
- On mobile the settings panel could not scroll when content overflowed, making deep tool panels (icon editor, appearance tools) unreachable.
- Content near the left/right edges was being clipped by the phone mask border radius on narrow viewports, affecting widget text and dock icons.

### Description
- Move the desktop grid container to `.home-page--settings .phone-shell__content` so `grid-area` targets the actual direct children and preview/settings display side-by-side. (`src/pages/HomePage.css`)
- Update the desktop settings shell sizing on `.home-page--settings .phone-shell` and apply a desktop border radius so the shell expands to full width at the desktop breakpoint. (`src/pages/HomePage.css`)
- Add mobile-only scroll constraints to `.home-page--settings .home-page__header` under `@media (max-width: 900px)` with `max-height`, `overflow-y: auto` and `-webkit-overflow-scrolling: touch` so long settings panels are reachable. (`src/pages/HomePage.css`)
- Reduce small-screen corner radius and increase horizontal padding in `.phone-shell__content` to avoid clipped content at the rounded edges, and use `overflow-y: auto` for header on desktop to make scrolling explicit. (`src/pages/HomePage.css`)

### Testing
- Ran `npm run build` successfully with the production build completing without errors. (passed)
- Launched the dev server with `npm run dev` and executed an automated Playwright script that visited `/home-layout` in desktop and mobile viewports and produced screenshots for verification, which ran successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb396cdb883308397003000ad2f34)