### PR TITLE
Fix Home layout emoji clear behavior and persist widget sizes

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -784,15 +784,11 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
   };
 
   const handleEmojiChange = (iconId: string, emoji: string) => {
-    const fallback =
-      (defaultAppIconConfigs[iconId] as { type: "emoji"; emoji: string })
-        ?.emoji ?? "🙂";
-    const nextEmoji = emoji.trim() || fallback;
     setAppIconConfigs((current) => ({
       ...current,
       [iconId]: {
         type: "emoji",
-        emoji: nextEmoji,
+        emoji,
       },
     }));
   };

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -188,7 +188,46 @@ const parseHomeSettings = (raw: string | null): HomeSettingsState | null => {
     return null
   }
   try {
-    return JSON.parse(raw) as HomeSettingsState
+    const parsed = JSON.parse(raw) as HomeSettingsState
+    const normalizedWidgets = Array.isArray(parsed.widgets)
+      ? parsed.widgets.reduce<DecorativeWidget[]>((accumulator, widget) => {
+          if (!widget || typeof widget !== 'object' || typeof widget.id !== 'string') {
+            return accumulator
+          }
+
+          if (widget.type === 'text') {
+            accumulator.push({
+              ...widget,
+              size: widget.size ?? '1x1',
+            })
+            return accumulator
+          }
+
+          if (widget.type === 'image') {
+            accumulator.push({
+              ...widget,
+              size: widget.size ?? '1x1',
+            })
+            return accumulator
+          }
+
+          if (widget.type === 'spacer') {
+            accumulator.push({
+              ...widget,
+              size: widget.size ?? '1x1',
+            })
+          }
+
+          return accumulator
+        }, [])
+      : []
+
+    return {
+      ...parsed,
+      widgetOrder: Array.isArray(parsed.widgetOrder) ? parsed.widgetOrder : [],
+      widgets: normalizedWidgets,
+      checkinSize: parsed.checkinSize ?? '1x1',
+    }
   } catch (error) {
     console.warn('解析 Home 配置失败', error)
     return null
@@ -210,7 +249,15 @@ export const loadHomeSettings = (): HomeSettingsState | null => {
 }
 
 export const saveHomeSettings = (state: HomeSettingsState) => {
-  localStorage.setItem(HOME_SETTINGS_STORAGE_KEY, JSON.stringify(state))
+  const nextState: HomeSettingsState = {
+    ...state,
+    widgets: state.widgets.map((widget) => ({
+      ...widget,
+      size: widget.size ?? '1x1',
+    })),
+    checkinSize: state.checkinSize ?? '1x1',
+  }
+  localStorage.setItem(HOME_SETTINGS_STORAGE_KEY, JSON.stringify(nextState))
   window.dispatchEvent(new Event('hamster-home-settings-changed'))
 }
 


### PR DESCRIPTION
### Motivation

- Allow the “Edit Icon” emoji field to be cleared and saved as an explicit empty value instead of reverting to a fallback emoji. 
- Ensure widget size changes are actually persisted and restored after Save + refresh, and provide safe defaults for older saved layouts.

### Description

- Update `handleEmojiChange` in `src/pages/HomePage.tsx` to persist the raw emoji value (including the empty string) instead of forcing a trimmed fallback, so clearing the field becomes a valid persisted state.
- Add normalization in `src/storage/homeLayout.ts` when parsing saved settings to ensure each widget has a `size` (defaults to `'1x1'`) and `checkinSize` is defaulted when missing, preserving backward compatibility for older saves.
- Update `saveHomeSettings` to always include widget `size` and `checkinSize` when writing to storage so size changes survive save + refresh.

### Testing

- Ran `npm run build`, which executes TypeScript compilation and the Vite build; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f5b983bc833089db021d5376aa0a)