### PR TITLE
Home: Use clock header on Page 2 and remove fixed checkin widget

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -86,7 +86,7 @@ const createDefaultPageLayouts = (): Record<HomeLayoutPageId, HomePageLayoutStat
   },
   page2: {
     iconOrder: DEFAULT_PAGE2_ICON_ORDER,
-    widgetOrder: [CORE_WIDGET_ID],
+    widgetOrder: [],
     widgets: [],
     checkinSize: "1x1",
     showEmptySlots: false,
@@ -289,6 +289,7 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
   const widgets = activeLayout.widgets;
   const checkinSize = activeLayout.checkinSize ?? "1x1";
   const showEmptySlots = activeLayout.showEmptySlots ?? false;
+  const hasCheckinWidget = widgetOrder.includes(CORE_WIDGET_ID);
   const appIconConfigs = useMemo(
     () => activeLayout.appIconConfigs ?? {},
     [activeLayout.appIconConfigs],
@@ -404,8 +405,8 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
   );
 
   const decoratedWidgetCount = useMemo(
-    () => widgets.length + 1,
-    [widgets.length],
+    () => widgets.length + (hasCheckinWidget ? 1 : 0),
+    [hasCheckinWidget, widgets.length],
   );
 
   useEffect(() => {
@@ -453,6 +454,7 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
       page: HomePageLayoutState | undefined,
       fallbackOrder: string[],
       fallbackConfigs: AppIconState,
+      includeCheckinWidget: boolean,
     ): HomePageLayoutState => {
       const safeIconOrder = fallbackOrder.filter((id) =>
         page?.iconOrder?.includes(id),
@@ -470,12 +472,16 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
       );
       const widgetIds = safeWidgets.map((widget) => widget.id);
       const restoredOrder = (page?.widgetOrder ?? []).filter(
-        (id) => id === CORE_WIDGET_ID || widgetIds.includes(id),
+        (id) =>
+          (includeCheckinWidget && id === CORE_WIDGET_ID) ||
+          widgetIds.includes(id),
       );
 
       return {
         iconOrder: [...safeIconOrder, ...extra, ...missing],
-        widgetOrder: Array.from(new Set([CORE_WIDGET_ID, ...restoredOrder])),
+        widgetOrder: includeCheckinWidget
+          ? Array.from(new Set([CORE_WIDGET_ID, ...restoredOrder]))
+          : restoredOrder,
         widgets: safeWidgets,
         checkinSize: page?.checkinSize ?? "1x1",
         showEmptySlots: page?.showEmptySlots ?? false,
@@ -501,6 +507,7 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
         pageLayoutsFromCache?.page1 ?? legacyPage1,
         DEFAULT_ICON_ORDER,
         defaultAppIconConfigs,
+        true,
       ),
       page2: normalizePage(
         pageLayoutsFromCache?.page2,
@@ -509,6 +516,7 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
           forum: defaultAppIconConfigs.forum,
           letters: defaultAppIconConfigs.letters,
         },
+        false,
       ),
     });
 
@@ -1118,17 +1126,8 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
                   >
                     编辑
                   </button>
-                  {activePage === "page1" ? (
-                    <>
-                      <h1 className="ui-title ui-numeric home-clock-title">{timeLabel}</h1>
-                      <p>{dateLabel}</p>
-                    </>
-                  ) : (
-                    <>
-                      <h1 className="ui-title">{PAGE_LABELS[activePage]}</h1>
-                      <p>主屏第 2 页</p>
-                    </>
-                  )}
+                  <h1 className="ui-title ui-numeric home-clock-title">{timeLabel}</h1>
+                  <p>{dateLabel}</p>
                 </>
               )}
             </header>


### PR DESCRIPTION
### Motivation
- Make the Home second screen match the first screen by showing the same time/date header and avoid duplicating the persistent checkin widget on both pages.
- Keep backwards compatibility with previously saved layouts while ensuring the checkin widget is only enforced on Page 1.

### Description
- Removed the fixed `widget-checkin` from the default `page2` `widgetOrder` and stop forcing it into Page 2 layouts (`src/pages/HomePage.tsx`).
- Added `hasCheckinWidget` derived flag and adjusted `decoratedWidgetCount` to account for pages that may not include the checkin widget.
- Updated the cached layout `normalizePage` helper to accept an `includeCheckinWidget` flag so the code keeps the checkin widget on Page 1 but filters it out for Page 2 when normalizing old saved layouts.
- Simplified header rendering so the time (`timeLabel`) and date (`dateLabel`) block is shown for both pages instead of showing a special Page 2 label.

### Testing
- Ran `npm run build` which completed successfully (TypeScript build + `vite build`).
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which launched successfully and served the app.
- Executed a Playwright script to capture a screenshot of the running app which completed, but the environment is unauthenticated so the screenshot landed on the login page rather than the Home second screen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa921b01c08330af00b3f963dbe911)