### PR TITLE
Improve Forum AI thread creation and compact thread list previews

### DIFF
--- a/src/pages/ForumNewThreadPage.tsx
+++ b/src/pages/ForumNewThreadPage.tsx
@@ -2,7 +2,13 @@ import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ForumAiProfile } from '../types'
 import { createForumThread, fetchAllMemoryEntries, fetchForumAiProfiles } from '../storage/supabaseSync'
-import { FORUM_AI_SLOTS, defaultForumProfile, loadForumGlobalAiConfig, requestForumAiContent, type ForumGlobalAiConfig } from './forumShared'
+import {
+  FORUM_AI_SLOTS,
+  defaultForumProfile,
+  loadForumGlobalAiConfig,
+  requestForumAiContent,
+  type ForumGlobalAiConfig,
+} from './forumShared'
 import './ForumPage.css'
 
 type AuthorDraft = 'user' | 'ai-1' | 'ai-2' | 'ai-3'
@@ -106,10 +112,6 @@ const ForumNewThreadPage = () => {
       setError('请先选择 AI 作者（AI Slot 1/2/3）后再生成。')
       return
     }
-    if (!title.trim()) {
-      setError('请先填写主题标题，再生成 AI 主题。')
-      return
-    }
     if (!globalAiConfig) {
       setError('AI 模型配置尚未就绪，请稍后重试或前往设置页检查。')
       return
@@ -131,7 +133,7 @@ const ForumNewThreadPage = () => {
         thread: {
           id: 'draft-thread',
           userId: profile.userId,
-          title: title.trim(),
+          title: '（由 AI 自拟）',
           content: content.trim() || '（空草稿）',
           authorType: 'user',
           authorSlot: null,
@@ -142,12 +144,22 @@ const ForumNewThreadPage = () => {
         replies: [],
         userPrompt: content.trim() || undefined,
       })
-      setContent(generated)
-      await createDirectThread(generated)
+      setTitle(generated.title)
+      setContent(generated.body)
+      setSubmitting(true)
+      const created = await createForumThread({
+        title: generated.title,
+        content: generated.body,
+        authorType: 'ai',
+        authorSlot: selectedSlot,
+        authorName: profile.displayName,
+      })
+      navigate(`/forum/thread/${created.id}`)
     } catch (generateError) {
       console.warn('生成 AI 主题失败', generateError)
       setError('生成失败，请检查模型配置后重试。')
     } finally {
+      setSubmitting(false)
       setGenerating(false)
     }
   }
@@ -163,10 +175,14 @@ const ForumNewThreadPage = () => {
 
       <section className="glass-card forum-editor">
         {loading ? <p>加载 AI 档案中…</p> : null}
-        <label>
-          标题
-          <input className="input-glass" value={title} onChange={(event) => setTitle(event.target.value)} />
-        </label>
+        {authorIsAi ? (
+          <p className="forum-settings-summary">标题将由 AI 自动生成</p>
+        ) : (
+          <label>
+            标题
+            <input className="input-glass" value={title} onChange={(event) => setTitle(event.target.value)} />
+          </label>
+        )}
         <label>
           作者
           <select
@@ -192,7 +208,7 @@ const ForumNewThreadPage = () => {
           </select>
         </label>
         <label>
-          正文
+          {authorIsAi ? '写作方向（可选）' : '正文'}
           <textarea
             className="textarea-glass"
             rows={8}

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -165,6 +165,15 @@
   white-space: pre-wrap;
 }
 
+.forum-thread-item__preview {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  white-space: normal;
+}
+
 .forum-thread-item__content small {
   display: block;
   margin-top: 0.2rem;

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -9,6 +9,16 @@ import './ForumPage.css'
 const formatTime = (value: string) =>
   new Date(value).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
 
+const THREAD_PREVIEW_MAX_LENGTH = 160
+
+const buildThreadPreview = (content: string) => {
+  const normalized = content.trim().replace(/\s+/g, ' ')
+  if (normalized.length <= THREAD_PREVIEW_MAX_LENGTH) {
+    return normalized
+  }
+  return `${normalized.slice(0, THREAD_PREVIEW_MAX_LENGTH)}…`
+}
+
 const ForumPage = () => {
   const navigate = useNavigate()
   const location = useLocation()
@@ -78,6 +88,7 @@ const ForumPage = () => {
         ...thread,
         author: thread.authorName ?? getForumAuthorLabel(thread.authorType, thread.authorSlot, []),
         replies: replyCountMap[thread.id] ?? 0,
+        preview: buildThreadPreview(thread.content),
       })),
     [threads, replyCountMap],
   )
@@ -116,7 +127,7 @@ const ForumPage = () => {
                 >
                   <div className="forum-thread-item__content">
                     <h3>{thread.title}</h3>
-                    <p>{thread.content}</p>
+                    <p className="forum-thread-item__preview">{thread.preview}</p>
                     <small>Author: {thread.author} | Date: {formatTime(thread.createdAt)}</small>
                   </div>
                 </button>

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -47,6 +47,14 @@ type RequestForumAiContentParams = {
   userPrompt?: string
 }
 
+type RequestForumAiNewThreadParams = Omit<RequestForumAiContentParams, 'task'> & { task: 'new-thread' }
+type RequestForumAiReplyParams = Omit<RequestForumAiContentParams, 'task'> & { task: 'reply' }
+
+export type ForumAiNewThreadDraft = {
+  title: string
+  body: string
+}
+
 export type ForumGlobalAiConfig = {
   defaultModelId: string
   enabledModelIds: string[]
@@ -74,7 +82,9 @@ export const loadForumGlobalAiConfig = async (): Promise<ForumGlobalAiConfig> =>
   }
 }
 
-export const requestForumAiContent = async ({
+export async function requestForumAiContent(params: RequestForumAiNewThreadParams): Promise<ForumAiNewThreadDraft>
+export async function requestForumAiContent(params: RequestForumAiReplyParams): Promise<string>
+export async function requestForumAiContent({
   profile,
   thread,
   replies,
@@ -83,7 +93,7 @@ export const requestForumAiContent = async ({
   task,
   replyTargetLabel,
   userPrompt,
-}: RequestForumAiContentParams) => {
+}: RequestForumAiContentParams) {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
@@ -112,7 +122,7 @@ export const requestForumAiContent = async ({
   const messagesPayload: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = []
   messagesPayload.push({
     role: 'system',
-    content: `Forum 模式指令层。你的身份是 slot_${profile.slotIndex}（${profile.displayName}）。仅输出帖子/回复正文，不要包含解释。`,
+    content: `Forum 模式指令层。你的身份是 slot_${profile.slotIndex}（${profile.displayName}）。严格遵循输出格式要求，不要包含额外解释。`,
   })
   if (profile.systemPrompt.trim()) {
     messagesPayload.push({ role: 'system', content: profile.systemPrompt.trim() })
@@ -128,7 +138,12 @@ export const requestForumAiContent = async ({
   if (task === 'new-thread') {
     messagesPayload.push({
       role: 'user',
-      content: `请生成一篇新的论坛主题正文，不要引用任何历史线程内容。拟定标题：${thread.title || '（未提供）'}。${userPrompt ? `用户补充：${userPrompt}` : ''}`,
+      content:
+        '请生成新的论坛主题，必须返回 JSON：{"title":"...","body":"..."}。title 为主题标题，body 为主题正文。禁止输出 JSON 之外的任何文字。',
+    })
+    messagesPayload.push({
+      role: 'user',
+      content: `写作方向（可选）：${userPrompt?.trim() || '（未提供）'}。不要引用任何历史线程内容。`,
     })
   } else {
     messagesPayload.push({
@@ -183,5 +198,43 @@ export const requestForumAiContent = async ({
   const message = ((choice?.message as Record<string, unknown>) ?? choice ?? {}) as Record<string, unknown>
   const content =
     typeof message.content === 'string' ? message.content : typeof choice?.text === 'string' ? choice.text : ''
-  return content.trim() || '（空回复）'
+  const normalizedContent = content.trim()
+
+  if (task === 'new-thread') {
+    const fallbackBody = normalizedContent || '（空主题）'
+    const parseStructuredDraft = (rawText: string): ForumAiNewThreadDraft | null => {
+      if (!rawText.trim()) {
+        return null
+      }
+      const normalized = rawText.trim()
+      const fencedMatch = normalized.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
+      const candidate = (fencedMatch?.[1] ?? normalized).trim()
+      try {
+        const parsed = JSON.parse(candidate) as Record<string, unknown>
+        const parsedTitle = typeof parsed.title === 'string' ? parsed.title.trim() : ''
+        const parsedBody = typeof parsed.body === 'string' ? parsed.body.trim() : ''
+        if (!parsedTitle || !parsedBody) {
+          return null
+        }
+        return {
+          title: parsedTitle,
+          body: parsedBody,
+        }
+      } catch {
+        return null
+      }
+    }
+
+    const structuredDraft = parseStructuredDraft(normalizedContent)
+    if (structuredDraft) {
+      return structuredDraft
+    }
+
+    return {
+      title: thread.title.trim() || `AI 主题 ${new Date().toLocaleString('zh-CN')}`,
+      body: fallbackBody,
+    }
+  }
+
+  return normalizedContent || '（空回复）'
 }


### PR DESCRIPTION
### Motivation
- Make AI-authored threads feel autonomous by having the model generate both the title and the body so the manual title input is not required for AI slots.
- Prevent the forum main page from rendering full post bodies so the thread list becomes denser and easier to scan.
- Ensure AI output is structured and robustly parsed so both `title` and `body` can be persisted reliably.

### Description
- Added typed overloads and changed `requestForumAiContent` to instruct the model to return strict JSON for `new-thread`, introduced `ForumAiNewThreadDraft`, implemented fenced-JSON parsing and a safe fallback, in `src/pages/forumShared.ts`.
- Updated the new-thread UI in `src/pages/ForumNewThreadPage.tsx` to hide the manual title input when an AI slot is selected, treat the textarea as an optional writing direction, and persist the AI-generated `title`+`body` directly as an AI-authored thread.
- Reworked forum index rendering in `src/pages/ForumPage.tsx` to compute a truncated `preview` (160 characters) for each thread and render that preview instead of the full body, and added `.forum-thread-item__preview` CSS with a 3-line clamp in `src/pages/ForumPage.css`.
- Kept user-authored direct-publish flow unchanged and added parsing fallbacks to avoid regressions when the model output is not perfectly structured.

### Testing
- Ran `npm run build` to validate TypeScript and the production build, which completed successfully after fixes to overloads. (succeeded)
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and captured a screenshot of the updated forum list for visual verification. (succeeded)
- No unit tests were added for UI flows; validation was performed via type-checked build and visual inspection of the running app. (noted)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6ad9f8c88330980475333d4936cb)