### PR TITLE
Refine Forum AI Settings layout with compact retro card UI

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -305,6 +305,9 @@
 .forum-settings-list__header {
   align-items: center;
   flex-wrap: wrap;
+  padding: 0.7rem 0;
+  border-bottom: 2px dashed #c7a8b8;
+  margin-bottom: 0.2rem;
 }
 
 .forum-settings-summary {
@@ -314,24 +317,56 @@
 }
 
 .forum-settings-summary-card {
-  align-items: center;
-  border: 2px solid #a1919a;
+  position: relative;
+  align-items: flex-start;
+  border: 2px solid #cdb7c4;
+  border-top-color: #fff4fa;
+  border-left-color: #fff4fa;
+  border-right-color: #8f7484;
+  border-bottom-color: #8f7484;
   border-radius: 0;
-  padding: 0.68rem;
+  min-height: 0;
+  height: auto;
+  padding: 1rem;
   background: #fffdf8;
-  box-shadow: 2px 2px 0 0 #ffe7f1;
+  box-shadow: 2px 2px 0 0 #edd0de;
 }
 
 .forum-settings-summary-card__name {
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 700;
+  font-size: 1.5rem;
+  line-height: 1.1;
   color: #5f505e;
+  font-family: 'VT323', 'DotGothic16', monospace;
 }
 
 .forum-settings-summary-card__meta {
-  margin-top: 0.2rem;
+  margin-top: 0.15rem;
   color: #7a7078;
-  font-size: 1rem;
+  font-size: 0.95rem;
+  line-height: 1.15;
   font-family: 'VT323', 'DotGothic16', monospace;
+}
+
+.forum-settings-summary-card__dot {
+  width: 10px;
+  height: 10px;
+  background: #27b148;
+  border: 1px solid #1a7d32;
+  box-shadow: inset 1px 1px 0 0 #9af0ac;
+}
+
+.forum-settings-summary-card__action {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+}
+
+.forum-settings-summary-card__info {
+  padding-right: 4.1rem;
 }
 
 .forum-settings-editor__grid {
@@ -365,12 +400,23 @@
 }
 
 .forum-settings-header {
-  grid-template-columns: auto 1fr auto;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 68px;
+  height: 68px;
+  padding: 0.4rem 0.9rem;
+  border-bottom: 2px solid #b886a1;
 }
 
-.forum-settings-header > div {
-  width: 1px;
-  height: 1px;
+.forum-settings-header .forum-pixel-btn {
+  position: absolute;
+  left: 0.9rem;
+}
+
+.forum-settings-header .ui-title {
+  justify-self: auto;
 }
 
 .forum-settings-list,
@@ -379,6 +425,11 @@
   background: #fffefb;
   box-shadow: 2px 2px 0 0 #ffe0ec;
   padding: 0.85rem;
+}
+
+.forum-settings-list__cards {
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
 }
 
 .forum-settings-editor .ui-title {

--- a/src/pages/ForumSettingsPage.tsx
+++ b/src/pages/ForumSettingsPage.tsx
@@ -129,7 +129,6 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
             返回论坛
           </button>
           <h1 className="ui-title">论坛 AI 设置</h1>
-          <div />
         </header>
 
         <section className="forum-thread-list forum-settings-content">
@@ -152,15 +151,18 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
                   const modelLabel = card.model.trim() ? card.model.trim() : '默认模型（跟随全局）'
                   return (
                     <article key={card.slotIndex} className="forum-settings-summary-card">
-                      <div>
-                        <p className="forum-settings-summary-card__name">{card.displayName || `AI 卡 ${card.slotIndex}`}</p>
+                      <button type="button" className="forum-pixel-btn forum-pixel-btn--subtle forum-settings-summary-card__action" onClick={() => startEdit(card.slotIndex)}>
+                        编辑
+                      </button>
+                      <div className="forum-settings-summary-card__info">
+                        <p className="forum-settings-summary-card__name">
+                          {card.enabled ? <span className="forum-settings-summary-card__dot" aria-hidden="true" /> : null}
+                          <span>{card.displayName || `AI 卡 ${card.slotIndex}`}</span>
+                        </p>
                         <p className="forum-settings-summary-card__meta">AI 卡 {card.slotIndex}</p>
                         <p className="forum-settings-summary-card__meta">模型：{modelLabel}</p>
                         <p className="forum-settings-summary-card__meta">状态：{card.enabled ? '已启用' : '已禁用'}</p>
                       </div>
-                      <button type="button" className="forum-pixel-btn forum-pixel-btn--subtle" onClick={() => startEdit(card.slotIndex)}>
-                        编辑
-                      </button>
                     </article>
                   )
                 })}


### PR DESCRIPTION
### Motivation
- Improve spacing and visual hierarchy on the Forum AI Settings page to remove excessive empty space and make AI cards scannable. 
- Strengthen the retro 90s/pixel aesthetic with a compact header, pixel-separators, and subtle 3D pixel borders on cards. 
- Make card actions easier to find by moving the edit control to a consistent top-right position and enable a responsive grid for future cards.

### Description
- Header: compressed header to a fixed height (68px), centered title using flexbox, back button pinned to the left, and added a darker pixelated bottom border (`2px solid #b886a1`). (updates in `src/pages/ForumPage.css`)
- Control bar: added padding and a dashed bottom divider to the count/add row (`padding: 0.7rem 0` and `border-bottom: 2px dashed #c7a8b8`). (updates in `src/pages/ForumPage.css`)
- Card layout and content: changed cards to `height: auto`, increased inner padding, tightened metadata line-height, enlarged/bolded AI name, and added a small green pixel status dot when enabled. (updates in `src/pages/ForumPage.css` and `src/pages/ForumSettingsPage.tsx`)
- Action placement: moved the `编辑` (Edit) button into an absolute top-right position within each card (`position: absolute` on the action, `position: relative` on the card). (updates in `src/pages/ForumSettingsPage.tsx` and `src/pages/ForumPage.css`)
- Retro 3D pixel styling: applied lighter top/left and darker bottom/right border colors to create a raised 3D look for cards. (updates in `src/pages/ForumPage.css`)
- Responsive grid: card container updated to CSS Grid with `grid-template-columns: repeat(auto-fill, minmax(300px, 1fr))` and consistent gaps for neat alignment. (updates in `src/pages/ForumPage.css`)

### Testing
- `npm run build` was executed and completed successfully.
- `npm run lint` was executed and completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` regarding a missing hook dependency; no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4a39294083308f0da65d401947bc)