### PR TITLE
Polish global scrollbar and declutter login interface

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,24 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #ffd6e7;
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: #ffc2d9;
+}
+
 html,
 body,
 #root {

--- a/src/pages/AuthPage.css
+++ b/src/pages/AuthPage.css
@@ -5,11 +5,9 @@
   justify-content: center;
   padding: 32px 16px;
   color: #5f4b54;
-  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Ctext y='21' font-size='20'%3E%F0%9F%90%BE%3C/text%3E%3C/svg%3E") 6 6, auto;
-  background-color: #fff7f2;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'%3E%3Ctext x='12' y='34' font-size='20'%3E%F0%9F%92%96%3C/text%3E%3Ctext x='90' y='28' font-size='18'%3E%E2%9C%A8%3C/text%3E%3Ctext x='44' y='70' font-size='18'%3E%F0%9F%90%B9%3C/text%3E%3Ctext x='8' y='112' font-size='16'%3E%E2%9C%A8%3C/text%3E%3Ctext x='86' y='108' font-size='18'%3E%F0%9F%92%96%3C/text%3E%3C/svg%3E"),
-    radial-gradient(circle at top, rgba(255, 214, 231, 0.55), transparent 64%);
-  background-repeat: repeat;
+  background:
+    radial-gradient(circle at 1px 1px, rgba(232, 232, 232, 0.55) 1px, transparent 0) 0 0 / 28px 28px,
+    linear-gradient(165deg, #fdfbfb 0%, #f4f5f7 100%);
 }
 
 .auth-card {
@@ -30,31 +28,51 @@
       border-box,
     radial-gradient(circle at calc(100% - 18px) calc(100% - 18px), rgba(255, 214, 231, 0.65) 0 4px, transparent 4px)
       border-box,
-    linear-gradient(145deg, #ffffff 0%, #fff8fc 100%);
+    linear-gradient(145deg, rgba(255, 255, 255, 0.9) 0%, rgba(255, 248, 252, 0.82) 100%);
+  box-shadow: 0 18px 42px rgba(108, 88, 96, 0.12);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .auth-card::before {
-  content: '🎀';
+  content: '';
   position: absolute;
-  top: -14px;
-  right: 18px;
-  font-size: 26px;
-  transform: rotate(10deg);
+  top: -12px;
+  right: 26px;
+  width: 44px;
+  height: 22px;
+  border-radius: 9999px;
+  border: 2px solid #ffc2d9;
+  background: linear-gradient(180deg, rgba(255, 214, 231, 0.95), rgba(255, 194, 217, 0.88));
+  box-shadow: 0 6px 12px rgba(216, 124, 163, 0.2);
+  transform: rotate(9deg);
 }
 
 .auth-card::after {
-  content: '📎';
+  content: '';
   position: absolute;
   left: 18px;
   top: -16px;
-  font-size: 24px;
+  width: 18px;
+  height: 32px;
+  border: 2px solid rgba(209, 213, 219, 0.95);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
   transform: rotate(-14deg);
 }
 
 .hamster-logo {
-  text-align: center;
-  font-size: 56px;
-  line-height: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.auth-logo-icon {
+  width: 56px;
+  height: 56px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M31.8 21.3c-8.8-11.2-20-9.7-20 .8 0 7.8 9 12.5 15.3 14-6.4 1.7-12.5 6.2-12.5 12.3 0 9 10.7 9.7 17.2-2 6.5 11.7 17.2 11 17.2 2 0-6.1-6.1-10.6-12.5-12.3 6.3-1.5 15.3-6.2 15.3-14 0-10.5-11.2-12-20-.8z' fill='%23ffd6e7'/%3E%3Cpath d='M32 27.5c-5.2-7.4-12.8-6.7-12.8.1 0 5.6 6.8 8.7 11 9.6-4.3 1.1-8.9 4.4-8.9 9.2 0 6.3 7.7 6.8 10.7-1.9 3 8.7 10.7 8.2 10.7 1.9 0-4.8-4.6-8.1-8.9-9.2 4.2-.9 11-4 11-9.6 0-6.8-7.6-7.5-12.8-.1z' fill='%23fff8fc'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
 }
 
 .auth-card h1 {
@@ -100,7 +118,9 @@
 }
 
 .input-icon {
-  font-size: 1.02rem;
+  font-size: 0.95rem;
+  color: #c97ea0;
+  font-weight: 700;
 }
 
 .field input {
@@ -143,15 +163,6 @@
   transform: rotate(-8deg);
 }
 
-.auth-card .primary::after {
-  content: '🩹';
-  position: absolute;
-  right: 8px;
-  top: -10px;
-  font-size: 20px;
-  transform: rotate(16deg);
-}
-
 .auth-card .primary:disabled {
   opacity: 0.68;
   cursor: not-allowed;
@@ -162,7 +173,7 @@
   margin-top: -4px;
   border: none;
   background: transparent;
-  color: #ffd6e7;
+  color: #d68db0;
   font-size: 0.8rem;
   cursor: pointer;
   padding: 0;

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -110,15 +110,15 @@ const AuthPage = ({ user }: AuthPageProps) => {
     <div className="auth-page">
       <div className="auth-card">
         <div className="hamster-logo" aria-hidden="true">
-          🐹🎀
+          <span className="auth-logo-icon" />
         </div>
-        <h1 className="ui-title">Welcome to Hamster Nest 🐹🏰</h1>
-        <p className="subtitle">Enter your password to unlock your secret lair 🤫🔑</p>
+        <h1 className="ui-title">Welcome to Hamster Nest</h1>
+        <p className="subtitle">Enter your password to unlock your secret lair</p>
         <label className="field">
           <span className="field-label">邮箱地址</span>
           <div className="input-shell">
             <span className="input-icon" aria-hidden="true">
-              👤
+              @
             </span>
             <input
               type="email"
@@ -134,13 +134,13 @@ const AuthPage = ({ user }: AuthPageProps) => {
           onClick={handleSendOtp}
           disabled={sending}
         >
-          {sending ? '发送中...' : 'Go! 🐹💨 发送验证码'}
+          {sending ? '发送中...' : '发送验证码 ✨'}
         </button>
         <label className="field">
           <span className="field-label">验证码</span>
           <div className="input-shell">
             <span className="input-icon" aria-hidden="true">
-              🔒
+              #
             </span>
             <input
               type="text"
@@ -156,7 +156,7 @@ const AuthPage = ({ user }: AuthPageProps) => {
           onClick={handleVerifyOtp}
           disabled={verifying}
         >
-          {verifying ? '验证中...' : 'Go! 🐹💨 验证并登录'}
+          {verifying ? '验证中...' : '验证并登录 ✨'}
         </button>
         <button type="button" className="forgot-link" onClick={handleSendOtp}>
           Forgot Password?


### PR DESCRIPTION
### Motivation
- Replace the clunky native scrollbar with a slim, pale-pink “jelly” scrollbar that matches the Salt-Style glassmorphism aesthetic.
- Remove noisy, device-dependent emoji assets in the login UI that cause inconsistent rendering across platforms.
- Simplify and standardize the login card to restore a premium scrapbook look while preserving existing glass/washi tape visual language.

### Description
- Added global WebKit scrollbar rules in `src/index.css` implementing a 6px slim track, pale-pink thumb `#ffd6e7`, fully pill-rounded corners, and a hover shade `#ffc2d9` via `::-webkit-scrollbar*` selectors.
- Reworked `src/pages/AuthPage.tsx` to remove native emojis from the header and CTAs, replacing the logo with a cross-platform `span.auth-logo-icon` and updating CTA text to `发送验证码 ✨` and `验证并登录 ✨`.
- Replaced the repeating emoji background and custom emoji cursor in `src/pages/AuthPage.css` with a soft creamy gradient plus a subtle light-grey dot/graph-paper pattern, added an inline SVG data-URI logo, removed emoji pseudo-elements, and tightened card/glass styling (shadows, blur) for cohesion.
- Standardized input/button visuals by removing inline emoji icons, swapping them for simple symbols/characters, adjusting input icon sizing and colors, and removing decorative emoji overlays on the primary button.

### Testing
- Ran `npm run build` and the build completed successfully.
- Started a dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the updated login UI served correctly.
- Captured an automated Playwright screenshot of the login page (artifact generated during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a100c7b79c8330a4745e0be6f9886a)