### PR TITLE
Fix Home/RP side strips by neutralizing shell overlays

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -51,9 +51,17 @@
   border-radius: inherit;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.6);
-  background: var(--page-overlay-bg);
-  backdrop-filter: blur(20px);
+  background: transparent !important;
+  background-image: none !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
   z-index: 0;
+}
+
+.phone-shell__mask::before,
+.phone-shell__mask::after {
+  background: none !important;
+  background-image: none !important;
 }
 
 .phone-shell__content {

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -21,10 +21,19 @@
   padding-top: 4px;
 }
 
+.rp-rooms-top.app-shell__header {
+  background: transparent;
+  background-image: none;
+}
+
 .rp-rooms-scroll {
   min-height: 0;
   overscroll-behavior: contain;
   padding-bottom: 16px;
+}
+
+.rp-rooms-scroll.app-shell__content {
+  background: transparent;
 }
 
 .rp-rooms-page::before {

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -146,6 +146,7 @@
   min-height: 0;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+  background: transparent;
   padding-bottom: env(safe-area-inset-bottom);
 }
 


### PR DESCRIPTION
### Motivation
- Remove faint left/right vertical strips caused by semi-transparent backgrounds on shell mask/header/content layers so the visible content area does not reveal an overlay at the sides.
- Ensure there is a single background source at the app root and that nested shell layers remain transparent so padding and rounded corners are preserved.

### Description
- Neutralized the Home phone shell mask by making `.phone-shell__mask` non-painting with `background: transparent !important`, `background-image: none !important`, `box-shadow: none !important`, and `backdrop-filter: none !important`, and cleared its pseudo-element backgrounds via `.phone-shell__mask::before`/`::after` in `src/pages/HomePage.css`.
- Kept RP rooms header and content transparent by adding `.rp-rooms-top.app-shell__header { background: transparent; background-image: none; }` and `.rp-rooms-scroll.app-shell__content { background: transparent; }` in `src/pages/RpRoomsPage.css` to avoid panel gutters behind content.
- Made the shared content layer explicitly transparent by adding `background: transparent;` to `.app-shell__content` in `src/styles/ui.css` so the page background remains a single source on the root shell.

### Testing
- Ran `npm run lint` which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to these changes.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app started and served pages.
- Captured full-page screenshots of `/` and `/rp` using an automated Playwright script to confirm no visible left/right side strips on Home and RP pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe4c93b3c8330a183d3bd02914567)