### PR TITLE
Polish check-in top navigation with glass-candy tab styling

### DIFF
--- a/src/pages/CheckinPage.css
+++ b/src/pages/CheckinPage.css
@@ -9,22 +9,49 @@
 }
 
 .checkin-page-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.checkin-page-header h1 {
-  margin: 0;
-  font-size: 1.4rem;
+  padding-block: 0.55rem;
 }
 
 .checkin-nav-actions {
   display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  gap: 0.55rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding: 0.35rem 0.1rem;
+}
+
+.checkin-nav-actions::-webkit-scrollbar {
+  display: none;
+}
+
+.checkin-nav-tab {
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  background: rgba(255, 255, 255, 0.4);
+  color: #a3a3a3;
+  border-radius: 9999px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.84rem;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+  flex-shrink: 0;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition: all 300ms ease;
+}
+
+.checkin-nav-tab:hover {
+  color: #7f7f7f;
+  transform: translateY(-1px);
+}
+
+.checkin-nav-tab.active {
+  background: #ffd6e7;
+  color: #5c5c5c;
+  border-color: transparent;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(255, 214, 231, 0.6);
 }
 
 .checkin-card.standalone {

--- a/src/pages/CheckinPage.tsx
+++ b/src/pages/CheckinPage.tsx
@@ -73,6 +73,18 @@ const CheckinPage = ({ user }: CheckinPageProps) => {
   const [checkinSubmitting, setCheckinSubmitting] = useState(false)
   const [checkinNotice, setCheckinNotice] = useState<string | null>(null)
   const navigate = useNavigate()
+  const navTabs = useMemo(
+    () => [
+      { label: '聊天', path: '/' },
+      { label: '囤囤库', path: '/memory-vault' },
+      { label: '零食罐罐', path: '/snacks' },
+      { label: '仓鼠饲养日志', path: '/syzygy' },
+      { label: '打卡', path: '/checkin' },
+      { label: '设置', path: '/settings' },
+      { label: '数据导出', path: '/export' },
+    ],
+    [],
+  )
 
   const todayKey = useMemo(() => formatDateKey(new Date()), [])
   const todayDisplay = useMemo(
@@ -128,26 +140,21 @@ const CheckinPage = ({ user }: CheckinPageProps) => {
   return (
     <div className="checkin-page">
       <header className="checkin-page-header">
-        <h1 className="ui-title">打卡</h1>
         <div className="checkin-nav-actions">
-          <button type="button" className="ghost" onClick={() => navigate('/')}>
-            聊天
-          </button>
-          <button type="button" className="ghost" onClick={() => navigate('/memory-vault')}>
-            囤囤库
-          </button>
-          <button type="button" className="ghost" onClick={() => navigate('/snacks')}>
-            零食罐罐
-          </button>
-          <button type="button" className="ghost" onClick={() => navigate('/syzygy')}>
-            仓鼠饲养日志
-          </button>
-          <button type="button" className="ghost" onClick={() => navigate('/settings')}>
-            设置
-          </button>
-          <button type="button" className="ghost" onClick={() => navigate('/export')}>
-            数据导出
-          </button>
+          {navTabs.map((tab) => {
+            const isActive = tab.path === '/checkin'
+            return (
+              <button
+                key={tab.path}
+                type="button"
+                className={`checkin-nav-tab ${isActive ? 'active' : ''}`}
+                aria-current={isActive ? 'page' : undefined}
+                onClick={() => navigate(tab.path)}
+              >
+                {tab.label}
+              </button>
+            )
+          })}
         </div>
       </header>
 


### PR DESCRIPTION
### Motivation

- Remove a redundant top-level page heading so the inner card title is the primary visual anchor and avoid duplicate context.
- Replace the cramped, multi-line nav buttons with a compact, horizontally scrollable tab row to improve usability on narrow screens.
- Introduce a "Glass Candy" pill-style visual language for nav tabs to match the soft pink theme and provide a clear active state.

### Description

- Removed the top-level `h1` heading from the check-in header and moved nav into a single mapped tab list in `src/pages/CheckinPage.tsx` via `navTabs` (added with `useMemo`).
- Replaced the inline nav buttons with mapped `<button>` elements using the `checkin-nav-tab` class and `aria-current` for the active tab in `src/pages/CheckinPage.tsx`.
- Added scrollable container behavior and spacing by updating `src/pages/CheckinPage.css` to set `.checkin-nav-actions` to `overflow-x: auto`, hide scrollbars, and add soft vertical padding to the header with `padding-block`.
- Implemented the glass-candy visual styles in `src/pages/CheckinPage.css` including translucent default pills (`rgba(255,255,255,0.4)`), subtle border, rounded pill shape, hover transition, and active styling with `#ffd6e7` background and soft pink glow shadow.

### Testing

- Ran `npm run build` which completed successfully and produced production assets (build completed successfully).
- Launched the dev server with `npm run dev` and verified the check-in route loaded locally.
- Captured a Playwright screenshot of `/checkin` to validate the top-nav visual (`artifacts/checkin-top-nav-glass-candy.png`) and confirmed the updated UI rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00ab769a48330977c3759fccc58b6)