### PR TITLE
Fix forum AI thread output normalization and markdown rendering

### DIFF
--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -621,6 +621,39 @@
   color: #334155;
 }
 
+
+.forum-bbs-card__content .assistant-markdown > :first-child {
+  margin-top: 0;
+}
+
+.forum-bbs-card__content .assistant-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.forum-bbs-card__content .assistant-markdown p,
+.forum-bbs-card__content .assistant-markdown h1,
+.forum-bbs-card__content .assistant-markdown h2,
+.forum-bbs-card__content .assistant-markdown h3,
+.forum-bbs-card__content .assistant-markdown h4,
+.forum-bbs-card__content .assistant-markdown li,
+.forum-bbs-card__content .assistant-markdown blockquote {
+  font-family: var(--font-sans);
+  color: #334155;
+}
+
+.forum-bbs-card__content .assistant-markdown ul,
+.forum-bbs-card__content .assistant-markdown ol {
+  margin: 0.35rem 0;
+  padding-left: 1.35rem;
+}
+
+.forum-bbs-card__content .assistant-markdown pre {
+  overflow-x: auto;
+  background: rgba(148, 163, 184, 0.14);
+  border-radius: 0.45rem;
+  padding: 0.55rem 0.7rem;
+}
+
 .forum-thread-page .forum-reply-item__footer,
 .forum-thread-page .forum-root-post footer {
   display: flex;

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import type { ForumThread } from '../types'
 import ConfirmDialog from '../components/ConfirmDialog'
 import { deleteForumThread, fetchForumReplyCountMap, fetchForumThreads } from '../storage/supabaseSync'
-import { getForumAuthorLabel } from './forumShared'
+import { getForumAuthorLabel, toForumPreviewText } from './forumShared'
 import './ForumPage.css'
 
 const formatTime = (value: string) =>
@@ -11,13 +11,7 @@ const formatTime = (value: string) =>
 
 const THREAD_PREVIEW_MAX_LENGTH = 160
 
-const buildThreadPreview = (content: string) => {
-  const normalized = content.trim().replace(/\s+/g, ' ')
-  if (normalized.length <= THREAD_PREVIEW_MAX_LENGTH) {
-    return normalized
-  }
-  return `${normalized.slice(0, THREAD_PREVIEW_MAX_LENGTH)}…`
-}
+const buildThreadPreview = (content: string) => toForumPreviewText(content, THREAD_PREVIEW_MAX_LENGTH)
 
 const ForumPage = () => {
   const navigate = useNavigate()

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -11,6 +11,7 @@ import {
   fetchForumThreadById,
 } from '../storage/supabaseSync'
 import ConfirmDialog from '../components/ConfirmDialog'
+import MarkdownRenderer from '../components/MarkdownRenderer'
 import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel, loadForumGlobalAiConfig, requestForumAiContent, type ForumGlobalAiConfig } from './forumShared'
 import './ForumPage.css'
 
@@ -243,7 +244,9 @@ const ForumThreadPage = () => {
         </header>
         <div className="forum-bbs-card__content forum-bbs-card__content--op">
           <h2>{thread.title}</h2>
-          <p>{thread.content}</p>
+          <div className="assistant-markdown">
+            <MarkdownRenderer content={thread.content} />
+          </div>
         </div>
         <footer>
           <button type="button" className="btn-secondary" onClick={() => setPendingDeleteThread(true)}>
@@ -271,7 +274,9 @@ const ForumThreadPage = () => {
                   <small>{formatTime(reply.createdAt)}</small>
                 </header>
                 <div className="forum-bbs-card__content forum-bbs-card__content--reply">
-                  <p>{reply.content}</p>
+                  <div className="assistant-markdown">
+                    <MarkdownRenderer content={reply.content} />
+                  </div>
                 </div>
                 <footer className="forum-reply-item__footer">
                   <span>回复给：{targetName}</span>

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -62,6 +62,121 @@ export type ForumGlobalAiConfig = {
 
 const DEFAULT_MODEL = 'openrouter/auto'
 
+const unwrapCodeFence = (value: string) => {
+  const trimmed = value.trim()
+  const fencedMatch = trimmed.match(/^```[\w-]*\s*([\s\S]*?)\s*```$/)
+  return fencedMatch ? fencedMatch[1].trim() : trimmed
+}
+
+const normalizeForumThreadBody = (value: string) => {
+  const withoutFence = unwrapCodeFence(value)
+  const cleaned = withoutFence
+    .replace(/^\s*(?:title|标题|主题)\s*[:：]\s*.*$/gim, '')
+    .replace(/^\s*(?:body|正文|内容)\s*[:：]\s*$/gim, '')
+    .replace(/^\s*[-*]\s*(?:title|body|标题|正文|内容)\s*[:：]\s*$/gim, '')
+    .replace(/^\s*```(?:json|markdown|md)?\s*$/gim, '')
+    .replace(/^\s*```\s*$/gim, '')
+    .trim()
+  return cleaned || '（空主题）'
+}
+
+const parseJsonDraft = (rawText: string): ForumAiNewThreadDraft | null => {
+  const candidates = [rawText.trim(), unwrapCodeFence(rawText)]
+  const jsonBlock = rawText.match(/\{[\s\S]*\}/)
+  if (jsonBlock) {
+    candidates.push(jsonBlock[0].trim())
+  }
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue
+    }
+    try {
+      const parsed = JSON.parse(candidate) as Record<string, unknown>
+      const parsedTitle = typeof parsed.title === 'string' ? parsed.title.trim() : ''
+      const parsedBody = typeof parsed.body === 'string' ? parsed.body.trim() : ''
+      if (parsedTitle && parsedBody) {
+        return {
+          title: parsedTitle,
+          body: normalizeForumThreadBody(parsedBody),
+        }
+      }
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+const parseLabeledDraft = (rawText: string): ForumAiNewThreadDraft | null => {
+  const cleaned = unwrapCodeFence(rawText)
+  const titleMatch = cleaned.match(/(?:^|\n)\s*(?:#+\s*)?(?:title|标题|主题)\s*[:：]\s*(.+)(?:\n|$)/i)
+  const bodyMatch = cleaned.match(/(?:^|\n)\s*(?:#+\s*)?(?:body|正文|内容)\s*[:：]\s*([\s\S]*)$/i)
+  if (!titleMatch || !bodyMatch) {
+    return null
+  }
+  const parsedTitle = titleMatch[1]?.trim()
+  const parsedBody = bodyMatch[1]?.trim()
+  if (!parsedTitle || !parsedBody) {
+    return null
+  }
+  return {
+    title: parsedTitle,
+    body: normalizeForumThreadBody(parsedBody),
+  }
+}
+
+const parseHeadingDraft = (rawText: string): ForumAiNewThreadDraft | null => {
+  const cleaned = unwrapCodeFence(rawText)
+  const headingMatch = cleaned.match(/^#+\s*(.+)$/m)
+  if (!headingMatch) {
+    return null
+  }
+  const parsedTitle = headingMatch[1].trim()
+  const body = cleaned.replace(headingMatch[0], '').trim()
+  if (!parsedTitle || !body) {
+    return null
+  }
+  return {
+    title: parsedTitle,
+    body: normalizeForumThreadBody(body),
+  }
+}
+
+
+const deriveFallbackTitle = (rawText: string) => {
+  const cleaned = unwrapCodeFence(rawText)
+    .replace(/^\s*(?:title|标题|主题|body|正文|内容)\s*[:：]\s*/gim, '')
+    .replace(/^#+\s*/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!cleaned) {
+    return ''
+  }
+  return cleaned.slice(0, 40)
+}
+
+const parseForumAiNewThreadDraft = (rawText: string): ForumAiNewThreadDraft | null => {
+  if (!rawText.trim()) {
+    return null
+  }
+  return parseJsonDraft(rawText) ?? parseLabeledDraft(rawText) ?? parseHeadingDraft(rawText)
+}
+
+export const toForumPreviewText = (markdownContent: string, maxLength: number) => {
+  const plainText = normalizeForumThreadBody(markdownContent)
+    .replace(/!\[[^\]]*]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
+    .replace(/`{1,3}/g, '')
+    .replace(/^[>#\-+*]+\s*/gm, '')
+    .replace(/\*\*|__|~~|\*/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (plainText.length <= maxLength) {
+    return plainText
+  }
+  return `${plainText.slice(0, maxLength)}…`
+}
+
 export const loadForumGlobalAiConfig = async (): Promise<ForumGlobalAiConfig> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
@@ -201,38 +316,20 @@ export async function requestForumAiContent({
   const normalizedContent = content.trim()
 
   if (task === 'new-thread') {
-    const fallbackBody = normalizedContent || '（空主题）'
-    const parseStructuredDraft = (rawText: string): ForumAiNewThreadDraft | null => {
-      if (!rawText.trim()) {
-        return null
-      }
-      const normalized = rawText.trim()
-      const fencedMatch = normalized.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
-      const candidate = (fencedMatch?.[1] ?? normalized).trim()
-      try {
-        const parsed = JSON.parse(candidate) as Record<string, unknown>
-        const parsedTitle = typeof parsed.title === 'string' ? parsed.title.trim() : ''
-        const parsedBody = typeof parsed.body === 'string' ? parsed.body.trim() : ''
-        if (!parsedTitle || !parsedBody) {
-          return null
-        }
-        return {
-          title: parsedTitle,
-          body: parsedBody,
-        }
-      } catch {
-        return null
-      }
-    }
-
-    const structuredDraft = parseStructuredDraft(normalizedContent)
+    const structuredDraft = parseForumAiNewThreadDraft(normalizedContent)
     if (structuredDraft) {
       return structuredDraft
     }
 
+    const threadTitle = thread.title.trim()
+    const fallbackTitle =
+      threadTitle && !/由\s*AI\s*自拟|ai\s*自拟|^（.*自拟.*）$/i.test(threadTitle)
+        ? threadTitle
+        : deriveFallbackTitle(normalizedContent)
+
     return {
-      title: thread.title.trim() || `AI 主题 ${new Date().toLocaleString('zh-CN')}`,
-      body: fallbackBody,
+      title: fallbackTitle || `AI 主题 ${new Date().toLocaleString('zh-CN')}`,
+      body: normalizeForumThreadBody(normalizedContent),
     }
   }
 


### PR DESCRIPTION
### Motivation
- AI-generated forum threads were stored and previewed with raw transport artifacts (code fences, `title:`/`body:` labels and placeholder titles), causing the UI to show unclean content instead of a proper thread title and Markdown-rendered body.
- The goal is to ensure AI results are parsed into a single clean `title` and a single clean Markdown `body` and that the UI renders the body as Markdown and previews a clean snippet.

### Description
- Add a robust normalization/parsing pipeline in `src/pages/forumShared.ts` which unwraps code fences, parses JSON payloads, extracts labeled `title`/`body` sections, falls back to heading-style outputs, and strips transport artifacts before returning a `ForumAiNewThreadDraft` via `requestForumAiContent`.
- Improve fallback title derivation so placeholder titles like `（由 AI 自拟）` are not persisted and instead a meaningful short fallback is derived from the generated content (implemented in `src/pages/forumShared.ts`).
- Provide `toForumPreviewText` to produce cleaned plain-text snippets from stored Markdown for thread list previews and switch list preview generation to use it (`src/pages/ForumPage.tsx`).
- Render stored Markdown in thread detail pages using the existing `MarkdownRenderer` and add forum-scoped CSS rules to keep rendered Markdown visually consistent (`src/pages/ForumThreadPage.tsx`, `src/pages/ForumPage.css`).

### Testing
- Ran `npm run lint` which completed successfully (one pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to this change).
- Ran `npm run build` which succeeded with a production build output.
- Started the dev server (`npm run dev`) and verified the forum pages; captured a screenshot of the running app to validate rendered Markdown and preview behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6e9d11b08330898135d6821f81a4)