### PR TITLE
Add pink header variant and apply to chat header

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -42,7 +42,14 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: var(--page-bg);
+}
+
+.chat-header--pink {
+  background: var(--accent);
+  background-image: none;
+  color: var(--text-main);
+  border-bottom: 1px solid var(--glass-border);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
 .chat-header .ghost {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -170,7 +170,7 @@ const ChatPage = ({
 
   return (
     <div className="chat-page chat-polka-dots">
-      <header className="chat-header top-nav">
+      <header className="chat-header top-nav chat-header--pink">
         <button type="button" className="ghost" onClick={onOpenDrawer}>
           会话
         </button>


### PR DESCRIPTION
### Motivation
- Introduce a dedicated accent/pink header style to support a highlighted header appearance for the chat page and avoid keeping a hard-coded background on the base `.chat-header` rule.

### Description
- Remove the `background` from the base `.chat-header` rule and add a new modifier class `.chat-header--pink` that sets `background`, `color`, `border-bottom`, and `box-shadow` to create the accent header.
- Apply the new `chat-header--pink` class to the header element in `ChatPage.tsx` so the chat page uses the new accent styling.

### Testing
- Ran a TypeScript type-check and a local build of the app (`tsc` and project build) with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fbb6007c08330b9f8093348b998e6)