### PR TITLE
Polish Forum Settings UI to match Hamster Nest forum style

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -299,7 +299,7 @@
 .forum-settings-summary-card {
   display: flex;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .forum-settings-list__header {
@@ -308,29 +308,34 @@
 }
 
 .forum-settings-summary {
-  color: #334155;
+  color: #7a7078;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.25rem;
 }
 
 .forum-settings-summary-card {
   align-items: center;
-  border: 1px solid rgba(148, 163, 184, 0.36);
-  border-radius: 14px;
-  padding: 0.8rem;
-  background: rgba(255, 255, 255, 0.62);
+  border: 2px solid #a1919a;
+  border-radius: 0;
+  padding: 0.68rem;
+  background: #fffdf8;
+  box-shadow: 2px 2px 0 0 #ffe7f1;
 }
 
 .forum-settings-summary-card__name {
   font-weight: 600;
+  color: #5f505e;
 }
 
 .forum-settings-summary-card__meta {
-  margin-top: 0.3rem;
-  color: #475569;
-  font-size: 0.92rem;
+  margin-top: 0.2rem;
+  color: #7a7078;
+  font-size: 1rem;
+  font-family: 'VT323', 'DotGothic16', monospace;
 }
 
 .forum-settings-editor__grid {
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .forum-settings-toggle {
@@ -342,6 +347,75 @@
 .forum-model-warning {
   margin: 0;
   color: #b45309;
+}
+
+.forum-settings-page {
+  display: flex;
+  justify-content: center;
+}
+
+.forum-settings-shell {
+  width: min(100%, 680px);
+}
+
+.forum-settings-content {
+  display: grid;
+  gap: 0.8rem;
+  padding-top: 0.75rem;
+}
+
+.forum-settings-header {
+  grid-template-columns: auto 1fr auto;
+}
+
+.forum-settings-header > div {
+  width: 1px;
+  height: 1px;
+}
+
+.forum-settings-list,
+.forum-settings-editor {
+  border: 2px solid #a1919a;
+  background: #fffefb;
+  box-shadow: 2px 2px 0 0 #ffe0ec;
+  padding: 0.85rem;
+}
+
+.forum-settings-editor .ui-title {
+  margin: 0;
+  color: #7a7078;
+  font-size: 1.7rem;
+}
+
+.forum-settings-editor label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.forum-settings-editor label span {
+  color: #6e5f6e;
+  font-size: 0.9rem;
+}
+
+.forum-settings-editor .input-glass,
+.forum-settings-editor .textarea-glass {
+  width: 100%;
+  min-height: 2.55rem;
+  border-radius: 12px;
+}
+
+.forum-settings-editor .textarea-glass {
+  min-height: 7rem;
+  border-radius: 14px;
+  resize: vertical;
+}
+
+.forum-settings-actions {
+  justify-content: flex-end;
+}
+
+.forum-settings-actions .forum-pixel-btn {
+  min-width: 92px;
 }
 
 .forum-thread-page .glass-card,
@@ -611,5 +685,14 @@
   .forum-settings-summary-card {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .forum-settings-editor__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .forum-settings-page {
+    padding-left: 0.72rem;
+    padding-right: 0.72rem;
   }
 }

--- a/src/pages/ForumSettingsPage.tsx
+++ b/src/pages/ForumSettingsPage.tsx
@@ -110,7 +110,7 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
       setDraft(null)
     } catch (saveError) {
       console.warn('保存论坛 AI 档案失败', saveError)
-      setError(`保存 Slot ${draft.slotIndex} 失败，请重试。`)
+      setError(`保存 AI 卡 ${draft.slotIndex} 失败，请重试。`)
     } finally {
       setSavingSlot(null)
     }
@@ -122,140 +122,150 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
       : true
 
   return (
-    <div className="forum-page app-shell__content">
-      <header className="forum-header glass-card">
-        <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
-          返回论坛
-        </button>
-        <h1 className="ui-title">Forum 设置</h1>
-      </header>
+    <div className="forum-page forum-settings-page app-shell__content">
+      <div className="forum-page__wrapper forum-settings-shell">
+        <header className="forum-header forum-header--index forum-settings-header">
+          <button type="button" className="forum-pixel-btn" onClick={() => navigate('/forum')}>
+            返回论坛
+          </button>
+          <h1 className="ui-title">论坛 AI 设置</h1>
+          <div />
+        </header>
 
-      {loading ? <p className="forum-loading">加载中…</p> : null}
-      {error ? <p className="forum-error">{error}</p> : null}
+        <section className="forum-thread-list forum-settings-content">
+          {loading ? <p className="forum-loading">加载中…</p> : null}
+          {error ? <p className="forum-error">{error}</p> : null}
 
-      {mode.type === 'list' ? (
-        <section className="glass-card forum-settings-list">
-          <div className="forum-settings-list__header">
-            <p className="forum-settings-summary">Enabled {enabledCount}/{FORUM_AI_SLOTS.length} AI</p>
-            <button type="button" className="btn-primary" onClick={startAdd} disabled={nextAvailableSlot === null}>
-              Add AI Card
-            </button>
-          </div>
+          {mode.type === 'list' ? (
+            <section className="forum-settings-list">
+              <div className="forum-settings-list__header">
+                <p className="forum-settings-summary">已启用 {enabledCount}/{FORUM_AI_SLOTS.length} 张 AI 卡片</p>
+                <button type="button" className="forum-pixel-btn forum-pixel-btn--primary" onClick={startAdd} disabled={nextAvailableSlot === null}>
+                  新增 AI 卡片
+                </button>
+              </div>
 
-          {visibleCards.length === 0 ? <p className="tips">还没有已保存的 AI 卡片，先添加一个吧。</p> : null}
+              {visibleCards.length === 0 ? <p className="tips">还没有已保存的 AI 卡片，先添加一个吧。</p> : null}
 
-          <div className="forum-settings-list__cards">
-            {visibleCards.map((card) => {
-              const modelLabel = card.model.trim() ? card.model.trim() : '默认模型（跟随全局）'
-              return (
-                <article key={card.slotIndex} className="forum-settings-summary-card">
-                  <div>
-                    <p className="forum-settings-summary-card__name">{card.displayName || `AI Slot ${card.slotIndex}`}</p>
-                    <p className="forum-settings-summary-card__meta">Slot {card.slotIndex}</p>
-                    <p className="forum-settings-summary-card__meta">模型：{modelLabel}</p>
-                    <p className="forum-settings-summary-card__meta">状态：{card.enabled ? '已启用' : '已禁用'}</p>
-                  </div>
-                  <button type="button" className="btn-secondary" onClick={() => startEdit(card.slotIndex)}>
-                    编辑
-                  </button>
-                </article>
-              )
-            })}
-          </div>
-        </section>
-      ) : null}
-
-      {mode.type === 'edit' && draft ? (
-        <section className="glass-card forum-settings-editor">
-          <h2 className="ui-title">{cardsBySlot.has(mode.slotIndex) ? '编辑 AI 卡片' : '新增 AI 卡片'}</h2>
-          <p className="forum-settings-summary">Slot {mode.slotIndex}</p>
-          <label>
-            <span>Display name</span>
-            <input
-              className="input-glass"
-              value={draft.displayName}
-              onChange={(event) => setDraft((current) => (current ? { ...current, displayName: event.target.value } : current))}
-            />
-          </label>
-          <label>
-            <span>System prompt</span>
-            <textarea
-              className="textarea-glass"
-              rows={5}
-              value={draft.systemPrompt}
-              onChange={(event) => setDraft((current) => (current ? { ...current, systemPrompt: event.target.value } : current))}
-            />
-          </label>
-          <label>
-            <span>Model</span>
-            <select
-              className="input-glass"
-              value={draft.model}
-              onChange={(event) => setDraft((current) => (current ? { ...current, model: event.target.value } : current))}
-              disabled={enabledModelOptions.length === 0}
-            >
-              <option value="">默认模型（跟随全局）</option>
-              {enabledModelOptions.map((model) => (
-                <option key={model.id} value={model.id}>
-                  {model.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          {!editingModelEnabled && draft.model.trim() ? (
-            <p className="forum-model-warning">当前：{draft.model.trim()}（未在全局模型库启用）</p>
+              <div className="forum-settings-list__cards">
+                {visibleCards.map((card) => {
+                  const modelLabel = card.model.trim() ? card.model.trim() : '默认模型（跟随全局）'
+                  return (
+                    <article key={card.slotIndex} className="forum-settings-summary-card">
+                      <div>
+                        <p className="forum-settings-summary-card__name">{card.displayName || `AI 卡 ${card.slotIndex}`}</p>
+                        <p className="forum-settings-summary-card__meta">AI 卡 {card.slotIndex}</p>
+                        <p className="forum-settings-summary-card__meta">模型：{modelLabel}</p>
+                        <p className="forum-settings-summary-card__meta">状态：{card.enabled ? '已启用' : '已禁用'}</p>
+                      </div>
+                      <button type="button" className="forum-pixel-btn forum-pixel-btn--subtle" onClick={() => startEdit(card.slotIndex)}>
+                        编辑
+                      </button>
+                    </article>
+                  )
+                })}
+              </div>
+            </section>
           ) : null}
-          <div className="forum-settings-editor__grid">
-            <label>
-              <span>Temperature</span>
-              <input
-                className="input-glass"
-                type="number"
-                step="0.1"
-                value={draft.temperature}
-                onChange={(event) =>
-                  setDraft((current) => (current ? { ...current, temperature: Number(event.target.value) } : current))
-                }
-              />
-            </label>
-            <label>
-              <span>Top P</span>
-              <input
-                className="input-glass"
-                type="number"
-                step="0.1"
-                value={draft.topP}
-                onChange={(event) =>
-                  setDraft((current) => (current ? { ...current, topP: Number(event.target.value) } : current))
-                }
-              />
-            </label>
-          </div>
-          <label className="forum-settings-toggle">
-            <input
-              type="checkbox"
-              checked={draft.enabled}
-              onChange={(event) => setDraft((current) => (current ? { ...current, enabled: event.target.checked } : current))}
-            />
-            <span>启用该 AI 卡片</span>
-          </label>
-          <div className="forum-editor__actions">
-            <button
-              type="button"
-              className="btn-secondary"
-              onClick={() => {
-                setMode({ type: 'list' })
-                setDraft(null)
-              }}
-            >
-              取消
-            </button>
-            <button type="button" className="btn-primary" disabled={savingSlot === draft.slotIndex} onClick={() => void handleSave()}>
-              {savingSlot === draft.slotIndex ? '保存中…' : '保存'}
-            </button>
-          </div>
+
+          {mode.type === 'edit' && draft ? (
+            <section className="forum-settings-editor">
+              <h2 className="ui-title">{cardsBySlot.has(mode.slotIndex) ? '编辑 AI 卡片' : '新增 AI 卡片'}</h2>
+              <p className="forum-settings-summary">AI 卡 {mode.slotIndex}</p>
+              <label>
+                <span>显示名称</span>
+                <input
+                  className="input-glass"
+                  value={draft.displayName}
+                  onChange={(event) => setDraft((current) => (current ? { ...current, displayName: event.target.value } : current))}
+                />
+              </label>
+              <label>
+                <span>System Prompt</span>
+                <textarea
+                  className="textarea-glass"
+                  rows={5}
+                  value={draft.systemPrompt}
+                  onChange={(event) => setDraft((current) => (current ? { ...current, systemPrompt: event.target.value } : current))}
+                />
+              </label>
+              <label>
+                <span>模型</span>
+                <select
+                  className="input-glass"
+                  value={draft.model}
+                  onChange={(event) => setDraft((current) => (current ? { ...current, model: event.target.value } : current))}
+                  disabled={enabledModelOptions.length === 0}
+                >
+                  <option value="">默认模型（跟随全局）</option>
+                  {enabledModelOptions.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {!editingModelEnabled && draft.model.trim() ? (
+                <p className="forum-model-warning">当前：{draft.model.trim()}（未在全局模型库启用）</p>
+              ) : null}
+              <div className="forum-settings-editor__grid">
+                <label>
+                  <span>温度</span>
+                  <input
+                    className="input-glass"
+                    type="number"
+                    step="0.1"
+                    value={draft.temperature}
+                    onChange={(event) =>
+                      setDraft((current) => (current ? { ...current, temperature: Number(event.target.value) } : current))
+                    }
+                  />
+                </label>
+                <label>
+                  <span>Top P</span>
+                  <input
+                    className="input-glass"
+                    type="number"
+                    step="0.1"
+                    value={draft.topP}
+                    onChange={(event) =>
+                      setDraft((current) => (current ? { ...current, topP: Number(event.target.value) } : current))
+                    }
+                  />
+                </label>
+              </div>
+              <label className="forum-settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={draft.enabled}
+                  onChange={(event) => setDraft((current) => (current ? { ...current, enabled: event.target.checked } : current))}
+                />
+                <span>启用该 AI 卡</span>
+              </label>
+              <div className="forum-editor__actions forum-settings-actions">
+                <button
+                  type="button"
+                  className="forum-pixel-btn"
+                  onClick={() => {
+                    setMode({ type: 'list' })
+                    setDraft(null)
+                  }}
+                >
+                  取消
+                </button>
+                <button
+                  type="button"
+                  className="forum-pixel-btn forum-pixel-btn--primary"
+                  disabled={savingSlot === draft.slotIndex}
+                  onClick={() => void handleSave()}
+                >
+                  {savingSlot === draft.slotIndex ? '保存中…' : '保存'}
+                </button>
+              </div>
+            </section>
+          ) : null}
         </section>
-      ) : null}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Make the Forum Settings page visually match the existing Hamster Nest forum/home UI, using the same soft pink/cream language, rounded cards and mobile-first spacing while keeping all behavior unchanged. 
- Localize visible UI copy to Chinese so the settings page reads consistently with other forum screens. 

### Description
- Reworked `ForumSettingsPage.tsx` to reuse the forum shell/header structure and a centered, narrower content flow so the settings page visually belongs to the forum experience, while keeping the existing back/navigation, save/load and slot logic intact. 
- Localized visible labels and copy to Chinese (`论坛 AI 设置`, `已启用 ... 张 AI 卡片`, `新增 AI 卡片`, `显示名称`, `System Prompt`, `模型`, `温度`, `Top P`, `启用该 AI 卡`, `取消`, `保存`, `AI 卡 N` etc.) without changing any data model or runtime behaviour. 
- Polished styling in `src/pages/ForumPage.css`: tightened spacing, adjusted card borders/background/shadows, standardized input/textarea sizing and radii, constrained editor grid for mobile-first layout, and improved action button sizing/alignment to match forum visuals. 
- No functional changes were made: API calls, persistence, validation, routing and state shape remain unchanged. 

### Testing
- Ran `npm run lint` and it completed successfully with a pre-existing unrelated warning in `src/pages/CheckinPage.tsx`. 
- Ran `npm run build` and the production build completed successfully. 
- Started the dev server and captured before/after screenshots of `/forum/settings` using a Playwright script to validate visual changes (screenshots produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad416e324c8330ac2ea3c0c1d7368c)