### PR TITLE
Make top header/nav background solid accent pink

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -42,7 +42,11 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: var(--page-bg);
+  background: var(--accent);
+  background-image: none;
+  color: var(--text-main);
+  border-bottom: 1px solid var(--glass-border);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
 .chat-header .ghost {

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -49,7 +49,11 @@
 }
 
 .rp-room-header-dashboard {
-  background: rgba(255, 255, 255, 0.56);
+  background: var(--accent);
+  background-image: none;
+  color: var(--text-main);
+  border-bottom: 1px solid var(--glass-border);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
 .rp-room-header h1 {

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -107,10 +107,11 @@
   position: sticky;
   top: 0;
   z-index: 10;
-  background: rgba(255, 255, 255, 0.42);
+  background: var(--accent);
+  background-image: none;
+  color: var(--text-main);
   border-bottom: 1px solid var(--glass-border);
-  backdrop-filter: blur(var(--blur));
-  -webkit-backdrop-filter: blur(var(--blur));
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
 .app-shell {
@@ -128,7 +129,11 @@
   top: 0;
   z-index: 10;
   padding-top: env(safe-area-inset-top);
-  background: inherit;
+  background: var(--accent);
+  background-image: none;
+  color: var(--text-main);
+  border-bottom: 1px solid var(--glass-border);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
 .app-shell__content {
@@ -152,22 +157,28 @@
 
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
   .glass-card,
-  .glass-panel,
-  .top-nav {
+  .glass-panel {
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     background: rgba(255, 255, 255, 0.76);
+  }
+
+  .top-nav {
+    background-image: none;
   }
 }
 
 @media (max-width: 560px) {
   .glass-card,
   .glass-panel,
-  .top-nav,
   .input-glass,
   .textarea-glass {
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     background: rgba(255, 255, 255, 0.35);
+  }
+
+  .top-nav {
+    background-image: none;
   }
 }


### PR DESCRIPTION
### Motivation
- The app-shell top header and various page headers were using translucent/glass backgrounds or gradients which clash with the full-page background and cause visual inconsistency. The header safe-area region also needed to be a uniform color. 

### Description
- Set shared header primitives to a solid accent pink by updating `.top-nav` and `.app-shell__header` to `background: var(--accent)` and `background-image: none`, and ensured the safe-area padding region uses the same color by applying the background to `.app-shell__header` (safe-area preserved via `padding-top: env(safe-area-inset-top)`).
- Added subtle separation between header and content by adding a soft bottom border using `var(--glass-border)` and a light shadow `box-shadow: 0 6px 18px rgba(0,0,0,0.06)` to the header containers.
- Ensured header text and icons remain readable by setting color to `var(--text-main)` where appropriate.
- Removed gradient/background-image references for headers in the fallback `@supports` and mobile `@media` blocks so the header remains a flat solid accent across environments.
- Applied the same solid-header treatment to page-specific header variants: updated chat header (`src/pages/ChatPage.css`) and RP room dashboard header (`src/pages/RpRoomPage.css`) for consistent look across chat, rooms, home, and settings.

Files changed: `src/styles/ui.css`, `src/pages/ChatPage.css`, `src/pages/RpRoomPage.css`.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and visually inspected the header styling in-browser; the header appears as a uniform solid pink with subtle separation and readable text.
- Captured a Playwright screenshot of the updated home view for visual verification (artifact generated) and used that to confirm consistency across pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fbb6007c08330b9f8093348b998e6)