### PR TITLE
Refine settings list to unified iOS-style container

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -19,10 +19,11 @@
 
 .settings-group {
   margin: 0 16px;
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid #ffd6e7;
-  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid #f0f0f0;
+  border-radius: 16px;
   backdrop-filter: blur(12px);
+  box-shadow: 0 10px 24px rgba(112, 112, 112, 0.08);
   overflow: hidden;
 }
 
@@ -75,6 +76,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+  background: transparent;
 }
 
 .section-title {
@@ -125,20 +127,21 @@
   background: transparent;
   border: none;
   border-radius: 0;
-  padding: 14px;
+  min-height: 56px;
+  padding: 12px 16px;
   text-align: left;
   transition: background-color 0.2s ease;
   position: relative;
 }
 
 .collapse-header[aria-expanded='false']:hover {
-  background: rgba(255, 245, 250, 0.65);
+  background: rgba(243, 243, 245, 0.45);
 }
 
 .settings-section:not(:last-child) .collapse-header::after {
   content: '';
   position: absolute;
-  left: 56px;
+  left: 0;
   right: 0;
   bottom: 0;
   border-bottom: 1px solid #f0f0f0;


### PR DESCRIPTION
### Motivation
- Enforce a single unified white/frosted container for the settings list so individual rows render as transparent plain rows rather than pink pill-like elements. 
- Remove excessive pink backgrounds and pill radii from row-level elements while preserving pink as a small accent for left icon boxes. 
- Match the requested iOS-native list layout with thin dividers, 56px row height, and a subtle lift shadow on the global container.

### Description
- Restyled the settings container `.settings-group` to use `background: rgba(255,255,255,0.7)`, `border: 1px solid #f0f0f0`, `border-radius: 16px`, and a subtle `box-shadow` to present a single frosted white card. 
- Made each top-level row transparent and non-pill by adding `background: transparent` to `.settings-section` and enforcing `min-height: 56px` plus horizontal padding on `.collapse-header`. 
- Reworked row separators to be full-width thin dividers by moving the divider to `left: 0` and using `border-bottom: 1px solid #f0f0f0`, and adjusted hover state to a neutral light background. 
- Preserved expanded panel content background as `#f8f4f8` and kept the small left icon box using the pink accent (`#ffd6e7`) so pink remains only as a minor detail.

### Testing
- Ran `npm run build` which completed successfully. 
- Launched the app with `npm run dev` and validated the `/settings` route visually. 
- Executed a Playwright script to visit `http://127.0.0.1:4173/settings` and captured a screenshot of the updated settings list for verification, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04494868c8330a36c833b6a68e84c)