### PR TITLE
Set Snacks + Hamster Journal pages background to shared pink‑mist gradient

### DIFF
--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -1,5 +1,7 @@
 .snacks-page {
   min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--page-bg);
   max-width: 720px;
   margin: 0 auto;
   padding: 12px;

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -572,7 +572,7 @@ const SnacksPage = ({ user, snackAiConfig }: SnacksPageProps) => {
   }
 
   return (
-    <div className="snacks-page">
+    <div className="snacks-page app-shell__content">
       <header className="snacks-header">
         <button type="button" className="ghost" onClick={() => navigate('/')}>
           返回聊天

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -605,7 +605,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
   }
 
   return (
-    <div className="snacks-page">
+    <div className="snacks-page app-shell__content">
       <header className="snacks-header">
         <button type="button" className="ghost" onClick={() => navigate('/')}>
           返回聊天


### PR DESCRIPTION
### Motivation
- Ensure the `Snacks` and `Hamster Journal (Syzygy)` pages use the same app-wide soft pink mist background (`--page-bg`) so they match other pages and avoid gray bands on mobile.

### Description
- Added the shared content layer class to the page root in `src/pages/SnacksPage.tsx` and `src/pages/SyzygyFeedPage.tsx` by changing the wrapper to include `app-shell__content` so the pages render on the app shell content layer.
- Applied the shared background token and mobile-safe height to the page root in `src/pages/SnacksPage.css` by adding `min-height: 100dvh;` and `background: var(--page-bg);` to `.snacks-page`.
- Kept all inner UI surfaces (glass cards, dotted feed blocks, composer, and buttons) unchanged and only adjusted the page-level wrapper and background.

### Testing
- Ran `npm run lint` which completed with the pre-existing unrelated warning in `src/pages/CheckinPage.tsx` (no new lint errors).
- Built the app with `npm run build` which succeeded without errors.
- Launched the dev server and captured automated screenshots of `/snacks` and `/syzygy` to verify the new background renders across pages and viewport sizes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0001e03c8833087b6cb1ad1f51f60)