### PR TITLE
Redesign API Settings into classic grouped iOS list layout

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -1,10 +1,10 @@
 .settings-shell {
   min-height: 100vh;
   min-height: 100dvh;
-  background-color: #fff8fc;
+  background-color: #fcfcfc;
   background-image:
-    radial-gradient(circle at 20px 20px, rgba(255, 214, 231, 0.45) 2px, transparent 2.2px),
-    radial-gradient(circle at 56px 56px, rgba(255, 214, 231, 0.3) 2px, transparent 2.2px);
+    radial-gradient(circle at 18px 18px, rgba(255, 214, 231, 0.28) 1.8px, transparent 2px),
+    radial-gradient(circle at 52px 52px, rgba(224, 224, 231, 0.24) 1.8px, transparent 2px);
   background-size: 72px 72px;
 }
 
@@ -12,9 +12,18 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   padding-bottom: calc(28px + env(safe-area-inset-bottom));
   overflow: visible;
+}
+
+.settings-group {
+  margin: 0 16px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid #ffd6e7;
+  border-radius: 20px;
+  backdrop-filter: blur(12px);
+  overflow: hidden;
 }
 
 .settings-header {
@@ -62,10 +71,10 @@
 }
 
 .settings-section {
-  margin: 0 16px;
+  margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 0;
 }
 
 .section-title {
@@ -113,19 +122,30 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: rgba(255, 255, 255, 0.65);
-  border: 1px solid #ffd6e7;
-  border-radius: 16px;
+  background: transparent;
+  border: none;
+  border-radius: 0;
   padding: 14px;
   text-align: left;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 8px 20px rgba(255, 200, 221, 0.18);
-  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease;
+  position: relative;
 }
 
 .collapse-header[aria-expanded='false']:hover {
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow: 0 10px 24px rgba(255, 214, 231, 0.4);
+  background: rgba(255, 245, 250, 0.65);
+}
+
+.settings-section:not(:last-child) .collapse-header::after {
+  content: '';
+  position: absolute;
+  left: 56px;
+  right: 0;
+  bottom: 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.settings-section .collapse-header[aria-expanded='true']::after {
+  display: none;
 }
 
 .collapse-header .section-title {
@@ -133,23 +153,22 @@
 }
 
 .collapse-indicator {
-  color: #ffd6e7;
-  font-size: 18px;
+  color: #c7c7cc;
+  font-size: 24px;
   line-height: 1;
   transform: rotate(0deg);
   transition: transform 0.2s ease;
 }
 
 .collapse-header[aria-expanded='true'] .collapse-indicator {
-  transform: rotate(180deg);
+  transform: rotate(90deg);
 }
 
 .accordion-content {
   background: #f8f4f8;
-  border: 1px solid rgba(255, 214, 231, 0.6);
-  border-radius: 16px;
-  padding: 16px;
-  box-shadow: inset 0 1px 10px rgba(255, 234, 244, 0.8);
+  border: none;
+  border-radius: 0;
+  padding: 14px 16px 16px;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -733,7 +733,8 @@ const SettingsPage = ({
       </header>
 
       <div className="settings-page app-shell__content">
-      <section className="settings-section">
+        <div className="settings-group" role="list">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -745,7 +746,7 @@ const SettingsPage = ({
             <h2 className="ui-title">模型库</h2>
             <p>管理已启用模型并设置默认模型。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {modelSectionExpanded ? (
           <div className="accordion-content">
@@ -854,7 +855,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-      <section className="settings-section">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -866,7 +867,7 @@ const SettingsPage = ({
             <h2 className="ui-title">生成参数</h2>
             <p>调整生成行为与推理开关。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {generationSectionExpanded ? (
           <div className="accordion-content">
@@ -913,7 +914,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-      <section className="settings-section">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -925,7 +926,7 @@ const SettingsPage = ({
             <h2 className="ui-title">思考链</h2>
             <p>分别控制日常聊天与跑跑滚轮是否请求思考链。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {reasoningSectionExpanded ? (
           <div className="accordion-content">
@@ -957,7 +958,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-      <section className="settings-section">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -969,7 +970,7 @@ const SettingsPage = ({
             <h2 className="ui-title">记忆相关</h2>
             <p>配置记忆抽取模型；自动提取与归并可在囤囤库中设置。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {memorySectionExpanded ? (
           <div className="accordion-content">
@@ -1012,7 +1013,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-      <section className="settings-section">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -1024,7 +1025,7 @@ const SettingsPage = ({
             <h2 className="ui-title">上下文压缩</h2>
             <p>配置压缩触发阈值、保留条数与摘要模型。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {compressionSectionExpanded ? (
           <div className="accordion-content">
@@ -1101,7 +1102,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-      <section className="settings-section">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -1113,7 +1114,7 @@ const SettingsPage = ({
             <h2 className="ui-title">系统提示词</h2>
             <p>用于引导模型的全局指令，仅对当前用户生效。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {systemPromptSectionExpanded ? (
           <div className="accordion-content">
@@ -1140,7 +1141,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-      <section className="settings-section">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -1152,7 +1153,7 @@ const SettingsPage = ({
             <h2 className="ui-title">Snack Feed</h2>
             <p>仅用于零食罐罐区；基础系统提示词保持不变。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {snackSectionExpanded ? (
           <div className="accordion-content">
@@ -1181,7 +1182,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
-      <section className="settings-section">
+      <section className="settings-section" role="listitem">
         <button
           type="button"
           className="collapse-header"
@@ -1193,7 +1194,7 @@ const SettingsPage = ({
             <h2 className="ui-title">仓鼠观察日志</h2>
             <p>控制发帖与回复时的提示词行为。</p>
           </span>
-          <span className="collapse-indicator" aria-hidden="true">˅</span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
         </button>
         {syzygySectionExpanded ? (
           <div className="accordion-content">
@@ -1248,6 +1249,7 @@ const SettingsPage = ({
         ) : null}
       </section>
 
+        </div>
       </div>
 
       <ConfirmDialog


### PR DESCRIPTION
### Motivation
- Reduce visual weight of the floating pill UI by reconstructing the Settings page into a single grouped-list that matches a classic iOS settings grouped list while retaining existing accordion expand/collapse behavior.
- Keep the Salt-style color palette and page pattern but soften the background and polish transitions so expanded panels feel like unfolding a notebook page.

### Description
- Replaced per-section floating pills with a single wrapper `div.settings-group` and marked it `role="list"` while each section is `role="listitem"`, moving sections into a continuous grouped container (file: `src/pages/SettingsPage.tsx`).
- Updated row affordances by replacing the previous caret glyph with a softer chevron `›`, adjusting the chevron color and rotation behavior via `.collapse-indicator`, and adding an inset divider line that starts after the icon using a `::after` pseudo-element (file: `src/pages/SettingsPage.tsx` and `src/pages/SettingsPage.css`).
- Restyled the group container to a frosted white background with `rgba(255,255,255,0.8)` and `border-radius: 20px`, changed global background to `#fcfcfc` with a lighter pink/grey polka-dot pattern, and removed closed-state gaps between items to create continuous rows (file: `src/pages/SettingsPage.css`).
- Adjusted expanded panel visuals to use the exact inner background `#F8F4F8`, removed harsh inner borders, and simplified accordion panel padding and borders so expansion unfolds smoothly (file: `src/pages/SettingsPage.css`).

### Testing
- `npm run build` initially failed due to a JSX tag mismatch introduced during the markup update and the issue was fixed, and the subsequent `npm run build` completed successfully.
- `npm run dev -- --host 0.0.0.0 --port 4173` started the dev server successfully and the updated UI was visually validated via an automated Playwright screenshot saved to `artifacts/settings-ios-list.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a042016af48330a52077d4824f219b)