### PR TITLE
Fix mobile settings accordion scroll trapping

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -6,6 +6,7 @@
 
 .settings-shell.app-shell {
   background: var(--page-bg);
+  overscroll-behavior: auto;
 }
 
 .settings-page {
@@ -15,7 +16,9 @@
   gap: 14px;
   background: var(--page-bg);
   padding-bottom: calc(28px + env(safe-area-inset-bottom));
-  overflow: visible;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: auto;
 }
 
 .settings-page .settings-group {
@@ -178,6 +181,16 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  max-height: none;
+  overflow: visible;
+}
+
+@media (max-width: 560px) {
+  .accordion-content {
+    transition: none;
+    max-height: none;
+    overflow: visible;
+  }
 }
 
 .nested-prompt-title {


### PR DESCRIPTION
### Motivation
- Mobile users reported that expanding a settings accordion section would "trap" touch scrolling and make lower controls unreachable, caused by nested scroll/overflow and max-height animation on the accordion body. 
- No skills were used — this is a local CSS-only fix to the Settings page.

### Description
- Made the Settings page content the single touch-friendly scroll container by setting `.settings-page` to `overflow: auto`, `-webkit-overflow-scrolling: touch`, and `overscroll-behavior: auto` in `src/pages/SettingsPage.css`.
- Relaxed overscroll behavior on `.settings-shell.app-shell` by setting `overscroll-behavior: auto` so the page can scroll naturally on mobile.
- Prevented nested scrolling regions by forcing `.accordion-content` to `max-height: none` and `overflow: visible` so expanded sections no longer intercept touch scroll.
- Disabled the accordion content transition on small screens via a `@media (max-width: 560px)` rule to avoid animation-driven `max-height`/`overflow` locking on mobile.

### Testing
- Ran `npm run build` which completed successfully (Vite build produced dist assets without errors).
- Launched the dev server with `npm run dev` and executed an automated Playwright script that loaded `/settings` at a 390×844 mobile viewport, expanded a section, and captured a screenshot; the script completed and produced the artifact successfully.
- No other automated test suites exist for this UI change, and the above build + runtime checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a049bf90a88330817d9ac064cf88d7)