### PR TITLE
Fix empty .glass-card borders on Home and RP pages

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -225,7 +225,7 @@
   grid-column: span 2;
 }
 
-.spacer-card {
+.home-page .glass-card.spacer-card {
   background: transparent;
   border: none;
   box-shadow: none;

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -104,6 +104,13 @@
   padding: 10px 14px;
 }
 
+.rp-room-page .glass-card:empty {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
 .rp-trigger-row {
   justify-content: flex-start;
 }


### PR DESCRIPTION
### Motivation
- Empty spacer widgets and some empty glass cards were rendering as visible transparent rectangles because `.home-page .glass-card` had higher specificity than `.spacer-card`. 
- RP room also contains `.glass-card` elements that can be empty and need an explicit override to avoid showing borders or shadows.

### Description
- Increased specificity for spacer widgets by changing `.spacer-card` to `.home-page .glass-card.spacer-card` in `src/pages/HomePage.css` so it overrides `.home-page .glass-card` styles. 
- Added a safeguard rule `.rp-room-page .glass-card:empty` in `src/pages/RpRoomPage.css` to clear `background`, `border`, `box-shadow`, and `backdrop-filter` when a glass card has no content. 
- Updated two files: `src/pages/HomePage.css` and `src/pages/RpRoomPage.css`.

### Testing
- Ran `npm run lint`, which completed successfully with one existing warning in `src/pages/CheckinPage.tsx`. 
- Launched the dev server with `npm run dev` and confirmed Vite started and served the site. 
- Executed a headless UI check with Playwright that loaded the homepage and captured a screenshot to validate the visual fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe890132883308f59649135a32df7)