### PR TITLE
MemoryVault: replace yellow paper with #E6EDF8 and use shared pink-mist page background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,7 +8,7 @@
   flex-direction: column;
   background:
     var(--app-background-image, none) center / cover no-repeat,
-    #f1f5f9;
+    var(--page-bg);
   color: #0f172a;
   overscroll-behavior: none;
 }

--- a/src/pages/CheckinPage.css
+++ b/src/pages/CheckinPage.css
@@ -1,5 +1,6 @@
 .checkin-page {
   min-height: 100vh;
+  min-height: 100dvh;
   width: min(980px, 100%);
   margin: 0 auto;
   padding: 1.25rem 1rem 2rem;
@@ -63,7 +64,11 @@
   border-radius: 24px;
   padding: 1.25rem;
   background-color: #ffffff;
-  background-image: radial-gradient(circle, rgba(255, 214, 231, 0.35) 1px, transparent 1px);
+  background-image: radial-gradient(
+    circle,
+    rgba(255, 214, 231, 0.35) 1px,
+    transparent 1px
+  );
   background-size: 12px 12px;
   box-shadow: 0 20px 35px rgba(92, 92, 92, 0.12);
 }
@@ -106,7 +111,9 @@
   padding: 0.85rem 1.4rem;
   font-size: 0.95rem;
   font-weight: 700;
-  transition: transform 160ms ease, box-shadow 160ms ease;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .checkin-button.unchecked {

--- a/src/pages/MemoryVaultPage.css
+++ b/src/pages/MemoryVaultPage.css
@@ -1,5 +1,6 @@
 .memory-page {
   min-height: 100vh;
+  min-height: 100dvh;
   max-width: 720px;
   margin: 0 auto;
   padding: 16px 14px 28px;
@@ -7,8 +8,13 @@
   flex-direction: column;
   gap: 16px;
   background:
-    radial-gradient(circle at 10px 10px, rgba(255, 214, 231, 0.4) 2px, transparent 2.5px) 0 0 / 24px 24px,
-    #fcfcfc;
+    radial-gradient(
+        circle at 10px 10px,
+        rgba(255, 214, 231, 0.4) 2px,
+        transparent 2.5px
+      )
+      0 0 / 24px 24px,
+    transparent;
 }
 
 .memory-header {
@@ -71,7 +77,7 @@
 .memory-card p {
   margin: 0;
   white-space: pre-wrap;
-  color: #5c5c5c;
+  color: var(--text-main);
 }
 
 .memory-actions {
@@ -102,8 +108,14 @@
   border: 1px solid #ffd6e7;
   border-radius: 14px;
   background:
-    repeating-linear-gradient(180deg, rgba(255, 214, 231, 0.24) 0, rgba(255, 214, 231, 0.24) 1px, transparent 1px, transparent 30px),
-    #fffdf0;
+    repeating-linear-gradient(
+      180deg,
+      rgba(255, 214, 231, 0.24) 0,
+      rgba(255, 214, 231, 0.24) 1px,
+      transparent 1px,
+      transparent 30px
+    ),
+    #e6edf8;
   padding: 12px;
   box-shadow: 0 8px 18px rgba(255, 214, 231, 0.28);
 }
@@ -112,6 +124,11 @@
   background: transparent;
   border: none;
   padding: 4px 2px;
+  color: var(--text-main);
+}
+
+.memory-memo-pad textarea::placeholder {
+  color: var(--text-subtle);
 }
 
 .memory-memo-pad textarea:focus {
@@ -138,7 +155,7 @@
 }
 
 .memory-card--archive {
-  background: #fffdf0;
+  background: #e6edf8;
   border: 1px solid #ffd6e7;
 }
 


### PR DESCRIPTION
### Motivation
- Update MemoryVault UI to replace the old yellow “paper” surfaces with the new light blue-gray (`#E6EDF8`) to match the redesigned look while keeping existing borders/shadows/shape. 
- Ensure MemoryVault and Checkin pages use the app-wide pink-mist gradient background (`var(--page-bg)`) so the page background is consistent and fills the full viewport.

### Description
- Changed app shell fallback background to use the shared gradient token by setting `.app-shell` background fallback to `var(--page-bg)` so pages inherit the pink-mist gradient. (`src/App.css`).
- MemoryVault: made the page base transparent so the shared gradient shows through while preserving the dot pattern, set page to full viewport height (`100dvh`), and replaced yellow paper surfaces with `#E6EDF8` for the memo pad and archived memory cards. Also updated text color on those surfaces to `var(--text-main)` and placeholder color to `var(--text-subtle)`. (`src/pages/MemoryVaultPage.css`).
- Checkin: ensured the page container uses `100dvh` so the shared gradient fills the viewport and applied minor CSS formatting fixes (radial gradient and transition formatting) without changing visual behavior of inner cards. (`src/pages/CheckinPage.css`).
- No JavaScript/logic changes were made; this is CSS-only.

### Testing
- Ran `npx prettier --write` to format modified files (succeeded).
- Ran `npm run lint` and verified there are no new lint errors (one pre-existing `react-hooks/exhaustive-deps` warning remains in `CheckinPage.tsx`).
- Started the dev server and captured visual verification screenshots for both pages (Playwright): `artifacts/memory-vault-gradient-updated.png` and `artifacts/checkin-gradient-updated.png` (screenshots captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0338fd3c88330b7ee85309c151523)