### PR TITLE
Use per-card max_tokens for Forum replies and relax truncation failure

### DIFF
--- a/src/pages/ForumSettingsPage.tsx
+++ b/src/pages/ForumSettingsPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { useEnabledModels } from '../hooks/useEnabledModels'
 import type { ForumAiProfile } from '../types'
 import { fetchForumAiProfiles, upsertForumAiProfile } from '../storage/supabaseSync'
-import { FORUM_AI_SLOTS, clampForumContextTokenLimit, defaultForumProfile } from './forumShared'
+import { FORUM_AI_SLOTS, clampForumContextTokenLimit, clampForumMaxOutputTokens, defaultForumProfile } from './forumShared'
 import './ForumPage.css'
 
 type ForumSettingsPageProps = {
@@ -99,6 +99,7 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
         temperature: draft.temperature,
         topP: draft.topP,
         contextTokenLimit: clampForumContextTokenLimit(draft.contextTokenLimit),
+        maxOutputTokens: clampForumMaxOutputTokens(draft.maxOutputTokens),
         apiBaseUrl: '',
       })
       setProfiles((current) => {
@@ -166,6 +167,7 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
                       <p className="forum-settings-summary-card__meta">模型：{modelLabel}</p>
                       <p className="forum-settings-summary-card__meta">状态：{card.enabled ? '已启用' : '未启用'}</p>
                       <p className="forum-settings-summary-card__meta">上下文约束：{card.contextTokenLimit}</p>
+                      <p className="forum-settings-summary-card__meta">最大输出 tokens：{card.maxOutputTokens}</p>
                     </article>
                   )
                 })}
@@ -264,6 +266,33 @@ const ForumSettingsPage = ({ user }: ForumSettingsPageProps) => {
                     }}
                   />
                   <small>范围 8000 - 128000，默认 32000</small>
+                </label>
+
+                <label>
+                  <span>最大输出 tokens</span>
+                  <input
+                    className="input-glass"
+                    type="number"
+                    min={128}
+                    max={4000}
+                    step={1}
+                    value={draft.maxOutputTokens}
+                    onChange={(event) => {
+                      const raw = Number(event.target.value)
+                      setDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              maxOutputTokens:
+                                Number.isFinite(raw) && raw >= 128 && raw <= 4000
+                                  ? Math.round(raw)
+                                  : 1600,
+                            }
+                          : current,
+                      )
+                    }}
+                  />
+                  <small>范围 128 - 4000，默认 1600（用于论坛回复生成）</small>
                 </label>
               </div>
               <label className="forum-settings-toggle">

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -15,6 +15,7 @@ export const defaultForumProfile = (slotIndex: number): Omit<ForumAiProfile, 'id
   temperature: 0.8,
   topP: 0.9,
   contextTokenLimit: 32000,
+  maxOutputTokens: 1600,
   apiBaseUrl: '',
 })
 
@@ -63,7 +64,6 @@ export type ForumGlobalAiConfig = {
 }
 
 const DEFAULT_MODEL = 'openrouter/auto'
-const FORUM_REPLY_MAX_TOKENS = 1600
 const FORUM_NEW_THREAD_MAX_TOKENS = 1200
 const FORUM_CONTEXT_TOKEN_LIMIT_MIN = 8000
 const FORUM_CONTEXT_TOKEN_LIMIT_MAX = 128000
@@ -302,6 +302,17 @@ const buildFullThreadConversationContext = (thread: ForumThread, replies: ForumR
   return [rootSection, repliesSection].join('\n\n')
 }
 
+export const clampForumMaxOutputTokens = (value: number | null | undefined) => {
+  if (!Number.isFinite(value)) {
+    return 1600
+  }
+  const rounded = Math.round(value as number)
+  if (rounded < 128 || rounded > 4000) {
+    return 1600
+  }
+  return rounded
+}
+
 export const clampForumContextTokenLimit = (value: number | null | undefined) => {
   if (!Number.isFinite(value)) {
     return FORUM_CONTEXT_TOKEN_LIMIT_DEFAULT
@@ -487,6 +498,7 @@ export async function requestForumAiContent({
   }
 
   const contextTokenLimit = clampForumContextTokenLimit(profile.contextTokenLimit)
+  const configuredMaxOutputTokens = clampForumMaxOutputTokens(profile.maxOutputTokens)
   const threadContext = buildFullThreadConversationContext(thread, replies)
   const threadAuthorName = resolveForumSpeakerName(thread)
 
@@ -594,7 +606,7 @@ export async function requestForumAiContent({
     messages: messagesPayload,
     temperature: profile.temperature,
     top_p: profile.topP,
-    max_tokens: task === 'reply' ? FORUM_REPLY_MAX_TOKENS : FORUM_NEW_THREAD_MAX_TOKENS,
+    max_tokens: task === 'reply' ? configuredMaxOutputTokens : FORUM_NEW_THREAD_MAX_TOKENS,
     stream: false,
     extra: {
       identitySlot: profile.slotIndex,
@@ -603,6 +615,15 @@ export async function requestForumAiContent({
       defaultModelId: globalModelConfig.defaultModelId,
       contextTokenLimit,
     },
+  }
+
+  if (task === 'reply') {
+    console.info('[Forum AI][reply] generation token settings', {
+      configuredMaxOutputTokens,
+      sentMaxTokens: requestBody.max_tokens,
+      profileSlot: profile.slotIndex,
+      model: resolvedModel,
+    })
   }
 
   const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`, {
@@ -646,14 +667,21 @@ export async function requestForumAiContent({
     return draft
   }
 
-  if (isLikelyTruncatedCompletion(payload)) {
+  const replyBody = normalizeForumAiReplyBody(normalizedContent)
+  const truncated = isLikelyTruncatedCompletion(payload)
+
+  if (truncated) {
     console.warn('[Forum AI][reply] model completion likely truncated by token limit', {
+      configuredMaxOutputTokens,
+      sentMaxTokens: requestBody.max_tokens,
+      parsedReplyLength: replyBody?.length ?? 0,
       payloadPreview: JSON.stringify(payload).slice(0, 1200),
     })
-    throw new Error('AI 回复疑似因长度限制被截断，请重试。')
+    if (!replyBody) {
+      throw new Error('AI 回复疑似因长度限制被截断，请重试。')
+    }
   }
 
-  const replyBody = normalizeForumAiReplyBody(normalizedContent)
   if (!replyBody) {
     throw new Error('AI 回复格式解析失败')
   }

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -184,6 +184,7 @@ type ForumAiProfileRow = {
   top_p: number | null
   api_base_url: string | null
   context_token_limit: number | null
+  max_output_tokens: number | null
   created_at: string
   updated_at: string
 }
@@ -342,6 +343,14 @@ const normalizeForumContextTokenLimit = (value: number | null | undefined) => {
   return rounded >= 8000 && rounded <= 128000 ? rounded : 32000
 }
 
+const normalizeForumMaxOutputTokens = (value: number | null | undefined) => {
+  if (!Number.isFinite(value)) {
+    return 1600
+  }
+  const rounded = Math.round(value as number)
+  return rounded >= 128 && rounded <= 4000 ? rounded : 1600
+}
+
 const mapForumAiProfileRow = (row: ForumAiProfileRow): ForumAiProfile => ({
   id: row.id,
   userId: row.user_id,
@@ -352,6 +361,7 @@ const mapForumAiProfileRow = (row: ForumAiProfileRow): ForumAiProfile => ({
   model: row.model ?? 'openrouter/auto',
   temperature: row.temperature ?? 0.8,
   topP: row.top_p ?? 0.9,
+  maxOutputTokens: normalizeForumMaxOutputTokens(row.max_output_tokens),
   contextTokenLimit: normalizeForumContextTokenLimit(row.context_token_limit),
   apiBaseUrl: row.api_base_url ?? '',
   createdAt: row.created_at,
@@ -1741,7 +1751,7 @@ export const fetchForumAiProfiles = async (): Promise<ForumAiProfile[]> => {
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_ai_profiles')
-    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,context_token_limit,created_at,updated_at')
+    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,context_token_limit,max_output_tokens,created_at,updated_at')
     .eq('user_id', userId)
     .in('slot_index', [1, 2, 3])
     .order('slot_index', { ascending: true })
@@ -1762,6 +1772,7 @@ export const upsertForumAiProfile = async (
     temperature: number
     topP: number
     contextTokenLimit: number
+    maxOutputTokens: number
     apiBaseUrl: string
   },
 ): Promise<ForumAiProfile> => {
@@ -1783,12 +1794,13 @@ export const upsertForumAiProfile = async (
         temperature: payload.temperature,
         top_p: payload.topP,
         context_token_limit: normalizeForumContextTokenLimit(payload.contextTokenLimit),
+        max_output_tokens: normalizeForumMaxOutputTokens(payload.maxOutputTokens),
         api_base_url: payload.apiBaseUrl,
         updated_at: now,
       },
       { onConflict: 'user_id,slot_index' },
     )
-    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,context_token_limit,created_at,updated_at')
+    .select('id,user_id,slot_index,enabled,name,system_prompt,model,temperature,top_p,api_base_url,context_token_limit,max_output_tokens,created_at,updated_at')
     .single()
 
   if (error || !data) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,7 @@ export type ForumAiProfile = {
   model: string
   temperature: number
   topP: number
+  maxOutputTokens: number
   contextTokenLimit: number
   apiBaseUrl: string
   createdAt: string


### PR DESCRIPTION
### Motivation
- Forum reply generation was using a hardcoded reply `max_tokens` and treated `finish_reason: "length"` as an immediate hard failure, causing usable partial replies to be discarded.
- The per-AI-card output-length setting was only stored in UI/state and not consistently applied end-to-end (UI → DB → generation request).

### Description
- Added a per-Forum-AI-card `maxOutputTokens` field to the `ForumAiProfile` type and default profile, and persisted it as `forum_ai_profiles.max_output_tokens`. (`src/types.ts`, `src/storage/supabaseSync.ts`, `src/pages/forumShared.ts`)
- Wired the Forum Settings UI to show/edit/save the `最大输出 tokens` value and display it on the card. (`src/pages/ForumSettingsPage.tsx`)
- Updated the forum generation helper to send the card's clamped `maxOutputTokens` as `max_tokens` for **reply** requests and added debug logging that reports `configuredMaxOutputTokens` vs `sentMaxTokens`. (`src/pages/forumShared.ts`)
- Changed truncation handling so `finish_reason: "length"` is logged and will not cause an immediate hard failure if a parseable partial reply exists; it only hard-fails when no usable reply body can be parsed. (`src/pages/forumShared.ts`)

### Testing
- Ran `npm run lint`, which completed successfully with one unrelated warning in `CheckinPage.tsx`.
- Ran `npm run build`, which completed successfully and produced the production bundles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8663b1108330971c89f41a6cb9a2)