### PR TITLE
Fix settings page scroll when accordion sections expand

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -28,7 +28,7 @@
   border-radius: 20px;
   backdrop-filter: blur(12px);
   box-shadow: var(--shadow-soft);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .settings-header {


### PR DESCRIPTION
### Motivation
- Expanded accordion content was being clipped because `.settings-page .settings-group` used `overflow: hidden`, preventing child content from contributing to the page's scrollable overflow in the fixed-height app shell.

### Description
- Replace `overflow: hidden` with `overflow: visible` on `.settings-page .settings-group` in `src/pages/SettingsPage.css` so expanded accordion panels can grow beyond the group and allow the page to scroll.
- Considered `overflow: clip` as a fallback if border-radius visuals are unacceptable, but the change applied uses `overflow: visible` as the primary fix.

### Testing
- Ran `npm run lint`, which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` about `react-hooks/exhaustive-deps`.
- Started the dev server with `npm run dev` and executed a Playwright script that loaded `/settings` and captured a screenshot (`artifacts/settings-page-initial.png`) to validate rendering; interactive scroll verification was blocked by a login gate in this environment so full end-to-end scroll behavior could not be exercised automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04e18a6ac8330aa9aa81aa24c64af)