### PR TITLE
Settings: scope collapse-header to remove pink pill and apply iOS-style rows

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -4,6 +4,10 @@
   background: var(--page-bg);
 }
 
+.settings-shell.app-shell {
+  background: var(--page-bg);
+}
+
 .settings-page {
   min-height: 0;
   display: flex;
@@ -14,7 +18,7 @@
   overflow: visible;
 }
 
-.settings-group {
+.settings-page .settings-group {
   margin: 0 16px;
   background: rgba(255, 255, 255, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.35);
@@ -115,13 +119,15 @@
   font-size: 13px;
 }
 
-.collapse-header {
+.settings-page .collapse-header {
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: transparent;
+  background: transparent !important;
+  background-image: none !important;
+  box-shadow: none !important;
   border: none;
   border-radius: 0;
   min-height: 56px;
@@ -131,19 +137,24 @@
   position: relative;
 }
 
-.collapse-header[aria-expanded='false']:hover {
+.settings-page .collapse-header::before,
+.settings-page .collapse-header::after {
+  background: none !important;
+}
+
+.settings-page .collapse-header[aria-expanded='false']:hover {
   background: rgba(255, 255, 255, 0.28);
 }
 
-.settings-section + .settings-section .collapse-header {
+.settings-page .settings-section + .settings-section .collapse-header {
   border-top: 1px solid rgba(0, 0, 0, 0.06);
 }
 
-.settings-section .collapse-header[aria-expanded='true']::after {
+.settings-page .settings-section .collapse-header[aria-expanded='true']::after {
   display: none;
 }
 
-.collapse-header .section-title {
+.settings-page .collapse-header .section-title {
   flex: 1;
 }
 
@@ -155,7 +166,7 @@
   transition: transform 0.2s ease;
 }
 
-.collapse-header[aria-expanded='true'] .collapse-indicator {
+.settings-page .collapse-header[aria-expanded='true'] .collapse-indicator {
   transform: rotate(90deg);
 }
 


### PR DESCRIPTION
### Motivation
- The Settings page was showing pink pill-style `.collapse-header` backgrounds (from a global button style) which should be removed only for the Settings page so other pages are unaffected.
- Rows should visually match iOS settings lists (flat rows with subtle separators inside a rounded, glassy group card) while preserving the page's pink-mist background gradient.

### Description
- Scoped the group card styling to the Settings page by changing `.settings-group` to `.settings-page .settings-group` in `src/pages/SettingsPage.css` so the rounded/clipped card is confined to Settings only.
- Scoped and force-overrode `.collapse-header` styles inside `.settings-page` to remove the pink pill (added `background: transparent !important`, `background-image: none !important`, `box-shadow: none !important`) and neutralized pseudo-elements with `.settings-page .collapse-header::before` and `::after` rules.
- Scoped row separators, hover, and expanded-state indicator selectors to `.settings-page` so they only affect the Settings page rows and create the subtle iOS-like separators.
- Added `.settings-shell.app-shell { background: var(--page-bg); }` to ensure the page background gradient (pink mist) is applied correctly for the Settings shell.

### Testing
- Ran `npm run build` which completed successfully (production bundle built). 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app started successfully.
- Captured a visual verification screenshot of `http://127.0.0.1:4173/settings` via a Playwright script to confirm rows are transparent and styled as an iOS list (screenshot captured for review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0484463f883308de56ddf6209aeab)