### PR TITLE
Refine global typography and polish check-in / settings UI details

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap"
       rel="stylesheet"
     />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%vite.svg" />

--- a/src/pages/CheckinPage.css
+++ b/src/pages/CheckinPage.css
@@ -163,6 +163,7 @@
   color: #ff9ac3;
   font-size: 1.6rem;
   line-height: 1.2;
+  font-family: var(--font-rounded);
 }
 
 .calendar-panel {

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -151,6 +151,12 @@
   backdrop-filter: blur(20px);
 }
 
+
+.home-clock-title {
+  font-family: var(--font-rounded);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
 .widget-toolbar {
   padding: 0.6rem;
   display: flex;
@@ -317,6 +323,7 @@
   font-size: 2rem;
   line-height: 0.95;
   color: #ffd6e7;
+  font-family: var(--font-rounded);
 }
 
 .checkin-streak-hero span {
@@ -334,26 +341,34 @@
   flex-wrap: wrap;
 }
 
+.checkin-stamp-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
 .checkin-stamp-button {
   width: 100%;
-  border: none;
+  border: 1px solid rgba(255, 214, 231, 0.72);
   border-radius: 999px;
   padding: 0.56rem 0.9rem;
   font-size: 0.83rem;
-  font-weight: 700;
+  font-weight: 800;
   letter-spacing: 0.01em;
+  color: #5c5c5c;
+  background: linear-gradient(to right, #fff0f5, #ffd6e7);
+  box-shadow: 0 4px 12px rgba(255, 214, 231, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.52);
 }
 
 .checkin-stamp-button.unchecked {
-  background: #ffd6e7;
-  color: #ffffff;
+  background: linear-gradient(to right, #fff0f5, #ffd6e7);
+  color: #5c5c5c;
 }
 
 .checkin-stamp-button.checked {
   color: #5c5c5c;
-  background: rgba(255, 255, 255, 0.42);
-  border: 1px solid rgba(255, 214, 231, 0.72);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  background: linear-gradient(to right, #fff4f8, #ffe0eb);
 }
 
 .checkin-stamp-button:disabled {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -960,7 +960,7 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
                   >
                     编辑
                   </button>
-                  <h1 className="ui-title">{timeLabel}</h1>
+                  <h1 className="ui-title ui-numeric home-clock-title">{timeLabel}</h1>
                   <p>{dateLabel}</p>
                 </>
               )}
@@ -1226,22 +1226,24 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
                                     <span>累计陪伴 {checkinTotal} 天</span>
                                     <span>{dateLabel}</span>
                                   </div>
-                                  <button
-                                    type="button"
-                                    className={`checkin-stamp-button ${checkedToday ? "checked" : "unchecked"}`}
-                                    disabled={
-                                      checkedToday ||
-                                      checkinSubmitting ||
-                                      checkinLoading
-                                    }
-                                    onClick={() => void handleCheckin()}
-                                  >
-                                    {checkedToday
-                                      ? "已陪伴 💖"
-                                      : checkinSubmitting
-                                        ? "盖章中…"
-                                        : "打卡 / Stamp"}
-                                  </button>
+                                  <div className="checkin-stamp-row">
+                                    <button
+                                      type="button"
+                                      className={`checkin-stamp-button ${checkedToday ? "checked" : "unchecked"}`}
+                                      disabled={
+                                        checkedToday ||
+                                        checkinSubmitting ||
+                                        checkinLoading
+                                      }
+                                      onClick={() => void handleCheckin()}
+                                    >
+                                      {checkedToday
+                                        ? "已陪伴 💖"
+                                        : checkinSubmitting
+                                          ? "盖章中…"
+                                          : "打卡 / Stamp"}
+                                    </button>
+                                  </div>
                                 </div>
                                 <div className="weekly-tracker" aria-label="weekly checkin tracker">
                                   {weeklyTracker.map((day) => (
@@ -1263,22 +1265,24 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
                                   <strong>{streakDays}</strong>
                                   <span>Days Together</span>
                                 </div>
-                                <button
-                                  type="button"
-                                  className={`checkin-stamp-button ${checkedToday ? "checked" : "unchecked"}`}
-                                  disabled={
-                                    checkedToday ||
-                                    checkinSubmitting ||
-                                    checkinLoading
-                                  }
-                                  onClick={() => void handleCheckin()}
-                                >
-                                  {checkedToday
-                                    ? "已陪伴 💖"
-                                    : checkinSubmitting
-                                      ? "盖章中…"
-                                      : "打卡 / Stamp"}
-                                </button>
+                                <div className="checkin-stamp-row">
+                                  <button
+                                    type="button"
+                                    className={`checkin-stamp-button ${checkedToday ? "checked" : "unchecked"}`}
+                                    disabled={
+                                      checkedToday ||
+                                      checkinSubmitting ||
+                                      checkinLoading
+                                    }
+                                    onClick={() => void handleCheckin()}
+                                  >
+                                    {checkedToday
+                                      ? "已陪伴 💖"
+                                      : checkinSubmitting
+                                        ? "盖章中…"
+                                        : "打卡 / Stamp"}
+                                  </button>
+                                </div>
                               </>
                             )}
                           </article>

--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -14,6 +14,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  padding-top: 32px;
   background: var(--page-bg);
   padding-bottom: calc(28px + env(safe-area-inset-bottom));
   overflow: auto;
@@ -21,6 +22,26 @@
   overscroll-behavior: auto;
 }
 
+
+.settings-ribbon-divider {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  width: calc(100% - 32px);
+  margin: 0 16px 10px;
+}
+
+.settings-ribbon-line {
+  width: 100%;
+  height: 1px;
+  border-bottom: 2px dashed #ffd6e7;
+}
+
+.settings-ribbon-icon {
+  padding: 0 12px;
+  font-size: 1rem;
+  line-height: 1;
+}
 .settings-page .settings-group {
   margin: 0 16px;
   background: rgba(255, 255, 255, 0.55);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -723,6 +723,11 @@ const SettingsPage = ({
           <span className="header-spacer" />
         </header>
         <div className="settings-page app-shell__content">
+          <div className="settings-ribbon-divider" aria-hidden="true">
+            <span className="settings-ribbon-line" />
+            <span className="settings-ribbon-icon">🎀</span>
+            <span className="settings-ribbon-line" />
+          </div>
           <div className="settings-loading">正在加载设置...</div>
         </div>
       </div>
@@ -744,6 +749,11 @@ const SettingsPage = ({
       </header>
 
       <div className="settings-page app-shell__content">
+        <div className="settings-ribbon-divider" aria-hidden="true">
+          <span className="settings-ribbon-line" />
+          <span className="settings-ribbon-icon">🎀</span>
+          <span className="settings-ribbon-line" />
+        </div>
         <div className="settings-group" role="list">
       <section className="settings-section" role="listitem">
         <button

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1,8 +1,10 @@
 :root {
-  --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Segoe UI',
+  --font-sans: 'Nunito', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Segoe UI',
     Roboto, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans SC', Arial,
     sans-serif;
-  --font-display: 'Pixelify Sans', var(--font-sans);
+  --font-rounded: 'Nunito', 'Quicksand', 'Comfortaa', 'Avenir Next Rounded', 'Arial Rounded MT Bold', var(--font-sans);
+  --font-display: 'Rounded Mplus 1c', 'Nunito', system-ui, -apple-system, 'PingFang SC',
+    'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
   --accent: #ffd6e7;
   --accent-strong: #f8bad4;
   --text-main: #111827;
@@ -19,12 +21,17 @@
 
 .ui-title {
   font-family: var(--font-display);
-  font-weight: 400;
-  letter-spacing: 0.04em;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   line-height: 1.15;
   text-transform: none;
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
+}
+
+.ui-numeric {
+  font-family: var(--font-rounded);
+  font-variant-numeric: tabular-nums lining-nums;
 }
 
 .glass-card,


### PR DESCRIPTION
### Motivation
- Move away from the pixel 8‑bit aesthetic toward a rounded, soft scrapbook look by switching the global type tokens to rounded geometric sans fonts and improving numeric/title typography.
- Center and visually polish the check‑in widget bottom row so the stamp action reads as a premium glass stamp rather than a left‑aligned flat button.
- Add breathing room and a decorative divider to the settings area to separate the header from the first settings block and reinforce the delicate aesthetic.

### Description
- Replaced the Pixelify font import with `Nunito` in `index.html` and introduced rounded/display font tokens in `src/styles/ui.css`, added `.ui-numeric` for tabular numerals and tightened `.ui-title` weight/letter spacing.
- Updated Home page markup in `src/pages/HomePage.tsx` to apply `ui-numeric` to the main clock and wrapped the check‑in stamp control in a centered `.checkin-stamp-row` container.
- Restyled the stamp button and numeric/streak typography in `src/pages/HomePage.css` and `src/pages/CheckinPage.css` to use the rounded font family, a soft glossy gradient (`#fff0f5 -> #ffd6e7`), stronger warm grey text (`#5c5c5c`), bolder weight, and a subtle glow shadow.
- Inserted top spacing and a decorative lace/ribbon divider (dashed pink lines + centered 🎀) into `src/pages/SettingsPage.tsx` and added corresponding styles in `src/pages/SettingsPage.css`.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.
- Ran linting with `npm run lint`, which passed with one existing non-blocking `react-hooks/exhaustive-deps` warning in `src/pages/CheckinPage.tsx`.
- Started the dev server with `npm run dev` and executed an automated Playwright script to capture screenshots of the updated Settings and Home surfaces, which completed and produced screenshots successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fd947320833085a2ca235ecbb554)