### PR TITLE
Fix phantom glass artifacts on Home and RP room pages

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -15,6 +15,11 @@
   gap: 0.9rem;
 }
 
+.home-page .app-shell__header {
+  border-bottom: none;
+  box-shadow: none;
+}
+
 .home-page__content {
   min-height: 0;
   overflow: auto;

--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -104,11 +104,13 @@
   padding: 10px 14px;
 }
 
-.rp-room-page .glass-card:empty {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  backdrop-filter: none;
+.rp-chat-composer {
+  border-radius: var(--radius-card);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(var(--blur));
+  -webkit-backdrop-filter: blur(var(--blur));
 }
 
 .rp-trigger-row {

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -1293,7 +1293,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
             </section>
 
             <form
-              className="chat-composer glass-card rp-chat-composer"
+              className="chat-composer rp-chat-composer"
               onSubmit={(event) => {
                 event.preventDefault()
                 void handleSend('player')


### PR DESCRIPTION
### Motivation
- The global `.glass-card` and `.app-shell__header` styles in `src/styles/ui.css` produced visible borders/shadows on elements that should not show them, causing phantom transparent boxes on the Home page and RP room dashboard. 
- The existing `:empty` workaround in `src/pages/RpRoomPage.css` is ineffective with React because React elements are rarely truly `:empty`. 

### Description
- Neutralize Home header chrome by adding a scoped override ` .home-page .app-shell__header { border-bottom: none; box-shadow: none; }` in `src/pages/HomePage.css` so the Home header no longer inherits global shell borders/shadows. 
- Remove the broad `glass-card` usage from the RP chat composer by changing the form `className` from `"chat-composer glass-card rp-chat-composer"` to `"chat-composer rp-chat-composer"` in `src/pages/RpRoomPage.tsx`. 
- Replace the ineffective `.rp-room-page .glass-card:empty` rule with an explicit ` .rp-chat-composer { ... }` style in `src/pages/RpRoomPage.css` so the RP composer retains intended visual styling without relying on global `.glass-card`. 
- Diagnostic mapping: Home artifact was `div` with classes `home-page__header app-shell__header` from `src/pages/HomePage.tsx` caused by ` .app-shell__header` in `src/styles/ui.css`; RP artifact was the `form` with classes `chat-composer glass-card rp-chat-composer` from `src/pages/RpRoomPage.tsx` caused by global `.glass-card` in `src/styles/ui.css`. 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Attempted Chromium-based Playwright inspection but the headless Chromium crashed in this environment (`SIGSEGV`) so Chrome DevTools style inspection could not be captured. 
- Ran a Firefox Playwright script which successfully loaded the app but the route redirected to `#/auth`, preventing unauthenticated Home/RP visual snapshot verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fee50391c83309c3c18ab4b6f6512)