### PR TITLE
Add per-card Forum context token limit and use it during AI generation

### DIFF
--- a/src/pages/ForumSettingsPage.tsx
+++ b/src/pages/ForumSettingsPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { useEnabledModels } from '../hooks/useEnabledModels'
 import type { ForumAiProfile } from '../types'
 import { fetchForumAiProfiles, upsertForumAiProfile } from '../storage/supabaseSync'
-import { FORUM_AI_SLOTS, defaultForumProfile } from './forumShared'
+import { FORUM_AI_SLOTS, clampForumContextTokenLimit, defaultForumProfile } from './forumShared'
 import './ForumPage.css'
 
 type ForumSettingsPageProps = {
@@ -98,6 +98,7 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
         model: draft.model,
         temperature: draft.temperature,
         topP: draft.topP,
+        contextTokenLimit: clampForumContextTokenLimit(draft.contextTokenLimit),
         apiBaseUrl: '',
       })
       setProfiles((current) => {
@@ -164,6 +165,7 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
                       <p className="forum-settings-summary-card__meta">AI 卡 {card.slotIndex}</p>
                       <p className="forum-settings-summary-card__meta">模型：{modelLabel}</p>
                       <p className="forum-settings-summary-card__meta">状态：{card.enabled ? '已启用' : '未启用'}</p>
+                      <p className="forum-settings-summary-card__meta">上下文约束：{card.contextTokenLimit}</p>
                     </article>
                   )
                 })}
@@ -235,6 +237,33 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
                       setDraft((current) => (current ? { ...current, topP: Number(event.target.value) } : current))
                     }
                   />
+                </label>
+
+                <label>
+                  <span>上下文约束</span>
+                  <input
+                    className="input-glass"
+                    type="number"
+                    min={8000}
+                    max={128000}
+                    step={1}
+                    value={draft.contextTokenLimit}
+                    onChange={(event) => {
+                      const raw = Number(event.target.value)
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              contextTokenLimit:
+                                Number.isFinite(raw) && raw >= 8000 && raw <= 128000
+                                  ? Math.round(raw)
+                                  : 32000,
+                            }
+                          : current,
+                      )
+                    }}
+                  />
+                  <small>范围 8000 - 128000，默认 32000</small>
                 </label>
               </div>
               <label className="forum-settings-toggle">

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -14,6 +14,7 @@ export const defaultForumProfile = (slotIndex: number): Omit<ForumAiProfile, 'id
   model: 'openrouter/auto',
   temperature: 0.8,
   topP: 0.9,
+  contextTokenLimit: 32000,
   apiBaseUrl: '',
 })
 
@@ -63,7 +64,9 @@ export type ForumGlobalAiConfig = {
 const DEFAULT_MODEL = 'openrouter/auto'
 const FORUM_REPLY_MAX_TOKENS = 1600
 const FORUM_NEW_THREAD_MAX_TOKENS = 1200
-const FORUM_REPLY_CONTEXT_MAX_REPLIES = 12
+const FORUM_CONTEXT_TOKEN_LIMIT_MIN = 8000
+const FORUM_CONTEXT_TOKEN_LIMIT_MAX = 128000
+const FORUM_CONTEXT_TOKEN_LIMIT_DEFAULT = 32000
 const FORUM_REPLY_CONTEXT_REPLY_MAX_CHARS = 280
 const FORUM_AI_DEBUG = import.meta.env.DEV
 
@@ -256,8 +259,8 @@ const normalizeForumAiNewThreadDraft = (
   return { draft: null, failureReasons }
 }
 
-const buildCompactReplyContext = (thread: ForumThread, replies: ForumReply[]) => {
-  const trimmedReplies = replies.slice(-FORUM_REPLY_CONTEXT_MAX_REPLIES).map((reply, index) => {
+const buildCompactReplyContext = (thread: ForumThread, replies: ForumReply[], omittedReplyCount = 0) => {
+  const compactReplies = replies.map((reply, index) => {
     const content = normalizeForumThreadBody(reply.content)
     const compactContent =
       content.length > FORUM_REPLY_CONTEXT_REPLY_MAX_CHARS
@@ -266,16 +269,66 @@ const buildCompactReplyContext = (thread: ForumThread, replies: ForumReply[]) =>
     return `${index + 1}. [${reply.authorType === 'user' ? 'user' : `ai_${reply.authorSlot ?? 1}`}] ${compactContent}`
   })
 
-  const omittedReplyCount = Math.max(0, replies.length - trimmedReplies.length)
-
   return [
     `主题标题：${thread.title}`,
     `主题正文：${thread.content}`,
     omittedReplyCount > 0 ? `（已省略较早 ${omittedReplyCount} 条回复，仅保留最近上下文）` : '',
-    ...trimmedReplies,
+    ...compactReplies,
   ]
     .filter(Boolean)
     .join('\n')
+}
+
+export const clampForumContextTokenLimit = (value: number | null | undefined) => {
+  if (!Number.isFinite(value)) {
+    return FORUM_CONTEXT_TOKEN_LIMIT_DEFAULT
+  }
+  const rounded = Math.round(value as number)
+  if (rounded < FORUM_CONTEXT_TOKEN_LIMIT_MIN || rounded > FORUM_CONTEXT_TOKEN_LIMIT_MAX) {
+    return FORUM_CONTEXT_TOKEN_LIMIT_DEFAULT
+  }
+  return rounded
+}
+
+const estimateForumContextTokens = (value: string) => Math.ceil(value.length / 4)
+
+const cropForumThreadContextToTokenLimit = (thread: ForumThread, replies: ForumReply[], contextTokenLimit: number) => {
+  const effectiveLimit = clampForumContextTokenLimit(contextTokenLimit)
+  let visibleReplies = replies
+  let omittedReplyCount = 0
+
+  while (visibleReplies.length >= 0) {
+    const candidate = buildCompactReplyContext(thread, visibleReplies, omittedReplyCount)
+    if (estimateForumContextTokens(candidate) <= effectiveLimit) {
+      return candidate
+    }
+    if (visibleReplies.length === 0) {
+      break
+    }
+    visibleReplies = visibleReplies.slice(1)
+    omittedReplyCount += 1
+  }
+
+  const threadBody = normalizeForumThreadBody(thread.content)
+  const threadBodyMaxChars = Math.max(1200, Math.floor(effectiveLimit * 2.2))
+  const compactThread = {
+    ...thread,
+    content: threadBody.length > threadBodyMaxChars ? `${threadBody.slice(0, threadBodyMaxChars)}…` : threadBody,
+  }
+  return buildCompactReplyContext(compactThread, [], replies.length)
+}
+
+
+const cropTextToTokenLimit = (value: string, tokenLimit: number) => {
+  if (!value.trim()) {
+    return value
+  }
+  const safeLimit = Math.max(1, tokenLimit)
+  const approxMaxChars = safeLimit * 4
+  if (value.length <= approxMaxChars) {
+    return value
+  }
+  return `${value.slice(0, approxMaxChars)}…`
 }
 
 const isLikelyTruncatedCompletion = (payload: Record<string, unknown>) => {
@@ -438,13 +491,15 @@ export async function requestForumAiContent({
     throw new Error('登录状态异常或环境变量未配置')
   }
 
-  const threadContext = buildCompactReplyContext(thread, replies)
+  const contextTokenLimit = clampForumContextTokenLimit(profile.contextTokenLimit)
+  const threadContext = cropForumThreadContextToTokenLimit(thread, replies, contextTokenLimit)
 
-  const memoryBlock = memoryEntries.length
+  const memoryBlockRaw = memoryEntries.length
     ? memoryEntries
         .map((entry, index) => `${index + 1}. (${entry.status}) ${entry.content}`)
         .join('\n')
     : '无'
+  const memoryBlock = cropTextToTokenLimit(memoryBlockRaw, Math.max(2000, Math.floor(contextTokenLimit * 0.45)))
 
   const messagesPayload: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = []
   messagesPayload.push({
@@ -461,6 +516,10 @@ export async function requestForumAiContent({
   messagesPayload.push({
     role: 'system',
     content: `memory_entries 全量注入：\n${memoryBlock}`,
+  })
+  messagesPayload.push({
+    role: 'system',
+    content: `forum_thread_context_token_limit：${contextTokenLimit}`,
   })
   if (task === 'new-thread') {
     messagesPayload.push({
@@ -503,6 +562,7 @@ export async function requestForumAiContent({
       scope: 'thread-only',
       enabledModelIds: globalModelConfig.enabledModelIds,
       defaultModelId: globalModelConfig.defaultModelId,
+      contextTokenLimit,
     },
   }
 

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -183,6 +183,7 @@ type ForumAiProfileRow = {
   temperature: number | null
   top_p: number | null
   api_base_url: string | null
+  context_token_limit: number | null
   created_at: string
   updated_at: string
 }
@@ -333,6 +334,14 @@ const mapForumReplyRow = (row: ForumReplyRow): ForumReply => ({
   createdAt: row.created_at,
 })
 
+const normalizeForumContextTokenLimit = (value: number | null | undefined) => {
+  if (!Number.isFinite(value)) {
+    return 32000
+  }
+  const rounded = Math.round(value as number)
+  return rounded >= 8000 && rounded <= 128000 ? rounded : 32000
+}
+
 const mapForumAiProfileRow = (row: ForumAiProfileRow): ForumAiProfile => ({
   id: row.id,
   userId: row.user_id,
@@ -343,6 +352,7 @@ const mapForumAiProfileRow = (row: ForumAiProfileRow): ForumAiProfile => ({
   model: row.model ?? 'openrouter/auto',
   temperature: row.temperature ?? 0.8,
   topP: row.top_p ?? 0.9,
+  contextTokenLimit: normalizeForumContextTokenLimit(row.context_token_limit),
   apiBaseUrl: row.api_base_url ?? '',
   createdAt: row.created_at,
   updatedAt: row.updated_at,
@@ -1731,7 +1741,7 @@ export const fetchForumAiProfiles = async (): Promise<ForumAiProfile[]> => {
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_ai_profiles')
-    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
+    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,context_token_limit,created_at,updated_at')
     .eq('user_id', userId)
     .in('slot_index', [1, 2, 3])
     .order('slot_index', { ascending: true })
@@ -1751,6 +1761,7 @@ export const upsertForumAiProfile = async (
     model: string
     temperature: number
     topP: number
+    contextTokenLimit: number
     apiBaseUrl: string
   },
 ): Promise<ForumAiProfile> => {
@@ -1771,12 +1782,13 @@ export const upsertForumAiProfile = async (
         model: payload.model,
         temperature: payload.temperature,
         top_p: payload.topP,
+        context_token_limit: normalizeForumContextTokenLimit(payload.contextTokenLimit),
         api_base_url: payload.apiBaseUrl,
         updated_at: now,
       },
       { onConflict: 'user_id,slot_index' },
     )
-    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,created_at,updated_at')
+    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,context_token_limit,created_at,updated_at')
     .single()
 
   if (error || !data) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,7 @@ export type ForumAiProfile = {
   model: string
   temperature: number
   topP: number
+  contextTokenLimit: number
   apiBaseUrl: string
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
### Motivation
- Replies were failing/truncating due to a fixed, hidden forum context budget; a per-AI-card configurable budget is required to control thread-context injection for both new-thread and reply generation.
- The product requires a numeric per-card setting `上下文约束` with range 8000–128000 and default 32000 persisted in Supabase as `forum_ai_profiles.context_token_limit`.

### Description
- Added `contextTokenLimit` to the `ForumAiProfile` type and default profile (`32000`) so each Forum AI card carries the setting (`src/types.ts`, `src/pages/forumShared.ts`).
- Wired storage: added `context_token_limit` to the Supabase row type, mapped/normalized the value on fetch, and persistently upsert it with range normalization (`src/storage/supabaseSync.ts`).
- UI: added a numeric input labeled `上下文约束` (helper text `范围 8000 - 128000，默认 32000`) to the Forum AI card editor and display the saved value on the summary card, with frontend guards that enforce the allowed range (`src/pages/ForumSettingsPage.tsx`).
- Runtime: implemented `clampForumContextTokenLimit`, `cropForumThreadContextToTokenLimit` and `cropTextToTokenLimit` in `forumShared.ts` and replaced the previous fixed reply-window logic to crop thread/reply/memory context based on the per-card token budget (simple char->token heuristic via `chars/4`), then injected the final context and the configured budget into the model request payload so both new-thread and reply flows respect the setting.

### Testing
- Built the project: ran `npm run build` and the production build succeeded. (✅)
- Linted the code: ran `npm run lint` which completed successfully with a single existing warning. (✅ with warning)
- Ran the dev server (`npm run dev`) to verify the UI serves and routes; server started and Vite reported readiness. (✅)
- Attempted an automated Playwright screenshot to capture the settings UI, but the headless browser crashed in this environment so no screenshot artifact was produced. (⚠️)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7f9dd7948330b83d6f15ea2f184a)