### PR TITLE
Add Forum MVP UI, routes and Supabase integration with manual AI triggers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,9 @@ import RpRoomPage from './pages/RpRoomPage'
 import HomePage from './pages/HomePage'
 import HomeLayoutSettingsPage from './pages/HomeLayoutSettingsPage'
 import ForumPage from './pages/ForumPage'
+import ForumNewThreadPage from './pages/ForumNewThreadPage'
+import ForumThreadPage from './pages/ForumThreadPage'
+import ForumSettingsPage from './pages/ForumSettingsPage'
 import LettersPage from './pages/LettersPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
@@ -1410,6 +1413,30 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <ForumPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/forum/new"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <ForumNewThreadPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/forum/thread/:id"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <ForumThreadPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/forum/settings"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <ForumSettingsPage />
             </RequireAuth>
           }
         />

--- a/src/pages/ForumNewThreadPage.tsx
+++ b/src/pages/ForumNewThreadPage.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { ForumAiProfile } from '../types'
+import { createForumThread, fetchAllMemoryEntries, fetchForumAiProfiles } from '../storage/supabaseSync'
+import { FORUM_AI_SLOTS, defaultForumProfile, requestForumAiContent } from './forumShared'
+import './ForumPage.css'
+
+type AuthorDraft = 'user' | 'ai-1' | 'ai-2' | 'ai-3'
+
+const ForumNewThreadPage = () => {
+  const navigate = useNavigate()
+  const [profiles, setProfiles] = useState<ForumAiProfile[]>([])
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [authorDraft, setAuthorDraft] = useState<AuthorDraft>('user')
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const authorIsAi = authorDraft !== 'user'
+  const selectedSlot = authorIsAi ? Number(authorDraft.split('-')[1]) : null
+
+  useEffect(() => {
+    const loadProfiles = async () => {
+      setLoading(true)
+      try {
+        const list = await fetchForumAiProfiles()
+        setProfiles(list)
+      } catch (loadError) {
+        console.warn('加载 AI 配置失败', loadError)
+      } finally {
+        setLoading(false)
+      }
+    }
+    void loadProfiles()
+  }, [])
+
+  const profileLookup = useMemo(() => {
+    const map = new Map<number, ForumAiProfile>()
+    profiles.forEach((item) => map.set(item.slotIndex, item))
+    return map
+  }, [profiles])
+
+  const createDirectThread = async (nextContent: string) => {
+    if (!title.trim() || !nextContent.trim()) {
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const created = await createForumThread({
+        title: title.trim(),
+        content: nextContent.trim(),
+        authorType: authorIsAi ? 'ai' : 'user',
+        authorSlot: selectedSlot,
+      })
+      navigate(`/forum/thread/${created.id}`)
+    } catch (submitError) {
+      console.warn('创建主题失败', submitError)
+      setError('创建主题失败，请稍后重试。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleCreate = async () => {
+    if (authorIsAi) {
+      setError('已选择 AI 作者，请使用“生成 AI 主题”按钮。')
+      return
+    }
+    await createDirectThread(content)
+  }
+
+  const handleGenerateAiThread = async () => {
+    if (!authorIsAi || !selectedSlot || !title.trim()) {
+      return
+    }
+    const profile = profileLookup.get(selectedSlot)
+    if (!profile?.enabled) {
+      setError('该 AI 档案未启用，请先在 Forum 设置页启用。')
+      return
+    }
+    setGenerating(true)
+    setError(null)
+    try {
+      const memoryEntries = await fetchAllMemoryEntries()
+      const generated = await requestForumAiContent({
+        profile,
+        memoryEntries,
+        task: 'new-thread',
+        thread: {
+          id: 'draft-thread',
+          userId: profile.userId,
+          title: title.trim(),
+          content: content.trim() || '（空草稿）',
+          authorType: 'user',
+          authorSlot: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        replies: [],
+        userPrompt: content.trim() || undefined,
+      })
+      setContent(generated)
+      await createDirectThread(generated)
+    } catch (generateError) {
+      console.warn('生成 AI 主题失败', generateError)
+      setError('生成失败，请检查模型配置后重试。')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  return (
+    <div className="forum-page app-shell__content">
+      <header className="forum-header glass-card">
+        <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
+          返回列表
+        </button>
+        <h1 className="ui-title">新建主题</h1>
+      </header>
+
+      <section className="glass-card forum-editor">
+        {loading ? <p>加载 AI 档案中…</p> : null}
+        <label>
+          标题
+          <input className="input-glass" value={title} onChange={(event) => setTitle(event.target.value)} />
+        </label>
+        <label>
+          作者
+          <select
+            className="input-glass"
+            value={authorDraft}
+            onChange={(event) => setAuthorDraft(event.target.value as AuthorDraft)}
+          >
+            <option value="user">我（直接发布）</option>
+            {FORUM_AI_SLOTS.map((slot) => {
+              const profile = profileLookup.get(slot) ?? {
+                ...defaultForumProfile(slot),
+                id: `slot-${slot}`,
+                userId: '',
+                createdAt: '',
+                updatedAt: '',
+              }
+              return (
+                <option key={slot} value={`ai-${slot}`}>
+                  {profile.displayName}（AI Slot {slot}）
+                </option>
+              )
+            })}
+          </select>
+        </label>
+        <label>
+          正文
+          <textarea
+            className="textarea-glass"
+            rows={8}
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            placeholder={authorIsAi ? '可填写 AI 写作方向。' : '输入你要发的主题内容。'}
+          />
+        </label>
+        {error ? <p className="forum-error">{error}</p> : null}
+        <div className="forum-editor__actions">
+          <button type="button" className="btn-primary" disabled={submitting || generating} onClick={handleCreate}>
+            直接发布（用户）
+          </button>
+          <button
+            type="button"
+            className="btn-secondary"
+            disabled={!authorIsAi || submitting || generating}
+            onClick={handleGenerateAiThread}
+          >
+            {generating ? 'AI 生成中…' : '生成 AI 主题'}
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default ForumNewThreadPage

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -1,0 +1,114 @@
+.forum-page {
+  padding: 1rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.forum-header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.forum-header__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.forum-ai-overview__cards,
+.forum-settings-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.forum-ai-mini-card {
+  border: 1px solid rgba(148, 163, 184, 0.36);
+  border-radius: 14px;
+  padding: 0.7rem;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.forum-thread-list__items {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.forum-thread-item,
+.forum-reply-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.36);
+  border-radius: 14px;
+  padding: 0.8rem;
+  text-decoration: none;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.forum-thread-item h3,
+.forum-thread-item p,
+.forum-reply-item p {
+  margin: 0;
+}
+
+.forum-thread-item p,
+.forum-reply-item p {
+  margin-top: 0.45rem;
+  color: #334155;
+  white-space: pre-wrap;
+}
+
+.forum-thread-item aside,
+.forum-root-post footer,
+.forum-reply-item header,
+.forum-reply-item footer {
+  display: grid;
+  gap: 0.2rem;
+  justify-items: end;
+  color: #475569;
+}
+
+.forum-root-post h2,
+.forum-root-post p,
+.forum-root-post footer {
+  margin: 0;
+}
+
+.forum-root-post p {
+  margin: 0.6rem 0;
+  white-space: pre-wrap;
+}
+
+.forum-editor {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.forum-editor label,
+.forum-settings-card label {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.forum-editor__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.forum-settings-card {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.forum-error {
+  color: #b91c1c;
+  margin: 0;
+}
+
+.forum-loading {
+  padding: 1rem;
+}

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -1,10 +1,102 @@
-const ForumPage = () => (
-  <main className="app-shell" style={{ padding: "1rem" }}>
-    <section className="glass-card" style={{ maxWidth: 560, margin: "0 auto", padding: "1rem" }}>
-      <h1 className="ui-title">Forum</h1>
-      <p>Forum 页面正在建设中，当前为可安全跳转的占位页。</p>
-    </section>
-  </main>
-);
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import type { ForumAiProfile, ForumThread } from '../types'
+import { fetchForumAiProfiles, fetchForumThreads } from '../storage/supabaseSync'
+import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel } from './forumShared'
+import './ForumPage.css'
 
-export default ForumPage;
+const formatTime = (value: string) =>
+  new Date(value).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+
+const ForumPage = () => {
+  const navigate = useNavigate()
+  const [threads, setThreads] = useState<ForumThread[]>([])
+  const [profiles, setProfiles] = useState<ForumAiProfile[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const profilesBySlot = useMemo(() => {
+    const entries = new Map<number, ForumAiProfile>()
+    profiles.forEach((profile) => entries.set(profile.slotIndex, profile))
+    return FORUM_AI_SLOTS.map((slot) => entries.get(slot) ?? {
+      ...defaultForumProfile(slot),
+      id: `slot-${slot}`,
+      userId: '',
+      createdAt: '',
+      updatedAt: '',
+    })
+  }, [profiles])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [threadList, profileList] = await Promise.all([fetchForumThreads(), fetchForumAiProfiles()])
+      setThreads(threadList)
+      setProfiles(profileList)
+    } catch (loadError) {
+      console.warn('加载论坛失败', loadError)
+      setError('论坛加载失败，请稍后重试。')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <div className="forum-page app-shell__content">
+      <header className="forum-header glass-card">
+        <button type="button" className="btn-secondary" onClick={() => navigate('/')}>
+          返回主页
+        </button>
+        <h1 className="ui-title">Forum</h1>
+        <div className="forum-header__actions">
+          <button type="button" className="btn-secondary" onClick={() => navigate('/forum/settings')}>
+            Forum 设置
+          </button>
+          <button type="button" className="btn-primary" onClick={() => navigate('/forum/new')}>
+            新建主题
+          </button>
+        </div>
+      </header>
+
+      <section className="forum-ai-overview glass-card">
+        <h2 className="ui-title">AI 档案</h2>
+        <div className="forum-ai-overview__cards">
+          {profilesBySlot.map((profile) => (
+            <article key={profile.slotIndex} className="forum-ai-mini-card">
+              <p>{profile.displayName}</p>
+              <small>{profile.enabled ? '已启用' : '已停用'}</small>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="forum-thread-list glass-card">
+        <h2 className="ui-title">主题列表</h2>
+        {loading ? <p>加载中…</p> : null}
+        {error ? <p className="forum-error">{error}</p> : null}
+        {!loading && !error && threads.length === 0 ? <p>还没有主题，先创建第一条吧。</p> : null}
+        <div className="forum-thread-list__items">
+          {threads.map((thread) => (
+            <Link key={thread.id} className="forum-thread-item" to={`/forum/thread/${thread.id}`}>
+              <div>
+                <h3>{thread.title}</h3>
+                <p>{thread.content}</p>
+              </div>
+              <aside>
+                <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles)}</strong>
+                <small>{formatTime(thread.createdAt)}</small>
+              </aside>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default ForumPage

--- a/src/pages/ForumSettingsPage.tsx
+++ b/src/pages/ForumSettingsPage.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { ForumAiProfile } from '../types'
+import { fetchForumAiProfiles, upsertForumAiProfile } from '../storage/supabaseSync'
+import { FORUM_AI_SLOTS, defaultForumProfile } from './forumShared'
+import './ForumPage.css'
+
+const toCard = (slotIndex: number, profile?: ForumAiProfile) => ({
+  ...(profile ?? {
+    ...defaultForumProfile(slotIndex),
+    id: `slot-${slotIndex}`,
+    userId: '',
+    createdAt: '',
+    updatedAt: '',
+  }),
+})
+
+const ForumSettingsPage = () => {
+  const navigate = useNavigate()
+  const [profiles, setProfiles] = useState<ForumAiProfile[]>([])
+  const [loading, setLoading] = useState(true)
+  const [savingSlot, setSavingSlot] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+      try {
+        const data = await fetchForumAiProfiles()
+        setProfiles(data)
+      } catch (loadError) {
+        console.warn('加载论坛 AI 档案失败', loadError)
+        setError('加载失败，请稍后重试。')
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [])
+
+  const cards = useMemo(() => {
+    const map = new Map<number, ForumAiProfile>()
+    profiles.forEach((item) => map.set(item.slotIndex, item))
+    return FORUM_AI_SLOTS.map((slot) => toCard(slot, map.get(slot)))
+  }, [profiles])
+
+  const updateCard = (slotIndex: number, updater: (card: ForumAiProfile) => ForumAiProfile) => {
+    setProfiles((current) => {
+      const map = new Map<number, ForumAiProfile>()
+      current.forEach((item) => map.set(item.slotIndex, item))
+      const card = toCard(slotIndex, map.get(slotIndex))
+      map.set(slotIndex, updater(card))
+      return Array.from(map.values()).sort((a, b) => a.slotIndex - b.slotIndex)
+    })
+  }
+
+  const handleSave = async (slotIndex: number) => {
+    const card = cards.find((item) => item.slotIndex === slotIndex)
+    if (!card) {
+      return
+    }
+    setSavingSlot(slotIndex)
+    setError(null)
+    try {
+      const saved = await upsertForumAiProfile(slotIndex, {
+        enabled: card.enabled,
+        displayName: card.displayName,
+        systemPrompt: card.systemPrompt,
+        model: card.model,
+        temperature: card.temperature,
+        topP: card.topP,
+        apiBaseUrl: card.apiBaseUrl,
+      })
+      updateCard(slotIndex, () => saved)
+    } catch (saveError) {
+      console.warn('保存论坛 AI 档案失败', saveError)
+      setError(`保存 Slot ${slotIndex} 失败，请重试。`)
+    } finally {
+      setSavingSlot(null)
+    }
+  }
+
+  return (
+    <div className="forum-page app-shell__content">
+      <header className="forum-header glass-card">
+        <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
+          返回论坛
+        </button>
+        <h1 className="ui-title">Forum 设置</h1>
+      </header>
+
+      {loading ? <p className="forum-loading">加载中…</p> : null}
+      {error ? <p className="forum-error">{error}</p> : null}
+
+      <div className="forum-settings-grid">
+        {cards.map((card) => (
+          <section key={card.slotIndex} className="glass-card forum-settings-card">
+            <h2 className="ui-title">AI Slot {card.slotIndex}</h2>
+            <label>
+              <span>Enabled</span>
+              <input
+                type="checkbox"
+                checked={card.enabled}
+                onChange={(event) =>
+                  updateCard(card.slotIndex, (current) => ({ ...current, enabled: event.target.checked }))
+                }
+              />
+            </label>
+            <label>
+              <span>Display name</span>
+              <input
+                className="input-glass"
+                value={card.displayName}
+                onChange={(event) =>
+                  updateCard(card.slotIndex, (current) => ({ ...current, displayName: event.target.value }))
+                }
+              />
+            </label>
+            <label>
+              <span>System prompt</span>
+              <textarea
+                className="textarea-glass"
+                rows={5}
+                value={card.systemPrompt}
+                onChange={(event) =>
+                  updateCard(card.slotIndex, (current) => ({ ...current, systemPrompt: event.target.value }))
+                }
+              />
+            </label>
+            <label>
+              <span>Model</span>
+              <input
+                className="input-glass"
+                value={card.model}
+                onChange={(event) =>
+                  updateCard(card.slotIndex, (current) => ({ ...current, model: event.target.value }))
+                }
+              />
+            </label>
+            <label>
+              <span>Temperature</span>
+              <input
+                className="input-glass"
+                type="number"
+                step="0.1"
+                value={card.temperature}
+                onChange={(event) =>
+                  updateCard(card.slotIndex, (current) => ({ ...current, temperature: Number(event.target.value) }))
+                }
+              />
+            </label>
+            <label>
+              <span>Top P</span>
+              <input
+                className="input-glass"
+                type="number"
+                step="0.1"
+                value={card.topP}
+                onChange={(event) =>
+                  updateCard(card.slotIndex, (current) => ({ ...current, topP: Number(event.target.value) }))
+                }
+              />
+            </label>
+            <label>
+              <span>API base url</span>
+              <input
+                className="input-glass"
+                value={card.apiBaseUrl}
+                onChange={(event) =>
+                  updateCard(card.slotIndex, (current) => ({ ...current, apiBaseUrl: event.target.value }))
+                }
+              />
+            </label>
+            <button
+              type="button"
+              className="btn-primary"
+              disabled={savingSlot === card.slotIndex}
+              onClick={() => void handleSave(card.slotIndex)}
+            >
+              {savingSlot === card.slotIndex ? '保存中…' : '保存'}
+            </button>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ForumSettingsPage

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import type { ForumAiProfile, ForumReply, ForumThread } from '../types'
+import {
+  createForumReply,
+  fetchAllMemoryEntries,
+  fetchForumAiProfiles,
+  fetchForumRepliesByThread,
+  fetchForumThreadById,
+} from '../storage/supabaseSync'
+import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel, requestForumAiContent } from './forumShared'
+import './ForumPage.css'
+
+const formatTime = (value: string) =>
+  new Date(value).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+
+const ForumThreadPage = () => {
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const [thread, setThread] = useState<ForumThread | null>(null)
+  const [replies, setReplies] = useState<ForumReply[]>([])
+  const [profiles, setProfiles] = useState<ForumAiProfile[]>([])
+  const [replyContent, setReplyContent] = useState('')
+  const [targetReplyId, setTargetReplyId] = useState<string>('thread-root')
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [generatingSlot, setGeneratingSlot] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!id) {
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const [threadData, replyData, profileData] = await Promise.all([
+        fetchForumThreadById(id),
+        fetchForumRepliesByThread(id),
+        fetchForumAiProfiles(),
+      ])
+      setThread(threadData)
+      setReplies(replyData)
+      setProfiles(profileData)
+    } catch (loadError) {
+      console.warn('加载论坛主题失败', loadError)
+      setError('加载失败，请刷新重试。')
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const profileMap = useMemo(() => {
+    const map = new Map<number, ForumAiProfile>()
+    profiles.forEach((item) => map.set(item.slotIndex, item))
+    return map
+  }, [profiles])
+
+  const targetLabel = useMemo(() => {
+    if (targetReplyId === 'thread-root') {
+      return '主题帖'
+    }
+    const target = replies.find((reply) => reply.id === targetReplyId)
+    if (!target) {
+      return '主题帖'
+    }
+    return `${getForumAuthorLabel(target.authorType, target.authorSlot, profiles)} 的回复`
+  }, [profiles, replies, targetReplyId])
+
+  const handleSubmitReply = async () => {
+    if (!thread || !replyContent.trim()) {
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const created = await createForumReply({
+        threadId: thread.id,
+        content: replyContent.trim(),
+        authorType: 'user',
+        replyToType: targetReplyId === 'thread-root' ? 'thread' : 'reply',
+        replyToReplyId: targetReplyId === 'thread-root' ? null : targetReplyId,
+      })
+      setReplies((current) => [...current, created])
+      setReplyContent('')
+      setTargetReplyId('thread-root')
+    } catch (submitError) {
+      console.warn('发送回复失败', submitError)
+      setError('发送失败，请稍后重试。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleGenerateAiReply = async (slot: number) => {
+    if (!thread || generatingSlot) {
+      return
+    }
+    const profile = profileMap.get(slot)
+    if (!profile?.enabled) {
+      setError('该 AI 档案未启用，请先到设置页开启。')
+      return
+    }
+    setGeneratingSlot(slot)
+    setError(null)
+    try {
+      const memoryEntries = await fetchAllMemoryEntries()
+      const generated = await requestForumAiContent({
+        profile,
+        thread,
+        replies,
+        memoryEntries,
+        task: 'reply',
+        replyTargetLabel: targetLabel,
+        userPrompt: replyContent.trim() || undefined,
+      })
+      const created = await createForumReply({
+        threadId: thread.id,
+        content: generated,
+        authorType: 'ai',
+        authorSlot: slot,
+        replyToType: targetReplyId === 'thread-root' ? 'thread' : 'reply',
+        replyToReplyId: targetReplyId === 'thread-root' ? null : targetReplyId,
+      })
+      setReplies((current) => [...current, created])
+      setReplyContent('')
+    } catch (generateError) {
+      console.warn('AI 回复失败', generateError)
+      setError('AI 生成失败，请检查配置后重试。')
+    } finally {
+      setGeneratingSlot(null)
+    }
+  }
+
+  if (loading) {
+    return <div className="forum-page app-shell__content forum-loading">加载中…</div>
+  }
+
+  if (!thread) {
+    return (
+      <div className="forum-page app-shell__content forum-loading">
+        <p>主题不存在或已被删除。</p>
+        <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
+          返回论坛
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="forum-page app-shell__content">
+      <header className="forum-header glass-card">
+        <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
+          返回列表
+        </button>
+        <h1 className="ui-title">主题详情</h1>
+      </header>
+
+      <article className="glass-card forum-root-post">
+        <h2>{thread.title}</h2>
+        <p>{thread.content}</p>
+        <footer>
+          <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles)}</strong>
+          <small>{formatTime(thread.createdAt)}</small>
+        </footer>
+      </article>
+
+      <section className="glass-card forum-thread-list">
+        <h3 className="ui-title">回复（按时间顺序）</h3>
+        <div className="forum-thread-list__items">
+          {replies.map((reply, index) => {
+            const target =
+              reply.replyToType === 'reply' ? replies.find((item) => item.id === reply.replyToReplyId) : null
+            const targetName =
+              reply.replyToType === 'thread'
+                ? getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles)
+                : target
+                  ? getForumAuthorLabel(target.authorType, target.authorSlot, profiles)
+                  : '未知目标'
+            return (
+              <article className="forum-reply-item" key={reply.id}>
+                <header>
+                  <strong>{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles)}</strong>
+                  <small>{formatTime(reply.createdAt)}</small>
+                </header>
+                <p>{reply.content}</p>
+                <footer>
+                  <span>#{index + 1}</span>
+                  <span>回复给：{targetName}</span>
+                </footer>
+              </article>
+            )
+          })}
+        </div>
+      </section>
+
+      <section className="glass-card forum-editor">
+        <h3 className="ui-title">手动回复</h3>
+        <label>
+          回复目标
+          <select
+            className="input-glass"
+            value={targetReplyId}
+            onChange={(event) => setTargetReplyId(event.target.value)}
+          >
+            <option value="thread-root">主题帖</option>
+            {replies.map((reply, index) => (
+              <option key={reply.id} value={reply.id}>
+                回复 #{index + 1}（{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles)}）
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          内容 / AI 指令
+          <textarea
+            className="textarea-glass"
+            rows={5}
+            value={replyContent}
+            onChange={(event) => setReplyContent(event.target.value)}
+            placeholder="输入手动回复；也可填写给 AI 的指令后点击下方按钮。"
+          />
+        </label>
+        {error ? <p className="forum-error">{error}</p> : null}
+        <div className="forum-editor__actions">
+          <button type="button" className="btn-primary" disabled={submitting} onClick={handleSubmitReply}>
+            发布用户回复
+          </button>
+          {FORUM_AI_SLOTS.map((slot) => {
+            const profile = profileMap.get(slot) ?? {
+              ...defaultForumProfile(slot),
+              id: `slot-${slot}`,
+              userId: '',
+              createdAt: '',
+              updatedAt: '',
+            }
+            return (
+              <button
+                key={slot}
+                type="button"
+                className="btn-secondary"
+                disabled={Boolean(generatingSlot) || !profile.enabled}
+                onClick={() => void handleGenerateAiReply(slot)}
+              >
+                {generatingSlot === slot ? '生成中…' : `${profile.displayName} 生成回复`}
+              </button>
+            )
+          })}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default ForumThreadPage

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -1,0 +1,141 @@
+import type { ForumAiProfile, ForumReply, ForumThread } from '../types'
+import { supabase } from '../supabase/client'
+import type { MemoryEntry } from '../types'
+
+export const FORUM_AI_SLOTS = [1, 2, 3] as const
+
+export const defaultForumProfile = (slotIndex: number): Omit<ForumAiProfile, 'id' | 'userId' | 'createdAt' | 'updatedAt'> => ({
+  slotIndex,
+  enabled: true,
+  displayName: `Forum AI ${slotIndex}`,
+  systemPrompt: '',
+  model: 'openrouter/auto',
+  temperature: 0.8,
+  topP: 0.9,
+  apiBaseUrl: '',
+})
+
+export const getForumAuthorLabel = (
+  authorType: 'user' | 'ai',
+  authorSlot: number | null,
+  profiles: ForumAiProfile[],
+) => {
+  if (authorType === 'user') {
+    return '你'
+  }
+  const profile = profiles.find((item) => item.slotIndex === authorSlot)
+  if (profile?.displayName) {
+    return profile.displayName
+  }
+  return `AI Slot ${authorSlot ?? 1}`
+}
+
+type RequestForumAiContentParams = {
+  profile: ForumAiProfile
+  thread: ForumThread
+  replies: ForumReply[]
+  memoryEntries: MemoryEntry[]
+  task: 'new-thread' | 'reply'
+  replyTargetLabel?: string
+  userPrompt?: string
+}
+
+export const requestForumAiContent = async ({
+  profile,
+  thread,
+  replies,
+  memoryEntries,
+  task,
+  replyTargetLabel,
+  userPrompt,
+}: RequestForumAiContentParams) => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { data } = await supabase.auth.getSession()
+  const accessToken = data.session?.access_token
+  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
+  if (!accessToken || !anonKey) {
+    throw new Error('登录状态异常或环境变量未配置')
+  }
+
+  const threadContext = [
+    `主题标题：${thread.title}`,
+    `主题正文：${thread.content}`,
+    ...replies.map(
+      (reply, index) =>
+        `${index + 1}. [${reply.authorType === 'user' ? 'user' : `ai_${reply.authorSlot ?? 1}`}] ${reply.content}`,
+    ),
+  ].join('\n')
+
+  const memoryBlock = memoryEntries.length
+    ? memoryEntries
+        .map((entry, index) => `${index + 1}. (${entry.status}) ${entry.content}`)
+        .join('\n')
+    : '无'
+
+  const messagesPayload: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = []
+  messagesPayload.push({
+    role: 'system',
+    content: `Forum 模式指令层。你的身份是 slot_${profile.slotIndex}（${profile.displayName}）。仅输出帖子/回复正文，不要包含解释。`,
+  })
+  if (profile.systemPrompt.trim()) {
+    messagesPayload.push({ role: 'system', content: profile.systemPrompt.trim() })
+  }
+  messagesPayload.push({
+    role: 'system',
+    content: `当前系统时间：${new Date().toISOString()}`,
+  })
+  messagesPayload.push({
+    role: 'system',
+    content: `memory_entries 全量注入：\n${memoryBlock}`,
+  })
+  messagesPayload.push({
+    role: 'user',
+    content: `当前线程上下文（严格线程内）：\n${threadContext}`,
+  })
+  messagesPayload.push({
+    role: 'user',
+    content:
+      task === 'new-thread'
+        ? `请以论坛新帖形式发言。${userPrompt ? `用户补充：${userPrompt}` : ''}`
+        : `请生成一条论坛回复。回复目标：${replyTargetLabel ?? '主题帖'}。${userPrompt ? `用户补充：${userPrompt}` : ''}`,
+  })
+
+  const requestBody: Record<string, unknown> = {
+    model: profile.model,
+    modelId: profile.model,
+    module: 'forum',
+    messages: messagesPayload,
+    temperature: profile.temperature,
+    top_p: profile.topP,
+    max_tokens: 800,
+    stream: false,
+    extra: {
+      forumApiBaseUrl: profile.apiBaseUrl,
+      identitySlot: profile.slotIndex,
+      scope: 'thread-only',
+    },
+  }
+
+  const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      apikey: anonKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  })
+
+  if (!response.ok) {
+    throw new Error(await response.text())
+  }
+
+  const payload = (await response.json()) as Record<string, unknown>
+  const choice = (payload?.choices as unknown[] | undefined)?.[0] as Record<string, unknown> | undefined
+  const message = ((choice?.message as Record<string, unknown>) ?? choice ?? {}) as Record<string, unknown>
+  const content =
+    typeof message.content === 'string' ? message.content : typeof choice?.text === 'string' ? choice.text : ''
+  return content.trim() || '（空回复）'
+}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -2,6 +2,10 @@ import type {
   ChatMessage,
   ChatSession,
   CheckinEntry,
+  ForumAiProfile,
+  ForumReply,
+  ForumThread,
+  ForumAuthorType,
   MemoryEntry,
   MemoryStatus,
   RpNpcCard,
@@ -141,6 +145,44 @@ type RpNpcCardRow = {
   updated_at: string | null
 }
 
+type ForumThreadRow = {
+  id: string
+  user_id: string
+  title: string
+  content: string
+  author_type: ForumAuthorType
+  author_slot: number | null
+  created_at: string
+  updated_at: string
+}
+
+type ForumReplyRow = {
+  id: string
+  thread_id: string
+  user_id: string
+  content: string
+  author_type: ForumAuthorType
+  author_slot: number | null
+  reply_to_type: 'thread' | 'reply' | null
+  reply_to_reply_id: string | null
+  created_at: string
+}
+
+type ForumAiProfileRow = {
+  id: string
+  user_id: string
+  slot_index: number
+  enabled: boolean | null
+  display_name: string | null
+  system_prompt: string | null
+  model: string | null
+  temperature: number | null
+  top_p: number | null
+  api_base_url: string | null
+  created_at: string
+  updated_at: string
+}
+
 const mapSnackPostRow = (row: SnackPostRow): SnackPost => ({
   id: row.id,
   userId: row.user_id,
@@ -257,6 +299,44 @@ const mapRpNpcCardRow = (row: RpNpcCardRow): RpNpcCard => ({
   modelConfig: row.model_config ?? {},
   apiConfig: row.api_config ?? {},
   enabled: row.enabled ?? false,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const mapForumThreadRow = (row: ForumThreadRow): ForumThread => ({
+  id: row.id,
+  userId: row.user_id,
+  title: row.title,
+  content: row.content,
+  authorType: row.author_type,
+  authorSlot: row.author_slot,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const mapForumReplyRow = (row: ForumReplyRow): ForumReply => ({
+  id: row.id,
+  threadId: row.thread_id,
+  userId: row.user_id,
+  content: row.content,
+  authorType: row.author_type,
+  authorSlot: row.author_slot,
+  replyToType: row.reply_to_type,
+  replyToReplyId: row.reply_to_reply_id,
+  createdAt: row.created_at,
+})
+
+const mapForumAiProfileRow = (row: ForumAiProfileRow): ForumAiProfile => ({
+  id: row.id,
+  userId: row.user_id,
+  slotIndex: row.slot_index,
+  enabled: row.enabled ?? true,
+  displayName: row.display_name ?? `AI Slot ${row.slot_index}`,
+  systemPrompt: row.system_prompt ?? '',
+  model: row.model ?? 'openrouter/auto',
+  temperature: row.temperature ?? 0.8,
+  topP: row.top_p ?? 0.9,
+  apiBaseUrl: row.api_base_url ?? '',
   createdAt: row.created_at,
   updatedAt: row.updated_at,
 })
@@ -1381,6 +1461,201 @@ export const permanentlyDeleteSyzygyReply = async (replyId: string): Promise<voi
   if (error) {
     throw error
   }
+}
+
+export const fetchForumThreads = async (): Promise<ForumThread[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('forum_threads')
+    .select('id,user_id,title,content,author_type,author_slot,created_at,updated_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapForumThreadRow(row as ForumThreadRow))
+}
+
+export const fetchForumThreadById = async (threadId: string): Promise<ForumThread | null> => {
+  if (!supabase) {
+    return null
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('forum_threads')
+    .select('id,user_id,title,content,author_type,author_slot,created_at,updated_at')
+    .eq('id', threadId)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+  return data ? mapForumThreadRow(data as ForumThreadRow) : null
+}
+
+export const createForumThread = async (params: {
+  title: string
+  content: string
+  authorType: ForumAuthorType
+  authorSlot?: number | null
+}): Promise<ForumThread> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('forum_threads')
+    .insert({
+      user_id: userId,
+      title: params.title,
+      content: params.content,
+      author_type: params.authorType,
+      author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id,user_id,title,content,author_type,author_slot,created_at,updated_at')
+    .single()
+
+  if (error || !data) {
+    throw error ?? new Error('创建论坛主题失败')
+  }
+  return mapForumThreadRow(data as ForumThreadRow)
+}
+
+export const fetchForumRepliesByThread = async (threadId: string): Promise<ForumReply[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('forum_replies')
+    .select('id,thread_id,user_id,content,author_type,author_slot,reply_to_type,reply_to_reply_id,created_at')
+    .eq('thread_id', threadId)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapForumReplyRow(row as ForumReplyRow))
+}
+
+export const createForumReply = async (params: {
+  threadId: string
+  content: string
+  authorType: ForumAuthorType
+  authorSlot?: number | null
+  replyToType?: 'thread' | 'reply' | null
+  replyToReplyId?: string | null
+}): Promise<ForumReply> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('forum_replies')
+    .insert({
+      thread_id: params.threadId,
+      user_id: userId,
+      content: params.content,
+      author_type: params.authorType,
+      author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
+      reply_to_type: params.replyToType ?? null,
+      reply_to_reply_id: params.replyToReplyId ?? null,
+    })
+    .select('id,thread_id,user_id,content,author_type,author_slot,reply_to_type,reply_to_reply_id,created_at')
+    .single()
+
+  if (error || !data) {
+    throw error ?? new Error('创建论坛回复失败')
+  }
+  return mapForumReplyRow(data as ForumReplyRow)
+}
+
+export const fetchForumAiProfiles = async (): Promise<ForumAiProfile[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('forum_ai_profiles')
+    .select('id,user_id,slot_index,enabled,display_name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
+    .eq('user_id', userId)
+    .in('slot_index', [1, 2, 3])
+    .order('slot_index', { ascending: true })
+
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapForumAiProfileRow(row as ForumAiProfileRow))
+}
+
+export const upsertForumAiProfile = async (
+  slotIndex: number,
+  payload: {
+    enabled: boolean
+    displayName: string
+    systemPrompt: string
+    model: string
+    temperature: number
+    topP: number
+    apiBaseUrl: string
+  },
+): Promise<ForumAiProfile> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('forum_ai_profiles')
+    .upsert(
+      {
+        user_id: userId,
+        slot_index: slotIndex,
+        enabled: payload.enabled,
+        display_name: payload.displayName,
+        system_prompt: payload.systemPrompt,
+        model: payload.model,
+        temperature: payload.temperature,
+        top_p: payload.topP,
+        api_base_url: payload.apiBaseUrl,
+        updated_at: now,
+      },
+      { onConflict: 'user_id,slot_index' },
+    )
+    .select('id,user_id,slot_index,enabled,display_name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
+    .single()
+
+  if (error || !data) {
+    throw error ?? new Error('保存论坛 AI 档案失败')
+  }
+
+  return mapForumAiProfileRow(data as ForumAiProfileRow)
+}
+
+export const fetchAllMemoryEntries = async (): Promise<MemoryEntry[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('memory_entries')
+    .select('id,user_id,content,source,status,created_at,updated_at,is_deleted')
+    .eq('user_id', userId)
+    .eq('is_deleted', false)
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapMemoryEntryRow(row as MemoryEntryRow))
 }
 
 export const listMemories = async (status: MemoryStatus): Promise<MemoryEntry[]> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,3 +170,43 @@ export type RpNpcCard = {
   createdAt: string
   updatedAt: string | null
 }
+
+export type ForumAuthorType = 'user' | 'ai'
+
+export type ForumThread = {
+  id: string
+  userId: string
+  title: string
+  content: string
+  authorType: ForumAuthorType
+  authorSlot: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ForumReply = {
+  id: string
+  threadId: string
+  userId: string
+  content: string
+  authorType: ForumAuthorType
+  authorSlot: number | null
+  replyToType: 'thread' | 'reply' | null
+  replyToReplyId: string | null
+  createdAt: string
+}
+
+export type ForumAiProfile = {
+  id: string
+  userId: string
+  slotIndex: number
+  enabled: boolean
+  displayName: string
+  systemPrompt: string
+  model: string
+  temperature: number
+  topP: number
+  apiBaseUrl: string
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
### Motivation
- Provide a first usable Forum feature as a post-style multi-author chat mode with explicit user control over AI generation. 
- Keep generation manual-only and thread-scoped so no background or cross-thread generation occurs. 
- Expose forum-specific AI profiles and settings so future generation flows can plug in identity, prompts and API config per slot. 

### Description
- Added routes and pages: `/forum` (thread list), `/forum/new` (create thread), `/forum/thread/:id` (thread detail), and `/forum/settings` (3 fixed AI profile cards). 
- Implemented UI flows for manual thread creation and reply creation, including author selection (user or AI slot 1/2/3) and explicit AI trigger buttons that call a request builder (no auto-generation). 
- Introduced new types `ForumThread`, `ForumReply`, `ForumAiProfile` and `ForumAuthorType` and wired Supabase CRUD helpers for `forum_threads`, `forum_replies`, `forum_ai_profiles`, plus `fetchAllMemoryEntries` to support future prompt layering. 
- Added `forumShared` helper to build a thread-scoped generation payload (system prompt layer, slot identity, current system time, full `memory_entries` injection, and thread-only context) and wired it to explicit OpenRouter-call style requests used by AI trigger buttons. 

### Testing
- Built the production bundle with `npm run build`, which completed successfully. 
- Ran linting with `npm run lint`, which completed successfully (one pre-existing `react-hooks/exhaustive-deps` warning in another page remained and did not block the PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9510eaf08330a779a8aa784d3f76)