### PR TITLE
Redesign Memory Vault into scrapbook-style collector's binder

### DIFF
--- a/src/pages/MemoryVaultPage.css
+++ b/src/pages/MemoryVaultPage.css
@@ -2,10 +2,13 @@
   min-height: 100vh;
   max-width: 720px;
   margin: 0 auto;
-  padding: 12px;
+  padding: 16px 14px 28px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
+  background:
+    radial-gradient(circle at 10px 10px, rgba(255, 214, 231, 0.4) 2px, transparent 2.5px) 0 0 / 24px 24px,
+    #fcfcfc;
 }
 
 .memory-header {
@@ -20,15 +23,18 @@
 }
 
 .memory-section {
-  background: #fff;
-  border-radius: 12px;
-  padding: 12px;
-  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.56);
+  border-radius: 18px;
+  padding: 14px;
+  border: 1px solid rgba(255, 214, 231, 0.7);
+  box-shadow: 0 10px 26px rgba(92, 92, 92, 0.1);
+  backdrop-filter: blur(12px);
 }
 
 .memory-section h2 {
-  margin: 0 0 10px;
+  margin: 0 0 12px;
   font-size: 16px;
+  color: #5c5c5c;
 }
 
 .memory-section textarea {
@@ -43,20 +49,29 @@
 
 .memory-list {
   margin-top: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  display: grid;
+  gap: 10px;
 }
 
 .memory-card {
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  padding: 10px;
+  border-radius: 12px;
+  padding: 14px 12px 10px;
+  position: relative;
+  transition: transform 180ms ease;
+}
+
+.memory-card:nth-child(even) {
+  transform: rotate(-1deg);
+}
+
+.memory-card:nth-child(odd) {
+  transform: rotate(1deg);
 }
 
 .memory-card p {
   margin: 0;
   white-space: pre-wrap;
+  color: #5c5c5c;
 }
 
 .memory-actions {
@@ -67,9 +82,8 @@
 
 .memory-section-heading {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
+  justify-content: flex-start;
+  align-items: baseline;
   margin-bottom: 10px;
 }
 
@@ -78,41 +92,180 @@
 }
 
 .memory-toggle-group {
+  flex: 1;
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
-.merge-toggle {
-  display: inline-flex;
+.memory-memo-pad {
+  border: 1px solid #ffd6e7;
+  border-radius: 14px;
+  background:
+    repeating-linear-gradient(180deg, rgba(255, 214, 231, 0.24) 0, rgba(255, 214, 231, 0.24) 1px, transparent 1px, transparent 30px),
+    #fffdf0;
+  padding: 12px;
+  box-shadow: 0 8px 18px rgba(255, 214, 231, 0.28);
+}
+
+.memory-memo-pad textarea {
+  background: transparent;
+  border: none;
+  padding: 4px 2px;
+}
+
+.memory-memo-pad textarea:focus {
+  outline: none;
+}
+
+.memory-save-sticker {
+  margin-top: 8px;
+  border: none;
+  border-radius: 999px;
+  background: #ffd6e7;
+  color: #5c5c5c;
+  font-weight: 700;
+  padding: 8px 16px;
+  box-shadow: 0 6px 14px rgba(255, 214, 231, 0.7);
+}
+
+.memory-save-sticker:disabled {
+  opacity: 0.6;
+}
+
+.memory-list--archive {
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+}
+
+.memory-card--archive {
+  background: #fffdf0;
+  border: 1px solid #ffd6e7;
+}
+
+.memory-washi {
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 72px;
+  height: 16px;
+  border-radius: 3px;
+  background: rgba(255, 214, 231, 0.56);
+}
+
+.memory-divider {
+  display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.memory-divider-line {
+  flex: 1;
+  border-top: 2px dotted rgba(92, 92, 92, 0.4);
+}
+
+.memory-divider-bow {
+  font-size: 15px;
+}
+
+.memory-control-bar {
+  border: 1px solid rgba(255, 214, 231, 0.8);
+  background: rgba(252, 252, 252, 0.7);
+  border-radius: 14px;
+  padding: 12px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  backdrop-filter: blur(10px);
+}
+
+.ios-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
   border-radius: 999px;
-  padding: 6px 10px;
-  border: 1px solid #cbd5e1;
-  background: #f8fafc;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
   font-size: 13px;
+  color: #5c5c5c;
 }
 
-.merge-toggle.is-on {
-  border-color: #16a34a;
-  background: #f0fdf4;
-}
-
-.merge-toggle.is-off {
-  border-color: #94a3b8;
-  background: #f8fafc;
-}
-
-.merge-toggle-state {
+.ios-toggle-track {
+  width: 42px;
+  height: 24px;
   border-radius: 999px;
-  padding: 2px 8px;
-  background: #e2e8f0;
-  font-weight: 700;
+  background: #d7d7d7;
+  padding: 2px;
+  display: inline-flex;
+  align-items: center;
+  transition: background-color 160ms ease;
 }
 
-.merge-toggle.is-on .merge-toggle-state {
-  background: #16a34a;
-  color: #fff;
+.ios-toggle-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  transform: translateX(0);
+  transition: transform 160ms ease;
+}
+
+.ios-toggle.is-on .ios-toggle-track {
+  background: #ffd6e7;
+}
+
+.ios-toggle.is-on .ios-toggle-thumb {
+  transform: translateX(18px);
+}
+
+.extract-button {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #ffd6e7, #ffe9f3);
+  color: #5c5c5c;
+  font-weight: 700;
+  padding: 10px 14px;
+  box-shadow: 0 8px 20px rgba(255, 214, 231, 0.55);
+}
+
+.memory-list--pending {
+  grid-template-columns: 1fr;
+}
+
+.memory-card--pending {
+  border: 1px dashed rgba(92, 92, 92, 0.5);
+  background: rgba(252, 252, 252, 0.82);
+  opacity: 0.9;
+}
+
+.stamp-button {
+  border: 1px solid;
+  border-radius: 999px;
+  background: transparent;
+  font-weight: 600;
+}
+
+.stamp-button--approve {
+  border-color: #ffd6e7;
+  color: #5c5c5c;
+  background: rgba(255, 214, 231, 0.35);
+}
+
+.stamp-button--reject {
+  border-color: rgba(92, 92, 92, 0.5);
+  color: #5c5c5c;
+}
+
+@media (max-width: 640px) {
+  .memory-control-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .memory-toggle-group {
+    flex-direction: column;
+  }
 }

--- a/src/pages/MemoryVaultPage.tsx
+++ b/src/pages/MemoryVaultPage.tsx
@@ -223,21 +223,29 @@ const MemoryVaultPage = ({
         </button>
       </header>
 
-      <section className="memory-section">
-        <h2 className="ui-title">Confirmed</h2>
-        <textarea
-          value={newMemory}
-          onChange={(event) => setNewMemory(event.target.value)}
-          placeholder="新增一条确认记忆"
-          rows={3}
-        />
-        <button type="button" onClick={handleCreate} disabled={saving || !newMemory.trim()}>
-          保存
-        </button>
-        <div className="memory-list">
+      <section className="memory-section memory-section--archive">
+        <h2 className="ui-title">我们的珍藏 (Archived Memories)</h2>
+        <div className="memory-memo-pad">
+          <textarea
+            value={newMemory}
+            onChange={(event) => setNewMemory(event.target.value)}
+            placeholder="写下一条值得收藏的记忆碎片..."
+            rows={3}
+          />
+          <button
+            type="button"
+            className="memory-save-sticker"
+            onClick={handleCreate}
+            disabled={saving || !newMemory.trim()}
+          >
+            Save
+          </button>
+        </div>
+        <div className="memory-list memory-list--archive">
           {confirmed.length === 0 ? <p className="tips">暂无 confirmed 记忆</p> : null}
           {confirmed.map((entry) => (
-            <article key={entry.id} className="memory-card">
+            <article key={entry.id} className="memory-card memory-card--archive">
+              <span className="memory-washi" aria-hidden="true" />
               {editingId === entry.id ? (
                 <textarea
                   rows={3}
@@ -286,47 +294,60 @@ const MemoryVaultPage = ({
         </div>
       </section>
 
-      <section className="memory-section">
+      <div className="memory-divider" aria-hidden="true">
+        <span className="memory-divider-line" />
+        <span className="memory-divider-bow">🎀</span>
+        <span className="memory-divider-line" />
+      </div>
+
+      <section className="memory-section memory-section--pending">
         <div className="memory-section-heading">
-          <h2 className="ui-title">Pending</h2>
+          <h2 className="ui-title">Syzygy的提取碎片 (Syzygy's Suggestions)</h2>
+        </div>
+        <div className="memory-control-bar">
           <div className="memory-toggle-group">
             <button
               type="button"
               role="switch"
               aria-checked={autoExtractEnabled}
-              className={`merge-toggle ${autoExtractEnabled ? 'is-on' : 'is-off'}`}
+              className={`ios-toggle ${autoExtractEnabled ? 'is-on' : 'is-off'}`}
               onClick={() => void handleToggleAutoExtract()}
               disabled={autoExtractSaving}
             >
-              <span className="merge-toggle-label">自动提取候选记忆（会产生费用）</span>
-              <span className="merge-toggle-state">{autoExtractEnabled ? 'ON' : 'OFF'}</span>
+              <span className="ios-toggle-track" aria-hidden="true">
+                <span className="ios-toggle-thumb" />
+              </span>
+              <span className="ios-toggle-label">自动提取候选记忆（会产生费用）</span>
             </button>
             <button
               type="button"
               role="switch"
               aria-checked={mergeEnabled}
-              className={`merge-toggle ${mergeEnabled ? 'is-on' : 'is-off'}`}
+              className={`ios-toggle ${mergeEnabled ? 'is-on' : 'is-off'}`}
               onClick={() => void handleToggleMerge()}
               disabled={mergeSaving}
             >
-              <span className="merge-toggle-label">自动归并同类项（额外模型调用）</span>
-              <span className="merge-toggle-state">{mergeEnabled ? 'ON' : 'OFF'}</span>
+              <span className="ios-toggle-track" aria-hidden="true">
+                <span className="ios-toggle-thumb" />
+              </span>
+              <span className="ios-toggle-label">自动归并同类项（额外模型调用）</span>
             </button>
           </div>
+          <button
+            type="button"
+            className="extract-button"
+            onClick={() => void handleExtractSuggestions()}
+            disabled={extracting || recentMessages.length === 0}
+          >
+            ✨ {extracting ? 'Extracting…' : 'Extract suggestions'}
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={() => void handleExtractSuggestions()}
-          disabled={extracting || recentMessages.length === 0}
-        >
-          {extracting ? 'Extracting…' : 'Extract suggestions'}
-        </button>
         {recentMessages.length === 0 ? <p className="tips">暂无可抽取的聊天上下文</p> : null}
         {extractMessage ? <p className="tips">{extractMessage}</p> : null}
-        <div className="memory-list">
+        <div className="memory-list memory-list--pending">
           {pending.length === 0 ? <p className="tips">暂无 pending 记忆</p> : null}
           {pending.map((entry) => (
-            <article key={entry.id} className="memory-card">
+            <article key={entry.id} className="memory-card memory-card--pending">
               {editingId === entry.id ? (
                 <textarea
                   rows={3}
@@ -359,8 +380,13 @@ const MemoryVaultPage = ({
                   </>
                 ) : (
                   <>
-                    <button type="button" onClick={() => void handleConfirm(entry)} disabled={saving}>
-                      确认
+                    <button
+                      type="button"
+                      className="stamp-button stamp-button--approve"
+                      onClick={() => void handleConfirm(entry)}
+                      disabled={saving}
+                    >
+                      💗 Keep
                     </button>
                     <button
                       type="button"
@@ -371,8 +397,12 @@ const MemoryVaultPage = ({
                     >
                       编辑+确认
                     </button>
-                    <button type="button" className="danger" onClick={() => void handleDiscard(entry.id)}>
-                      丢弃
+                    <button
+                      type="button"
+                      className="stamp-button stamp-button--reject"
+                      onClick={() => void handleDiscard(entry.id)}
+                    >
+                      🗑 Reject
                     </button>
                   </>
                 )}


### PR DESCRIPTION
### Motivation
- Rework the existing generic Memory Vault into a maximalist scrapbook / collector's binder UI to improve visual distinctiveness and better surface confirmed vs suggested memories. 
- Apply a Salt-style glassmorphism aesthetic and the specified color palette (`#ffd6e7`, `#fcfcfc`, `#5c5c5c`) to align with the new design concept. 
- Clarify and reorganize the two-panel flow so confirmed memories feel like curated keepsakes while pending suggestions look like drafts awaiting stamps. 

### Description
- Updated `src/pages/MemoryVaultPage.tsx` to rename headers to `我们的珍藏 (Archived Memories)` and `Syzygy的提取碎片 (Syzygy's Suggestions)`, add a memo-pad style input for confirmed memories, insert a decorative dotted divider with a bow, render washi tape on archive cards, convert toggles to iOS-style switches, add a sparkle `Extract suggestions` CTA, and replace pending action buttons with stamp-like approve/reject buttons. 
- Reworked `src/pages/MemoryVaultPage.css` to add the soft-white polka-dot page background, glassmorphism panels, paper-like memo-pad styling, polaroid/sticky-note card visuals with subtle tilt, pink washi tape accent, iOS toggle styles using `#ffd6e7` for the active track, dashed/dimmed pending-card styling, and responsive tweaks for small screens. 
- Kept existing data logic and API interactions intact (`createMemory`, `confirmMemory`, `discardMemory`, `invokeMemoryExtraction`, etc.) while only changing presentation and control affordances. 

### Testing
- Ran `npm run build` and the production build completed successfully with Vite reporting built assets. 
- Started the dev server with `npm run dev` and the app served locally (Vite ready). 
- Executed an automated Playwright script to capture `/memory-vault`, which ran successfully but the route is auth-gated in this environment and redirected to `/auth`, so the captured screenshot shows the auth redirect rather than the vault UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00d4da5108330a35a2ccdd286b5dc)