### PR TITLE
Implement AI thread generation on Forum New Thread page

### DIFF
--- a/src/pages/ForumNewThreadPage.tsx
+++ b/src/pages/ForumNewThreadPage.tsx
@@ -44,6 +44,23 @@ const ForumNewThreadPage = () => {
     return map
   }, [profiles])
 
+  const selectedAiProfile = useMemo(() => {
+    if (!selectedSlot) {
+      return null
+    }
+    const existing = profileLookup.get(selectedSlot)
+    if (existing) {
+      return existing
+    }
+    return {
+      ...defaultForumProfile(selectedSlot),
+      id: `slot-${selectedSlot}`,
+      userId: '',
+      createdAt: '',
+      updatedAt: '',
+    }
+  }, [profileLookup, selectedSlot])
+
   const createDirectThread = async (nextContent: string) => {
     if (!title.trim() || !nextContent.trim()) {
       return
@@ -56,6 +73,7 @@ const ForumNewThreadPage = () => {
         content: nextContent.trim(),
         authorType: authorIsAi ? 'ai' : 'user',
         authorSlot: selectedSlot,
+        authorName: authorIsAi ? selectedAiProfile?.displayName : undefined,
       })
       navigate(`/forum/thread/${created.id}`)
     } catch (submitError) {
@@ -78,7 +96,7 @@ const ForumNewThreadPage = () => {
     if (!authorIsAi || !selectedSlot || !title.trim() || !globalAiConfig) {
       return
     }
-    const profile = profileLookup.get(selectedSlot)
+    const profile = selectedAiProfile
     if (!profile?.enabled) {
       setError('该 AI 档案未启用，请先在 Forum 设置页启用。')
       return
@@ -117,6 +135,7 @@ const ForumNewThreadPage = () => {
   }
 
   const aiConfigReady = Boolean(globalAiConfig)
+  const canGenerateAi = Boolean(authorIsAi && selectedAiProfile?.enabled && title.trim() && aiConfigReady)
 
   return (
     <div className="forum-page app-shell__content">
@@ -175,7 +194,7 @@ const ForumNewThreadPage = () => {
           <button
             type="button"
             className="btn-secondary"
-            disabled={!authorIsAi || submitting || generating || !aiConfigReady}
+            disabled={!canGenerateAi || submitting || generating}
             onClick={handleGenerateAiThread}
           >
             {generating ? 'AI 生成中…' : '生成 AI 主题'}

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -125,17 +125,21 @@ export const requestForumAiContent = async ({
     role: 'system',
     content: `memory_entries 全量注入：\n${memoryBlock}`,
   })
-  messagesPayload.push({
-    role: 'user',
-    content: `当前线程上下文（严格线程内）：\n${threadContext}`,
-  })
-  messagesPayload.push({
-    role: 'user',
-    content:
-      task === 'new-thread'
-        ? `请以论坛新帖形式发言。${userPrompt ? `用户补充：${userPrompt}` : ''}`
-        : `请生成一条论坛回复。回复目标：${replyTargetLabel ?? '主题帖'}。${userPrompt ? `用户补充：${userPrompt}` : ''}`,
-  })
+  if (task === 'new-thread') {
+    messagesPayload.push({
+      role: 'user',
+      content: `请生成一篇新的论坛主题正文，不要引用任何历史线程内容。拟定标题：${thread.title || '（未提供）'}。${userPrompt ? `用户补充：${userPrompt}` : ''}`,
+    })
+  } else {
+    messagesPayload.push({
+      role: 'user',
+      content: `当前线程上下文（严格线程内）：\n${threadContext}`,
+    })
+    messagesPayload.push({
+      role: 'user',
+      content: `请生成一条论坛回复。回复目标：${replyTargetLabel ?? '主题帖'}。${userPrompt ? `用户补充：${userPrompt}` : ''}`,
+    })
+  }
 
   const selectedModel = profile.model.trim()
   const resolvedModel =

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1474,6 +1474,7 @@ const resolveForumAuthorPayload = async (
   userId: string,
   authorType: ForumAuthorType,
   authorSlot?: number | null,
+  preferredAuthorName?: string,
 ): Promise<{ authorSlot: number | null; authorName: string }> => {
   if (authorType === 'user') {
     return { authorSlot: null, authorName: FORUM_USER_AUTHOR_NAME }
@@ -1484,6 +1485,14 @@ const resolveForumAuthorPayload = async (
   }
 
   const normalizedSlot = authorSlot ?? 1
+  const preferredName = preferredAuthorName?.trim()
+  if (preferredName) {
+    return {
+      authorSlot: normalizedSlot,
+      authorName: preferredName,
+    }
+  }
+
   const { data, error } = await supabase
     .from('forum_ai_profiles')
     .select('name')
@@ -1603,13 +1612,14 @@ export const createForumThread = async (params: {
   content: string
   authorType: ForumAuthorType
   authorSlot?: number | null
+  authorName?: string
 }): Promise<ForumThread> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
   const now = new Date().toISOString()
-  const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
+  const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot, params.authorName)
   const { data, error } = await supabase
     .from('forum_threads')
     .insert({


### PR DESCRIPTION
### Motivation
- Finish wiring the previously non-functional “生成 AI 主题” button so selecting an AI author generates thread content and persists it to `forum_threads` using the existing global API/model pipeline.
- Preserve the existing user direct-publish flow and UX while preventing accidental AI publishes via clear guidance and button enablement rules.
- Ensure generated threads save correct AI metadata (`author_type`, `author_slot`, `author_name`) and reuse the global model configuration and OpenRouter integration.

### Description
- Add selection/fallback resolution for the chosen AI card in `src/pages/ForumNewThreadPage.tsx` and compute `canGenerateAi` to control button state and prevent duplicate submits.
- Wire the AI generation flow in `ForumNewThreadPage.tsx` to call `requestForumAiContent`, set the generated content into the editor, and then create the thread and navigate to the created thread; pass the selected AI display name into thread creation as `authorName`.
- Split prompt composition in `src/pages/forumShared.ts` so `task === 'new-thread'` explicitly instructs the model to generate a new thread body without injecting historical thread context while keeping existing system layers (identity, system prompt, time, memory); the `reply` flow retains strict thread-context injection.
- Extend `src/storage/supabaseSync.ts` to accept an optional `authorName` when resolving author payload and to pass that preferred name into the forum thread insert so AI-generated threads persist correct `author_type`, `author_slot`, and `author_name`.

### Testing
- Ran `npm run lint` which completed successfully with a single unrelated warning in `CheckinPage.tsx`.
- Ran full build with `npm run build` (TypeScript + Vite) which succeeded and produced the production build.
- Started the dev server (`npm run dev`) and captured a UI screenshot via an automated Playwright script to validate the new-thread page and AI controls visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad62000df88330b5013c7bb6fed4ad)