### PR TITLE
Soften HomePage shadows and add horizontal padding to layout

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -26,6 +26,8 @@
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   padding-bottom: 0.25rem;
 }
 
@@ -39,7 +41,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.22);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
   overflow: visible;
 }
 
@@ -130,7 +132,7 @@
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.5);
   background: rgba(255, 255, 255, 0.28);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
   backdrop-filter: blur(12px);
 }
 
@@ -361,7 +363,7 @@
   border-radius: 18px;
   background: var(--icon-tile-bg);
   border: 1px solid rgba(255, 255, 255, 0.8);
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
   font-size: clamp(1.35rem, 4.8vw, 1.8rem);
   overflow: hidden;
 }


### PR DESCRIPTION
### Motivation
- Reduce the visual heaviness of multiple components on the Home page by softening box-shadow values and improve spacing on small screens with horizontal padding.

### Description
- Added `padding-left` and `padding-right` to `.home-layout` to provide consistent horizontal spacing on narrow viewports.
- Reduced box-shadow intensity on `.phone-shell` from `0 20px 50px rgba(15, 23, 42, 0.22)` to `0 8px 24px rgba(15, 23, 42, 0.08)` for a subtler elevation.
- Reduced box-shadow on `.home-page .glass-card` from `0 10px 30px rgba(15, 23, 42, 0.16)` to `0 4px 12px rgba(15, 23, 42, 0.06)` to match the softer visual language.
- Reduced box-shadow on `.icon-emoji` from `0 10px 20px rgba(15, 23, 42, 0.14)` to `0 2px 8px rgba(15, 23, 42, 0.06)` for a lighter icon tile appearance.

### Testing
- Ran project build and test suite with `npm run build` and `npm test`, and all checks passed successfully.
- Verified there were no CSS compilation errors and layout changes apply without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb6c11e408330be13da2e0ea85c8a)