### PR TITLE
Fix Forum MVP regression: remove inline AI settings and align Supabase queries

### DIFF
--- a/src/pages/ForumNewThreadPage.tsx
+++ b/src/pages/ForumNewThreadPage.tsx
@@ -96,6 +96,7 @@ const ForumNewThreadPage = () => {
           content: content.trim() || '（空草稿）',
           authorType: 'user',
           authorSlot: null,
+          authorName: null,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         },

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import type { ForumAiProfile, ForumThread } from '../types'
-import { fetchForumAiProfiles, fetchForumThreads } from '../storage/supabaseSync'
-import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel } from './forumShared'
+import type { ForumThread } from '../types'
+import { fetchForumThreads } from '../storage/supabaseSync'
+import { getForumAuthorLabel } from './forumShared'
 import './ForumPage.css'
 
 const formatTime = (value: string) =>
@@ -11,31 +11,16 @@ const formatTime = (value: string) =>
 const ForumPage = () => {
   const navigate = useNavigate()
   const [threads, setThreads] = useState<ForumThread[]>([])
-  const [profiles, setProfiles] = useState<ForumAiProfile[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-
-  const profilesBySlot = useMemo(() => {
-    const entries = new Map<number, ForumAiProfile>()
-    profiles.forEach((profile) => entries.set(profile.slotIndex, profile))
-    return FORUM_AI_SLOTS.map((slot) => entries.get(slot) ?? {
-      ...defaultForumProfile(slot),
-      id: `slot-${slot}`,
-      userId: '',
-      createdAt: '',
-      updatedAt: '',
-    })
-  }, [profiles])
 
   const refresh = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      const [threadList, profileList] = await Promise.all([fetchForumThreads(), fetchForumAiProfiles()])
+      const threadList = await fetchForumThreads()
       setThreads(threadList)
-      setProfiles(profileList)
-    } catch (loadError) {
-      console.warn('加载论坛失败', loadError)
+    } catch {
       setError('论坛加载失败，请稍后重试。')
     } finally {
       setLoading(false)
@@ -63,18 +48,6 @@ const ForumPage = () => {
         </div>
       </header>
 
-      <section className="forum-ai-overview glass-card">
-        <h2 className="ui-title">AI 档案</h2>
-        <div className="forum-ai-overview__cards">
-          {profilesBySlot.map((profile) => (
-            <article key={profile.slotIndex} className="forum-ai-mini-card">
-              <p>{profile.displayName}</p>
-              <small>{profile.enabled ? '已启用' : '已停用'}</small>
-            </article>
-          ))}
-        </div>
-      </section>
-
       <section className="forum-thread-list glass-card">
         <h2 className="ui-title">主题列表</h2>
         {loading ? <p>加载中…</p> : null}
@@ -88,7 +61,7 @@ const ForumPage = () => {
                 <p>{thread.content}</p>
               </div>
               <aside>
-                <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles)}</strong>
+                <strong>{thread.authorName ?? getForumAuthorLabel(thread.authorType, thread.authorSlot, [])}</strong>
                 <small>{formatTime(thread.createdAt)}</small>
               </aside>
             </Link>

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -68,7 +68,7 @@ const ForumThreadPage = () => {
     if (!target) {
       return '主题帖'
     }
-    return `${getForumAuthorLabel(target.authorType, target.authorSlot, profiles)} 的回复`
+    return `${getForumAuthorLabel(target.authorType, target.authorSlot, profiles, target.authorName)} 的回复`
   }, [profiles, replies, targetReplyId])
 
   const handleSubmitReply = async () => {
@@ -164,7 +164,7 @@ const ForumThreadPage = () => {
         <h2>{thread.title}</h2>
         <p>{thread.content}</p>
         <footer>
-          <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles)}</strong>
+          <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)}</strong>
           <small>{formatTime(thread.createdAt)}</small>
         </footer>
       </article>
@@ -177,14 +177,14 @@ const ForumThreadPage = () => {
               reply.replyToType === 'reply' ? replies.find((item) => item.id === reply.replyToReplyId) : null
             const targetName =
               reply.replyToType === 'thread'
-                ? getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles)
+                ? getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)
                 : target
-                  ? getForumAuthorLabel(target.authorType, target.authorSlot, profiles)
+                  ? getForumAuthorLabel(target.authorType, target.authorSlot, profiles, target.authorName)
                   : '未知目标'
             return (
               <article className="forum-reply-item" key={reply.id}>
                 <header>
-                  <strong>{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles)}</strong>
+                  <strong>{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}</strong>
                   <small>{formatTime(reply.createdAt)}</small>
                 </header>
                 <p>{reply.content}</p>
@@ -210,7 +210,7 @@ const ForumThreadPage = () => {
             <option value="thread-root">主题帖</option>
             {replies.map((reply, index) => (
               <option key={reply.id} value={reply.id}>
-                回复 #{index + 1}（{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles)}）
+                回复 #{index + 1}（{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}）
               </option>
             ))}
           </select>

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -19,7 +19,11 @@ export const getForumAuthorLabel = (
   authorType: 'user' | 'ai',
   authorSlot: number | null,
   profiles: ForumAiProfile[],
+  authorName?: string | null,
 ) => {
+  if (authorName && authorName.trim()) {
+    return authorName
+  }
   if (authorType === 'user') {
     return '你'
   }

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -149,9 +149,10 @@ type ForumThreadRow = {
   id: string
   user_id: string
   title: string
-  content: string
+  body: string
   author_type: ForumAuthorType
   author_slot: number | null
+  author_name: string | null
   created_at: string
   updated_at: string
 }
@@ -160,11 +161,12 @@ type ForumReplyRow = {
   id: string
   thread_id: string
   user_id: string
-  content: string
+  body: string
   author_type: ForumAuthorType
   author_slot: number | null
-  reply_to_type: 'thread' | 'reply' | null
+  author_name: string | null
   reply_to_reply_id: string | null
+  reply_to_author_name: string | null
   created_at: string
 }
 
@@ -173,7 +175,7 @@ type ForumAiProfileRow = {
   user_id: string
   slot_index: number
   enabled: boolean | null
-  display_name: string | null
+  name: string | null
   system_prompt: string | null
   model: string | null
   temperature: number | null
@@ -307,9 +309,10 @@ const mapForumThreadRow = (row: ForumThreadRow): ForumThread => ({
   id: row.id,
   userId: row.user_id,
   title: row.title,
-  content: row.content,
+  content: row.body,
   authorType: row.author_type,
   authorSlot: row.author_slot,
+  authorName: row.author_name,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
 })
@@ -318,11 +321,13 @@ const mapForumReplyRow = (row: ForumReplyRow): ForumReply => ({
   id: row.id,
   threadId: row.thread_id,
   userId: row.user_id,
-  content: row.content,
+  content: row.body,
   authorType: row.author_type,
   authorSlot: row.author_slot,
-  replyToType: row.reply_to_type,
+  authorName: row.author_name,
+  replyToType: row.reply_to_reply_id ? 'reply' : 'thread',
   replyToReplyId: row.reply_to_reply_id,
+  replyToAuthorName: row.reply_to_author_name,
   createdAt: row.created_at,
 })
 
@@ -331,7 +336,7 @@ const mapForumAiProfileRow = (row: ForumAiProfileRow): ForumAiProfile => ({
   userId: row.user_id,
   slotIndex: row.slot_index,
   enabled: row.enabled ?? true,
-  displayName: row.display_name ?? `AI Slot ${row.slot_index}`,
+  displayName: row.name ?? `AI Slot ${row.slot_index}`,
   systemPrompt: row.system_prompt ?? '',
   model: row.model ?? 'openrouter/auto',
   temperature: row.temperature ?? 0.8,
@@ -1470,7 +1475,7 @@ export const fetchForumThreads = async (): Promise<ForumThread[]> => {
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_threads')
-    .select('id,user_id,title,content,author_type,author_slot,created_at,updated_at')
+    .select('id,user_id,title,body,author_type,author_slot,author_name,created_at,updated_at')
     .eq('user_id', userId)
     .order('created_at', { ascending: false })
 
@@ -1487,7 +1492,7 @@ export const fetchForumThreadById = async (threadId: string): Promise<ForumThrea
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_threads')
-    .select('id,user_id,title,content,author_type,author_slot,created_at,updated_at')
+    .select('id,user_id,title,body,author_type,author_slot,author_name,created_at,updated_at')
     .eq('id', threadId)
     .eq('user_id', userId)
     .maybeSingle()
@@ -1514,13 +1519,14 @@ export const createForumThread = async (params: {
     .insert({
       user_id: userId,
       title: params.title,
-      content: params.content,
+      body: params.content,
       author_type: params.authorType,
       author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
+      author_name: null,
       created_at: now,
       updated_at: now,
     })
-    .select('id,user_id,title,content,author_type,author_slot,created_at,updated_at')
+    .select('id,user_id,title,body,author_type,author_slot,author_name,created_at,updated_at')
     .single()
 
   if (error || !data) {
@@ -1536,7 +1542,7 @@ export const fetchForumRepliesByThread = async (threadId: string): Promise<Forum
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_replies')
-    .select('id,thread_id,user_id,content,author_type,author_slot,reply_to_type,reply_to_reply_id,created_at')
+    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
     .eq('thread_id', threadId)
     .eq('user_id', userId)
     .order('created_at', { ascending: true })
@@ -1564,13 +1570,14 @@ export const createForumReply = async (params: {
     .insert({
       thread_id: params.threadId,
       user_id: userId,
-      content: params.content,
+      body: params.content,
       author_type: params.authorType,
       author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
-      reply_to_type: params.replyToType ?? null,
+      author_name: null,
       reply_to_reply_id: params.replyToReplyId ?? null,
+      reply_to_author_name: null,
     })
-    .select('id,thread_id,user_id,content,author_type,author_slot,reply_to_type,reply_to_reply_id,created_at')
+    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
     .single()
 
   if (error || !data) {
@@ -1586,7 +1593,7 @@ export const fetchForumAiProfiles = async (): Promise<ForumAiProfile[]> => {
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_ai_profiles')
-    .select('id,user_id,slot_index,enabled,display_name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
+    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
     .eq('user_id', userId)
     .in('slot_index', [1, 2, 3])
     .order('slot_index', { ascending: true })
@@ -1621,7 +1628,7 @@ export const upsertForumAiProfile = async (
         user_id: userId,
         slot_index: slotIndex,
         enabled: payload.enabled,
-        display_name: payload.displayName,
+        name: payload.displayName,
         system_prompt: payload.systemPrompt,
         model: payload.model,
         temperature: payload.temperature,
@@ -1631,7 +1638,7 @@ export const upsertForumAiProfile = async (
       },
       { onConflict: 'user_id,slot_index' },
     )
-    .select('id,user_id,slot_index,enabled,display_name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
+    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
     .single()
 
   if (error || !data) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,7 @@ export type ForumThread = {
   content: string
   authorType: ForumAuthorType
   authorSlot: number | null
+  authorName: string | null
   createdAt: string
   updatedAt: string
 }
@@ -191,8 +192,10 @@ export type ForumReply = {
   content: string
   authorType: ForumAuthorType
   authorSlot: number | null
+  authorName: string | null
   replyToType: 'thread' | 'reply' | null
   replyToReplyId: string | null
+  replyToAuthorName: string | null
   createdAt: string
 }
 


### PR DESCRIPTION
### Motivation
- The Forum main page was embedding the 3 AI profile cards and fetching AI profile columns that do not match the Supabase schema, causing PostgREST 400 errors and a broken thread list load. 
- The product behavior requires the AI profiles to live on a separate settings page and the thread list to load successfully from the existing Supabase schema. 

### Description
- Aligned all Forum queries with the Supabase schema by switching `content` → `body` on `forum_threads`/`forum_replies`, and `display_name` → `name` on `forum_ai_profiles`, and by using `reply_to_reply_id` and `reply_to_author_name` where appropriate. 
- Updated row mappers (`mapForumThreadRow`, `mapForumReplyRow`, `mapForumAiProfileRow`) to map DB fields to app domain fields (`content`, `displayName`) and added `authorName` / `replyToAuthorName` to the domain shapes. 
- Removed AI profile fetching and inline AI-mini cards from the `/forum` main page and left the `Forum 设置` button to navigate to the dedicated `/forum/settings` page where the 3 AI profile cards are managed. 
- Updated `getForumAuthorLabel` and thread/reply rendering to prefer server-provided `authorName` when present, and adjusted new-thread AI draft objects to include `authorName: null` for type compatibility. 

### Testing
- Ran `npm run build` which succeeded after the schema fixes were applied. 
- Ran `npm run lint` which completed successfully (there is one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`). 
- Started the dev server and verified the app built and served assets locally (`vite` dev server started). 
- Attempted a Playwright screenshot run to capture the `/forum` page, but the Chromium process crashed in this environment (SIGSEGV), so no E2E screenshot artifact was produced; the runtime crash is environmental and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac4143ac348330a4ae7b9832d0dac4)