### PR TITLE
Polish forum thread header and post hierarchy visuals

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -227,8 +227,6 @@
 .forum-thread-page .glass-card,
 .forum-thread-page .glass-panel,
 .forum-thread-page .forum-thread-list,
-.forum-thread-page .forum-reply-item,
-.forum-thread-page .forum-root-post,
 .forum-thread-page .forum-editor,
 .forum-thread-page .forum-inline-editor,
 .forum-thread-page .forum-header {
@@ -240,7 +238,40 @@
   background: #fff;
 }
 
-.forum-thread-page .forum-header,
+.forum-thread-page .forum-header--thread {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  background: #5c5c5c;
+  border: 3px solid #5c5c5c;
+  box-shadow: 6px 6px 0 0 #ffd6e7;
+  padding: 0.6rem 0.75rem;
+}
+
+.forum-thread-page .forum-header--thread .ui-title {
+  margin: 0;
+  justify-self: center;
+  color: #ffffff;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 2rem;
+  letter-spacing: 0.05em;
+}
+
+.forum-thread-page .forum-header__back-btn {
+  border-radius: 0;
+  border: 3px solid #5c5c5c;
+  background: #ffd6e7;
+  box-shadow: 4px 4px 0 0 #5c5c5c;
+  color: #5c5c5c;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  padding: 0.2rem 0.75rem;
+}
+
+.forum-thread-page .forum-header__back-btn::before {
+  content: '[ESC] ';
+}
+
 .forum-thread-page .forum-thread-list,
 .forum-thread-page .forum-editor {
   background: #fff;
@@ -253,14 +284,34 @@
   padding: 0;
 }
 
+.forum-thread-page .forum-root-post {
+  border: 3px solid #5c5c5c;
+  box-shadow: 6px 6px 0 0 #5c5c5c;
+}
+
+.forum-thread-page .forum-reply-item {
+  border: 2px solid #5c5c5c;
+  box-shadow: 3px 3px 0 0 #ffd6e7;
+  border-radius: 0;
+  background: #ffffff;
+}
+
 .forum-bbs-card__author {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 0.2rem 0.75rem;
   align-items: center;
   padding: 0.65rem 0.8rem;
+}
+
+.forum-bbs-card__author--op {
   background: #ffeaf2;
   border-bottom: 3px solid #5c5c5c;
+}
+
+.forum-bbs-card__author--reply {
+  background: #ffffff;
+  border-bottom: 1px dashed #5c5c5c;
 }
 
 .forum-bbs-card__author strong,
@@ -273,6 +324,21 @@
 .forum-thread-page .btn-secondary {
   font-family: 'DotGothic16', 'VT323', monospace;
   color: #5c5c5c;
+}
+
+.forum-bbs-card__author strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.forum-op-badge {
+  display: inline-block;
+  background: #ffd6e7;
+  color: #ffffff;
+  border: 2px solid #5c5c5c;
+  padding: 0.05rem 0.45rem;
+  line-height: 1.2;
 }
 
 .forum-bbs-card__author small {
@@ -292,9 +358,16 @@
 
 .forum-bbs-card__content {
   padding: 0.85rem 0.8rem;
-  background-color: #fff;
-  background-image: linear-gradient(#fff4f8 1px, transparent 1px), linear-gradient(90deg, #fff4f8 1px, transparent 1px);
+}
+
+.forum-bbs-card__content--op {
+  background: #ffeaf2;
+  background-image: linear-gradient(#ffdce9 1px, transparent 1px), linear-gradient(90deg, #ffdce9 1px, transparent 1px);
   background-size: 12px 12px;
+}
+
+.forum-bbs-card__content--reply {
+  background: #ffffff;
 }
 
 .forum-bbs-card__content p,
@@ -312,7 +385,11 @@
   justify-content: flex-start;
   gap: 0.45rem;
   padding: 0.65rem 0.8rem;
-  border-top: 3px solid #5c5c5c;
+  border-top: 2px solid #5c5c5c;
+}
+
+.forum-thread-page .forum-root-post footer {
+  border-top-width: 3px;
 }
 
 .forum-thread-page .forum-inline-editor {

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -226,20 +226,23 @@ const ForumThreadPage = () => {
 
   return (
     <div className="forum-page forum-thread-page app-shell__content">
-      <header className="forum-header glass-card">
-        <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
+      <header className="forum-header forum-header--thread glass-card">
+        <button type="button" className="btn-secondary forum-header__back-btn" onClick={() => navigate('/forum')}>
           返回列表
         </button>
         <h1 className="ui-title">主题详情</h1>
       </header>
 
       <article className="glass-card forum-root-post forum-bbs-card">
-        <header className="forum-bbs-card__author">
-          <strong>{getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)}</strong>
+        <header className="forum-bbs-card__author forum-bbs-card__author--op">
+          <strong>
+            {getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)}
+            <span className="forum-op-badge">楼主 / OP</span>
+          </strong>
           <small>{formatTime(thread.createdAt)}</small>
           <span className="forum-floor-tag">#1</span>
         </header>
-        <div className="forum-bbs-card__content">
+        <div className="forum-bbs-card__content forum-bbs-card__content--op">
           <h2>{thread.title}</h2>
           <p>{thread.content}</p>
         </div>
@@ -264,12 +267,12 @@ const ForumThreadPage = () => {
                   : '未知目标'
             return (
               <article className="forum-reply-item" key={reply.id}>
-                <header className="forum-bbs-card__author">
+                <header className="forum-bbs-card__author forum-bbs-card__author--reply">
                   <strong>{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}</strong>
                   <small>{formatTime(reply.createdAt)}</small>
                   <span className="forum-floor-tag">#{index + 2}</span>
                 </header>
-                <div className="forum-bbs-card__content">
+                <div className="forum-bbs-card__content forum-bbs-card__content--reply">
                   <p>{reply.content}</p>
                 </div>
                 <footer className="forum-reply-item__footer">


### PR DESCRIPTION
### Motivation
- Make the Forum Thread Detail UI match the 8-bit kawaii retro design and increase visual hierarchy so the OP dominates while replies are visually subordinate.
- Replace the current plain header with a retro OS title-bar style and provide a clearer back affordance.

### Description
- Updated thread page markup to add targeted classes and structure (`forum-header--thread`, `forum-header__back-btn`, `forum-bbs-card__author--op`, `forum-bbs-card__author--reply`, `forum-bbs-card__content--op`, `forum-bbs-card__content--reply`) in `src/pages/ForumThreadPage.tsx` to support distinct OP and reply styling.
- Added an OP badge (`forum-op-badge`) next to the main author name and separated OP/reply content containers so the OP card can receive heavier styling.
- Reworked `src/pages/ForumPage.css` to implement the retro header (dark grey background, centered pixel-font title using `VT323`/`DotGothic16`, `[ESC]`-style pink back button), stronger OP treatment (pink-tinted background, thicker border, heavy block shadow), and lighter reply cards (pure white background, 2px border, smaller shadow, dashed author separator).
- Kept existing behaviors and component structure while only adding classes and CSS so changes are localized to the thread-detail view.

### Testing
- Ran a production build with `npm run build` which completed successfully.
- Started the dev server via `npm run dev` and captured a rendering using a Playwright script to produce a screenshot artifact confirming the layout and visual changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad3471b7b88330b7727aa77319904d)