### PR TITLE
Refine API settings accordion glass styling

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -12,7 +12,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
   padding-bottom: calc(28px + env(safe-area-inset-bottom));
   overflow: visible;
 }
@@ -87,7 +87,8 @@
   align-items: center;
   justify-content: center;
   border-radius: 12px;
-  background: rgba(255, 214, 231, 0.35);
+  background: #ffd6e7;
+  color: #ffffff;
   font-size: 18px;
 }
 
@@ -112,13 +113,19 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.65);
   border: 1px solid #ffd6e7;
   border-radius: 16px;
   padding: 14px;
   text-align: left;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 8px 20px rgba(255, 200, 221, 0.22);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 8px 20px rgba(255, 200, 221, 0.18);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.collapse-header[aria-expanded='false']:hover {
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 10px 24px rgba(255, 214, 231, 0.4);
 }
 
 .collapse-header .section-title {
@@ -126,7 +133,7 @@
 }
 
 .collapse-indicator {
-  color: #ff93bc;
+  color: #ffd6e7;
   font-size: 18px;
   line-height: 1;
   transform: rotate(0deg);
@@ -138,10 +145,10 @@
 }
 
 .accordion-content {
-  background: #fffdf5;
+  background: #f8f4f8;
   border: 1px solid rgba(255, 214, 231, 0.6);
   border-radius: 16px;
-  padding: 14px;
+  padding: 16px;
   box-shadow: inset 0 1px 10px rgba(255, 234, 244, 0.8);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Motivation
- Restore a lighter “salt-style” glassmorphism for the API Settings accordion so headers feel translucent and less heavy. 
- Restrict solid pink to small accents (icon chip and arrow) while keeping primary text high-contrast and readable. 
- Make the expanded panel look like an opened notebook page by applying the requested background and inner padding. 

### Description
- Updated `src/pages/SettingsPage.css` to tighten section spacing from `24px` to `16px` (gap-4) so accordion items float individually. 
- Restyled the left icon chip to a solid accent `#ffd6e7` with white foreground and kept the main title text `#5c5c5c`. 
- Converted collapsed headers to frosted white using `background: rgba(255,255,255,0.65)` with `backdrop-filter: blur(12px)`, preserved a `1px` `#ffd6e7` border, adjusted shadow and added transitions. 
- Added a hover rule for collapsed headers that increases opacity and adds a soft pink glow, changed the expand arrow color to `#ffd6e7`, and ensured the collapse indicator rotates on expand. 
- Changed expanded content background to `#F8F4F8` and increased inner padding to `16px` for a notebook-like interior. 

### Testing
- Ran `npm run lint` which completed successfully with a single pre-existing warning in `src/pages/CheckinPage.tsx` about `react-hooks/exhaustive-deps`. 
- Started the dev server with `npm run dev` and verified the UI served successfully. 
- Captured an automated Playwright screenshot of the `/settings` route to visually validate the updated accordion styling (artifact generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03eff945c833098d5952a0a729897)