### PR TITLE
Redesign login interface into Secret Diary themed UI

### DIFF
--- a/src/pages/AuthPage.css
+++ b/src/pages/AuthPage.css
@@ -4,94 +4,203 @@
   align-items: center;
   justify-content: center;
   padding: 32px 16px;
-  background: radial-gradient(circle at top, rgba(75, 103, 255, 0.12), transparent 60%),
-    #0f1115;
-  color: #f5f5f5;
+  color: #5f4b54;
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Ctext y='21' font-size='20'%3E%F0%9F%90%BE%3C/text%3E%3C/svg%3E") 6 6, auto;
+  background-color: #fff7f2;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'%3E%3Ctext x='12' y='34' font-size='20'%3E%F0%9F%92%96%3C/text%3E%3Ctext x='90' y='28' font-size='18'%3E%E2%9C%A8%3C/text%3E%3Ctext x='44' y='70' font-size='18'%3E%F0%9F%90%B9%3C/text%3E%3Ctext x='8' y='112' font-size='16'%3E%E2%9C%A8%3C/text%3E%3Ctext x='86' y='108' font-size='18'%3E%F0%9F%92%96%3C/text%3E%3C/svg%3E"),
+    radial-gradient(circle at top, rgba(255, 214, 231, 0.55), transparent 64%);
+  background-repeat: repeat;
 }
 
 .auth-card {
-  width: min(480px, 100%);
-  background: #171a21;
-  border-radius: 20px;
-  padding: 32px;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
+  position: relative;
+  width: min(520px, 100%);
+  border-radius: 28px;
+  border: 2px solid #f6d7e5;
+  padding: 34px 30px 28px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
+  background:
+    linear-gradient(#fff, #fff) padding-box,
+    radial-gradient(circle at 18px 18px, rgba(255, 214, 231, 0.65) 0 4px, transparent 4px) border-box,
+    radial-gradient(circle at calc(100% - 18px) 18px, rgba(255, 214, 231, 0.65) 0 4px, transparent 4px)
+      border-box,
+    radial-gradient(circle at 18px calc(100% - 18px), rgba(255, 214, 231, 0.65) 0 4px, transparent 4px)
+      border-box,
+    radial-gradient(circle at calc(100% - 18px) calc(100% - 18px), rgba(255, 214, 231, 0.65) 0 4px, transparent 4px)
+      border-box,
+    linear-gradient(145deg, #ffffff 0%, #fff8fc 100%);
+}
+
+.auth-card::before {
+  content: '🎀';
+  position: absolute;
+  top: -14px;
+  right: 18px;
+  font-size: 26px;
+  transform: rotate(10deg);
+}
+
+.auth-card::after {
+  content: '📎';
+  position: absolute;
+  left: 18px;
+  top: -16px;
+  font-size: 24px;
+  transform: rotate(-14deg);
+}
+
+.hamster-logo {
+  text-align: center;
+  font-size: 56px;
+  line-height: 1;
 }
 
 .auth-card h1 {
   margin: 0;
-  font-size: 24px;
+  text-align: center;
+  color: #d87ca3;
+  font-size: clamp(1.65rem, 3.2vw, 2.05rem);
+  letter-spacing: 0.02em;
 }
 
 .auth-card .subtitle {
-  margin: 0;
-  color: #a9b1c7;
-  font-size: 14px;
+  margin: 0 0 4px;
+  text-align: center;
+  color: #8c8c8c;
+  font-size: 0.95rem;
 }
 
 .field {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  font-size: 14px;
-  color: #c5cbe0;
+}
+
+.field-label {
+  font-size: 0.88rem;
+  color: #a46a86;
+}
+
+.input-shell {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border-radius: 15px;
+  border: 1px dashed #efb9ce;
+  background: #fff;
+  padding: 10px 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-shell:focus-within {
+  border-color: #f4a9c8;
+  box-shadow: 0 0 0 3px #ffd6e7;
+}
+
+.input-icon {
+  font-size: 1.02rem;
 }
 
 .field input {
-  border-radius: 12px;
-  border: 1px solid #2b2f3b;
-  background: #10121a;
-  padding: 10px 12px;
-  color: #f5f5f5;
-  font-size: 14px;
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: #5f4b54;
+  font-size: 0.95rem;
+}
+
+.field input::placeholder {
+  color: #cda2b6;
 }
 
 .auth-card .primary {
-  border-radius: 12px;
-  padding: 10px 12px;
-  border: none;
-  background: #4b67ff;
+  position: relative;
+  overflow: hidden;
+  border-radius: 15px;
+  border: 1px solid #d87ca3;
+  padding: 12px 14px;
+  background: linear-gradient(180deg, #ffd6e7 0%, #f9b9d3 100%);
   color: #fff;
-  font-weight: 600;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
   cursor: pointer;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+}
+
+.auth-card .primary::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -15%;
+  width: 55%;
+  height: 58%;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 20px;
+  transform: rotate(-8deg);
+}
+
+.auth-card .primary::after {
+  content: '🩹';
+  position: absolute;
+  right: 8px;
+  top: -10px;
+  font-size: 20px;
+  transform: rotate(16deg);
 }
 
 .auth-card .primary:disabled {
-  opacity: 0.6;
+  opacity: 0.68;
   cursor: not-allowed;
+}
+
+.forgot-link {
+  align-self: flex-end;
+  margin-top: -4px;
+  border: none;
+  background: transparent;
+  color: #ffd6e7;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.forgot-link:hover {
+  text-decoration: underline dotted;
 }
 
 .auth-card .ghost,
 .auth-card .danger {
   border-radius: 12px;
   padding: 8px 12px;
-  border: 1px solid #2b2f3b;
-  background: transparent;
-  color: #c5cbe0;
+  border: 1px solid #efb9ce;
+  background: #fff7fb;
+  color: #9f6f85;
   cursor: pointer;
 }
 
 .auth-card .danger {
-  border-color: rgba(255, 107, 107, 0.4);
-  color: #ff8a8a;
+  border-color: #f3aac7;
+  color: #d16e99;
 }
 
 .status {
-  color: #6cf7b1;
+  color: #5bbf87;
   margin: 0;
 }
 
 .error {
-  color: #ff8a8a;
+  color: #dd6d96;
   margin: 0;
 }
 
 .divider {
   height: 1px;
-  background: #262a36;
-  margin: 8px 0;
+  background: #f5d6e4;
+  margin: 6px 0;
 }
 
 .auth-user {
@@ -106,6 +215,6 @@
 }
 
 .hint {
-  color: #8a92aa;
+  color: #9f8f97;
   margin: 0;
 }

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -109,16 +109,24 @@ const AuthPage = ({ user }: AuthPageProps) => {
   return (
     <div className="auth-page">
       <div className="auth-card">
-        <h1 className="ui-title">邮箱验证码登录</h1>
-        <p className="subtitle">使用邮箱验证码登录后即可同步云端会话。</p>
+        <div className="hamster-logo" aria-hidden="true">
+          🐹🎀
+        </div>
+        <h1 className="ui-title">Welcome to Hamster Nest 🐹🏰</h1>
+        <p className="subtitle">Enter your password to unlock your secret lair 🤫🔑</p>
         <label className="field">
-          <span>邮箱地址</span>
-          <input
-            type="email"
-            placeholder="输入你的邮箱"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
+          <span className="field-label">邮箱地址</span>
+          <div className="input-shell">
+            <span className="input-icon" aria-hidden="true">
+              👤
+            </span>
+            <input
+              type="email"
+              placeholder="输入你的邮箱"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </div>
         </label>
         <button
           type="button"
@@ -126,16 +134,21 @@ const AuthPage = ({ user }: AuthPageProps) => {
           onClick={handleSendOtp}
           disabled={sending}
         >
-          {sending ? '发送中...' : '发送验证码'}
+          {sending ? '发送中...' : 'Go! 🐹💨 发送验证码'}
         </button>
         <label className="field">
-          <span>验证码</span>
-          <input
-            type="text"
-            placeholder="输入邮箱中的验证码"
-            value={otp}
-            onChange={(event) => setOtp(event.target.value)}
-          />
+          <span className="field-label">验证码</span>
+          <div className="input-shell">
+            <span className="input-icon" aria-hidden="true">
+              🔒
+            </span>
+            <input
+              type="text"
+              placeholder="输入邮箱中的验证码"
+              value={otp}
+              onChange={(event) => setOtp(event.target.value)}
+            />
+          </div>
         </label>
         <button
           type="button"
@@ -143,7 +156,10 @@ const AuthPage = ({ user }: AuthPageProps) => {
           onClick={handleVerifyOtp}
           disabled={verifying}
         >
-          {verifying ? '验证中...' : '验证并登录'}
+          {verifying ? '验证中...' : 'Go! 🐹💨 验证并登录'}
+        </button>
+        <button type="button" className="forgot-link" onClick={handleSendOtp}>
+          Forgot Password?
         </button>
         {status ? <p className="status">{status}</p> : null}
         {error ? <p className="error">{error}</p> : null}


### PR DESCRIPTION
### Motivation
- Make the login screen feel like a personalized “Secret Diary Access” with maximalist hamster-themed decoration and softer, scrapbook-like visuals.

### Description
- Reworked the auth page structure and copy in `src/pages/AuthPage.tsx` to add a large hamster logo, new welcome title (`Welcome to Hamster Nest 🐹🏰`) and secret-lair subtext, unified input shells with emoji icons, and a soft pink "Forgot Password?" link.
- Replaced and rebuilt `src/pages/AuthPage.css` to apply a dense repeating background pattern (hearts, stars, hamster heads), page-level paw-cursor, layered scrapbook/card styling with rounded 28px corners, lace/sticker accents, dashed pink input borders with pink focus ring, and glossy plump pink primary buttons with decorative tape accent.
- Kept existing authentication logic intact while updating button labels to include the playful `Go! 🐹💨` text and wrapped inputs in an `input-shell` to present pixel-art emoji icons for username (`👤`) and password (`🔒`).

### Testing
- Ran `npm run build` which completed successfully; production build emitted client assets without errors.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and performed an automated page render screenshot via Playwright to visually validate the redesign (screenshot generated at `artifacts/auth-page-redesign.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04fa010ac83308a1b42da5aa3cdd2)