### PR TITLE
Fix forum AI response extraction for successful openrouter-chat payloads

### DIFF
--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -61,6 +61,7 @@ export type ForumGlobalAiConfig = {
 }
 
 const DEFAULT_MODEL = 'openrouter/auto'
+const FORUM_AI_DEBUG = import.meta.env.DEV
 
 const unwrapCodeFence = (value: string) => {
   let next = value.trim()
@@ -197,6 +198,45 @@ const normalizeForumAiNewThreadDraft = (rawText: string): ForumAiNewThreadDraft 
     title: parsed.title,
     body: parsed.body,
   }
+}
+
+const flattenTextParts = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (!Array.isArray(value)) {
+    return ''
+  }
+  return value
+    .map((part) => {
+      if (typeof part === 'string') {
+        return part
+      }
+      if (!part || typeof part !== 'object') {
+        return ''
+      }
+      const candidate = part as Record<string, unknown>
+      if (typeof candidate.text === 'string') {
+        return candidate.text
+      }
+      if (typeof candidate.content === 'string') {
+        return candidate.content
+      }
+      return ''
+    })
+    .filter(Boolean)
+    .join('')
+}
+
+const extractOpenRouterContent = (payload: Record<string, unknown>) => {
+  const choice = (payload?.choices as unknown[] | undefined)?.[0] as Record<string, unknown> | undefined
+  const message = ((choice?.message as Record<string, unknown>) ?? choice ?? {}) as Record<string, unknown>
+  const messageContent = flattenTextParts(message.content)
+  const choiceText = typeof choice?.text === 'string' ? choice.text : ''
+  const outputText = flattenTextParts(payload.output_text)
+  const outputParts = flattenTextParts(payload.output)
+  const candidate = [messageContent, choiceText, outputText, outputParts].find((item) => item.trim())
+  return (candidate ?? '').trim()
 }
 
 const parseReplyFromJson = (rawText: string) => {
@@ -398,11 +438,10 @@ export async function requestForumAiContent({
   }
 
   const payload = (await response.json()) as Record<string, unknown>
-  const choice = (payload?.choices as unknown[] | undefined)?.[0] as Record<string, unknown> | undefined
-  const message = ((choice?.message as Record<string, unknown>) ?? choice ?? {}) as Record<string, unknown>
-  const content =
-    typeof message.content === 'string' ? message.content : typeof choice?.text === 'string' ? choice.text : ''
-  const normalizedContent = content.trim()
+  if (FORUM_AI_DEBUG) {
+    console.info('[Forum AI] openrouter-chat payload', payload)
+  }
+  const normalizedContent = extractOpenRouterContent(payload)
 
   if (task === 'new-thread') {
     const draft = normalizeForumAiNewThreadDraft(normalizedContent)


### PR DESCRIPTION
### Motivation
- Forum "生成 AI 主题" could fail with a 200 response because the UI only read `choices[0].message.content` and missed other valid provider response shapes. 
- The change targets the response-handling layer after the `openrouter-chat` call to avoid false "AI 主题稿件生成失败" errors when usable content exists.

### Description
- Added a dev-only `FORUM_AI_DEBUG` switch and temporary `console.info` logging of the full `openrouter-chat` payload via `console.info('[Forum AI] openrouter-chat payload', payload)` to inspect response shapes in development. 
- Implemented `flattenTextParts` to normalize string/array/object content parts into a single text string. 
- Implemented `extractOpenRouterContent` to robustly extract model output by falling back across `choices[0].message.content`, `choices[0].text`, `output_text`, and `output` (and any text-part arrays). 
- Wired forum new-thread and reply flows to use the normalized extracted content so parsing only fails when there is truly no usable generated text.

### Testing
- Built the app with `npm run build`, which completed successfully. 
- Ran lint with `npm run lint`, which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` (`react-hooks/exhaustive-deps`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7587185c833087e1fac165e9c178)