### PR TITLE
Improve RP NPC form validation with inline name error

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -307,6 +307,18 @@
   gap: 4px;
 }
 
+
+.rp-dashboard-section .rp-input-invalid {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18);
+}
+
+.rp-field-error {
+  margin: 0;
+  font-size: 12px;
+  color: #b91c1c;
+}
+
 .rp-dashboard-section .danger-text {
   color: #b91c1c;
 }

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -116,6 +116,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
   const [npcLoading, setNpcLoading] = useState(false)
   const [editingNpcId, setEditingNpcId] = useState<string | null>(null)
   const [npcForm, setNpcForm] = useState<NpcFormState>(createEmptyNpcForm)
+  const [npcNameError, setNpcNameError] = useState<string | null>(null)
   const [savingNpc, setSavingNpc] = useState(false)
   const [pendingDeleteNpc, setPendingDeleteNpc] = useState<RpNpcCard | null>(null)
   const [deletingNpcId, setDeletingNpcId] = useState<string | null>(null)
@@ -832,6 +833,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
 
   const startCreateNpc = () => {
     setEditingNpcId('new')
+    setNpcNameError(null)
     setNpcForm((current) => ({
       ...createEmptyNpcForm(),
       model: enabledModelIds[0] ?? current.model,
@@ -840,6 +842,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
 
   const startEditNpc = (card: RpNpcCard) => {
     setEditingNpcId(card.id)
+    setNpcNameError(null)
     setNpcForm({
       displayName: card.displayName,
       systemPrompt: card.systemPrompt ?? '',
@@ -862,7 +865,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
     }
     const displayName = npcForm.displayName.trim()
     if (!displayName) {
-      setError('NPC名称不能为空。')
+      setNpcNameError('NPC名称不能为空。')
       return
     }
     const nextEnabled = npcForm.enabled
@@ -891,6 +894,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
     }
 
     setSavingNpc(true)
+    setNpcNameError(null)
     setError(null)
     setNotice(null)
     try {
@@ -916,6 +920,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
         setNpcCards((current) => current.map((item) => (item.id === editingNpcId ? updated : item)))
       }
       setEditingNpcId(null)
+      setNpcNameError(null)
       setNpcForm((current) => ({
         ...createEmptyNpcForm(),
         model: enabledModelIds[0] ?? current.model,
@@ -983,7 +988,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
     return <div className="rp-room-page rp-room-chat-page chat-polka-dots"><p className="tips">房间加载中…</p></div>
   }
 
-  if (error || !room) {
+  if (!room) {
     return (
       <div className="rp-room-page rp-room-chat-page chat-polka-dots">
         <header className="rp-room-header">
@@ -1090,9 +1095,17 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
               <input
                 type="text"
                 value={npcForm.displayName}
-                onChange={(event) => setNpcForm((current) => ({ ...current, displayName: event.target.value }))}
+                onChange={(event) => {
+                  const nextDisplayName = event.target.value
+                  setNpcForm((current) => ({ ...current, displayName: nextDisplayName }))
+                  if (nextDisplayName.trim()) {
+                    setNpcNameError(null)
+                  }
+                }}
+                className={npcNameError ? 'rp-input-invalid' : undefined}
                 placeholder="例如：店主阿杰"
               />
+              {npcNameError ? <p className="rp-field-error">{npcNameError}</p> : null}
             </label>
             <label>
               System Prompt
@@ -1171,7 +1184,10 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
               启用
             </label>
             <div className="rp-npc-form-actions">
-              <button type="button" className="ghost" onClick={() => setEditingNpcId(null)}>
+              <button type="button" className="ghost" onClick={() => {
+                setEditingNpcId(null)
+                setNpcNameError(null)
+              }}>
                 取消
               </button>
               <button type="button" className="primary" onClick={() => void handleSaveNpc()} disabled={savingNpc}>


### PR DESCRIPTION
### Motivation
- Prevent navigation to the full-page error when saving an NPC with an empty name and avoid clearing the editor inputs on validation failure.
- Provide clear inline feedback near the `NPC名称` field and keep the dashboard form state intact until a successful save.

### Description
- Added a dedicated validation state `npcNameError` and show `NPC名称不能为空。` inline instead of calling the page-level `setError` when the trimmed name is empty.
- Adjusted the room fallback gating to only render the “无法进入房间” screen when `room` is actually missing (changed `if (error || !room)` to `if (!room)`).
- Added input handling to clear `npcNameError` as soon as the user types a non-empty name and preserved all other `npcForm` fields on validation failure.
- Introduced CSS classes `rp-input-invalid` and `rp-field-error` and corresponding styles to apply red border and error text for the name field.

### Testing
- Ran `npm run build` and the build completed successfully (TypeScript compile and Vite build passed).
- Started the dev server (`npm run dev`) and captured a UI screenshot to verify the inline validation UI; the app launched and the screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae85b34ee88330b2c87d8d2450b157)