### PR TITLE
Refactor RP Zone header and Create Room panel to scrapbook style

### DIFF
--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -11,13 +11,13 @@
   padding: 12px 16px 16px;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 12px;
+  gap: 18px;
 }
 
 .rp-rooms-top {
   z-index: 12;
   display: grid;
-  gap: 12px;
+  gap: 24px;
   padding-top: 4px;
 }
 
@@ -68,10 +68,17 @@
 }
 
 .rp-rooms-header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
+  padding: 16px 18px;
+  border: none;
+  border-bottom: 1px dashed #ffd6e7;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 14px 30px rgba(148, 163, 184, 0.15);
+  backdrop-filter: blur(14px);
 }
 
 .rp-rooms-header h1,
@@ -81,7 +88,34 @@
 
 .rp-rooms-header p {
   margin: 6px 0 0;
-  color: var(--text-subtle);
+  color: #8c8c8c;
+}
+
+.rp-rooms-header .ui-title {
+  color: #5c5c5c;
+  font-weight: 800;
+}
+
+.rp-back-btn {
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 999px;
+  padding: 7px 14px;
+  background: rgba(255, 255, 255, 0.68);
+  color: #5c5c5c;
+  font-weight: 600;
+  box-shadow: 0 8px 18px rgba(92, 92, 92, 0.1);
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+  transition: box-shadow 140ms ease, transform 140ms ease;
+}
+
+.rp-back-btn:hover {
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.4), 0 10px 20px rgba(92, 92, 92, 0.14);
+  transform: translateY(-1px);
+}
+
+.rp-back-btn:active {
+  transform: translateY(1px);
 }
 
 .rp-create-row {
@@ -90,12 +124,87 @@
   gap: 8px;
 }
 
+.rp-create-card {
+  position: relative;
+  overflow: visible;
+  background-color: #ffffff;
+  background-image:
+    linear-gradient(rgba(231, 231, 231, 0.35) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(231, 231, 231, 0.35) 1px, transparent 1px);
+  background-size: 18px 18px;
+  border: 1px solid #ffd6e7;
+  box-shadow: 0 14px 30px rgba(92, 92, 92, 0.1);
+}
+
+.rp-create-card::before {
+  content: '';
+  position: absolute;
+  top: -11px;
+  left: 16px;
+  width: 66px;
+  height: 20px;
+  border-radius: 4px;
+  background: linear-gradient(120deg, rgba(255, 214, 231, 0.7), rgba(255, 214, 231, 0.45));
+  box-shadow: 0 4px 8px rgba(92, 92, 92, 0.12);
+  transform: rotate(-7deg);
+}
+
+.rp-create-card .ui-title {
+  color: #5c5c5c;
+  margin-bottom: 14px;
+}
+
 .rp-create-row input,
 .rp-rename-row input {
   border: 1px solid var(--glass-border);
   border-radius: 12px;
   padding: 10px 12px;
   background: rgba(255, 255, 255, 0.74);
+}
+
+.rp-create-row input {
+  border: 0;
+  border-bottom: 2px solid #f0f0f0;
+  border-radius: 0;
+  background: rgba(255, 255, 255, 0.9);
+  color: #5c5c5c;
+  padding-left: 2px;
+}
+
+.rp-create-row input::placeholder {
+  color: #a8a8a8;
+}
+
+.rp-create-row input:focus {
+  outline: none;
+  border-bottom-color: #ffd6e7;
+  box-shadow: 0 6px 10px -8px rgba(255, 214, 231, 0.9);
+}
+
+.rp-create-btn {
+  border: 1px solid #ffd6e7;
+  border-radius: 999px;
+  background: #ffd6e7;
+  color: #5c5c5c;
+  font-weight: 700;
+  padding: 10px 16px;
+  cursor: pointer;
+  box-shadow: 0 10px 18px rgba(255, 214, 231, 0.45);
+  transition: transform 110ms ease, box-shadow 120ms ease;
+}
+
+.rp-create-btn:hover:not(:disabled) {
+  box-shadow: 0 12px 20px rgba(255, 214, 231, 0.55);
+}
+
+.rp-create-btn:active:not(:disabled) {
+  transform: translateY(2px) scale(0.99);
+  box-shadow: 0 4px 10px rgba(255, 214, 231, 0.45);
+}
+
+.rp-create-btn:disabled {
+  opacity: 0.7;
+  cursor: wait;
 }
 
 .rp-list-head {

--- a/src/pages/RpRoomsPage.tsx
+++ b/src/pages/RpRoomsPage.tsx
@@ -473,27 +473,27 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
     <div className="rp-rooms-page app-shell">
       <div className="rp-rooms-shell">
         <section className="rp-rooms-top app-shell__header">
-          <header className="rp-rooms-header glass-panel">
+          <header className="rp-rooms-header">
             <div>
-              <h1 className="ui-title">跑跑滚轮区</h1>
-              <p>管理 RP 房间，用颜色区分剧情分线与角色组。</p>
+              <h1 className="ui-title">跑跑滚轮区 🎡🐹</h1>
+              <p>管理 RP 房间，给每段剧情留好场记与分镜。</p>
             </div>
-            <button type="button" className="ghost" onClick={() => navigate('/')}>
+            <button type="button" className="rp-back-btn" onClick={() => navigate('/')}>
               返回聊天
             </button>
           </header>
 
-          <section className="rp-create-card glass-card">
+          <section className="rp-create-card">
             <h2 className="ui-title">新建房间</h2>
             <div className="rp-create-row">
               <input
                 value={newTitle}
                 onChange={(event) => setNewTitle(event.target.value)}
-                placeholder="输入房间标题（可留空）"
+                placeholder="给新剧本起个名字... 📝"
                 maxLength={80}
               />
-              <button type="button" className="btn-primary" disabled={creating} onClick={handleCreateRoom}>
-                {creating ? '创建中…' : '新建房间'}
+              <button type="button" className="rp-create-btn" disabled={creating} onClick={handleCreateRoom}>
+                {creating ? '准备中…' : '开跑！/ Start! 🎬'}
               </button>
             </div>
           </section>


### PR DESCRIPTION
### Motivation
- Refresh the RP Zone top area and the Create Room box to a Salt-Style Scrapbook / Director's Clipboard look while keeping the existing active room grid/cards unchanged.
- Make the header feel lighter and frosted with a perforated bottom edge and update the tone and visual cues to match the requested pink/grey/white palette.
- Turn the Create Room area into a tactile ticket/sticky-note UI with a graph-paper background, playful tape accent, and a stronger pink CTA to encourage creation.

### Description
- Updated `src/pages/RpRoomsPage.tsx` to change header and create-card markup: replaced the `glass-panel`/`glass-card` usage, added emoji and copy updates, renamed the back button to `rp-back-btn`, and replaced the create button and placeholder text with `rp-create-btn` and `给新剧本起个名字... 📝` / `开跑！/ Start! 🎬` respectively.
- Extended `src/pages/RpRoomsPage.css` with layout and visual changes: increased vertical spacing, implemented a frosted semi-transparent header (`background: rgba(255,255,255,0.6)`) with a bottom dashed pink border, and styled `rp-back-btn` as a pill-shaped glassy tag with a pink glow hover state.
- Rebuilt the create-card styling in `src/pages/RpRoomsPage.css` to a white ticket with a faint grid background, added a decorative pseudo-element to simulate pink washi-tape, converted the input to an underline style with a pink focus ring, and added the pink pill CTA with press-down animation.
- Kept all room grid and card behaviors intact (no changes to room list rendering or logic), only adjusted header/create-area presentation.

### Testing
- Ran `npm run build` successfully and verified the production build completed without errors.
- Launched the dev server with `npm run dev` and confirmed the application served the `/rp-rooms` page for manual/visual verification.
- Captured a Playwright screenshot of `/rp-rooms` which succeeded and was used to validate the header and create-card visuals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ef782dec8330ab48282d66939de9)