### PR TITLE
Make non-chat headers transparent and preserve ChatPage pink header

### DIFF
--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -107,7 +107,7 @@
   position: sticky;
   top: 0;
   z-index: 10;
-  background: var(--accent);
+  background: transparent;
   background-image: none;
   color: var(--text-main);
   border-bottom: 1px solid var(--glass-border);
@@ -129,11 +129,16 @@
   top: 0;
   z-index: 10;
   padding-top: env(safe-area-inset-top);
-  background: var(--accent);
+  background: transparent;
   background-image: none;
   color: var(--text-main);
   border-bottom: 1px solid var(--glass-border);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+}
+
+.app-shell__header::before,
+.app-shell__header::after {
+  background: none;
 }
 
 .app-shell__content {


### PR DESCRIPTION
### Motivation
- Remove the global pink header fill so only the Chat page shows a solid accent background and other pages allow the page background to show through.
- Prevent pseudo-element or inherited header backgrounds from producing an unintended color band on non-chat pages.

### Description
- Changed `.top-nav` default background to `transparent` and kept `background-image: none` to avoid global fills (updated `src/styles/ui.css`).
- Changed `.app-shell__header` default background to `transparent` and added `.app-shell__header::before, .app-shell__header::after { background: none; }` to clear pseudo-element fills (updated `src/styles/ui.css`).
- Did not modify Chat-specific rules; the existing `.chat-page .app-shell__header` override in `src/pages/ChatPage.css` still applies the solid `var(--accent)` pink only on the Chat page.

### Testing
- Ran `npm run build` successfully with no errors.
- Started the dev server (`npm run dev`) and visually validated pages by capturing screenshots of the home page (header transparent) and `/chat` (header solid pink) using Playwright; captures generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fc7256d408330be6837923857c591)