### PR TITLE
Forum UI restyle, add reply counts and reply-count fetcher

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -2,15 +2,40 @@
 
 .forum-page {
   padding: 1rem;
-  display: grid;
-  gap: 0.9rem;
+  background-color: #fffaf2;
+  background-image: linear-gradient(rgba(255, 233, 242, 0.72) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 233, 242, 0.72) 1px, transparent 1px);
+  background-size: 10px 10px;
 }
 
-.forum-header {
-  display: flex;
-  gap: 0.75rem;
+.forum-page__wrapper {
+  border: 2px solid #7a7078;
+  box-shadow: 4px 4px 0 0 #ffe0ec;
+  background: #fffefb;
+  display: grid;
+  gap: 0;
+}
+
+.forum-header--index {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid #7a7078;
+  background: #ffdfe9;
+  background-image: linear-gradient(rgba(255, 247, 250, 0.5) 50%, transparent 50%),
+    linear-gradient(90deg, rgba(255, 247, 250, 0.5) 50%, transparent 50%);
+  background-size: 6px 6px;
+}
+
+.forum-header--index .ui-title {
+  margin: 0;
+  justify-self: center;
+  color: #7a7078;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 2rem;
+  letter-spacing: 0.04em;
 }
 
 .forum-header__actions {
@@ -18,76 +43,216 @@
   gap: 0.5rem;
 }
 
+.forum-pixel-btn {
+  border-radius: 0;
+  border: 2px solid #9a8a93;
+  background: #fff7ec;
+  box-shadow: 2px 2px 0 0 #efd4de;
+  color: #7a7078;
+  padding: 0.25rem 0.8rem;
+  min-height: auto;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.2rem;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: transform 100ms steps(2), box-shadow 100ms steps(2), filter 120ms ease;
+}
+
+.forum-pixel-btn:hover {
+  filter: brightness(1.02);
+}
+
+.forum-pixel-btn:active {
+  transform: translate(2px, 2px);
+  box-shadow: 0 0 0 0 #efd4de;
+}
+
+.forum-pixel-btn--primary {
+  background: #ffe8f1;
+  border-color: #c8adb9;
+}
+
+.forum-pixel-btn--subtle {
+  padding: 0.12rem 0.68rem;
+  font-size: 1.05rem;
+}
+
+.forum-thread-list {
+  padding: 0.85rem;
+}
+
+.forum-thread-list__title {
+  margin: 0 0 0.7rem;
+  color: #7a7078;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.8rem;
+}
+
+.forum-thread-list__items,
 .forum-ai-overview__cards,
-.forum-settings-grid {
+.forum-settings-grid,
+.forum-settings-list,
+.forum-settings-editor,
+.forum-settings-list__cards,
+.forum-editor,
+.forum-inline-editor,
+.forum-settings-card,
+.forum-settings-editor__grid {
   display: grid;
   gap: 0.75rem;
+}
+
+.forum-settings-grid {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.forum-ai-mini-card {
-  border: 1px solid rgba(148, 163, 184, 0.36);
-  border-radius: 14px;
-  padding: 0.7rem;
-  background: rgba(255, 255, 255, 0.6);
-}
-
-.forum-thread-list__items {
-  display: grid;
-  gap: 0.7rem;
 }
 
 .forum-thread-item,
 .forum-reply-item {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.36);
-  border-radius: 14px;
-  padding: 0.8rem;
-  color: inherit;
-  background: rgba(255, 255, 255, 0.62);
+  border: 2px solid #a1919a;
+  background: #fffdf8;
+  box-shadow: 2px 2px 0 0 #ffe7f1;
+  border-radius: 0;
+}
+
+.forum-thread-item {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.55rem;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.forum-thread-item:hover {
+  transform: scale(1.02);
+  box-shadow: 4px 4px 0 0 #ffdce9;
 }
 
 .forum-thread-item__main {
   border: none;
   background: transparent;
-  padding: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
   width: 100%;
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  color: inherit;
+  padding: 0;
   text-align: left;
+  align-items: start;
+  color: inherit;
   cursor: pointer;
 }
 
-.forum-thread-item__actions {
-  display: flex;
-  align-items: center;
+.forum-thread-item__left {
+  display: grid;
+  gap: 0.4rem;
+  justify-items: center;
+  padding-top: 0.1rem;
 }
 
-.forum-thread-item h3,
-.forum-thread-item p,
-.forum-reply-item p {
+.forum-thread-stamp {
+  min-width: 48px;
+  text-align: center;
+  padding: 0.1rem 0.3rem;
+  border: 2px solid #a1919a;
+  background: #ffe8f1;
+  box-shadow: inset -1px -1px 0 0 #f3cedf;
+  color: #7a7078;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.2rem;
+}
+
+.forum-thread-type {
+  font-size: 1.15rem;
+}
+
+.forum-thread-item__content h3,
+.forum-thread-item__content p,
+.forum-reply-item p,
+.forum-root-post h2,
+.forum-root-post p,
+.forum-root-post footer,
+.forum-settings-summary,
+.forum-settings-summary-card__name,
+.forum-settings-summary-card__meta {
   margin: 0;
 }
 
-.forum-thread-item p,
+.forum-thread-item__content h3 {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: #4f4750;
+}
+
+.forum-thread-item__content p,
 .forum-reply-item p {
-  margin-top: 0.45rem;
-  color: #334155;
+  margin-top: 0.35rem;
+  color: #6a5d6b;
   white-space: pre-wrap;
 }
 
-.forum-thread-item aside,
-.forum-root-post footer,
-.forum-reply-item header,
-.forum-reply-item footer {
-  display: grid;
-  gap: 0.2rem;
-  justify-items: end;
-  color: #475569;
+.forum-thread-item__content small {
+  display: block;
+  margin-top: 0.35rem;
+  color: #8d8090;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1rem;
+}
+
+.forum-thread-item__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-left: calc(48px + 0.75rem);
+  min-height: 2rem;
+}
+
+.forum-thread-replies,
+.forum-thread-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 2px solid #c3b2bb;
+  background: #fff5e7;
+  color: #7a7078;
+  padding: 0.05rem 0.45rem;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.02rem;
+}
+
+.forum-heart-pixel {
+  width: 9px;
+  height: 9px;
+  background: #f39dc4;
+  position: relative;
+  transform: rotate(45deg);
+  margin-right: 2px;
+}
+
+.forum-heart-pixel::before,
+.forum-heart-pixel::after {
+  content: '';
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  background: #f39dc4;
+}
+
+.forum-heart-pixel::before {
+  left: -5px;
+}
+
+.forum-heart-pixel::after {
+  top: -5px;
+}
+
+.forum-status-check {
+  width: 11px;
+  height: 11px;
+  border: 2px solid #b8aab2;
+  background: #ffe5ef;
+  box-shadow: inset 0 0 0 1px #fff9ef;
+}
+
+.forum-thread-item__footer .forum-pixel-btn {
+  margin-left: auto;
 }
 
 .forum-success {
@@ -95,9 +260,8 @@
   margin: 0;
 }
 
-.forum-root-post h2,
-.forum-root-post p,
-.forum-root-post footer {
+.forum-error {
+  color: #b91c1c;
   margin: 0;
 }
 
@@ -106,13 +270,9 @@
   white-space: pre-wrap;
 }
 
-.forum-editor {
-  display: grid;
-  gap: 0.6rem;
-}
-
 .forum-editor label,
-.forum-settings-card label {
+.forum-settings-card label,
+.forum-inline-editor label {
   display: grid;
   gap: 0.3rem;
 }
@@ -122,7 +282,6 @@
   flex-wrap: wrap;
   gap: 0.5rem;
 }
-
 
 .forum-editor__target,
 .forum-inline-editor__target {
@@ -134,67 +293,30 @@
   margin-top: 0.7rem;
   border-top: 1px solid rgba(148, 163, 184, 0.35);
   padding-top: 0.7rem;
-  display: grid;
-  gap: 0.6rem;
 }
 
-.forum-inline-editor label {
-  display: grid;
-  gap: 0.3rem;
-}
-
-.forum-settings-card {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.forum-error {
-  color: #b91c1c;
-  margin: 0;
-}
-
-.forum-loading {
-  padding: 1rem;
-}
-
-.forum-settings-list,
-.forum-settings-editor {
-  display: grid;
-  gap: 0.8rem;
+.forum-settings-list__header,
+.forum-settings-summary-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .forum-settings-list__header {
-  display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
 .forum-settings-summary {
-  margin: 0;
   color: #334155;
 }
 
-.forum-settings-list__cards {
-  display: grid;
-  gap: 0.7rem;
-}
-
 .forum-settings-summary-card {
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 0.75rem;
   border: 1px solid rgba(148, 163, 184, 0.36);
   border-radius: 14px;
   padding: 0.8rem;
   background: rgba(255, 255, 255, 0.62);
-}
-
-.forum-settings-summary-card__name,
-.forum-settings-summary-card__meta {
-  margin: 0;
 }
 
 .forum-settings-summary-card__name {
@@ -208,8 +330,6 @@
 }
 
 .forum-settings-editor__grid {
-  display: grid;
-  gap: 0.6rem;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
@@ -455,6 +575,27 @@
 .forum-thread-page .btn-secondary:active {
   transform: translate(3px, 3px);
   box-shadow: 0 0 0 0 #5c5c5c;
+}
+
+@media (max-width: 720px) {
+  .forum-header--index,
+  .forum-thread-item__main {
+    grid-template-columns: 1fr;
+  }
+
+  .forum-header__actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .forum-thread-item__footer {
+    padding-left: 0;
+    flex-wrap: wrap;
+  }
+
+  .forum-thread-item__footer .forum-pixel-btn {
+    margin-left: 0;
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import type { ForumThread } from '../types'
 import ConfirmDialog from '../components/ConfirmDialog'
-import { deleteForumThread, fetchForumThreads } from '../storage/supabaseSync'
+import { deleteForumThread, fetchForumReplyCountMap, fetchForumThreads } from '../storage/supabaseSync'
 import { getForumAuthorLabel } from './forumShared'
 import './ForumPage.css'
 
@@ -13,6 +13,7 @@ const ForumPage = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const [threads, setThreads] = useState<ForumThread[]>([])
+  const [replyCountMap, setReplyCountMap] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
@@ -25,6 +26,8 @@ const ForumPage = () => {
     try {
       const threadList = await fetchForumThreads()
       setThreads(threadList)
+      const counts = await fetchForumReplyCountMap(threadList.map((thread) => thread.id))
+      setReplyCountMap(counts)
     } catch {
       setError('论坛加载失败，请稍后重试。')
     } finally {
@@ -41,7 +44,6 @@ const ForumPage = () => {
     void refresh()
   }, [location.pathname, location.state, navigate, refresh])
 
-
   const handleOpenDeleteDialog = (threadId: string) => {
     setPendingDeleteThreadId(threadId)
   }
@@ -55,6 +57,11 @@ const ForumPage = () => {
     try {
       await deleteForumThread(pendingDeleteThreadId)
       setThreads((current) => current.filter((thread) => thread.id !== pendingDeleteThreadId))
+      setReplyCountMap((current) => {
+        const next = { ...current }
+        delete next[pendingDeleteThreadId]
+        return next
+      })
       setSuccessMessage('主题已删除。')
       setPendingDeleteThreadId(null)
     } catch (deleteError) {
@@ -65,60 +72,86 @@ const ForumPage = () => {
     }
   }
 
+  const threadCards = useMemo(
+    () =>
+      threads.map((thread, index) => ({
+        ...thread,
+        order: index + 1,
+        author: thread.authorName ?? getForumAuthorLabel(thread.authorType, thread.authorSlot, []),
+        replies: replyCountMap[thread.id] ?? 0,
+        isHot: (replyCountMap[thread.id] ?? 0) >= 5,
+      })),
+    [threads, replyCountMap],
+  )
+
   return (
     <div className="forum-page app-shell__content">
-      <header className="forum-header glass-card">
-        <button type="button" className="btn-secondary" onClick={() => navigate('/')}>
-          返回主页
-        </button>
-        <h1 className="ui-title">Forum</h1>
-        <div className="forum-header__actions">
-          <button type="button" className="btn-secondary" onClick={() => navigate('/forum/settings')}>
-            Forum 设置
+      <div className="forum-page__wrapper">
+        <header className="forum-header forum-header--index">
+          <button type="button" className="forum-pixel-btn" onClick={() => navigate('/')}>
+            返回主页
           </button>
-          <button type="button" className="btn-primary" onClick={() => navigate('/forum/new')}>
-            新建主题
-          </button>
-        </div>
-      </header>
+          <h1 className="ui-title">🎀 小窝论坛 🎀</h1>
+          <div className="forum-header__actions">
+            <button type="button" className="forum-pixel-btn" onClick={() => navigate('/forum/settings')}>
+              Forum 设置
+            </button>
+            <button type="button" className="forum-pixel-btn forum-pixel-btn--primary" onClick={() => navigate('/forum/new')}>
+              新建主题
+            </button>
+          </div>
+        </header>
 
-      <section className="forum-thread-list glass-card">
-        <h2 className="ui-title">主题列表</h2>
-        {loading ? <p>加载中…</p> : null}
-        {error ? <p className="forum-error">{error}</p> : null}
-        {successMessage ? <p className="forum-success">{successMessage}</p> : null}
-        {!loading && !error && threads.length === 0 ? <p>还没有主题，先创建第一条吧。</p> : null}
-        <div className="forum-thread-list__items">
-          {threads.map((thread) => (
-            <article key={thread.id} className="forum-thread-item">
-              <button
-                type="button"
-                className="forum-thread-item__main"
-                onClick={() => navigate(`/forum/thread/${thread.id}`)}
-              >
-                <div>
-                  <h3>{thread.title}</h3>
-                  <p>{thread.content}</p>
-                </div>
-                <aside>
-                  <strong>{thread.authorName ?? getForumAuthorLabel(thread.authorType, thread.authorSlot, [])}</strong>
-                  <small>{formatTime(thread.createdAt)}</small>
-                </aside>
-              </button>
-              <div className="forum-thread-item__actions">
+        <section className="forum-thread-list">
+          <h2 className="ui-title forum-thread-list__title">主题列表</h2>
+          {loading ? <p>加载中…</p> : null}
+          {error ? <p className="forum-error">{error}</p> : null}
+          {successMessage ? <p className="forum-success">{successMessage}</p> : null}
+          {!loading && !error && threadCards.length === 0 ? <p>还没有主题，先创建第一条吧。</p> : null}
+          <div className="forum-thread-list__items">
+            {threadCards.map((thread) => (
+              <article key={thread.id} className="forum-thread-item">
                 <button
                   type="button"
-                  className="btn-secondary"
-                  onClick={() => handleOpenDeleteDialog(thread.id)}
-                  disabled={deletingThreadId === thread.id}
+                  className="forum-thread-item__main"
+                  onClick={() => navigate(`/forum/thread/${thread.id}`)}
                 >
-                  {deletingThreadId === thread.id ? '删除中…' : '删除'}
+                  <div className="forum-thread-item__left">
+                    <span className="forum-thread-stamp">#{thread.order}</span>
+                    <span className="forum-thread-type" aria-label={thread.isHot ? '热门主题' : '讨论主题'}>
+                      {thread.isHot ? '🔥' : '💬'}
+                    </span>
+                  </div>
+
+                  <div className="forum-thread-item__content">
+                    <h3>{thread.title}</h3>
+                    <p>{thread.content}</p>
+                    <small>Author: {thread.author} | Date: {formatTime(thread.createdAt)}</small>
+                  </div>
                 </button>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
+
+                <div className="forum-thread-item__footer">
+                  <div className="forum-thread-replies" aria-label={`点赞数 ${thread.replies}`}>
+                    <span className="forum-heart-pixel" aria-hidden="true" />x{thread.replies}
+                  </div>
+                  <div className="forum-thread-status" aria-label="主题状态：开放">
+                    <span className="forum-status-check" aria-hidden="true" />
+                    <span>Open</span>
+                  </div>
+                  <button
+                    type="button"
+                    className="forum-pixel-btn forum-pixel-btn--subtle"
+                    onClick={() => handleOpenDeleteDialog(thread.id)}
+                    disabled={deletingThreadId === thread.id}
+                  >
+                    {deletingThreadId === thread.id ? '删除中…' : '删除'}
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
 
       <ConfirmDialog
         open={pendingDeleteThreadId !== null}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1576,6 +1576,28 @@ export const fetchForumThreadById = async (threadId: string): Promise<ForumThrea
   return data ? mapForumThreadRow(data as ForumThreadRow) : null
 }
 
+export const fetchForumReplyCountMap = async (threadIds: string[]): Promise<Record<string, number>> => {
+  if (!supabase || threadIds.length === 0) {
+    return {}
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('forum_replies')
+    .select('thread_id')
+    .eq('user_id', userId)
+    .in('thread_id', threadIds)
+
+  if (error) {
+    throw error
+  }
+
+  return (data ?? []).reduce<Record<string, number>>((acc, row) => {
+    const threadId = String((row as { thread_id: string }).thread_id)
+    acc[threadId] = (acc[threadId] ?? 0) + 1
+    return acc
+  }, {})
+}
+
 export const createForumThread = async (params: {
   title: string
   content: string


### PR DESCRIPTION
### Motivation

- Refresh the forum list UI with a pixel / retro aesthetic and improve layout and responsiveness.
- Surface reply counts and a simple "hot" indicator for threads so users can see activity at a glance.
- Optimize thread rendering and keep reply counts in sync when a thread is deleted.

### Description

- Reworked `ForumPage.css` with a new pixel-themed design, new classes (`.forum-page__wrapper`, `.forum-pixel-btn`, `.forum-thread-stamp`, etc.), and responsive rules for smaller screens.
- Rewrote the forum list layout in `ForumPage.tsx` to compute `threadCards` via `useMemo`, show an order stamp, replies/hot indicator, and moved header/actions into a grid-based `forum-header--index` layout, plus added `useMemo` import.
- Added reply-count support by calling a new `fetchForumReplyCountMap` from `supabaseSync` during `refresh`, storing counts in `replyCountMap`, and updating that map when a thread is deleted.
- Implemented `fetchForumReplyCountMap(threadIds: string[])` in `src/storage/supabaseSync.ts` to return a `Record<string, number>` by counting `forum_replies` rows for the current user scoped to provided thread IDs.

### Testing

- Ran TypeScript type-check and project build with `npm run typecheck` and `npm run build`, and both completed successfully.
- Ran the existing automated test suite with `npm test`, and the suite passed without changes required for the updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad3812406483309078c0bae938c80f)