### PR TITLE
Persist forum author names/slots and use unified forum user display name

### DIFF
--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -3,6 +3,7 @@ import { supabase } from '../supabase/client'
 import type { MemoryEntry } from '../types'
 
 export const FORUM_AI_SLOTS = [1, 2, 3] as const
+export const FORUM_USER_DISPLAY_NAME = '串串'
 
 export const defaultForumProfile = (slotIndex: number): Omit<ForumAiProfile, 'id' | 'userId' | 'createdAt' | 'updatedAt'> => ({
   slotIndex,
@@ -25,7 +26,7 @@ export const getForumAuthorLabel = (
     return authorName
   }
   if (authorType === 'user') {
-    return '你'
+    return FORUM_USER_DISPLAY_NAME
   }
   const profile = profiles.find((item) => item.slotIndex === authorSlot)
   if (profile?.displayName) {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -18,6 +18,8 @@ import type {
 } from '../types'
 import { supabase } from '../supabase/client'
 
+const FORUM_USER_AUTHOR_NAME = '串串'
+
 type SessionRow = {
   id: string
   user_id: string
@@ -1468,6 +1470,77 @@ export const permanentlyDeleteSyzygyReply = async (replyId: string): Promise<voi
   }
 }
 
+const resolveForumAuthorPayload = async (
+  userId: string,
+  authorType: ForumAuthorType,
+  authorSlot?: number | null,
+): Promise<{ authorSlot: number | null; authorName: string }> => {
+  if (authorType === 'user') {
+    return { authorSlot: null, authorName: FORUM_USER_AUTHOR_NAME }
+  }
+
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+
+  const normalizedSlot = authorSlot ?? 1
+  const { data, error } = await supabase
+    .from('forum_ai_profiles')
+    .select('name')
+    .eq('user_id', userId)
+    .eq('slot_index', normalizedSlot)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  const profileName = data?.name?.trim()
+  return {
+    authorSlot: normalizedSlot,
+    authorName: profileName || `AI Slot ${normalizedSlot}`,
+  }
+}
+
+const resolveReplyTargetAuthorName = async (userId: string, threadId: string, replyId?: string | null) => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+
+  if (replyId) {
+    const { data, error } = await supabase
+      .from('forum_replies')
+      .select('author_name')
+      .eq('id', replyId)
+      .eq('thread_id', threadId)
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    const targetName = data?.author_name?.trim()
+    if (targetName) {
+      return targetName
+    }
+  }
+
+  const { data: threadData, error: threadError } = await supabase
+    .from('forum_threads')
+    .select('author_name')
+    .eq('id', threadId)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (threadError) {
+    throw threadError
+  }
+
+  const threadAuthorName = threadData?.author_name?.trim()
+  return threadAuthorName || FORUM_USER_AUTHOR_NAME
+}
+
 export const fetchForumThreads = async (): Promise<ForumThread[]> => {
   if (!supabase) {
     return []
@@ -1514,6 +1587,7 @@ export const createForumThread = async (params: {
   }
   const userId = await requireAuthenticatedUserId()
   const now = new Date().toISOString()
+  const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
   const { data, error } = await supabase
     .from('forum_threads')
     .insert({
@@ -1521,8 +1595,8 @@ export const createForumThread = async (params: {
       title: params.title,
       body: params.content,
       author_type: params.authorType,
-      author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
-      author_name: null,
+      author_slot: authorPayload.authorSlot,
+      author_name: authorPayload.authorName,
       created_at: now,
       updated_at: now,
     })
@@ -1565,6 +1639,9 @@ export const createForumReply = async (params: {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
+  const normalizedReplyToReplyId = params.replyToType === 'thread' ? null : params.replyToReplyId ?? null
+  const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
+  const replyToAuthorName = await resolveReplyTargetAuthorName(userId, params.threadId, normalizedReplyToReplyId)
   const { data, error } = await supabase
     .from('forum_replies')
     .insert({
@@ -1572,10 +1649,10 @@ export const createForumReply = async (params: {
       user_id: userId,
       body: params.content,
       author_type: params.authorType,
-      author_slot: params.authorType === 'ai' ? params.authorSlot ?? 1 : null,
-      author_name: null,
-      reply_to_reply_id: params.replyToReplyId ?? null,
-      reply_to_author_name: null,
+      author_slot: authorPayload.authorSlot,
+      author_name: authorPayload.authorName,
+      reply_to_reply_id: normalizedReplyToReplyId,
+      reply_to_author_name: replyToAuthorName,
     })
     .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
     .single()


### PR DESCRIPTION
### Motivation

- Ensure forum posts and replies store a consistent readable author name for user-created content instead of a hardcoded label, and unify the displayed user label across the app.

### Description

- Add `FORUM_USER_DISPLAY_NAME` in `src/pages/forumShared.ts` and use it in `getForumAuthorLabel` to replace the previous hardcoded `'你'` label.
- Add `FORUM_USER_AUTHOR_NAME` and two helper functions `resolveForumAuthorPayload` and `resolveReplyTargetAuthorName` in `src/storage/supabaseSync.ts` to resolve and return `author_slot` and `author_name` for threads and replies, including looking up AI profile names from `forum_ai_profiles` and falling back to a default.
- Update `createForumThread` to populate `author_slot` and `author_name` using the new resolver before inserting into `forum_threads`.
- Update `createForumReply` to normalize `replyToReplyId` for thread replies and populate `author_slot`, `author_name`, and `reply_to_author_name` using the new resolvers before inserting into `forum_replies`.

### Testing

- Ran the TypeScript typecheck and project build (`tsc`/`yarn build`) and the automated test suite (`yarn test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac454fccc083309daa2f3d5f30843d)