### PR TITLE
Add delete actions for forum threads and replies

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -43,9 +43,26 @@
   border: 1px solid rgba(148, 163, 184, 0.36);
   border-radius: 14px;
   padding: 0.8rem;
-  text-decoration: none;
   color: inherit;
   background: rgba(255, 255, 255, 0.62);
+}
+
+.forum-thread-item__main {
+  border: none;
+  background: transparent;
+  padding: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.forum-thread-item__actions {
+  display: flex;
+  align-items: center;
 }
 
 .forum-thread-item h3,
@@ -69,6 +86,11 @@
   gap: 0.2rem;
   justify-items: end;
   color: #475569;
+}
+
+.forum-success {
+  color: #047857;
+  margin: 0;
 }
 
 .forum-root-post h2,

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import type { ForumThread } from '../types'
-import { fetchForumThreads } from '../storage/supabaseSync'
+import ConfirmDialog from '../components/ConfirmDialog'
+import { deleteForumThread, fetchForumThreads } from '../storage/supabaseSync'
 import { getForumAuthorLabel } from './forumShared'
 import './ForumPage.css'
 
@@ -10,9 +11,13 @@ const formatTime = (value: string) =>
 
 const ForumPage = () => {
   const navigate = useNavigate()
+  const location = useLocation()
   const [threads, setThreads] = useState<ForumThread[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [deletingThreadId, setDeletingThreadId] = useState<string | null>(null)
+  const [pendingDeleteThreadId, setPendingDeleteThreadId] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -28,8 +33,37 @@ const ForumPage = () => {
   }, [])
 
   useEffect(() => {
+    const initialSuccess = (location.state as { forumSuccessMessage?: string } | null)?.forumSuccessMessage
+    if (initialSuccess) {
+      setSuccessMessage(initialSuccess)
+      navigate(location.pathname, { replace: true, state: null })
+    }
     void refresh()
-  }, [refresh])
+  }, [location.pathname, location.state, navigate, refresh])
+
+
+  const handleOpenDeleteDialog = (threadId: string) => {
+    setPendingDeleteThreadId(threadId)
+  }
+
+  const handleDeleteThread = async () => {
+    if (!pendingDeleteThreadId) {
+      return
+    }
+    setDeletingThreadId(pendingDeleteThreadId)
+    setError(null)
+    try {
+      await deleteForumThread(pendingDeleteThreadId)
+      setThreads((current) => current.filter((thread) => thread.id !== pendingDeleteThreadId))
+      setSuccessMessage('主题已删除。')
+      setPendingDeleteThreadId(null)
+    } catch (deleteError) {
+      console.warn('删除主题失败', deleteError)
+      setError('删除失败，请稍后重试。')
+    } finally {
+      setDeletingThreadId(null)
+    }
+  }
 
   return (
     <div className="forum-page app-shell__content">
@@ -52,22 +86,51 @@ const ForumPage = () => {
         <h2 className="ui-title">主题列表</h2>
         {loading ? <p>加载中…</p> : null}
         {error ? <p className="forum-error">{error}</p> : null}
+        {successMessage ? <p className="forum-success">{successMessage}</p> : null}
         {!loading && !error && threads.length === 0 ? <p>还没有主题，先创建第一条吧。</p> : null}
         <div className="forum-thread-list__items">
           {threads.map((thread) => (
-            <Link key={thread.id} className="forum-thread-item" to={`/forum/thread/${thread.id}`}>
-              <div>
-                <h3>{thread.title}</h3>
-                <p>{thread.content}</p>
+            <article key={thread.id} className="forum-thread-item">
+              <button
+                type="button"
+                className="forum-thread-item__main"
+                onClick={() => navigate(`/forum/thread/${thread.id}`)}
+              >
+                <div>
+                  <h3>{thread.title}</h3>
+                  <p>{thread.content}</p>
+                </div>
+                <aside>
+                  <strong>{thread.authorName ?? getForumAuthorLabel(thread.authorType, thread.authorSlot, [])}</strong>
+                  <small>{formatTime(thread.createdAt)}</small>
+                </aside>
+              </button>
+              <div className="forum-thread-item__actions">
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={() => handleOpenDeleteDialog(thread.id)}
+                  disabled={deletingThreadId === thread.id}
+                >
+                  {deletingThreadId === thread.id ? '删除中…' : '删除'}
+                </button>
               </div>
-              <aside>
-                <strong>{thread.authorName ?? getForumAuthorLabel(thread.authorType, thread.authorSlot, [])}</strong>
-                <small>{formatTime(thread.createdAt)}</small>
-              </aside>
-            </Link>
+            </article>
           ))}
         </div>
       </section>
+
+      <ConfirmDialog
+        open={pendingDeleteThreadId !== null}
+        title="确定删除这个主题吗？"
+        description="删除后将同时移除该主题下的全部回复。"
+        confirmLabel="删除"
+        cancelLabel="取消"
+        confirmDisabled={deletingThreadId !== null}
+        cancelDisabled={deletingThreadId !== null}
+        onCancel={() => setPendingDeleteThreadId(null)}
+        onConfirm={() => void handleDeleteThread()}
+      />
     </div>
   )
 }

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -3,11 +3,14 @@ import { useNavigate, useParams } from 'react-router-dom'
 import type { ForumAiProfile, ForumReply, ForumThread } from '../types'
 import {
   createForumReply,
+  deleteForumReply,
+  deleteForumThread,
   fetchAllMemoryEntries,
   fetchForumAiProfiles,
   fetchForumRepliesByThread,
   fetchForumThreadById,
 } from '../storage/supabaseSync'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel, requestForumAiContent } from './forumShared'
 import './ForumPage.css'
 
@@ -26,6 +29,11 @@ const ForumThreadPage = () => {
   const [submitting, setSubmitting] = useState(false)
   const [generatingSlot, setGeneratingSlot] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [pendingDeleteThread, setPendingDeleteThread] = useState(false)
+  const [pendingDeleteReplyId, setPendingDeleteReplyId] = useState<string | null>(null)
+  const [deletingThread, setDeletingThread] = useState(false)
+  const [deletingReplyId, setDeletingReplyId] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
     if (!id) {
@@ -33,6 +41,7 @@ const ForumThreadPage = () => {
     }
     setLoading(true)
     setError(null)
+    setSuccessMessage(null)
     try {
       const [threadData, replyData, profileData] = await Promise.all([
         fetchForumThreadById(id),
@@ -53,6 +62,47 @@ const ForumThreadPage = () => {
   useEffect(() => {
     void refresh()
   }, [refresh])
+
+
+  const handleDeleteThread = async () => {
+    if (!thread || deletingThread) {
+      return
+    }
+    setDeletingThread(true)
+    setError(null)
+    setSuccessMessage(null)
+    try {
+      await deleteForumThread(thread.id)
+      navigate('/forum', { replace: true, state: { forumSuccessMessage: '主题已删除。' } })
+    } catch (deleteError) {
+      console.warn('删除主题失败', deleteError)
+      setError('删除主题失败，请稍后重试。')
+    } finally {
+      setDeletingThread(false)
+      setPendingDeleteThread(false)
+    }
+  }
+
+  const handleDeleteReply = async () => {
+    if (!thread || !pendingDeleteReplyId) {
+      return
+    }
+    setDeletingReplyId(pendingDeleteReplyId)
+    setError(null)
+    setSuccessMessage(null)
+    try {
+      await deleteForumReply(pendingDeleteReplyId, thread.id)
+      setReplies((current) => current.filter((item) => item.id !== pendingDeleteReplyId))
+      setTargetReplyId((current) => (current === pendingDeleteReplyId ? 'thread-root' : current))
+      setSuccessMessage('回复已删除。')
+      setPendingDeleteReplyId(null)
+    } catch (deleteError) {
+      console.warn('删除回复失败', deleteError)
+      setError('删除回复失败，请稍后重试。')
+    } finally {
+      setDeletingReplyId(null)
+    }
+  }
 
   const profileMap = useMemo(() => {
     const map = new Map<number, ForumAiProfile>()
@@ -166,6 +216,9 @@ const ForumThreadPage = () => {
         <footer>
           <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)}</strong>
           <small>{formatTime(thread.createdAt)}</small>
+          <button type="button" className="btn-secondary" onClick={() => setPendingDeleteThread(true)}>
+            删除主题
+          </button>
         </footer>
       </article>
 
@@ -191,6 +244,14 @@ const ForumThreadPage = () => {
                 <footer>
                   <span>#{index + 1}</span>
                   <span>回复给：{targetName}</span>
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={() => setPendingDeleteReplyId(reply.id)}
+                    disabled={deletingReplyId === reply.id}
+                  >
+                    {deletingReplyId === reply.id ? '删除中…' : '删除'}
+                  </button>
                 </footer>
               </article>
             )
@@ -226,6 +287,7 @@ const ForumThreadPage = () => {
           />
         </label>
         {error ? <p className="forum-error">{error}</p> : null}
+        {successMessage ? <p className="forum-success">{successMessage}</p> : null}
         <div className="forum-editor__actions">
           <button type="button" className="btn-primary" disabled={submitting} onClick={handleSubmitReply}>
             发布用户回复
@@ -252,6 +314,28 @@ const ForumThreadPage = () => {
           })}
         </div>
       </section>
+
+      <ConfirmDialog
+        open={pendingDeleteThread}
+        title="确定删除这个主题吗？"
+        description="删除后将同时移除该主题下的全部回复。"
+        confirmLabel="删除"
+        cancelLabel="取消"
+        confirmDisabled={deletingThread}
+        cancelDisabled={deletingThread}
+        onCancel={() => setPendingDeleteThread(false)}
+        onConfirm={() => void handleDeleteThread()}
+      />
+      <ConfirmDialog
+        open={pendingDeleteReplyId !== null}
+        title="确定删除这条回复吗？"
+        confirmLabel="删除"
+        cancelLabel="取消"
+        confirmDisabled={deletingReplyId !== null}
+        cancelDisabled={deletingReplyId !== null}
+        onCancel={() => setPendingDeleteReplyId(null)}
+        onConfirm={() => void handleDeleteReply()}
+      />
     </div>
   )
 }

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1663,6 +1663,35 @@ export const createForumReply = async (params: {
   return mapForumReplyRow(data as ForumReplyRow)
 }
 
+export const deleteForumThread = async (threadId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase.from('forum_threads').delete().eq('id', threadId).eq('user_id', userId)
+
+  if (error) {
+    throw error
+  }
+}
+
+export const deleteForumReply = async (replyId: string, threadId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('forum_replies')
+    .delete()
+    .eq('id', replyId)
+    .eq('thread_id', threadId)
+    .eq('user_id', userId)
+
+  if (error) {
+    throw error
+  }
+}
+
 export const fetchForumAiProfiles = async (): Promise<ForumAiProfile[]> => {
   if (!supabase) {
     return []


### PR DESCRIPTION
### Motivation
- Provide deletion support for the Forum MVP so users can remove entire threads (with replies) and individual replies.  
- Ensure destructive actions require confirmation and provide lightweight success feedback and correct UI refresh/navigation.  
- Keep permission behavior simple by relying on existing RLS/user-scoping and database cascade for thread -> replies removal.

### Description
- Add `deleteForumThread(threadId)` and `deleteForumReply(replyId, threadId)` helpers in `src/storage/supabaseSync.ts` that call Supabase `.delete()` and scope by authenticated `user_id`.  
- Update forum list UI in `src/pages/ForumPage.tsx` to present thread cards with a per-item delete button, a confirmation dialog using the existing `ConfirmDialog` component, inline success/error messages, and local state removal of deleted threads.  
- Update thread detail UI in `src/pages/ForumThreadPage.tsx` to add a delete button on the root post and a delete button for each reply, confirmation dialogs, local reply list updates after deletion, and navigation back to `/forum` with a success message when a thread is deleted.  
- Adjust styles in `src/pages/ForumPage.css` to support the new card/action layout and success text while keeping destructive visuals non-aggressive.

### Testing
- Executed `npm run build` (TypeScript compile + Vite build) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad08978e308330a294b40bb49d7985)