### PR TITLE
Center Forum AI Settings page and unify background layout

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -355,15 +355,24 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-self: start;
+  width: 100%;
+  min-height: 100%;
 }
 
 .forum-settings-shell {
-  width: min(100%, 560px);
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
   border: none;
   box-shadow: none;
   background: transparent;
   gap: 0.55rem;
+}
+
+@media (max-width: 640px) {
+  .forum-settings-page {
+    padding-inline: 0.75rem;
+  }
 }
 
 .forum-settings-content {


### PR DESCRIPTION
### Motivation
- The Forum AI Settings page used a left-pinned inner container and left a mismatched gray/blank side area instead of showing the forum pale-yellow grid background across the full page.
- The goal was to make the background continuous and center the settings content while preserving the compact UI and mobile responsiveness with no functional changes.

### Description
- Updated `src/pages/ForumPage.css` to make the outer settings wrapper fill the available width/height so the pale yellow grid background renders continuously across the page.
- Changed the inner shell to use `max-width: 560px` with `margin: 0 auto` so the settings content is horizontally centered and remains compact on wide screens.
- Replaced the previous fixed `width` with a responsive `width: 100%` / `max-width` combo and added a mobile breakpoint to add horizontal padding via `@media (max-width: 640px)`.
- This is a UI-only CSS change; no routing, data, or interaction code was modified.

### Testing
- Ran `npm run lint`, which completed successfully with one pre-existing unrelated warning in `src/pages/CheckinPage.tsx`.
- Ran `npm run build`, which completed successfully and produced a production build.
- Launched the dev server and executed an automated Playwright script to capture a screenshot of `/forum/settings` to visually verify the centered layout (screenshot artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad5d4020688330992b65917cd14e71)