### PR TITLE
Redesign home check-in widget with frosted glass stamp style

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -142,11 +142,13 @@
 }
 
 .home-page .glass-card {
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  background: rgba(255, 255, 255, 0.28);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
-  backdrop-filter: blur(12px);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 214, 231, 0.78);
+  background: rgba(255, 255, 255, 0.45);
+  box-shadow:
+    0 8px 24px rgba(255, 214, 231, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.52);
+  backdrop-filter: blur(20px);
 }
 
 .widget-toolbar {
@@ -218,7 +220,7 @@
 
 .widget-card {
   min-height: 105px;
-  padding: 0.7rem;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -286,36 +288,123 @@
 .checkin-inner {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.7rem;
+  height: 100%;
 }
 
-.checkin-wide .checkin-metrics-mini {
+.checkin-wide {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.8rem;
+  align-items: stretch;
 }
 
-.checkin-head {
+.checkin-wide-left {
   display: flex;
-  justify-content: space-between;
-  gap: 0.4rem;
-  align-items: center;
-  font-size: 0.9rem;
+  flex-direction: column;
+  gap: 0.55rem;
+  min-width: 0;
 }
 
-.checkin-head .done {
-  color: #15803d;
+.checkin-streak-hero {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.45rem;
+  color: #5c5c5c;
 }
 
-.checkin-head .todo {
-  color: #b45309;
+.checkin-streak-hero strong {
+  font-size: 2rem;
+  line-height: 0.95;
+  color: #ffd6e7;
+}
+
+.checkin-streak-hero span {
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin-bottom: 0.18rem;
 }
 
 .checkin-metrics-mini {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.4rem;
-  color: #334155;
+  color: #5c5c5c;
   font-size: 0.78rem;
   flex-wrap: wrap;
+}
+
+.checkin-stamp-button {
+  width: 100%;
+  border: none;
+  border-radius: 999px;
+  padding: 0.56rem 0.9rem;
+  font-size: 0.83rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.checkin-stamp-button.unchecked {
+  background: #ffd6e7;
+  color: #ffffff;
+}
+
+.checkin-stamp-button.checked {
+  color: #5c5c5c;
+  background: rgba(255, 255, 255, 0.42);
+  border: 1px solid rgba(255, 214, 231, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.checkin-stamp-button:disabled {
+  opacity: 1;
+  cursor: default;
+}
+
+.weekly-tracker {
+  display: flex;
+  align-items: center;
+  gap: 0.38rem;
+  justify-content: flex-end;
+}
+
+.weekly-day-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.weekly-day-item small {
+  color: #5c5c5c;
+  font-size: 0.58rem;
+  line-height: 1;
+}
+
+.weekly-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: inline-grid;
+  place-items: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+}
+
+.weekly-dot.unchecked {
+  border: 1px dashed #ffd6e7;
+  color: transparent;
+  background: transparent;
+}
+
+.weekly-dot.checked {
+  border: 1px solid #ffd6e7;
+  background: #ffd6e7;
+  color: #ffffff;
+}
+
+.weekly-dot.today {
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.24);
 }
 
 .widget-delete {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -262,6 +262,26 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
     () => computeStreak(checkinDates, todayKey),
     [checkinDates, todayKey],
   );
+  const weeklyTracker = useMemo(() => {
+    const checkedSet = new Set(checkinDates);
+    const currentDay = now.getDay();
+    const mondayOffset = currentDay === 0 ? -6 : 1 - currentDay;
+    const monday = new Date(now);
+    monday.setHours(0, 0, 0, 0);
+    monday.setDate(now.getDate() + mondayOffset);
+
+    return Array.from({ length: 7 }).map((_, index) => {
+      const date = new Date(monday);
+      date.setDate(monday.getDate() + index);
+      const dateKey = formatDateKey(date);
+      return {
+        dateKey,
+        label: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][index],
+        checked: checkedSet.has(dateKey),
+        isToday: dateKey === todayKey,
+      };
+    });
+  }, [checkinDates, now, todayKey]);
   const dateLabel = useMemo(
     () =>
       now.toLocaleDateString("zh-CN", {
@@ -1199,37 +1219,72 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
                           <article
                             className={`checkin-inner ${item.size === "2x1" ? "checkin-wide" : ""}`}
                           >
-                            <div className="checkin-head">
-                              <strong>今日打卡</strong>
-                              <span className={checkedToday ? "done" : "todo"}>
-                                {checkedToday ? "已完成" : "未完成"}
-                              </span>
-                            </div>
-                            <div className="checkin-metrics-mini">
-                              <span>连续 {streakDays} 天</span>
-                              <span>累计 {checkinTotal} 次</span>
-                              {item.size === "2x1" ? (
-                                <span>
-                                  {checkedToday ? "今天已打卡" : "今天还没打卡"}
-                                </span>
-                              ) : null}
-                            </div>
-                            <button
-                              type="button"
-                              className="primary"
-                              disabled={
-                                checkedToday ||
-                                checkinSubmitting ||
-                                checkinLoading
-                              }
-                              onClick={() => void handleCheckin()}
-                            >
-                              {checkedToday
-                                ? "已打卡"
-                                : checkinSubmitting
-                                  ? "打卡中…"
-                                  : "立即打卡"}
-                            </button>
+                            {item.size === "2x1" ? (
+                              <>
+                                <div className="checkin-wide-left">
+                                  <div className="checkin-streak-hero">
+                                    <strong>{streakDays}</strong>
+                                    <span>Days Together</span>
+                                  </div>
+                                  <div className="checkin-metrics-mini">
+                                    <span>累计陪伴 {checkinTotal} 天</span>
+                                    <span>{dateLabel}</span>
+                                  </div>
+                                  <button
+                                    type="button"
+                                    className={`checkin-stamp-button ${checkedToday ? "checked" : "unchecked"}`}
+                                    disabled={
+                                      checkedToday ||
+                                      checkinSubmitting ||
+                                      checkinLoading
+                                    }
+                                    onClick={() => void handleCheckin()}
+                                  >
+                                    {checkedToday
+                                      ? "已陪伴 💖"
+                                      : checkinSubmitting
+                                        ? "盖章中…"
+                                        : "打卡 / Stamp"}
+                                  </button>
+                                </div>
+                                <div className="weekly-tracker" aria-label="weekly checkin tracker">
+                                  {weeklyTracker.map((day) => (
+                                    <div key={day.dateKey} className="weekly-day-item">
+                                      <span
+                                        className={`weekly-dot ${day.checked ? "checked" : "unchecked"} ${day.isToday ? "today" : ""}`}
+                                        aria-label={`${day.label} ${day.checked ? "已打卡" : "未打卡"}`}
+                                      >
+                                        {day.checked ? "✓" : ""}
+                                      </span>
+                                      <small>{day.label}</small>
+                                    </div>
+                                  ))}
+                                </div>
+                              </>
+                            ) : (
+                              <>
+                                <div className="checkin-streak-hero">
+                                  <strong>{streakDays}</strong>
+                                  <span>Days Together</span>
+                                </div>
+                                <button
+                                  type="button"
+                                  className={`checkin-stamp-button ${checkedToday ? "checked" : "unchecked"}`}
+                                  disabled={
+                                    checkedToday ||
+                                    checkinSubmitting ||
+                                    checkinLoading
+                                  }
+                                  onClick={() => void handleCheckin()}
+                                >
+                                  {checkedToday
+                                    ? "已陪伴 💖"
+                                    : checkinSubmitting
+                                      ? "盖章中…"
+                                      : "打卡 / Stamp"}
+                                </button>
+                              </>
+                            )}
                           </article>
                         ) : widget ? (
                           widget.type === "text" ? (


### PR DESCRIPTION
### Motivation
- Update the home check-in widget to a salt-style frosted-glass stamp visual (glassmorphism) with the provided palette `#ffd6e7` (pink) and `#5c5c5c` (warm dark grey).  
- Make the small widget emphasize the streak number and replace generic status text with a friendly stamp action, and make the large widget show a 7-day weekly stamp tracker.  

### Description
- Restyled the global widget base in `src/pages/HomePage.css` to a frosted translucent glass look (24px radius, `rgba(255,255,255,0.45)` background, `backdrop-filter: blur(20px)`, soft pink border/glow) and increased widget padding for breathing room.  
- Reworked check-in UI in `src/pages/HomePage.tsx` to replace the previous heading/status with a streak-first layout and a stateful pill button (`打卡 / Stamp` when unchecked, `已陪伴 💖` when checked), with text in warm dark grey.  
- Added a weekly tracker computed in `HomePage.tsx` (`weeklyTracker` useMemo) and rendered a right-side 7-day row for the large `2x1` widget variant, with dashed pink circles for unchecked days and filled pink dots (with checkmark) for checked days, and a subtle glow for today.  
- Introduced new CSS classes for the redesign: `.checkin-streak-hero`, `.checkin-stamp-button`, `.weekly-tracker`, `.weekly-dot`, and related styles in `src/pages/HomePage.css`; removed the previous green completion styling in the home widget.  

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.  
- Started the dev server with `npm run dev` and captured a visual smoke screenshot to validate layout and styles.  
- Ran `npm run lint`, which completed successfully and reports one pre-existing warning in `src/pages/CheckinPage.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f2e9078883309b1dd8936eded75b)