### PR TITLE
Fix forum thread/reply inserts to always include author_name

### DIFF
--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -3,6 +3,7 @@ import { supabase } from '../supabase/client'
 import type { MemoryEntry } from '../types'
 
 export const FORUM_AI_SLOTS = [1, 2, 3] as const
+export const FORUM_USER_DISPLAY_NAME = '串串'
 
 export const defaultForumProfile = (slotIndex: number): Omit<ForumAiProfile, 'id' | 'userId' | 'createdAt' | 'updatedAt'> => ({
   slotIndex,
@@ -25,7 +26,7 @@ export const getForumAuthorLabel = (
     return authorName
   }
   if (authorType === 'user') {
-    return '你'
+    return FORUM_USER_DISPLAY_NAME
   }
   const profile = profiles.find((item) => item.slotIndex === authorSlot)
   if (profile?.displayName) {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -18,6 +18,8 @@ import type {
 } from '../types'
 import { supabase } from '../supabase/client'
 
+const FORUM_USER_AUTHOR_NAME = '串串'
+
 type SessionRow = {
   id: string
   user_id: string
@@ -1468,6 +1470,63 @@ export const permanentlyDeleteSyzygyReply = async (replyId: string): Promise<voi
   }
 }
 
+const resolveForumAuthorPayload = async (
+  userId: string,
+  authorType: ForumAuthorType,
+  authorSlot?: number | null,
+): Promise<{ authorSlot: number | null; authorName: string }> => {
+  if (authorType === 'user') {
+    return { authorSlot: null, authorName: FORUM_USER_AUTHOR_NAME }
+  }
+
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+
+  const normalizedSlot = authorSlot ?? 1
+  const { data, error } = await supabase
+    .from('forum_ai_profiles')
+    .select('name')
+    .eq('user_id', userId)
+    .eq('slot_index', normalizedSlot)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  const profileName = data?.name?.trim()
+  return {
+    authorSlot: normalizedSlot,
+    authorName: profileName || `AI Slot ${normalizedSlot}`,
+  }
+}
+
+const resolveReplyTargetAuthorName = async (userId: string, threadId: string, replyId?: string | null) => {
+  if (!replyId) {
+    return null
+  }
+
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+
+  const { data, error } = await supabase
+    .from('forum_replies')
+    .select('author_name')
+    .eq('id', replyId)
+    .eq('thread_id', threadId)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  const targetName = data?.author_name?.trim()
+  return targetName || null
+}
+
 export const fetchForumThreads = async (): Promise<ForumThread[]> => {
   if (!supabase) {
     return []
@@ -1514,6 +1573,7 @@ export const createForumThread = async (params: {
   }
   const userId = await requireAuthenticatedUserId()
   const now = new Date().toISOString()
+  const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
   const { data, error } = await supabase
     .from('forum_threads')
     .insert({
@@ -1521,8 +1581,8 @@ export const createForumThread = async (params: {
       title: params.title,
       body: params.content,
       author_type: params.authorType,
-      author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
-      author_name: null,
+      author_slot: authorPayload.authorSlot,
+      author_name: authorPayload.authorName,
       created_at: now,
       updated_at: now,
     })
@@ -1565,6 +1625,8 @@ export const createForumReply = async (params: {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
+  const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
+  const replyToAuthorName = await resolveReplyTargetAuthorName(userId, params.threadId, params.replyToReplyId)
   const { data, error } = await supabase
     .from('forum_replies')
     .insert({
@@ -1572,10 +1634,10 @@ export const createForumReply = async (params: {
       user_id: userId,
       body: params.content,
       author_type: params.authorType,
-      author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
-      author_name: null,
+      author_slot: authorPayload.authorSlot,
+      author_name: authorPayload.authorName,
       reply_to_reply_id: params.replyToReplyId ?? null,
-      reply_to_author_name: null,
+      reply_to_author_name: replyToAuthorName,
     })
     .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
     .single()


### PR DESCRIPTION
### Motivation
- Inserts into `forum_threads` and `forum_replies` were omitting `author_name`, triggering Supabase NOT NULL violations and inconsistent author display behavior.
- The insert payload must embed a stable non-null author name and correct `author_slot` semantics for both user-created and AI-created content.
- Replies must also populate `reply_to_author_name` when replying to another reply to keep UI labels consistent.

### Description
- Added `FORUM_USER_DISPLAY_NAME` in `src/pages/forumShared.ts` and `FORUM_USER_AUTHOR_NAME` in `src/storage/supabaseSync.ts` to centralize the local user display name (`'串串'`).
- Introduced `resolveForumAuthorPayload` to compute `{ authorSlot, authorName }` for a given author type and slot, reading `forum_ai_profiles.name` for AI slots and falling back to `AI Slot N` when needed.
- Introduced `resolveReplyTargetAuthorName` to resolve `reply_to_author_name` when replying to a reply.
- Updated `createForumThread` and `createForumReply` to use the resolved payload so inserts always include non-null `author_name` and correct `author_slot` values.
- Updated `getForumAuthorLabel` fallback to use the stable local display name instead of `你` for consistent UI labeling.
- No database schema changes were made; this is a frontend payload construction fix only.

### Testing
- Ran the TypeScript build and app build via `npm run build`, which completed successfully.
- Verified the application compiles with the modified `supabaseSync` logic (no runtime type errors during build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac454fccc083309daa2f3d5f30843d)