### PR TITLE
Tighten forum spacing and remove thread decorative badges

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -20,7 +20,7 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   padding: 0.6rem 0.75rem;
   border-bottom: 2px solid #7a7078;
   background: #ffdfe9;
@@ -78,11 +78,11 @@
 }
 
 .forum-thread-list {
-  padding: 0.85rem;
+  padding: 0.65rem 0.75rem 0.75rem;
 }
 
 .forum-thread-list__title {
-  margin: 0 0 0.7rem;
+  margin: 0 0 0.45rem;
   color: #7a7078;
   font-family: 'VT323', 'DotGothic16', monospace;
   font-size: 1.8rem;
@@ -99,7 +99,7 @@
 .forum-settings-card,
 .forum-settings-editor__grid {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .forum-settings-grid {
@@ -116,8 +116,8 @@
 
 .forum-thread-item {
   display: grid;
-  gap: 0.55rem;
-  padding: 0.55rem;
+  gap: 0.4rem;
+  padding: 0.45rem 0.5rem;
   transition: transform 140ms ease, box-shadow 140ms ease;
 }
 
@@ -130,37 +130,14 @@
   border: none;
   background: transparent;
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.75rem;
+  grid-template-columns: 1fr;
+  gap: 0.4rem;
   width: 100%;
   padding: 0;
   text-align: left;
   align-items: start;
   color: inherit;
   cursor: pointer;
-}
-
-.forum-thread-item__left {
-  display: grid;
-  gap: 0.4rem;
-  justify-items: center;
-  padding-top: 0.1rem;
-}
-
-.forum-thread-stamp {
-  min-width: 48px;
-  text-align: center;
-  padding: 0.1rem 0.3rem;
-  border: 2px solid #a1919a;
-  background: #ffe8f1;
-  box-shadow: inset -1px -1px 0 0 #f3cedf;
-  color: #7a7078;
-  font-family: 'VT323', 'DotGothic16', monospace;
-  font-size: 1.2rem;
-}
-
-.forum-thread-type {
-  font-size: 1.15rem;
 }
 
 .forum-thread-item__content h3,
@@ -183,14 +160,14 @@
 
 .forum-thread-item__content p,
 .forum-reply-item p {
-  margin-top: 0.35rem;
+  margin-top: 0.2rem;
   color: #6a5d6b;
   white-space: pre-wrap;
 }
 
 .forum-thread-item__content small {
   display: block;
-  margin-top: 0.35rem;
+  margin-top: 0.2rem;
   color: #8d8090;
   font-family: 'VT323', 'DotGothic16', monospace;
   font-size: 1rem;
@@ -199,9 +176,8 @@
 .forum-thread-item__footer {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding-left: calc(48px + 0.75rem);
-  min-height: 2rem;
+  gap: 0.4rem;
+  min-height: 0;
 }
 
 .forum-thread-replies,
@@ -305,9 +281,9 @@
 .forum-settings-list__header {
   align-items: center;
   flex-wrap: wrap;
-  padding: 0.7rem 0;
+  padding: 0.45rem 0;
   border-bottom: 2px dashed #c7a8b8;
-  margin-bottom: 0.2rem;
+  margin-bottom: 0;
 }
 
 .forum-settings-summary {
@@ -327,7 +303,7 @@
   border-radius: 0;
   min-height: 0;
   height: auto;
-  padding: 1rem;
+  padding: 0.75rem;
   background: #fffdf8;
   box-shadow: 2px 2px 0 0 #edd0de;
 }
@@ -395,8 +371,8 @@
 
 .forum-settings-content {
   display: grid;
-  gap: 0.8rem;
-  padding-top: 0.35rem;
+  gap: 0.6rem;
+  padding-top: 0.15rem;
 }
 
 .forum-settings-header {
@@ -404,14 +380,14 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 58px;
-  padding: 0.4rem 0.9rem;
+  min-height: 44px;
+  padding: 0.2rem 0.75rem;
   border-bottom: 2px solid #b886a1;
 }
 
 .forum-settings-header .forum-pixel-btn {
   position: absolute;
-  left: 0.9rem;
+  left: 0.75rem;
 }
 
 .forum-settings-header .ui-title {
@@ -423,12 +399,12 @@
   border: 2px solid #a1919a;
   background: #fffefb;
   box-shadow: 2px 2px 0 0 #ffe0ec;
-  padding: 0.85rem;
+  padding: 0.65rem 0.7rem;
 }
 
 .forum-settings-list__cards {
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .forum-settings-editor .ui-title {
@@ -486,7 +462,7 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   background: #5c5c5c;
   border: 3px solid #5c5c5c;
   box-shadow: 6px 6px 0 0 #ffd6e7;
@@ -528,6 +504,10 @@
   padding: 0;
 }
 
+.forum-thread-page .forum-thread-list {
+  padding: 0.65rem;
+}
+
 .forum-thread-page .forum-root-post {
   border: 3px solid #5c5c5c;
   box-shadow: 6px 6px 0 0 #5c5c5c;
@@ -543,9 +523,9 @@
 .forum-bbs-card__author {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 0.2rem 0.75rem;
+  gap: 0.15rem 0.55rem;
   align-items: center;
-  padding: 0.65rem 0.8rem;
+  padding: 0.5rem 0.65rem;
 }
 
 .forum-bbs-card__author--op {
@@ -560,7 +540,6 @@
 
 .forum-bbs-card__author strong,
 .forum-bbs-card__author small,
-.forum-floor-tag,
 .forum-reply-item__footer span,
 .forum-thread-page .forum-editor__target,
 .forum-thread-page .forum-inline-editor__target,
@@ -589,19 +568,8 @@
   justify-self: start;
 }
 
-.forum-floor-tag {
-  grid-row: 1 / span 2;
-  grid-column: 2;
-  justify-self: end;
-  align-self: start;
-  background: #ffd6e7;
-  border: 2px solid #5c5c5c;
-  box-shadow: 3px 3px 0 0 #5c5c5c;
-  padding: 0.1rem 0.5rem;
-}
-
 .forum-bbs-card__content {
-  padding: 0.85rem 0.8rem;
+  padding: 0.65rem;
 }
 
 .forum-bbs-card__content--op {
@@ -627,8 +595,8 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
-  gap: 0.45rem;
-  padding: 0.65rem 0.8rem;
+  gap: 0.35rem;
+  padding: 0.5rem 0.65rem;
   border-top: 2px solid #5c5c5c;
 }
 

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -74,12 +74,10 @@ const ForumPage = () => {
 
   const threadCards = useMemo(
     () =>
-      threads.map((thread, index) => ({
+      threads.map((thread) => ({
         ...thread,
-        order: index + 1,
         author: thread.authorName ?? getForumAuthorLabel(thread.authorType, thread.authorSlot, []),
         replies: replyCountMap[thread.id] ?? 0,
-        isHot: (replyCountMap[thread.id] ?? 0) >= 5,
       })),
     [threads, replyCountMap],
   )
@@ -116,13 +114,6 @@ const ForumPage = () => {
                   className="forum-thread-item__main"
                   onClick={() => navigate(`/forum/thread/${thread.id}`)}
                 >
-                  <div className="forum-thread-item__left">
-                    <span className="forum-thread-stamp">#{thread.order}</span>
-                    <span className="forum-thread-type" aria-label={thread.isHot ? '热门主题' : '讨论主题'}>
-                      {thread.isHot ? '🔥' : '💬'}
-                    </span>
-                  </div>
-
                   <div className="forum-thread-item__content">
                     <h3>{thread.title}</h3>
                     <p>{thread.content}</p>

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -240,7 +240,6 @@ const ForumThreadPage = () => {
             <span className="forum-op-badge">楼主 / OP</span>
           </strong>
           <small>{formatTime(thread.createdAt)}</small>
-          <span className="forum-floor-tag">#1</span>
         </header>
         <div className="forum-bbs-card__content forum-bbs-card__content--op">
           <h2>{thread.title}</h2>
@@ -256,7 +255,7 @@ const ForumThreadPage = () => {
       <section className="glass-card forum-thread-list">
         <h3 className="ui-title">回复（按时间顺序）</h3>
         <div className="forum-thread-list__items">
-          {replies.map((reply, index) => {
+          {replies.map((reply) => {
             const target =
               reply.replyToType === 'reply' ? replies.find((item) => item.id === reply.replyToReplyId) : null
             const targetName =
@@ -270,7 +269,6 @@ const ForumThreadPage = () => {
                 <header className="forum-bbs-card__author forum-bbs-card__author--reply">
                   <strong>{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}</strong>
                   <small>{formatTime(reply.createdAt)}</small>
-                  <span className="forum-floor-tag">#{index + 2}</span>
                 </header>
                 <div className="forum-bbs-card__content forum-bbs-card__content--reply">
                   <p>{reply.content}</p>


### PR DESCRIPTION
### Motivation
- Make Forum pages visually denser and avoid poster-like spacing while preserving the existing cute pink-gingham style and all functionality. 
- Remove unnecessary decorative thread meta (order badges and speech-bubble emoji) that add noise without adding useful information.
- Ensure the Forum AI Settings header no longer behaves like a giant hero banner by reducing min-height/padding/gaps.

### Description
- Removed thread-order badge and speech-bubble/hot emoji from the forum list by deleting the left-column markup and the related memoized fields in `src/pages/ForumPage.tsx`.
- Removed floor-number badges (`#1`, `#2`, ...) from the thread detail and reply headers in `src/pages/ForumThreadPage.tsx` and simplified the replies mapping to not rely on index.
- Tightened vertical spacing across forum layouts by reducing header min-heights, paddings, margins, gaps and card paddings in `src/pages/ForumPage.css`, and removed unused decorative CSS selectors for the removed badges.
- All changes are UI-only (CSS/markup); no routes, API, data-shape, save/load/delete/reply logic or behavior were altered.

### Testing
- Ran a production build with `npm run build`, which completed successfully.
- Launched the dev server (`vite`) and captured a Playwright screenshot of `http://localhost:4173/forum/settings` to validate the compact header and tighter spacing, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad5096734c833093c3c9a5f5e9b94b)