### PR TITLE
Beautify export zone with cute memory packaging card UI

### DIFF
--- a/src/pages/ExportPage.css
+++ b/src/pages/ExportPage.css
@@ -17,29 +17,116 @@
 .export-header h1 {
   margin: 0;
   font-size: 1.1rem;
+  color: #5c5c5c;
 }
 
-.export-card {
-  border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: 14px;
-  background: var(--card-bg, #fff);
-  padding: 14px;
+.export-package-card {
+  position: relative;
+  border: 1px solid #ffd6e7;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.export-package-card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #5c5c5c;
+  font-weight: 700;
+}
+
+.export-washi-tape {
+  position: absolute;
+  top: -12px;
+  left: 20px;
+  width: 92px;
+  height: 24px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, rgba(255, 214, 231, 0.86), rgba(255, 255, 255, 0.6));
+  border: 1px dashed rgba(255, 255, 255, 0.8);
+  transform: rotate(-10deg);
+  box-shadow: 0 4px 8px rgba(92, 92, 92, 0.08);
+}
+
+.export-subsection {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.export-card h2 {
+.export-subsection h3 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.95rem;
+  color: #5c5c5c;
 }
 
-.export-card label {
+.export-format-stickers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.export-sticker {
+  border: 1px solid #ffd6e7;
+  background: transparent;
+  color: #8c8c8c;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.export-sticker.active {
+  background: #ffd6e7;
+  color: #5c5c5c;
+}
+
+.export-package-card label {
   display: flex;
   align-items: center;
   gap: 8px;
+  color: #5c5c5c;
+}
+
+.export-note,
+.export-signoff {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #8c8c8c;
+}
+
+.export-signoff {
+  font-style: italic;
 }
 
 .export-button {
-  align-self: flex-start;
+  align-self: stretch;
+  border: 0;
+  border-radius: 999px;
+  background: #ffd6e7;
+  color: #5c5c5c;
+  font-size: 0.98rem;
+  font-weight: 700;
+  padding: 12px 18px;
+  cursor: pointer;
+  transition: transform 0.15s ease, filter 0.2s ease;
+}
+
+.export-button:hover {
+  filter: brightness(0.98);
+}
+
+.export-button:active {
+  transform: scale(0.98);
+}
+
+.export-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }

--- a/src/pages/ExportPage.tsx
+++ b/src/pages/ExportPage.tsx
@@ -89,6 +89,12 @@ type ExportDataBundle = {
   checkins: CheckinRow[]
 }
 
+const formatOptions: Array<{ value: ExportFormat; label: string }> = [
+  { value: 'markdown', label: 'Markdown (.md)' },
+  { value: 'json', label: 'JSON (.json)' },
+  { value: 'txt', label: 'TXT (.txt)' },
+]
+
 const defaultModules: ExportModules = {
   chat: true,
   snacks: true,
@@ -464,62 +470,71 @@ const ExportPage = ({ user }: { user: User | null }) => {
         </button>
       </header>
 
-      <section className="export-card">
-        <h2 className="ui-title">导出格式</h2>
-        <label>
-          <input
-            type="radio"
-            name="format"
-            checked={format === 'markdown'}
-            onChange={() => setFormat('markdown')}
-          />
-          Markdown (.md)
-        </label>
-        <label>
-          <input type="radio" name="format" checked={format === 'json'} onChange={() => setFormat('json')} />
-          JSON (.json)
-        </label>
-        <label>
-          <input type="radio" name="format" checked={format === 'txt'} onChange={() => setFormat('txt')} />
-          TXT (.txt)
-        </label>
+      <section className="export-card export-package-card">
+        <span className="export-washi-tape" aria-hidden="true" />
+        <h2 className="ui-title">我的数据仓库 📦🐹</h2>
+
+        <div className="export-subsection">
+          <h3>格式便签贴</h3>
+          <div className="export-format-stickers" role="radiogroup" aria-label="导出格式">
+            {formatOptions.map((option) => {
+              const isActive = format === option.value
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  className={`export-sticker ${isActive ? 'active' : ''}`}
+                  onClick={() => setFormat(option.value)}
+                >
+                  {isActive ? '✔ ' : ''}
+                  {option.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="export-subsection">
+          <h3>导出模块</h3>
+          <label>
+            <input type="checkbox" checked={modules.chat} onChange={() => toggleModule('chat')} />
+            吱吱吱区（sessions + messages）
+          </label>
+          <label>
+            <input type="checkbox" checked={modules.snacks} onChange={() => toggleModule('snacks')} />
+            零食罐罐（snack_posts + snack_replies）
+          </label>
+          <label>
+            <input type="checkbox" checked={modules.syzygy} onChange={() => toggleModule('syzygy')} />
+            仓鼠饲养日志（syzygy_posts + syzygy_replies）
+          </label>
+          <label>
+            <input type="checkbox" checked={modules.memory} onChange={() => toggleModule('memory')} />
+            囤囤库（memory_entries）
+          </label>
+          <label>
+            <input type="checkbox" checked={modules.checkins} onChange={() => toggleModule('checkins')} />
+            打卡（checkins）
+          </label>
+        </div>
+
+        <p className="export-note">可一次性打包多个模块，导出后将自动下载到本地设备。</p>
+        <p className="export-signoff">Your memories are safely packed by Syzygy. 🎀</p>
+
+        {warning ? <p className="tips">{warning}</p> : null}
+        {error ? <p className="error">{error}</p> : null}
+
+        <button
+          type="button"
+          className="export-button"
+          disabled={!user || !supabase || selectedCount === 0 || exporting}
+          onClick={() => void handleExport()}
+        >
+          {exporting ? '打包中…' : '打包我的藏品 / Pack My Hoard 📥✨'}
+        </button>
       </section>
-
-      <section className="export-card">
-        <h2 className="ui-title">导出模块</h2>
-        <label>
-          <input type="checkbox" checked={modules.chat} onChange={() => toggleModule('chat')} />
-          吱吱吱区（sessions + messages）
-        </label>
-        <label>
-          <input type="checkbox" checked={modules.snacks} onChange={() => toggleModule('snacks')} />
-          零食罐罐（snack_posts + snack_replies）
-        </label>
-        <label>
-          <input type="checkbox" checked={modules.syzygy} onChange={() => toggleModule('syzygy')} />
-          仓鼠饲养日志（syzygy_posts + syzygy_replies）
-        </label>
-        <label>
-          <input type="checkbox" checked={modules.memory} onChange={() => toggleModule('memory')} />
-          囤囤库（memory_entries）
-        </label>
-        <label>
-          <input type="checkbox" checked={modules.checkins} onChange={() => toggleModule('checkins')} />
-          打卡（checkins）
-        </label>
-      </section>
-
-      {warning ? <p className="tips">{warning}</p> : null}
-      {error ? <p className="error">{error}</p> : null}
-
-      <button
-        type="button"
-        className="primary export-button"
-        disabled={!user || !supabase || selectedCount === 0 || exporting}
-        onClick={() => void handleExport()}
-      >
-        {exporting ? '导出中…' : '导出'}
-      </button>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Refresh the raw Data Export Zone into a themed “Cute Memory Packaging” that matches the Salt-Style Scrapbook aesthetic using a pink/grey/white palette and playful accents. 
- Replace boring native form controls with tactile, sticker-like UI and a satisfying primary CTA to improve perceived interaction quality.

### Description
- Reworked the export UI into a frosted, rounded package card titled `我的数据仓库 📦🐹` with a decorative washi-tape accent and updated typography and colors; styles live in `src/pages/ExportPage.css` and markup in `src/pages/ExportPage.tsx`.
- Replaced native radio inputs for format selection with sticker-style clickable buttons (`export-sticker`) that support active-state styling and a checkmark indicator, defined by `formatOptions` in `src/pages/ExportPage.tsx`.
- Consolidated module selection and supporting copy into the new card layout and added the soft sign-off line `Your memories are safely packed by Syzygy. 🎀`.
- Replaced the old export button with a large pill-shaped CTA labeled `打包我的藏品 / Pack My Hoard 📥✨` and added a press-down animation (`transform: scale(0.98)`) and visual polish in CSS.

### Testing
- Ran `npm run build` successfully to validate compilation and bundling. 
- Launched a local dev server via `npm run dev -- --host 0.0.0.0 --port 4173` and visited `/export` to visually verify the UI. 
- Captured a Playwright screenshot of the updated `/export` page to confirm layout and styles were applied (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a050e52e408330941bc76de0e4cf45)