### PR TITLE
Fix settings accordion scroll lock on mobile/desktop

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,18 @@ html.no-fx {
   body.chat-page-active #root {
     height: 100dvh;
   }
+
+  html.settings-page-active,
+  html.settings-page-active body,
+  body.settings-page-active {
+    height: auto;
+    overflow: auto !important;
+    overscroll-behavior: auto;
+  }
+
+  body.settings-page-active #root {
+    height: 100%;
+  }
 }
 
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -90,6 +90,17 @@ const SettingsPage = ({
   const pendingNavigationRef = useRef<null | (() => void)>(null)
 
   useEffect(() => {
+    document.documentElement.classList.add('settings-page-active')
+    document.body.classList.add('settings-page-active')
+    document.body.classList.remove('chat-page-active')
+
+    return () => {
+      document.documentElement.classList.remove('settings-page-active')
+      document.body.classList.remove('settings-page-active')
+    }
+  }, [])
+
+  useEffect(() => {
     if (!settings) {
       return
     }


### PR DESCRIPTION
### Motivation
- Prevent the Settings page accordion from making the entire app unscrollable by avoiding leftover global scroll-lock classes and mobile overflow rules when Settings is open.

### Description
- Add a mount/unmount effect in `src/pages/SettingsPage.tsx` that adds `settings-page-active` to `html` and `body`, removes any lingering `chat-page-active`, and cleans up on unmount.
- Add scoped mobile CSS overrides in `src/index.css` under `@media (max-width: 768px)` so `html.settings-page-active`, `body.settings-page-active`, and `body.settings-page-active #root` use `overflow: auto`/appropriate heights to keep the page scrollable.

### Testing
- Ran `npm run lint`, which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` about hook dependencies.
- Ran `npm run build`, which completed successfully and produced a production bundle.
- Launched the dev server and exercised `/settings` with a Playwright script that opened an accordion and captured a screenshot; the automation observed `overlayCount: 0` and no global `overflow: hidden`, while noting the test environment could not fully exercise all UI states (the script reported `hasScroller: false` in the runtime scroller check).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04b9aa7308330ba68e27f46e836ec)