### PR TITLE
Add GPT-5.1/5.2 high-thinking toggles for chat and RP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ import {
   resolveSyzygyPostPrompt,
   resolveSyzygyReplyPrompt,
 } from './constants/aiOverlays'
-import { resolveModelId } from './utils/modelResolver'
+import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
@@ -558,6 +558,7 @@ const App = () => {
       const activeSettings = settingsRef.current ?? fallbackSettings
       const effectiveModel = resolveSessionModel(sessionId)
       const reasoningEnabled = resolveSessionReasoning(sessionId)
+      const highThinkingEnabled = activeSettings.chatHighThinkingEnabled
       const paramsSnapshot = {
         temperature: activeSettings.temperature,
         top_p: activeSettings.topP,
@@ -858,7 +859,9 @@ const App = () => {
             isFirstMessage: isFirstMessageInSession,
           }
           if (reasoningEnabled) {
-            requestBody.reasoning = true
+            requestBody.reasoning = highThinkingEnabled && isGpt5Auto(effectiveModel)
+              ? { effort: 'high' }
+              : true
           }
           if (reasoningEnabled && isClaudeModel(effectiveModel)) {
             const maxTokens = paramsSnapshot.max_tokens ?? 1024
@@ -1460,7 +1463,7 @@ const App = () => {
           path="/rp/:sessionId"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <RpRoomPage user={user} mode="chat" rpReasoningEnabled={activeSettings.rpReasoningEnabled} onDisableRpReasoning={handleDisableRpReasoning} />
+              <RpRoomPage user={user} mode="chat" rpReasoningEnabled={activeSettings.rpReasoningEnabled} rpHighThinkingEnabled={activeSettings.rpHighThinkingEnabled} onDisableRpReasoning={handleDisableRpReasoning} />
             </RequireAuth>
           }
         />
@@ -1468,7 +1471,7 @@ const App = () => {
           path="/rp/:sessionId/dashboard"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <RpRoomPage user={user} mode="dashboard" rpReasoningEnabled={activeSettings.rpReasoningEnabled} onDisableRpReasoning={handleDisableRpReasoning} />
+              <RpRoomPage user={user} mode="dashboard" rpReasoningEnabled={activeSettings.rpReasoningEnabled} rpHighThinkingEnabled={activeSettings.rpHighThinkingEnabled} onDisableRpReasoning={handleDisableRpReasoning} />
             </RequireAuth>
           }
         />

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -7,6 +7,7 @@ import MarkdownRenderer from '../components/MarkdownRenderer'
 import ReasoningPanel from '../components/ReasoningPanel'
 import { useEnabledModels } from '../hooks/useEnabledModels'
 import { stripSpeakerPrefix } from '../utils/rpMessage'
+import { isGpt5Auto } from '../utils/modelResolver'
 import { supabase } from '../supabase/client'
 import {
   createRpMessage,
@@ -27,6 +28,7 @@ type RpRoomPageProps = {
   user: User | null
   mode?: 'chat' | 'dashboard'
   rpReasoningEnabled: boolean
+  rpHighThinkingEnabled: boolean
   onDisableRpReasoning: () => Promise<void>
 }
 
@@ -87,7 +89,7 @@ const readRoomContextTokenLimit = (value: unknown) => {
   return Math.min(Math.max(normalized, RP_ROOM_CONTEXT_TOKEN_LIMIT_MIN), RP_ROOM_CONTEXT_TOKEN_LIMIT_MAX)
 }
 
-const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReasoning }: RpRoomPageProps) => {
+const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEnabled, onDisableRpReasoning }: RpRoomPageProps) => {
   const { sessionId } = useParams()
   const navigate = useNavigate()
   const [room, setRoom] = useState<RpSession | null>(null)
@@ -347,6 +349,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
     reasoning?: boolean
     rpKeepRecentMessages?: number
     bypassReasoning?: boolean
+    highThinking?: boolean
   }) => {
     if (!supabase) {
       throw new Error('Supabase 客户端未配置')
@@ -377,7 +380,9 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
       requestBody.rpKeepRecentMessages = payload.rpKeepRecentMessages
     }
     if (payload.reasoning && !payload.bypassReasoning) {
-      requestBody.reasoning = true
+      requestBody.reasoning = payload.highThinking && isGpt5Auto(payload.modelId)
+        ? { effort: 'high' }
+        : true
       if (/claude|anthropic/i.test(payload.modelId)) {
         requestBody.thinking = {
           type: 'enabled',
@@ -611,6 +616,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
           topP,
           messagesPayload: modelMessages,
           reasoning: reasoningEnabled,
+          highThinking: rpHighThinkingEnabled,
           rpKeepRecentMessages: readRoomKeepRecentMessages(room.settings),
           stream: true,
           onDelta: (delta) => {
@@ -644,6 +650,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, onDisableRpReason
           topP,
           messagesPayload: modelMessages,
           reasoning: reasoningEnabled,
+          highThinking: rpHighThinkingEnabled,
           rpKeepRecentMessages: readRoomKeepRecentMessages(room.settings),
           stream: false,
         })

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -66,6 +66,8 @@ const SettingsPage = ({
   const [draftDefaultModel, setDraftDefaultModel] = useState(defaultModelId)
   const [draftChatReasoning, setDraftChatReasoning] = useState(true)
   const [draftRpReasoning, setDraftRpReasoning] = useState(false)
+  const [draftChatHighThinking, setDraftChatHighThinking] = useState(false)
+  const [draftRpHighThinking, setDraftRpHighThinking] = useState(false)
   const [draftMemoryExtractModel, setDraftMemoryExtractModel] = useState<string | null>(null)
   const [modelStatus, setModelStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [modelError, setModelError] = useState<string | null>(null)
@@ -117,6 +119,8 @@ const SettingsPage = ({
       setDraftMemoryExtractModel(settings.memoryExtractModel)
       setDraftChatReasoning(settings.chatReasoningEnabled)
       setDraftRpReasoning(settings.rpReasoningEnabled)
+      setDraftChatHighThinking(settings.chatHighThinkingEnabled)
+      setDraftRpHighThinking(settings.rpHighThinkingEnabled)
     }, 0)
     return () => {
       window.clearTimeout(timer)
@@ -285,7 +289,9 @@ const SettingsPage = ({
       settings.compressionKeepRecentMessages !== parsedCompressionKeepRecent ||
       (settings.summarizerModel ?? '') !== (draftSummarizerModel ?? '') ||
       settings.chatReasoningEnabled !== draftChatReasoning ||
-      settings.rpReasoningEnabled !== draftRpReasoning
+      settings.rpReasoningEnabled !== draftRpReasoning ||
+      settings.chatHighThinkingEnabled !== draftChatHighThinking ||
+      settings.rpHighThinkingEnabled !== draftRpHighThinking
     : false
   const hasUnsavedSystemPrompt = settings ? draftSystemPrompt !== settings.systemPrompt : false
   const hasUnsavedSnackOverlay = settings
@@ -440,6 +446,16 @@ const SettingsPage = ({
     setGenerationStatus('idle')
   }
 
+  const handleChatHighThinkingToggle = (enabled: boolean) => {
+    setDraftChatHighThinking(enabled)
+    setGenerationStatus('idle')
+  }
+
+  const handleRpHighThinkingToggle = (enabled: boolean) => {
+    setDraftRpHighThinking(enabled)
+    setGenerationStatus('idle')
+  }
+
   const handleCompressionRatioChange = (value: string) => {
     setCompressionRatioInput(value)
     const parsed = Number(value)
@@ -504,6 +520,8 @@ const SettingsPage = ({
       summarizerModel: draftSummarizerModel,
       chatReasoningEnabled: draftChatReasoning,
       rpReasoningEnabled: draftRpReasoning,
+      chatHighThinkingEnabled: draftChatHighThinking,
+      rpHighThinkingEnabled: draftRpHighThinking,
     })
     if (!nextSettings) {
       return
@@ -655,6 +673,8 @@ const SettingsPage = ({
       setDraftMemoryExtractModel(settings.memoryExtractModel)
       setDraftChatReasoning(settings.chatReasoningEnabled)
       setDraftRpReasoning(settings.rpReasoningEnabled)
+      setDraftChatHighThinking(settings.chatHighThinkingEnabled)
+      setDraftRpHighThinking(settings.rpHighThinkingEnabled)
       setModelStatus('idle')
       setModelError(null)
       setDraftSystemPrompt(settings.systemPrompt)
@@ -974,6 +994,31 @@ const SettingsPage = ({
                 />
                 <span>{draftRpReasoning ? '已开启' : '已关闭'}</span>
               </label>
+            </div>
+            <div className="field-group">
+              <label htmlFor="chatHighThinkingEnabled">聊天：高触发 Thinking（仅 GPT-5.1/5.2）</label>
+              <label className="toggle-control">
+                <input
+                  id="chatHighThinkingEnabled"
+                  type="checkbox"
+                  checked={draftChatHighThinking}
+                  onChange={(event) => handleChatHighThinkingToggle(event.target.checked)}
+                />
+                <span>{draftChatHighThinking ? '已开启' : '已关闭'}</span>
+              </label>
+            </div>
+            <div className="field-group">
+              <label htmlFor="rpHighThinkingEnabled">跑跑滚轮区/RP：高触发 Thinking（仅 GPT-5.1/5.2）</label>
+              <label className="toggle-control">
+                <input
+                  id="rpHighThinkingEnabled"
+                  type="checkbox"
+                  checked={draftRpHighThinking}
+                  onChange={(event) => handleRpHighThinkingToggle(event.target.checked)}
+                />
+                <span>{draftRpHighThinking ? '已开启' : '已关闭'}</span>
+              </label>
+              <p className="field-hint">仅对 GPT-5.1 / GPT-5.2 生效；其他模型自动忽略。开启后会更积极触发思考（可能更慢/更耗费）。</p>
             </div>
           </div>
         ) : null}

--- a/src/storage/userSettings.ts
+++ b/src/storage/userSettings.ts
@@ -35,6 +35,49 @@ type UserSettingsRow = {
 
 const defaultModel = 'openrouter/auto'
 
+const HIGH_THINKING_STORAGE_KEY_PREFIX = 'hamster-high-thinking:'
+
+type HighThinkingLocalSettings = {
+  chatHighThinkingEnabled: boolean
+  rpHighThinkingEnabled: boolean
+}
+
+const readHighThinkingLocalSettings = (userId: string): HighThinkingLocalSettings => {
+  if (typeof window === 'undefined') {
+    return { chatHighThinkingEnabled: false, rpHighThinkingEnabled: false }
+  }
+  try {
+    const raw = window.localStorage.getItem(`${HIGH_THINKING_STORAGE_KEY_PREFIX}${userId}`)
+    if (!raw) {
+      return { chatHighThinkingEnabled: false, rpHighThinkingEnabled: false }
+    }
+    const parsed = JSON.parse(raw) as Partial<HighThinkingLocalSettings>
+    return {
+      chatHighThinkingEnabled: parsed.chatHighThinkingEnabled === true,
+      rpHighThinkingEnabled: parsed.rpHighThinkingEnabled === true,
+    }
+  } catch {
+    return { chatHighThinkingEnabled: false, rpHighThinkingEnabled: false }
+  }
+}
+
+const writeHighThinkingLocalSettings = (
+  userId: string,
+  settings: HighThinkingLocalSettings,
+) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(
+      `${HIGH_THINKING_STORAGE_KEY_PREFIX}${userId}`,
+      JSON.stringify(settings),
+    )
+  } catch {
+    // ignore storage failures
+  }
+}
+
 export const createDefaultSettings = (userId: string): UserSettings => ({
   userId,
   enabledModels: [defaultModel],
@@ -55,10 +98,14 @@ export const createDefaultSettings = (userId: string): UserSettings => ({
   syzygyReplySystemPrompt: DEFAULT_SYZYGY_REPLY_PROMPT,
   chatReasoningEnabled: true,
   rpReasoningEnabled: false,
+  chatHighThinkingEnabled: false,
+  rpHighThinkingEnabled: false,
   updatedAt: new Date().toISOString(),
 })
 
-const mapSettingsRow = (row: UserSettingsRow): UserSettings => ({
+const mapSettingsRow = (row: UserSettingsRow): UserSettings => {
+  const localHighThinking = readHighThinkingLocalSettings(row.user_id)
+  return ({
   userId: row.user_id,
   enabledModels: row.enabled_models ?? [defaultModel],
   defaultModel: row.default_model ?? defaultModel,
@@ -78,8 +125,11 @@ const mapSettingsRow = (row: UserSettingsRow): UserSettings => ({
   syzygyReplySystemPrompt: resolveSyzygyReplyPrompt(row.syzygy_reply_system_prompt),
   chatReasoningEnabled: row.chat_reasoning_enabled ?? row.enable_reasoning ?? true,
   rpReasoningEnabled: row.rp_reasoning_enabled ?? false,
+  chatHighThinkingEnabled: localHighThinking.chatHighThinkingEnabled,
+  rpHighThinkingEnabled: localHighThinking.rpHighThinkingEnabled,
   updatedAt: row.updated_at,
 })
+}
 
 export const ensureUserSettings = async (userId: string): Promise<UserSettings> => {
   if (!supabase) {
@@ -168,6 +218,10 @@ export const updateUserSettings = async (settings: UserSettings): Promise<void> 
   if (error) {
     throw error
   }
+  writeHighThinkingLocalSettings(settings.userId, {
+    chatHighThinkingEnabled: settings.chatHighThinkingEnabled,
+    rpHighThinkingEnabled: settings.rpHighThinkingEnabled,
+  })
 }
 
 export const saveSnackSystemPrompt = async (userId: string, value: string): Promise<void> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export type UserSettings = {
   syzygyReplySystemPrompt: string
   chatReasoningEnabled: boolean
   rpReasoningEnabled: boolean
+  chatHighThinkingEnabled: boolean
+  rpHighThinkingEnabled: boolean
   updatedAt: string
 }
 

--- a/src/utils/modelResolver.ts
+++ b/src/utils/modelResolver.ts
@@ -32,3 +32,13 @@ export const resolveModelId = (
 
   return defaultModelId
 }
+
+export const isGpt5Auto = (modelId: string) => {
+  const normalized = modelId.trim().toLowerCase()
+  return (
+    normalized.includes('gpt-5.1') ||
+    normalized.includes('gpt-5.2') ||
+    normalized.includes('openai/gpt-5.1') ||
+    normalized.includes('openai/gpt-5.2')
+  )
+}

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -14,7 +14,7 @@ type OpenRouterPayload = {
   temperature?: number
   top_p?: number
   max_tokens?: number
-  reasoning?: boolean
+  reasoning?: boolean | Record<string, unknown>
   stream?: boolean
   isFirstMessage?: boolean
   module?: 'snack-feed' | 'syzygy-feed' | 'rp-room' | string
@@ -118,6 +118,16 @@ const injectMemoryBlock = (messages: OpenAiMessage[], memoryMessage: OpenAiMessa
 }
 
 const shouldInjectSnackFeedMemory = (payload: OpenRouterPayload) => payload.module === 'snack-feed'
+
+const resolveReasoningPayload = (reasoning: OpenRouterPayload['reasoning']) => {
+  if (reasoning === true) {
+    return { effort: 'medium' }
+  }
+  if (reasoning && typeof reasoning === 'object' && !Array.isArray(reasoning)) {
+    return reasoning
+  }
+  return null
+}
 
 const shouldInjectSyzygyFeedMemory = (payload: OpenRouterPayload) => payload.module === 'syzygy-feed'
 
@@ -956,7 +966,7 @@ serve(async (req) => {
         temperature,
         top_p,
         max_tokens,
-        ...(reasoning ? { reasoning: { effort: 'medium' } } : {}),
+        ...(resolveReasoningPayload(reasoning) ? { reasoning: resolveReasoningPayload(reasoning) } : {}),
         stream,
       }),
     })


### PR DESCRIPTION
### Motivation
- Provide a user-facing toggle to increase the chance/strength of Thinking for OpenAI auto-routed GPT-5.1 / GPT-5.2 models only. 
- Ensure the change is frontend-only and avoids sending boolean reasoning flags that could cause OpenRouter 400 errors. 
- Persist the toggles across refresh without changing the Supabase schema.

### Description
- Added two new toggles in Settings → 思考链: `聊天：高触发 Thinking（仅 GPT-5.1/5.2）` and `跑跑滚轮区/RP：高触发 Thinking（仅 GPT-5.1/5.2）`, wired into the settings save/reset and unsaved-change detection flows. 
- Persisted these flags locally per-user using a user-scoped `localStorage` key so they survive refresh while avoiding any DB schema changes. 
- Implemented `isGpt5Auto(modelId: string)` helper to robustly match GPT-5.1 / GPT-5.2 model ids and applied it in both chat (App) and RP request builders. 
- Modified request logic so that when (reasoning enabled) AND (high-thinking toggle enabled) AND (model matches GPT-5.1/5.2) the OpenRouter payload sends a non-boolean object form (`{ reasoning: { effort: 'high' } }`), and left non-GPT behavior unchanged. 
- Updated the OpenRouter edge handler to accept either boolean or object `reasoning` from the frontend and normalize/forward an object to upstream (e.g., `{ effort: 'medium' }` for boolean `true`), preventing boolean->object mismatches upstream.

### Testing
- Built the app with `npm run build` and the build completed successfully. 
- Ran linter with `npm run lint` and it passed (there is one pre-existing unrelated warning in `src/pages/CheckinPage.tsx`). 
- Captured an automated screenshot of the updated Settings page via a Playwright script to validate the new toggles rendering (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f9d8695c83308ff14d6507b87318)