### PR TITLE
Fix clipped widget card shadows on home layout

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -26,6 +26,8 @@
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   padding-bottom: 0.25rem;
 }
 


### PR DESCRIPTION
### Motivation
- `overflow: auto` on `.home-page__content` causes widget cards' `box-shadow`s to be clipped at the left/right edges, so the layout needs horizontal spacing inside the scrollable area.

### Description
- Add horizontal padding to `.home-layout` by setting `padding-left: 0.5rem;` and `padding-right: 0.5rem;` in `src/pages/HomePage.css` so widget cards and their `box-shadow`s render inside the overflow boundary while leaving `overflow: auto` unchanged.

### Testing
- Ran `npm run build` which completed successfully, and executed an automated Playwright script that captured `artifacts/home-layout-padding-fix.png` showing the visual fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb6c11e408330be13da2e0ea85c8a)