### PR TITLE
Refactor Forum AI settings UI and align generation with global model settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1436,7 +1436,7 @@ const App = () => {
           path="/forum/settings"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <ForumSettingsPage />
+              <ForumSettingsPage user={user} />
             </RequireAuth>
           }
         />

--- a/src/pages/ForumNewThreadPage.tsx
+++ b/src/pages/ForumNewThreadPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ForumAiProfile } from '../types'
 import { createForumThread, fetchAllMemoryEntries, fetchForumAiProfiles } from '../storage/supabaseSync'
-import { FORUM_AI_SLOTS, defaultForumProfile, requestForumAiContent } from './forumShared'
+import { FORUM_AI_SLOTS, defaultForumProfile, loadForumGlobalAiConfig, requestForumAiContent, type ForumGlobalAiConfig } from './forumShared'
 import './ForumPage.css'
 
 type AuthorDraft = 'user' | 'ai-1' | 'ai-2' | 'ai-3'
@@ -17,6 +17,7 @@ const ForumNewThreadPage = () => {
   const [submitting, setSubmitting] = useState(false)
   const [generating, setGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [globalAiConfig, setGlobalAiConfig] = useState<ForumGlobalAiConfig | null>(null)
 
   const authorIsAi = authorDraft !== 'user'
   const selectedSlot = authorIsAi ? Number(authorDraft.split('-')[1]) : null
@@ -25,8 +26,9 @@ const ForumNewThreadPage = () => {
     const loadProfiles = async () => {
       setLoading(true)
       try {
-        const list = await fetchForumAiProfiles()
+        const [list, config] = await Promise.all([fetchForumAiProfiles(), loadForumGlobalAiConfig()])
         setProfiles(list)
+        setGlobalAiConfig(config)
       } catch (loadError) {
         console.warn('加载 AI 配置失败', loadError)
       } finally {
@@ -73,7 +75,7 @@ const ForumNewThreadPage = () => {
   }
 
   const handleGenerateAiThread = async () => {
-    if (!authorIsAi || !selectedSlot || !title.trim()) {
+    if (!authorIsAi || !selectedSlot || !title.trim() || !globalAiConfig) {
       return
     }
     const profile = profileLookup.get(selectedSlot)
@@ -88,6 +90,7 @@ const ForumNewThreadPage = () => {
       const generated = await requestForumAiContent({
         profile,
         memoryEntries,
+        globalModelConfig: globalAiConfig,
         task: 'new-thread',
         thread: {
           id: 'draft-thread',
@@ -112,6 +115,8 @@ const ForumNewThreadPage = () => {
       setGenerating(false)
     }
   }
+
+  const aiConfigReady = Boolean(globalAiConfig)
 
   return (
     <div className="forum-page app-shell__content">
@@ -170,7 +175,7 @@ const ForumNewThreadPage = () => {
           <button
             type="button"
             className="btn-secondary"
-            disabled={!authorIsAi || submitting || generating}
+            disabled={!authorIsAi || submitting || generating || !aiConfigReady}
             onClick={handleGenerateAiThread}
           >
             {generating ? 'AI 生成中…' : '生成 AI 主题'}

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -134,3 +134,77 @@
 .forum-loading {
   padding: 1rem;
 }
+
+.forum-settings-list,
+.forum-settings-editor {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.forum-settings-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.forum-settings-summary {
+  margin: 0;
+  color: #334155;
+}
+
+.forum-settings-list__cards {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.forum-settings-summary-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.36);
+  border-radius: 14px;
+  padding: 0.8rem;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.forum-settings-summary-card__name,
+.forum-settings-summary-card__meta {
+  margin: 0;
+}
+
+.forum-settings-summary-card__name {
+  font-weight: 600;
+}
+
+.forum-settings-summary-card__meta {
+  margin-top: 0.3rem;
+  color: #475569;
+  font-size: 0.92rem;
+}
+
+.forum-settings-editor__grid {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.forum-settings-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.forum-model-warning {
+  margin: 0;
+  color: #b45309;
+}
+
+@media (max-width: 640px) {
+  .forum-settings-summary-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/pages/ForumSettingsPage.tsx
+++ b/src/pages/ForumSettingsPage.tsx
@@ -1,11 +1,21 @@
 import { useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
 import { useNavigate } from 'react-router-dom'
+import { useEnabledModels } from '../hooks/useEnabledModels'
 import type { ForumAiProfile } from '../types'
 import { fetchForumAiProfiles, upsertForumAiProfile } from '../storage/supabaseSync'
 import { FORUM_AI_SLOTS, defaultForumProfile } from './forumShared'
 import './ForumPage.css'
 
-const toCard = (slotIndex: number, profile?: ForumAiProfile) => ({
+type ForumSettingsPageProps = {
+  user: User | null
+}
+
+type EditorMode =
+  | { type: 'list' }
+  | { type: 'edit'; slotIndex: number }
+
+const toCard = (slotIndex: number, profile?: ForumAiProfile): ForumAiProfile => ({
   ...(profile ?? {
     ...defaultForumProfile(slotIndex),
     id: `slot-${slotIndex}`,
@@ -15,19 +25,22 @@ const toCard = (slotIndex: number, profile?: ForumAiProfile) => ({
   }),
 })
 
-const ForumSettingsPage = () => {
+const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
   const navigate = useNavigate()
   const [profiles, setProfiles] = useState<ForumAiProfile[]>([])
   const [loading, setLoading] = useState(true)
   const [savingSlot, setSavingSlot] = useState<number | null>(null)
+  const [mode, setMode] = useState<EditorMode>({ type: 'list' })
+  const [draft, setDraft] = useState<ForumAiProfile | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const { enabledModelOptions } = useEnabledModels(user)
 
   useEffect(() => {
     const load = async () => {
       setLoading(true)
       try {
         const data = await fetchForumAiProfiles()
-        setProfiles(data)
+        setProfiles(data.sort((a, b) => a.slotIndex - b.slotIndex))
       } catch (loadError) {
         console.warn('加载论坛 AI 档案失败', loadError)
         setError('加载失败，请稍后重试。')
@@ -38,47 +51,75 @@ const ForumSettingsPage = () => {
     void load()
   }, [])
 
-  const cards = useMemo(() => {
+  const cardsBySlot = useMemo(() => {
     const map = new Map<number, ForumAiProfile>()
     profiles.forEach((item) => map.set(item.slotIndex, item))
-    return FORUM_AI_SLOTS.map((slot) => toCard(slot, map.get(slot)))
+    return map
   }, [profiles])
 
-  const updateCard = (slotIndex: number, updater: (card: ForumAiProfile) => ForumAiProfile) => {
-    setProfiles((current) => {
-      const map = new Map<number, ForumAiProfile>()
-      current.forEach((item) => map.set(item.slotIndex, item))
-      const card = toCard(slotIndex, map.get(slotIndex))
-      map.set(slotIndex, updater(card))
-      return Array.from(map.values()).sort((a, b) => a.slotIndex - b.slotIndex)
-    })
-  }
+  const enabledCount = useMemo(() => profiles.filter((item) => item.enabled).length, [profiles])
 
-  const handleSave = async (slotIndex: number) => {
-    const card = cards.find((item) => item.slotIndex === slotIndex)
-    if (!card) {
+  const nextAvailableSlot = useMemo(
+    () => FORUM_AI_SLOTS.find((slot) => !cardsBySlot.has(slot)) ?? null,
+    [cardsBySlot],
+  )
+
+  const visibleCards = useMemo(
+    () => profiles.slice().sort((a, b) => a.slotIndex - b.slotIndex),
+    [profiles],
+  )
+
+  const startAdd = () => {
+    if (nextAvailableSlot === null) {
       return
     }
-    setSavingSlot(slotIndex)
+    setDraft(toCard(nextAvailableSlot))
+    setMode({ type: 'edit', slotIndex: nextAvailableSlot })
+    setError(null)
+  }
+
+  const startEdit = (slotIndex: number) => {
+    setDraft(toCard(slotIndex, cardsBySlot.get(slotIndex)))
+    setMode({ type: 'edit', slotIndex })
+    setError(null)
+  }
+
+  const handleSave = async () => {
+    if (!draft) {
+      return
+    }
+    setSavingSlot(draft.slotIndex)
     setError(null)
     try {
-      const saved = await upsertForumAiProfile(slotIndex, {
-        enabled: card.enabled,
-        displayName: card.displayName,
-        systemPrompt: card.systemPrompt,
-        model: card.model,
-        temperature: card.temperature,
-        topP: card.topP,
-        apiBaseUrl: card.apiBaseUrl,
+      const saved = await upsertForumAiProfile(draft.slotIndex, {
+        enabled: draft.enabled,
+        displayName: draft.displayName,
+        systemPrompt: draft.systemPrompt,
+        model: draft.model,
+        temperature: draft.temperature,
+        topP: draft.topP,
+        apiBaseUrl: '',
       })
-      updateCard(slotIndex, () => saved)
+      setProfiles((current) => {
+        const map = new Map<number, ForumAiProfile>()
+        current.forEach((item) => map.set(item.slotIndex, item))
+        map.set(saved.slotIndex, saved)
+        return Array.from(map.values()).sort((a, b) => a.slotIndex - b.slotIndex)
+      })
+      setMode({ type: 'list' })
+      setDraft(null)
     } catch (saveError) {
       console.warn('保存论坛 AI 档案失败', saveError)
-      setError(`保存 Slot ${slotIndex} 失败，请重试。`)
+      setError(`保存 Slot ${draft.slotIndex} 失败，请重试。`)
     } finally {
       setSavingSlot(null)
     }
   }
+
+  const editingModelEnabled =
+    draft?.model.trim() && enabledModelOptions.length > 0
+      ? enabledModelOptions.some((model) => model.id === draft.model.trim())
+      : true
 
   return (
     <div className="forum-page app-shell__content">
@@ -92,60 +133,88 @@ const ForumSettingsPage = () => {
       {loading ? <p className="forum-loading">加载中…</p> : null}
       {error ? <p className="forum-error">{error}</p> : null}
 
-      <div className="forum-settings-grid">
-        {cards.map((card) => (
-          <section key={card.slotIndex} className="glass-card forum-settings-card">
-            <h2 className="ui-title">AI Slot {card.slotIndex}</h2>
-            <label>
-              <span>Enabled</span>
-              <input
-                type="checkbox"
-                checked={card.enabled}
-                onChange={(event) =>
-                  updateCard(card.slotIndex, (current) => ({ ...current, enabled: event.target.checked }))
-                }
-              />
-            </label>
-            <label>
-              <span>Display name</span>
-              <input
-                className="input-glass"
-                value={card.displayName}
-                onChange={(event) =>
-                  updateCard(card.slotIndex, (current) => ({ ...current, displayName: event.target.value }))
-                }
-              />
-            </label>
-            <label>
-              <span>System prompt</span>
-              <textarea
-                className="textarea-glass"
-                rows={5}
-                value={card.systemPrompt}
-                onChange={(event) =>
-                  updateCard(card.slotIndex, (current) => ({ ...current, systemPrompt: event.target.value }))
-                }
-              />
-            </label>
-            <label>
-              <span>Model</span>
-              <input
-                className="input-glass"
-                value={card.model}
-                onChange={(event) =>
-                  updateCard(card.slotIndex, (current) => ({ ...current, model: event.target.value }))
-                }
-              />
-            </label>
+      {mode.type === 'list' ? (
+        <section className="glass-card forum-settings-list">
+          <div className="forum-settings-list__header">
+            <p className="forum-settings-summary">Enabled {enabledCount}/{FORUM_AI_SLOTS.length} AI</p>
+            <button type="button" className="btn-primary" onClick={startAdd} disabled={nextAvailableSlot === null}>
+              Add AI Card
+            </button>
+          </div>
+
+          {visibleCards.length === 0 ? <p className="tips">还没有已保存的 AI 卡片，先添加一个吧。</p> : null}
+
+          <div className="forum-settings-list__cards">
+            {visibleCards.map((card) => {
+              const modelLabel = card.model.trim() ? card.model.trim() : '默认模型（跟随全局）'
+              return (
+                <article key={card.slotIndex} className="forum-settings-summary-card">
+                  <div>
+                    <p className="forum-settings-summary-card__name">{card.displayName || `AI Slot ${card.slotIndex}`}</p>
+                    <p className="forum-settings-summary-card__meta">Slot {card.slotIndex}</p>
+                    <p className="forum-settings-summary-card__meta">模型：{modelLabel}</p>
+                    <p className="forum-settings-summary-card__meta">状态：{card.enabled ? '已启用' : '已禁用'}</p>
+                  </div>
+                  <button type="button" className="btn-secondary" onClick={() => startEdit(card.slotIndex)}>
+                    编辑
+                  </button>
+                </article>
+              )
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {mode.type === 'edit' && draft ? (
+        <section className="glass-card forum-settings-editor">
+          <h2 className="ui-title">{cardsBySlot.has(mode.slotIndex) ? '编辑 AI 卡片' : '新增 AI 卡片'}</h2>
+          <p className="forum-settings-summary">Slot {mode.slotIndex}</p>
+          <label>
+            <span>Display name</span>
+            <input
+              className="input-glass"
+              value={draft.displayName}
+              onChange={(event) => setDraft((current) => (current ? { ...current, displayName: event.target.value } : current))}
+            />
+          </label>
+          <label>
+            <span>System prompt</span>
+            <textarea
+              className="textarea-glass"
+              rows={5}
+              value={draft.systemPrompt}
+              onChange={(event) => setDraft((current) => (current ? { ...current, systemPrompt: event.target.value } : current))}
+            />
+          </label>
+          <label>
+            <span>Model</span>
+            <select
+              className="input-glass"
+              value={draft.model}
+              onChange={(event) => setDraft((current) => (current ? { ...current, model: event.target.value } : current))}
+              disabled={enabledModelOptions.length === 0}
+            >
+              <option value="">默认模型（跟随全局）</option>
+              {enabledModelOptions.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {model.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {!editingModelEnabled && draft.model.trim() ? (
+            <p className="forum-model-warning">当前：{draft.model.trim()}（未在全局模型库启用）</p>
+          ) : null}
+          <div className="forum-settings-editor__grid">
             <label>
               <span>Temperature</span>
               <input
                 className="input-glass"
                 type="number"
                 step="0.1"
-                value={card.temperature}
+                value={draft.temperature}
                 onChange={(event) =>
-                  updateCard(card.slotIndex, (current) => ({ ...current, temperature: Number(event.target.value) }))
+                  setDraft((current) => (current ? { ...current, temperature: Number(event.target.value) } : current))
                 }
               />
             </label>
@@ -155,33 +224,38 @@ const ForumSettingsPage = () => {
                 className="input-glass"
                 type="number"
                 step="0.1"
-                value={card.topP}
+                value={draft.topP}
                 onChange={(event) =>
-                  updateCard(card.slotIndex, (current) => ({ ...current, topP: Number(event.target.value) }))
+                  setDraft((current) => (current ? { ...current, topP: Number(event.target.value) } : current))
                 }
               />
             </label>
-            <label>
-              <span>API base url</span>
-              <input
-                className="input-glass"
-                value={card.apiBaseUrl}
-                onChange={(event) =>
-                  updateCard(card.slotIndex, (current) => ({ ...current, apiBaseUrl: event.target.value }))
-                }
-              />
-            </label>
+          </div>
+          <label className="forum-settings-toggle">
+            <input
+              type="checkbox"
+              checked={draft.enabled}
+              onChange={(event) => setDraft((current) => (current ? { ...current, enabled: event.target.checked } : current))}
+            />
+            <span>启用该 AI 卡片</span>
+          </label>
+          <div className="forum-editor__actions">
             <button
               type="button"
-              className="btn-primary"
-              disabled={savingSlot === card.slotIndex}
-              onClick={() => void handleSave(card.slotIndex)}
+              className="btn-secondary"
+              onClick={() => {
+                setMode({ type: 'list' })
+                setDraft(null)
+              }}
             >
-              {savingSlot === card.slotIndex ? '保存中…' : '保存'}
+              取消
             </button>
-          </section>
-        ))}
-      </div>
+            <button type="button" className="btn-primary" disabled={savingSlot === draft.slotIndex} onClick={() => void handleSave()}>
+              {savingSlot === draft.slotIndex ? '保存中…' : '保存'}
+            </button>
+          </div>
+        </section>
+      ) : null}
     </div>
   )
 }

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -11,7 +11,7 @@ import {
   fetchForumThreadById,
 } from '../storage/supabaseSync'
 import ConfirmDialog from '../components/ConfirmDialog'
-import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel, requestForumAiContent } from './forumShared'
+import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel, loadForumGlobalAiConfig, requestForumAiContent, type ForumGlobalAiConfig } from './forumShared'
 import './ForumPage.css'
 
 const formatTime = (value: string) =>
@@ -34,6 +34,7 @@ const ForumThreadPage = () => {
   const [pendingDeleteReplyId, setPendingDeleteReplyId] = useState<string | null>(null)
   const [deletingThread, setDeletingThread] = useState(false)
   const [deletingReplyId, setDeletingReplyId] = useState<string | null>(null)
+  const [globalAiConfig, setGlobalAiConfig] = useState<ForumGlobalAiConfig | null>(null)
 
   const refresh = useCallback(async () => {
     if (!id) {
@@ -43,14 +44,16 @@ const ForumThreadPage = () => {
     setError(null)
     setSuccessMessage(null)
     try {
-      const [threadData, replyData, profileData] = await Promise.all([
+      const [threadData, replyData, profileData, globalConfig] = await Promise.all([
         fetchForumThreadById(id),
         fetchForumRepliesByThread(id),
         fetchForumAiProfiles(),
+        loadForumGlobalAiConfig(),
       ])
       setThread(threadData)
       setReplies(replyData)
       setProfiles(profileData)
+      setGlobalAiConfig(globalConfig)
     } catch (loadError) {
       console.warn('加载论坛主题失败', loadError)
       setError('加载失败，请刷新重试。')
@@ -147,7 +150,7 @@ const ForumThreadPage = () => {
   }
 
   const handleGenerateAiReply = async (slot: number) => {
-    if (!thread || generatingSlot) {
+    if (!thread || generatingSlot || !globalAiConfig) {
       return
     }
     const profile = profileMap.get(slot)
@@ -164,6 +167,7 @@ const ForumThreadPage = () => {
         thread,
         replies,
         memoryEntries,
+        globalModelConfig: globalAiConfig,
         task: 'reply',
         replyTargetLabel: targetLabel,
         userPrompt: replyContent.trim() || undefined,
@@ -305,7 +309,7 @@ const ForumThreadPage = () => {
                 key={slot}
                 type="button"
                 className="btn-secondary"
-                disabled={Boolean(generatingSlot) || !profile.enabled}
+                disabled={Boolean(generatingSlot) || !profile.enabled || !globalAiConfig}
                 onClick={() => void handleGenerateAiReply(slot)}
               >
                 {generatingSlot === slot ? '生成中…' : `${profile.displayName} 生成回复`}

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -1,6 +1,7 @@
 import type { ForumAiProfile, ForumReply, ForumThread } from '../types'
 import { supabase } from '../supabase/client'
 import type { MemoryEntry } from '../types'
+import { ensureUserSettings } from '../storage/userSettings'
 
 export const FORUM_AI_SLOTS = [1, 2, 3] as const
 export const FORUM_USER_DISPLAY_NAME = '串串'
@@ -40,9 +41,37 @@ type RequestForumAiContentParams = {
   thread: ForumThread
   replies: ForumReply[]
   memoryEntries: MemoryEntry[]
+  globalModelConfig: ForumGlobalAiConfig
   task: 'new-thread' | 'reply'
   replyTargetLabel?: string
   userPrompt?: string
+}
+
+export type ForumGlobalAiConfig = {
+  defaultModelId: string
+  enabledModelIds: string[]
+}
+
+const DEFAULT_MODEL = 'openrouter/auto'
+
+export const loadForumGlobalAiConfig = async (): Promise<ForumGlobalAiConfig> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  if (error || !user) {
+    throw error ?? new Error('登录状态异常')
+  }
+  const settings = await ensureUserSettings(user.id)
+  const defaultModelId = settings.defaultModel?.trim() || DEFAULT_MODEL
+  const enabled = Array.from(new Set([...settings.enabledModels, defaultModelId]))
+  return {
+    defaultModelId,
+    enabledModelIds: enabled,
+  }
 }
 
 export const requestForumAiContent = async ({
@@ -50,6 +79,7 @@ export const requestForumAiContent = async ({
   thread,
   replies,
   memoryEntries,
+  globalModelConfig,
   task,
   replyTargetLabel,
   userPrompt,
@@ -107,9 +137,15 @@ export const requestForumAiContent = async ({
         : `请生成一条论坛回复。回复目标：${replyTargetLabel ?? '主题帖'}。${userPrompt ? `用户补充：${userPrompt}` : ''}`,
   })
 
+  const selectedModel = profile.model.trim()
+  const resolvedModel =
+    selectedModel && globalModelConfig.enabledModelIds.includes(selectedModel)
+      ? selectedModel
+      : globalModelConfig.defaultModelId
+
   const requestBody: Record<string, unknown> = {
-    model: profile.model,
-    modelId: profile.model,
+    model: resolvedModel,
+    modelId: resolvedModel,
     module: 'forum',
     messages: messagesPayload,
     temperature: profile.temperature,
@@ -117,9 +153,10 @@ export const requestForumAiContent = async ({
     max_tokens: 800,
     stream: false,
     extra: {
-      forumApiBaseUrl: profile.apiBaseUrl,
       identitySlot: profile.slotIndex,
       scope: 'thread-only',
+      enabledModelIds: globalModelConfig.enabledModelIds,
+      defaultModelId: globalModelConfig.defaultModelId,
     },
   }
 


### PR DESCRIPTION
### Motivation
- Make Forum AI settings mobile-friendly and match the RP-room single-card edit flow instead of three inline full forms. 
- Ensure forum generation uses the app-wide API/model configuration and the globally enabled model library, not per-card API base overrides. 
- Keep the existing Supabase persistence for forum AI profiles while removing forum-specific api base use in runtime for MVP.

### Description
- Replace the 3-inline edit forms with a vertical list view and a dedicated add/edit detail view, show compact summary cards with display name, slot, model, enabled state and an edit action, and add an `Add AI Card` CTA with a 3-slot cap. (`src/pages/ForumSettingsPage.tsx`, `src/pages/ForumPage.css`) 
- Wire the model selector to the global enabled model library via `useEnabledModels`, showing a default/fallback option when no model is selected. (`src/hooks/useEnabledModels.ts`, `src/pages/ForumSettingsPage.tsx`) 
- Stop using per-card `apiBaseUrl` at runtime: the settings editor persists an empty `apiBaseUrl` for MVP and the API routing no longer relies on per-card overrides. (`src/pages/ForumSettingsPage.tsx`, `src/pages/forumShared.ts`) 
- Add a global forum AI config loader and change `requestForumAiContent` to resolve the final model from the global enabled models + default fallback, and include the enabled/default model info in the request `extra` payload rather than using per-card base URL. (`src/pages/forumShared.ts`) 
- Load and pass the global model config into forum generation flows (`/forum/new` and thread reply generation`) so generation uses global settings. (`src/pages/ForumNewThreadPage.tsx`, `src/pages/ForumThreadPage.tsx`) 
- Pass the authenticated `user` into `ForumSettingsPage` so it can read global enabled models from the hook. (`src/App.tsx`) 

### Testing
- Ran a production build with `npm run build` which completed successfully. 
- Started the dev server with `npm run dev` and validated the pages loaded. 
- Ran a Playwright script to load `/forum/settings` at a mobile viewport and saved a screenshot to verify the mobile-friendly layout; the script completed and produced the artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad231de2688330b42f1e6d1ce2766c)