### PR TITLE
Tighten vertical spacing on Forum AI Settings page

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -396,7 +396,7 @@
 .forum-settings-content {
   display: grid;
   gap: 0.8rem;
-  padding-top: 0.75rem;
+  padding-top: 0.35rem;
 }
 
 .forum-settings-header {
@@ -404,8 +404,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 68px;
-  height: 68px;
+  min-height: 58px;
   padding: 0.4rem 0.9rem;
   border-bottom: 2px solid #b886a1;
 }


### PR DESCRIPTION
### Motivation
- Remove the large empty gap between the page header and the AI settings card area so the Forum AI Settings page reads as one continuous, compact settings panel while preserving all behavior and existing visual styling.

### Description
- Updated `src/pages/ForumPage.css` to reduce `.forum-settings-content` top padding from `0.75rem` to `0.35rem` and to lower the `.forum-settings-header` minimum height from `68px` to `58px` (removed the fixed `height`), which brings the enabled count / add button / card list closer to the header without changing any logic.

### Testing
- Ran `npm run build` which completed successfully, and captured an automated Playwright screenshot of the `/forum/settings` route to visually validate the tighter spacing (the local route redirected to auth during capture).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4d9272388330a0eb589d0e7ae7ba)