### PR TITLE
Fix delete confirmation modal layering and prevent clipping in sessions drawer

### DIFF
--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  z-index: 40;
+  z-index: calc(var(--z-popover) + 100);
 }
 
 .confirm-dialog {
@@ -14,6 +14,9 @@
   border-radius: 16px;
   padding: 20px;
   width: min(360px, 100%);
+  max-height: min(calc(100vh - 48px), 100%);
+  max-height: min(calc(100dvh - 48px), 100%);
+  overflow: auto;
   box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
 }
 


### PR DESCRIPTION
### Motivation
- The delete confirmation dialog in the Conversations (sessions) sidebar was being covered or clipped by the drawer/container and needed to reliably appear above all UI.
- The modal must not be trapped by parent stacking contexts or constrained by sidebar dimensions, and it must remain usable on small viewports.

### Description
- Raise the confirmation backdrop z-index to `calc(var(--z-popover) + 100)` so the modal sits above the drawer/scrim and other overlays by updating `src/components/ConfirmDialog.css`.
- Constrain the dialog height to the viewport and enable internal scrolling by adding `max-height` and `overflow: auto` to the dialog so content and action buttons are never clipped on small screens.
- No behavior/logic changes to deletion were made; `ConfirmDialog` continues to render via `createPortal(..., document.body)` in `src/components/ConfirmDialog.tsx` so the fix is styling-only.

### Testing
- Ran `npm run build` successfully to ensure the production build still works.
- Started the dev server with `npm run dev` and executed a Playwright script that opened the app and captured a screenshot to validate overlay rendering, which completed but landed on an auth-gated screen so the conversation delete flow could not be exercised end-to-end in this environment.
- No automated tests failed; changes are limited to `src/components/ConfirmDialog.css` and are styling only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a544a547388330a9614741f73c9061)