### PR TITLE
Fix oversized Forum Settings header and back button clipping

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -372,25 +372,38 @@
 .forum-settings-content {
   display: grid;
   gap: 0.6rem;
-  padding-top: 0.15rem;
+  padding-top: 0;
 }
 
 .forum-settings-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.3rem 0.75rem;
+  gap: 0.45rem;
+  padding: 0.35rem 0.75rem;
   border-bottom: 2px solid #b886a1;
 }
 
 .forum-settings-header .ui-title {
-  flex: 1;
+  justify-self: center;
   text-align: center;
   margin: 0;
+  font-size: 1.7rem;
+  line-height: 1;
 }
 
 .forum-settings-header .forum-pixel-btn {
-  flex-shrink: 0;
+  justify-self: start;
+  width: fit-content;
+  min-width: 6.6rem;
+  padding-inline: 0.75rem;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.forum-settings-header__spacer {
+  width: 1px;
+  height: 1px;
 }
 
 .forum-settings-list,

--- a/src/pages/ForumSettingsPage.tsx
+++ b/src/pages/ForumSettingsPage.tsx
@@ -129,6 +129,7 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
             返回论坛
           </button>
           <h1 className="ui-title">论坛 AI 设置</h1>
+          <span className="forum-settings-header__spacer" aria-hidden="true" />
         </header>
 
         <section className="forum-thread-list forum-settings-content">


### PR DESCRIPTION
### Motivation
- The Forum AI Settings page header was rendering as a tall banner with excessive vertical space instead of a compact single-row title bar. 
- The left "返回论坛" back button could have its text clipped when the viewport changed size due to fixed/narrow sizing and wrapping behavior. 
- Preserve the forum's pixel/pink visual style and avoid any behavioral or data changes while improving responsiveness and spacing. 

### Description
- Converted the settings header into a compact 3-column grid (`auto 1fr auto`) and added a right-side spacer element to keep the title visually centered without banner-like vertical space (changed markup in `src/pages/ForumSettingsPage.tsx`).
- Removed extra top padding from the settings content container to tighten the gap between the header and main content (`src/pages/ForumPage.css`).
- Updated header title styling to `justify-self: center`, a reduced `font-size`, and `line-height: 1` so the title sits on a single line in a compact header (`src/pages/ForumPage.css`).
- Made the back button resilient to clipping by using `width: fit-content`, a `min-width`, natural horizontal padding (`padding-inline`), `white-space: nowrap`, and a stable `line-height` while keeping the existing `.forum-pixel-btn` look (`src/pages/ForumPage.css`).

### Testing
- Ran `npm run lint` which completed successfully with one pre-existing unrelated warning in `src/pages/CheckinPage.tsx` for `react-hooks/exhaustive-deps`.
- Built the production bundle via `npm run build` which succeeded with the usual chunk size warnings but no errors.
- Started the dev server (`npm run dev`) and captured a Playwright screenshot of the `/forum/settings` route to validate layout rendering in a real browser environment (capture produced an artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad56c413a4833092ac424d1e24a6f4)