### PR TITLE
Kawaii Pixel BBS: Fix reply layout and refactor thread detail into pixel-style cards

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=DotGothic16&family=VT323&display=swap');
+
 .forum-page {
   padding: 1rem;
   display: grid;
@@ -220,6 +222,162 @@
 .forum-model-warning {
   margin: 0;
   color: #b45309;
+}
+
+.forum-thread-page .glass-card,
+.forum-thread-page .glass-panel,
+.forum-thread-page .forum-thread-list,
+.forum-thread-page .forum-reply-item,
+.forum-thread-page .forum-root-post,
+.forum-thread-page .forum-editor,
+.forum-thread-page .forum-inline-editor,
+.forum-thread-page .forum-header {
+  border-radius: 0;
+  border: 3px solid #5c5c5c;
+  box-shadow: 4px 4px 0 0 #ffd6e7;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  background: #fff;
+}
+
+.forum-thread-page .forum-header,
+.forum-thread-page .forum-thread-list,
+.forum-thread-page .forum-editor {
+  background: #fff;
+}
+
+.forum-thread-page .forum-root-post,
+.forum-thread-page .forum-reply-item {
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+}
+
+.forum-bbs-card__author {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.2rem 0.75rem;
+  align-items: center;
+  padding: 0.65rem 0.8rem;
+  background: #ffeaf2;
+  border-bottom: 3px solid #5c5c5c;
+}
+
+.forum-bbs-card__author strong,
+.forum-bbs-card__author small,
+.forum-floor-tag,
+.forum-reply-item__footer span,
+.forum-thread-page .forum-editor__target,
+.forum-thread-page .forum-inline-editor__target,
+.forum-thread-page .btn-primary,
+.forum-thread-page .btn-secondary {
+  font-family: 'DotGothic16', 'VT323', monospace;
+  color: #5c5c5c;
+}
+
+.forum-bbs-card__author small {
+  justify-self: start;
+}
+
+.forum-floor-tag {
+  grid-row: 1 / span 2;
+  grid-column: 2;
+  justify-self: end;
+  align-self: start;
+  background: #ffd6e7;
+  border: 2px solid #5c5c5c;
+  box-shadow: 3px 3px 0 0 #5c5c5c;
+  padding: 0.1rem 0.5rem;
+}
+
+.forum-bbs-card__content {
+  padding: 0.85rem 0.8rem;
+  background-color: #fff;
+  background-image: linear-gradient(#fff4f8 1px, transparent 1px), linear-gradient(90deg, #fff4f8 1px, transparent 1px);
+  background-size: 12px 12px;
+}
+
+.forum-bbs-card__content p,
+.forum-bbs-card__content h2 {
+  font-family: var(--font-sans);
+  color: #334155;
+}
+
+.forum-thread-page .forum-reply-item__footer,
+.forum-thread-page .forum-root-post footer {
+  display: flex;
+  width: 100%;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.45rem;
+  padding: 0.65rem 0.8rem;
+  border-top: 3px solid #5c5c5c;
+}
+
+.forum-thread-page .forum-inline-editor {
+  width: 100%;
+  margin-top: 0;
+  border-top: 3px solid #5c5c5c;
+  padding: 0.8rem;
+  background: #fff;
+}
+
+.forum-thread-page .forum-inline-editor label,
+.forum-thread-page .forum-editor label {
+  width: 100%;
+}
+
+.forum-thread-page .forum-terminal-field {
+  position: relative;
+}
+
+.forum-thread-page .textarea-glass {
+  width: 100%;
+  border-radius: 0;
+  border: 3px solid #5c5c5c;
+  box-shadow: inset 0 0 0 2px #fff;
+  background: #fff;
+  font-family: var(--font-sans);
+  padding-right: 1.3rem;
+}
+
+.forum-thread-page .forum-terminal-field::after {
+  content: '';
+  position: absolute;
+  right: 0.8rem;
+  bottom: 0.9rem;
+  width: 8px;
+  height: 14px;
+  background: #5c5c5c;
+  animation: forum-pixel-cursor 1s steps(1) infinite;
+  pointer-events: none;
+}
+
+@keyframes forum-pixel-cursor {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.forum-thread-page .btn-primary,
+.forum-thread-page .btn-secondary {
+  border-radius: 0;
+  border: 2px solid #5c5c5c;
+  background: #ffd6e7;
+  box-shadow: 3px 3px 0 0 #5c5c5c;
+  color: #5c5c5c;
+}
+
+.forum-thread-page .btn-primary:active,
+.forum-thread-page .btn-secondary:active {
+  transform: translate(3px, 3px);
+  box-shadow: 0 0 0 0 #5c5c5c;
 }
 
 @media (max-width: 640px) {

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -225,7 +225,7 @@ const ForumThreadPage = () => {
   }
 
   return (
-    <div className="forum-page app-shell__content">
+    <div className="forum-page forum-thread-page app-shell__content">
       <header className="forum-header glass-card">
         <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
           返回列表
@@ -233,12 +233,17 @@ const ForumThreadPage = () => {
         <h1 className="ui-title">主题详情</h1>
       </header>
 
-      <article className="glass-card forum-root-post">
-        <h2>{thread.title}</h2>
-        <p>{thread.content}</p>
-        <footer>
+      <article className="glass-card forum-root-post forum-bbs-card">
+        <header className="forum-bbs-card__author">
           <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)}</strong>
           <small>{formatTime(thread.createdAt)}</small>
+          <span className="forum-floor-tag">#1</span>
+        </header>
+        <div className="forum-bbs-card__content">
+          <h2>{thread.title}</h2>
+          <p>{thread.content}</p>
+        </div>
+        <footer>
           <button type="button" className="btn-secondary" onClick={() => setPendingDeleteThread(true)}>
             删除主题
           </button>
@@ -259,13 +264,15 @@ const ForumThreadPage = () => {
                   : '未知目标'
             return (
               <article className="forum-reply-item" key={reply.id}>
-                <header>
+                <header className="forum-bbs-card__author">
                   <strong>{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}</strong>
                   <small>{formatTime(reply.createdAt)}</small>
+                  <span className="forum-floor-tag">#{index + 2}</span>
                 </header>
-                <p>{reply.content}</p>
-                <footer>
-                  <span>#{index + 1}</span>
+                <div className="forum-bbs-card__content">
+                  <p>{reply.content}</p>
+                </div>
+                <footer className="forum-reply-item__footer">
                   <span>回复给：{targetName}</span>
                   <button
                     type="button"
@@ -295,13 +302,15 @@ const ForumThreadPage = () => {
                     </p>
                     <label>
                       内容 / AI 指令
-                      <textarea
-                        className="textarea-glass"
-                        rows={4}
-                        value={inlineReplyContent}
-                        onChange={(event) => setInlineReplyContent(event.target.value)}
-                        placeholder="输入对该回复的内容；也可填写给 AI 的指令后点击下方按钮。"
-                      />
+                      <div className="forum-terminal-field">
+                        <textarea
+                          className="textarea-glass"
+                          rows={4}
+                          value={inlineReplyContent}
+                          onChange={(event) => setInlineReplyContent(event.target.value)}
+                          placeholder="输入对该回复的内容；也可填写给 AI 的指令后点击下方按钮。"
+                        />
+                      </div>
                     </label>
                     <div className="forum-editor__actions">
                       <button
@@ -365,13 +374,15 @@ const ForumThreadPage = () => {
         <p className="forum-editor__target">目标：{rootTargetLabel}</p>
         <label>
           内容 / AI 指令
-          <textarea
-            className="textarea-glass"
-            rows={5}
-            value={rootReplyContent}
-            onChange={(event) => setRootReplyContent(event.target.value)}
-            placeholder="输入对主题帖的回复；也可填写给 AI 的指令后点击下方按钮。"
-          />
+          <div className="forum-terminal-field">
+            <textarea
+              className="textarea-glass"
+              rows={5}
+              value={rootReplyContent}
+              onChange={(event) => setRootReplyContent(event.target.value)}
+              placeholder="输入对主题帖的回复；也可填写给 AI 的指令后点击下方按钮。"
+            />
+          </div>
         </label>
         {error ? <p className="forum-error">{error}</p> : null}
         {successMessage ? <p className="forum-success">{successMessage}</p> : null}


### PR DESCRIPTION
### Motivation
- Fix a broken side-by-side reply layout so inline reply editors appear below each reply and implement a retro "Kawaii Pixel" aesthetic for the thread detail page per the design spec.
- Make UI chrome feel pixelated and BBS-like with sharp corners, thick dark borders, hard offset shadows and pixel fonts for buttons/timestamps/usernames/floor tags.

### Description
- Updated `src/pages/ForumThreadPage.tsx` to add a scoped `forum-thread-page` wrapper, convert the root post and replies into BBS-style blocks with a dedicated author strip and prominent `forum-floor-tag`, and ensure inline reply editors are rendered below the comment content and use full width by wrapping textareas in `forum-terminal-field`.
- Reworked reply markup so reply items are vertical stacks (`flex-direction: column`) and content/author areas are separated (`forum-bbs-card__author` and `forum-bbs-card__content`).
- Added scoped styling in `src/pages/ForumPage.css` including an `@import` of pixel fonts, removal of `border-radius`, 2–3px dark-grey borders `#5c5c5c`, hard offset box-shadows (pixel shadows), pale-pink author bars `#ffeaf2`, pink accents `#ffd6e7`, pixel-font usage for UI chrome, retro chunky button styles and pressed state transform, terminal-style textarea visuals and a blinking pixel cursor animation.
- Kept main post and reply text in the regular sans-serif for readability while applying pixel fonts only to UI elements like buttons, timestamps, usernames and floor numbers.

### Testing
- Ran `npm run build` successfully to verify TypeScript compile and production build completed without errors. (Succeeded)
- Started the dev server with `npm run dev` and confirmed the app serves the forum pages for visual verification. (Succeeded)
- Executed a Playwright script that navigated to the forum page and captured a screenshot of the updated thread detail UI to validate layout and styling changes; the screenshot artifact was produced. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad311807e88330ab118d47fcd9f37d)