### PR TITLE
Fix RP rooms dashboard header transparent box artifacts

### DIFF
--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -22,6 +22,8 @@
 }
 
 .rp-rooms-top.app-shell__header {
+  border-bottom: none;
+  box-shadow: none;
   background: transparent;
   background-image: none;
 }


### PR DESCRIPTION
### Motivation
- The RP rooms dashboard header was inheriting global `.app-shell__header` chrome (border-bottom and box-shadow) which produced visible transparent box artifacts around the header area.
- The intent is to remove those artifacts for the RP rooms dashboard while keeping other pages that use `.app-shell__header` unaffected.

### Description
- Added a scoped override in `src/pages/RpRoomsPage.css` to disable the inherited chrome by adding `border-bottom: none;` and `box-shadow: none;` to `.rp-rooms-top.app-shell__header` while preserving the transparent background.
- The change is localized to the `.rp-rooms-top.app-shell__header` selector so other uses of `.app-shell__header` are not altered.
- No `:empty`/`.glass-card:empty` rule was present in the current styles, so nothing was removed for that part of the original report.

### Testing
- Ran `npm run lint` which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx`.
- Launched the dev server with `npm run dev` and verified the dashboard rendering, then captured a screenshot `artifacts/rp-rooms-dashboard-fix.png` to confirm the header no longer shows borders or shadows.
- Used `rg` to search for `:empty` and `.glass-card:empty` and found no matches, confirming there was nothing to delete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff11958048330b017a10a322383cd)