### PR TITLE
Refactor snack and syzygy feeds into social profile-style layouts

### DIFF
--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -7,7 +7,7 @@
   padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 18px;
 }
 
 .snacks-header {
@@ -21,11 +21,76 @@
   margin: 0;
 }
 
+
+.profile-header-card {
+  position: relative;
+  margin-top: 4px;
+  border-radius: 18px;
+  border: 1px solid #ffd6e7;
+  background: #fff;
+  padding: 0 16px 16px;
+  box-shadow: 0 10px 24px rgba(255, 214, 231, 0.25);
+}
+
+.profile-cover-banner {
+  height: 120px;
+  border-radius: 16px 16px 12px 12px;
+  background-color: #fff;
+  background-image: radial-gradient(circle at 2px 2px, #ffd6e7 2px, transparent 2px);
+  background-size: 14px 14px;
+}
+
+.profile-avatar-surrogate {
+  width: 110px;
+  height: 110px;
+  margin: -52px auto 0;
+  border-radius: 50%;
+  border: 6px solid #fff;
+  background: #ffe4ef;
+  box-shadow: 0 8px 18px rgba(92, 92, 92, 0.14);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.profile-avatar-letter {
+  font-size: 52px;
+  line-height: 1;
+  color: #5c5c5c;
+  font-family: 'Comic Sans MS', 'Bradley Hand', 'Marker Felt', cursive;
+}
+
+.profile-avatar-accent {
+  position: absolute;
+  right: 12px;
+  bottom: 14px;
+  font-size: 14px;
+}
+
+.profile-meta {
+  margin-top: 10px;
+  text-align: center;
+}
+
+.profile-title {
+  margin: 0;
+  font-size: 24px;
+  color: #5c5c5c;
+  letter-spacing: 0.5px;
+}
+
+.profile-bio {
+  margin: 6px 0 0;
+  color: #8f8f8f;
+  font-size: 13px;
+}
+
 .snacks-composer {
   background: #fff;
   border-radius: 12px;
-  padding: 12px;
+  padding: 10px 12px;
   border: 1px solid #ffd6e7;
+  margin-top: 6px;
 }
 
 .snacks-composer textarea {
@@ -66,6 +131,7 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+  margin-top: 8px;
   padding-bottom: 20px;
   padding: 12px;
   border-radius: 16px;

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -655,9 +655,21 @@ const SnacksPage = ({ user, snackAiConfig }: SnacksPageProps) => {
         </main>
       ) : (
         <>
+          <section className="profile-header-card" aria-label="串串主页头部">
+            <div className="profile-cover-banner" />
+            <div className="profile-avatar-surrogate" aria-hidden="true">
+              <span className="profile-avatar-letter">C</span>
+              <span className="profile-avatar-accent">🐾</span>
+            </div>
+            <div className="profile-meta">
+              <h2 className="profile-title">串串的零食罐罐</h2>
+              <p className="profile-bio">专属于某只小仓鼠的加餐记录</p>
+            </div>
+          </section>
+
           <section className="snacks-composer">
             <textarea
-              rows={3}
+              rows={2}
               placeholder="写点今天的零食…"
               value={draft}
               onChange={(event) => setDraft(event.target.value)}

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -705,9 +705,21 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
         </main>
       ) : (
         <>
+          <section className="profile-header-card" aria-label="Syzygy主页头部">
+            <div className="profile-cover-banner" />
+            <div className="profile-avatar-surrogate" aria-hidden="true">
+              <span className="profile-avatar-letter">S</span>
+              <span className="profile-avatar-accent">❤</span>
+            </div>
+            <div className="profile-meta">
+              <h2 className="profile-title">Syzygy的观察日志</h2>
+              <p className="profile-bio">专属于某只小仓鼠的饲养记录</p>
+            </div>
+          </section>
+
           <section className="snacks-composer">
             <textarea
-              rows={3}
+              rows={2}
               placeholder="写点今天的观察…"
               value={draft}
               onChange={(event) => setDraft(event.target.value)}


### PR DESCRIPTION
### Motivation
- Convert the linear feed pages into a richer social-profile style layout with a clear hierarchy: header → composer → timeline. 
- Preserve the existing salt-style aesthetic (pink/grey/white, polka dots) while introducing a more prominent page identity area. 
- Make the composer feel more integrated in the profile page by compacting the input and increasing vertical breathing room.

### Description
- Inserted a new profile header card (cover banner, circular avatar surrogate with initial and small accent, title and bio) above the publish composer in `src/pages/SnacksPage.tsx` and `src/pages/SyzygyFeedPage.tsx`.
- Added CSS rules for `.profile-header-card`, `.profile-cover-banner`, `.profile-avatar-surrogate`, `.profile-avatar-letter`, `.profile-avatar-accent`, `.profile-meta`, `.profile-title`, and `.profile-bio` in `src/pages/SnacksPage.css` and adjusted shared spacing to keep the pink/grey/white polka-dot motif.
- Reduced the publish textarea height from `rows={3}` to `rows={2}` and adjusted composer padding/spacing (`gap`, `margin-top`, `padding`) so the composer reads as part of the profile layout rather than a standalone block.
- Kept existing feed/timeline rendering and post/reply logic unchanged so the dynamic cards remain stacked as a continuous timeline below the composer.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm run lint`, which passed but reports a pre-existing warning in `src/pages/CheckinPage.tsx` about a missing hook dependency.
- Attempted an automated Playwright screenshot of `/syzygy` to visually validate the page, but the route is gated behind authentication in this environment so the UI update could not be captured (auth gate prevented full verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00358ad348330bdf6b6d8afc11480)