### PR TITLE
Apply app-shell__header class and style chat header accent

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -42,7 +42,16 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: var(--page-bg);
+}
+
+.chat-page .app-shell__header {
+  background: var(--accent) !important;
+  background-image: none !important;
+}
+
+.chat-page .app-shell__header::before,
+.chat-page .app-shell__header::after {
+  background: none !important;
 }
 
 .chat-header .ghost {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -170,7 +170,7 @@ const ChatPage = ({
 
   return (
     <div className="chat-page chat-polka-dots">
-      <header className="chat-header top-nav">
+      <header className="chat-header top-nav app-shell__header">
         <button type="button" className="ghost" onClick={onOpenDrawer}>
           会话
         </button>


### PR DESCRIPTION
### Motivation
- Ensure the chat page header uses the app accent color and remove conflicting background images so the header visually matches the shell and polka-dot overlay behavior.

### Description
- Add the `app-shell__header` class to the chat page header element in `ChatPage.tsx` and update `ChatPage.css` to style `.chat-page .app-shell__header` with `background: var(--accent)`, disable `background-image`, and clear pseudo-element backgrounds so the accent shows consistently.

### Testing
- Ran the project build and test suite with `yarn build` and `yarn test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fbb6007c08330b9f8093348b998e6)