### PR TITLE
Polish API Settings UI: unified glassmorphism accordions and visual refresh

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -1,15 +1,19 @@
 .settings-shell {
   min-height: 100vh;
   min-height: 100dvh;
+  background-color: #fff8fc;
+  background-image:
+    radial-gradient(circle at 20px 20px, rgba(255, 214, 231, 0.45) 2px, transparent 2.2px),
+    radial-gradient(circle at 56px 56px, rgba(255, 214, 231, 0.3) 2px, transparent 2.2px);
+  background-size: 72px 72px;
 }
 
 .settings-page {
   min-height: 0;
-  background: #f8fafc;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding-bottom: calc(24px + env(safe-area-inset-bottom));
+  gap: 24px;
+  padding-bottom: calc(28px + env(safe-area-inset-bottom));
   overflow: visible;
 }
 
@@ -18,20 +22,22 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
+  background: rgba(255, 255, 255, 0.86);
+  border-bottom: 1px solid rgba(255, 214, 231, 0.7);
+  backdrop-filter: blur(12px);
 }
 
 .settings-header h1 {
   margin: 0;
   font-size: 16px;
+  color: #5c5c5c;
 }
 
 .settings-header .ghost {
   border: none;
   background: transparent;
-  color: #0f172a;
-  font-weight: 600;
+  color: #5c5c5c;
+  font-weight: 700;
   font-size: 14px;
   cursor: pointer;
 }
@@ -42,37 +48,61 @@
 
 .settings-loading {
   padding: 24px 16px;
-  color: #64748b;
+  color: #8c8c8c;
   font-size: 14px;
 }
 
 .settings-page .empty-state {
-  color: #64748b;
+  color: #7c7c7c;
   font-size: 13px;
-  background: #f1f5f9;
+  background: #fffdf5;
   border-radius: 12px;
   padding: 12px;
+  border: 1px solid #ffe4ee;
 }
 
 .settings-section {
-  background: #fff;
-  border-radius: 16px;
   margin: 0 16px;
-  padding: 16px;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
+.section-title {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-areas:
+    'icon title'
+    'icon subtitle';
+  column-gap: 10px;
+  row-gap: 2px;
+  align-items: center;
+}
+
+.section-icon {
+  grid-area: icon;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: rgba(255, 214, 231, 0.35);
+  font-size: 18px;
+}
+
 .section-title h2 {
+  grid-area: title;
   margin: 0;
   font-size: 16px;
+  color: #5c5c5c;
+  font-weight: 700;
 }
 
 .section-title p {
-  margin: 4px 0 0;
-  color: #64748b;
+  grid-area: subtitle;
+  margin: 0;
+  color: #8c8c8c;
   font-size: 13px;
 }
 
@@ -82,10 +112,13 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: transparent;
-  border: none;
-  padding: 0;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid #ffd6e7;
+  border-radius: 16px;
+  padding: 14px;
   text-align: left;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 8px 20px rgba(255, 200, 221, 0.22);
 }
 
 .collapse-header .section-title {
@@ -93,40 +126,38 @@
 }
 
 .collapse-indicator {
-  font-size: 12px;
-  color: #475569;
+  color: #ff93bc;
+  font-size: 18px;
+  line-height: 1;
+  transform: rotate(0deg);
+  transition: transform 0.2s ease;
+}
+
+.collapse-header[aria-expanded='true'] .collapse-indicator {
+  transform: rotate(180deg);
+}
+
+.accordion-content {
+  background: #fffdf5;
+  border: 1px solid rgba(255, 214, 231, 0.6);
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: inset 0 1px 10px rgba(255, 234, 244, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .nested-prompt-title {
   margin-top: 8px;
 }
 
-.model-list,
-.catalog-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.model-item,
-.catalog-item {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px;
+.model-select-card,
+.catalog-result-item,
+.catalog-dropdown {
   border-radius: 12px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-}
-
-.model-meta,
-.catalog-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  border: 1px solid #ffe3ee;
+  background: rgba(255, 255, 255, 0.9);
 }
 
 .model-select-card {
@@ -134,9 +165,6 @@
   flex-direction: column;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
 }
 
 .model-select-row {
@@ -146,55 +174,64 @@
   align-items: center;
 }
 
-.model-select-row label {
+.model-select-row label,
+.field-group label {
   font-size: 13px;
-  color: #0f172a;
+  color: #5c5c5c;
 }
 
-.model-select-row select {
-  border: 1px solid #e2e8f0;
+.model-select-row select,
+.field-group input,
+.field-group select,
+.system-prompt,
+.search-input,
+.compression-fields input,
+.compression-fields select {
+  border: 1px solid #ffdce9;
   border-radius: 12px;
   padding: 10px 12px;
   font-size: 14px;
   font-family: inherit;
   background: #fff;
-  width: 100%;
+  color: #5c5c5c;
 }
 
-.model-selected-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.system-prompt {
+  min-height: 140px;
+  resize: vertical;
+  border-style: dashed;
+  border-color: #ffd6e7;
+  background: #fffefb;
+}
+
+.system-prompt:focus {
+  outline: none;
+  border-style: solid;
+  border-width: 2px;
+  border-color: #ffc2da;
 }
 
 .model-id {
   font-size: 12px;
-  color: #94a3b8;
+  color: #9a9a9a;
   word-break: break-all;
 }
 
-.model-actions,
-.catalog-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-}
-
 .settings-page button {
-  border: none;
-  border-radius: 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
   padding: 8px 12px;
-  background: #0f172a;
-  color: #fff;
+  background: #ffb7d2;
+  color: #5c5c5c;
   font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
 }
 
 .settings-page button.ghost {
-  background: transparent;
-  color: #0f172a;
-  border: 1px solid #cbd5f5;
+  background: rgba(255, 255, 255, 0.8);
+  border-color: #ffd6e7;
+  color: #6d6d6d;
 }
 
 .settings-page button.small {
@@ -203,43 +240,26 @@
 }
 
 .settings-page button.danger {
-  color: #b91c1c;
-  border-color: rgba(185, 28, 28, 0.3);
+  color: #b2547d;
+  border-color: #ffc9dd;
 }
 
 .badge {
-  background: #0f172a;
-  color: #fff;
+  background: #ffd6e7;
+  color: #6d6d6d;
   font-size: 11px;
   padding: 4px 8px;
   border-radius: 999px;
 }
 
 .badge.subtle {
-  background: rgba(15, 23, 42, 0.1);
-  color: #0f172a;
+  background: #ffe7f1;
 }
 
 .field-group {
   display: flex;
   flex-direction: column;
   gap: 6px;
-}
-
-.field-group label {
-  font-size: 13px;
-  color: #0f172a;
-}
-
-.field-group input,
-.field-group select,
-.system-prompt,
-.search-input {
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 10px 12px;
-  font-size: 14px;
-  font-family: inherit;
 }
 
 .compression-fields {
@@ -251,45 +271,60 @@
 .toggle-control {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
+  gap: 10px;
   width: fit-content;
   font-size: 13px;
-  color: #0f172a;
+  color: #5c5c5c;
 }
 
 .toggle-control input {
-  accent-color: #0f172a;
+  appearance: none;
+  width: 40px;
+  height: 22px;
+  border-radius: 999px;
+  background: #e3e3e3;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.toggle-control input::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.toggle-control input:checked {
+  background: #ffd6e7;
+}
+
+.toggle-control input:checked::after {
+  transform: translateX(18px);
 }
 
 .field-error {
-  color: #b91c1c;
+  color: #c35e86;
   font-size: 12px;
-}
-
-.system-prompt {
-  min-height: 140px;
-  resize: vertical;
 }
 
 .system-prompt-actions {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-top: 12px;
+  margin-top: 8px;
+  flex-wrap: wrap;
 }
 
 .system-prompt-actions .primary {
-  border: none;
-  border-radius: 999px;
-  padding: 8px 16px;
-  font-size: 14px;
-  cursor: pointer;
-  background: #0f172a;
-  color: #fff;
+  background: #ffb7d2;
+  color: #5c5c5c;
 }
 
 .system-prompt-actions .primary:disabled {
@@ -297,23 +332,13 @@
   opacity: 0.5;
 }
 
-.system-prompt-status {
-  font-size: 13px;
-  color: #0f172a;
-}
-
-.search-input {
-  width: 100%;
-}
-
-.catalog-dropdown {
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  background: #f8fafc;
-  padding: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+.system-prompt-status,
+.catalog-hint,
+.catalog-empty,
+.catalog-status,
+.context-length {
+  font-size: 12px;
+  color: #8c8c8c;
 }
 
 .catalog-results {
@@ -332,27 +357,8 @@
   flex-direction: column;
   gap: 6px;
   padding: 10px;
-  border-radius: 10px;
-  background: #fff;
-  border: 1px solid #e2e8f0;
-}
-
-.catalog-hint,
-.catalog-empty {
-  font-size: 12px;
-  color: #64748b;
-}
-
-.catalog-status {
-  color: #64748b;
-  font-size: 13px;
 }
 
 .catalog-status.error {
-  color: #b91c1c;
-}
-
-.context-length {
-  font-size: 12px;
-  color: #475569;
+  color: #c35e86;
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -56,10 +56,12 @@ const SettingsPage = ({
   const [compressionRatioInput, setCompressionRatioInput] = useState('0.65')
   const [compressionKeepRecentInput, setCompressionKeepRecentInput] = useState('20')
   const [draftSummarizerModel, setDraftSummarizerModel] = useState<string | null>(null)
-  const [modelSectionExpanded, setModelSectionExpanded] = useState(true)
-  const [generationSectionExpanded, setGenerationSectionExpanded] = useState(true)
-  const [memorySectionExpanded, setMemorySectionExpanded] = useState(true)
+  const [modelSectionExpanded, setModelSectionExpanded] = useState(false)
+  const [generationSectionExpanded, setGenerationSectionExpanded] = useState(false)
+  const [reasoningSectionExpanded, setReasoningSectionExpanded] = useState(false)
+  const [memorySectionExpanded, setMemorySectionExpanded] = useState(false)
   const [compressionSectionExpanded, setCompressionSectionExpanded] = useState(false)
+  const [systemPromptSectionExpanded, setSystemPromptSectionExpanded] = useState(false)
   const [draftEnabledModels, setDraftEnabledModels] = useState<string[]>([])
   const [draftDefaultModel, setDraftDefaultModel] = useState(defaultModelId)
   const [draftChatReasoning, setDraftChatReasoning] = useState(true)
@@ -739,13 +741,14 @@ const SettingsPage = ({
           aria-expanded={modelSectionExpanded}
         >
           <span className="section-title">
+            <span className="section-icon" aria-hidden="true">⚙️</span>
             <h2 className="ui-title">模型库</h2>
             <p>管理已启用模型并设置默认模型。</p>
           </span>
-          <span className="collapse-indicator">{modelSectionExpanded ? '收起' : '展开'}</span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
         </button>
         {modelSectionExpanded ? (
-          <>
+          <div className="accordion-content">
             {draftEnabledModels.length === 0 ? (
               <div className="empty-state">暂无启用模型，请从下方模型库启用。</div>
             ) : (
@@ -847,7 +850,7 @@ const SettingsPage = ({
               {modelStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
               {modelStatus === 'error' ? <span className="field-error">{modelError}</span> : null}
             </div>
-          </>
+          </div>
         ) : null}
       </section>
 
@@ -859,13 +862,14 @@ const SettingsPage = ({
           aria-expanded={generationSectionExpanded}
         >
           <span className="section-title">
+            <span className="section-icon" aria-hidden="true">🎛️</span>
             <h2 className="ui-title">生成参数</h2>
             <p>调整生成行为与推理开关。</p>
           </span>
-          <span className="collapse-indicator">{generationSectionExpanded ? '收起' : '展开'}</span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
         </button>
         {generationSectionExpanded ? (
-          <>
+          <div className="accordion-content">
             <div className="field-group">
               <label htmlFor="temperature">温度 (0 - 2)</label>
               <input
@@ -905,39 +909,52 @@ const SettingsPage = ({
               />
               {errors.maxTokens ? <span className="field-error">{errors.maxTokens}</span> : null}
             </div>
-          </>
+          </div>
         ) : null}
       </section>
 
       <section className="settings-section">
-        <div className="section-title">
-          <h2 className="ui-title">思考链</h2>
-          <p>分别控制日常聊天与跑跑滚轮是否请求思考链。</p>
-        </div>
-        <div className="field-group">
-          <label htmlFor="chatReasoningEnabled">日常聊天思考链</label>
-          <label className="toggle-control">
-            <input
-              id="chatReasoningEnabled"
-              type="checkbox"
-              checked={draftChatReasoning}
-              onChange={(event) => handleChatReasoningToggle(event.target.checked)}
-            />
-            <span>{draftChatReasoning ? '已开启' : '已关闭'}</span>
-          </label>
-        </div>
-        <div className="field-group">
-          <label htmlFor="rpReasoningEnabled">跑跑滚轮思考链</label>
-          <label className="toggle-control">
-            <input
-              id="rpReasoningEnabled"
-              type="checkbox"
-              checked={draftRpReasoning}
-              onChange={(event) => handleRpReasoningToggle(event.target.checked)}
-            />
-            <span>{draftRpReasoning ? '已开启' : '已关闭'}</span>
-          </label>
-        </div>
+        <button
+          type="button"
+          className="collapse-header"
+          onClick={() => setReasoningSectionExpanded((current) => !current)}
+          aria-expanded={reasoningSectionExpanded}
+        >
+          <span className="section-title">
+            <span className="section-icon" aria-hidden="true">🔮</span>
+            <h2 className="ui-title">思考链</h2>
+            <p>分别控制日常聊天与跑跑滚轮是否请求思考链。</p>
+          </span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
+        </button>
+        {reasoningSectionExpanded ? (
+          <div className="accordion-content">
+            <div className="field-group">
+              <label htmlFor="chatReasoningEnabled">日常聊天思考链</label>
+              <label className="toggle-control">
+                <input
+                  id="chatReasoningEnabled"
+                  type="checkbox"
+                  checked={draftChatReasoning}
+                  onChange={(event) => handleChatReasoningToggle(event.target.checked)}
+                />
+                <span>{draftChatReasoning ? '已开启' : '已关闭'}</span>
+              </label>
+            </div>
+            <div className="field-group">
+              <label htmlFor="rpReasoningEnabled">跑跑滚轮思考链</label>
+              <label className="toggle-control">
+                <input
+                  id="rpReasoningEnabled"
+                  type="checkbox"
+                  checked={draftRpReasoning}
+                  onChange={(event) => handleRpReasoningToggle(event.target.checked)}
+                />
+                <span>{draftRpReasoning ? '已开启' : '已关闭'}</span>
+              </label>
+            </div>
+          </div>
+        ) : null}
       </section>
 
       <section className="settings-section">
@@ -948,45 +965,48 @@ const SettingsPage = ({
           aria-expanded={memorySectionExpanded}
         >
           <span className="section-title">
+            <span className="section-icon" aria-hidden="true">🗂️</span>
             <h2 className="ui-title">记忆相关</h2>
             <p>配置记忆抽取模型；自动提取与归并可在囤囤库中设置。</p>
           </span>
-          <span className="collapse-indicator">{memorySectionExpanded ? '收起' : '展开'}</span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
         </button>
         {memorySectionExpanded ? (
-          <div className="field-group">
-            <label htmlFor="memoryExtractModel">Memory Extract Model</label>
-            <select
-              id="memoryExtractModel"
-              value={draftMemoryExtractModel ?? ''}
-              onChange={(event) => {
-                const next = event.target.value.trim()
-                setDraftMemoryExtractModel(next.length > 0 ? next : null)
-                setExtractModelStatus('idle')
-              }}
-            >
-              <option value="">跟随默认模型（{draftDefaultModel}）</option>
-              {draftEnabledModels.map((modelId) => (
-                <option key={modelId} value={modelId}>
-                  {catalogMap.get(modelId) ?? modelId}
-                </option>
-              ))}
-            </select>
-            {!extractModelValid ? (
-              <span className="field-error">所选模型不在 enabled_models 中，请先启用该模型。</span>
-            ) : null}
-            <div className="system-prompt-actions">
-              <button
-                type="button"
-                className="primary"
-                onClick={() => void handleSaveExtractModel()}
-                disabled={!hasUnsavedExtractModel || !extractModelValid || extractModelStatus === 'saving'}
+          <div className="accordion-content">
+            <div className="field-group">
+              <label htmlFor="memoryExtractModel">Memory Extract Model</label>
+              <select
+                id="memoryExtractModel"
+                value={draftMemoryExtractModel ?? ''}
+                onChange={(event) => {
+                  const next = event.target.value.trim()
+                  setDraftMemoryExtractModel(next.length > 0 ? next : null)
+                  setExtractModelStatus('idle')
+                }}
               >
-                {extractModelStatus === 'saving' ? '保存中…' : '保存'}
-              </button>
-              {hasUnsavedExtractModel ? <span className="system-prompt-status">有未保存修改</span> : null}
-              {extractModelStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
-              {extractModelStatus === 'error' ? <span className="field-error">{extractModelError}</span> : null}
+                <option value="">跟随默认模型（{draftDefaultModel}）</option>
+                {draftEnabledModels.map((modelId) => (
+                  <option key={modelId} value={modelId}>
+                    {catalogMap.get(modelId) ?? modelId}
+                  </option>
+                ))}
+              </select>
+              {!extractModelValid ? (
+                <span className="field-error">所选模型不在 enabled_models 中，请先启用该模型。</span>
+              ) : null}
+              <div className="system-prompt-actions">
+                <button
+                  type="button"
+                  className="primary"
+                  onClick={() => void handleSaveExtractModel()}
+                  disabled={!hasUnsavedExtractModel || !extractModelValid || extractModelStatus === 'saving'}
+                >
+                  {extractModelStatus === 'saving' ? '保存中…' : '保存'}
+                </button>
+                {hasUnsavedExtractModel ? <span className="system-prompt-status">有未保存修改</span> : null}
+                {extractModelStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
+                {extractModelStatus === 'error' ? <span className="field-error">{extractModelError}</span> : null}
+              </div>
             </div>
           </div>
         ) : null}
@@ -1000,13 +1020,15 @@ const SettingsPage = ({
           aria-expanded={compressionSectionExpanded}
         >
           <span className="section-title">
+            <span className="section-icon" aria-hidden="true">🧩</span>
             <h2 className="ui-title">上下文压缩</h2>
             <p>配置压缩触发阈值、保留条数与摘要模型。</p>
           </span>
-          <span className="collapse-indicator">{compressionSectionExpanded ? '收起' : '展开'}</span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
         </button>
         {compressionSectionExpanded ? (
-          <div className="compression-fields">
+          <div className="accordion-content">
+            <div className="compression-fields">
             <label className="toggle-control" htmlFor="compressionEnabled">
               <input
                 id="compressionEnabled"
@@ -1061,47 +1083,61 @@ const SettingsPage = ({
                 </option>
               ))}
             </select>
+            </div>
+            <div className="system-prompt-actions">
+              <button
+                type="button"
+                className="primary"
+                onClick={() => void handleSaveGenerationSettings()}
+                disabled={!hasUnsavedGeneration || !generationDraftValid || generationStatus === 'saving'}
+              >
+                {generationStatus === 'saving' ? '保存中…' : '保存'}
+              </button>
+              {hasUnsavedGeneration ? <span className="system-prompt-status">有未保存修改</span> : null}
+              {generationStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
+              {generationStatus === 'error' ? <span className="field-error">{generationError}</span> : null}
+            </div>
           </div>
         ) : null}
-        <div className="system-prompt-actions">
-          <button
-            type="button"
-            className="primary"
-            onClick={() => void handleSaveGenerationSettings()}
-            disabled={!hasUnsavedGeneration || !generationDraftValid || generationStatus === 'saving'}
-          >
-            {generationStatus === 'saving' ? '保存中…' : '保存'}
-          </button>
-          {hasUnsavedGeneration ? <span className="system-prompt-status">有未保存修改</span> : null}
-          {generationStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
-          {generationStatus === 'error' ? <span className="field-error">{generationError}</span> : null}
-        </div>
       </section>
 
       <section className="settings-section">
-        <div className="section-title">
-          <h2 className="ui-title">系统提示词</h2>
-          <p>用于引导模型的全局指令，仅对当前用户生效。</p>
-        </div>
-        <textarea
-          className="system-prompt"
-          placeholder="例如：你是一个耐心的助手，请用简洁的方式回答。"
-          value={draftSystemPrompt}
-          onChange={(event) => handleSystemPromptChange(event.target.value)}
-        />
-        <div className="system-prompt-actions">
-          <button
-            type="button"
-            className="primary"
-            disabled={!hasUnsavedSystemPrompt}
-            onClick={() => void handleSaveSystemPrompt()}
-          >
-            保存
-          </button>
-          {systemPromptStatus === 'saved' ? (
-            <span className="system-prompt-status">已保存</span>
-          ) : null}
-        </div>
+        <button
+          type="button"
+          className="collapse-header"
+          onClick={() => setSystemPromptSectionExpanded((current) => !current)}
+          aria-expanded={systemPromptSectionExpanded}
+        >
+          <span className="section-title">
+            <span className="section-icon" aria-hidden="true">📝</span>
+            <h2 className="ui-title">系统提示词</h2>
+            <p>用于引导模型的全局指令，仅对当前用户生效。</p>
+          </span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
+        </button>
+        {systemPromptSectionExpanded ? (
+          <div className="accordion-content">
+            <textarea
+              className="system-prompt"
+              placeholder="例如：你是一个耐心的助手，请用简洁的方式回答。"
+              value={draftSystemPrompt}
+              onChange={(event) => handleSystemPromptChange(event.target.value)}
+            />
+            <div className="system-prompt-actions">
+              <button
+                type="button"
+                className="primary"
+                disabled={!hasUnsavedSystemPrompt}
+                onClick={() => void handleSaveSystemPrompt()}
+              >
+                保存
+              </button>
+              {systemPromptStatus === 'saved' ? (
+                <span className="system-prompt-status">已保存</span>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
       </section>
 
       <section className="settings-section">
@@ -1112,13 +1148,14 @@ const SettingsPage = ({
           aria-expanded={snackSectionExpanded}
         >
           <span className="section-title">
+            <span className="section-icon" aria-hidden="true">🍪</span>
             <h2 className="ui-title">Snack Feed</h2>
             <p>仅用于零食罐罐区；基础系统提示词保持不变。</p>
           </span>
-          <span className="collapse-indicator">{snackSectionExpanded ? '收起' : '展开'}</span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
         </button>
         {snackSectionExpanded ? (
-          <>
+          <div className="accordion-content">
             <textarea
               className="system-prompt"
               value={draftSnackSystemPrompt}
@@ -1140,7 +1177,7 @@ const SettingsPage = ({
                 <span className="system-prompt-status">已保存</span>
               ) : null}
             </div>
-          </>
+          </div>
         ) : null}
       </section>
 
@@ -1152,13 +1189,14 @@ const SettingsPage = ({
           aria-expanded={syzygySectionExpanded}
         >
           <span className="section-title">
+            <span className="section-icon" aria-hidden="true">📓</span>
             <h2 className="ui-title">仓鼠观察日志</h2>
             <p>控制发帖与回复时的提示词行为。</p>
           </span>
-          <span className="collapse-indicator">{syzygySectionExpanded ? '收起' : '展开'}</span>
+          <span className="collapse-indicator" aria-hidden="true">˅</span>
         </button>
         {syzygySectionExpanded ? (
-          <>
+          <div className="accordion-content">
             <div className="section-title">
               <h2 className="ui-title">发帖风格（Syzygy Post Prompt）</h2>
               <p>控制 🤖 发帖按钮的文风与输出约束。</p>
@@ -1206,7 +1244,7 @@ const SettingsPage = ({
               </button>
               {syzygyReplyStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
             </div>
-          </>
+          </div>
         ) : null}
       </section>
 


### PR DESCRIPTION
### Motivation

- Make the API 设置 page visually consistent and softer by unifying all configuration modules into the same accordion pattern and removing harsh dark tones.
- Fold previously exposed sections (`思考链`, `系统提示词`) into the same accordion hierarchy so all 8 modules share equal-level collapsible cards.

### Description

- Converted the settings layout to use pill-shaped, frosted-glass accordion headers with emoji icons and a rotating pink chevron, applied across `模型库`, `生成参数`, `思考链`, `记忆相关`, `上下文压缩`, `系统提示词`, `Snack Feed`, and `仓鼠观察日志` in `src/pages/SettingsPage.tsx`.
- Defaulted major sections to collapsed and added explicit expand state variables (`reasoningSectionExpanded`, `systemPromptSectionExpanded`) in `src/pages/SettingsPage.tsx` while wrapping content in a new `.accordion-content` container for consistent inner styling.
- Reworked visual styles in `src/pages/SettingsPage.css` to a Salt-Style Glassmorphism theme: semi-transparent white headers (`rgba(255,255,255,0.7)`), `#ffd6e7` pink borders, warm greys for typography (`#5c5c5c` / `#8c8c8c`), a faint pink polka-dot page background, increased vertical gaps, and softened buttons/badges.
- Polished controls: `系统提示词` textarea now has a dashed pink border and stronger focus state, and checkboxes were restyled to iOS-like toggles with an active track color of `#ffd6e7`.

### Testing

- Ran a production build with `npm run build` which completed successfully.
- Launched a dev server (`vite`) and captured an automated Playwright screenshot of `/settings` to validate the visual changes; screenshot artifact produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03bc9b09c8330a33207566ec09e31)