### PR TITLE
Add parent_id-based forum reply tree support in storage and thread page

### DIFF
--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -7,7 +7,7 @@ import {
   deleteForumThread,
   fetchAllMemoryEntries,
   fetchForumAiProfiles,
-  fetchForumRepliesByThread,
+  fetchForumReplyTreeByThread,
   fetchForumThreadById,
 } from '../storage/supabaseSync'
 import ConfirmDialog from '../components/ConfirmDialog'
@@ -48,7 +48,7 @@ const ForumThreadPage = () => {
     try {
       const [threadData, replyData, profileData, globalConfig] = await Promise.all([
         fetchForumThreadById(id),
-        fetchForumRepliesByThread(id),
+        fetchForumReplyTreeByThread(id),
         fetchForumAiProfiles(),
         loadForumGlobalAiConfig(),
       ])

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -167,8 +167,11 @@ type ForumReplyRow = {
   author_type: ForumAuthorType
   author_slot: number | null
   author_name: string | null
+  parent_id: string | null
   reply_to_reply_id: string | null
   reply_to_author_name: string | null
+  depth?: number | null
+  sort_path?: string | null
   created_at: string
 }
 
@@ -320,19 +323,26 @@ const mapForumThreadRow = (row: ForumThreadRow): ForumThread => ({
   updatedAt: row.updated_at,
 })
 
-const mapForumReplyRow = (row: ForumReplyRow): ForumReply => ({
-  id: row.id,
-  threadId: row.thread_id,
-  userId: row.user_id,
-  content: row.body,
-  authorType: row.author_type,
-  authorSlot: row.author_slot,
-  authorName: row.author_name,
-  replyToType: row.reply_to_reply_id ? 'reply' : 'thread',
-  replyToReplyId: row.reply_to_reply_id,
-  replyToAuthorName: row.reply_to_author_name,
-  createdAt: row.created_at,
-})
+const mapForumReplyRow = (row: ForumReplyRow): ForumReply => {
+  const canonicalParentId = row.parent_id ?? row.reply_to_reply_id
+
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    userId: row.user_id,
+    content: row.body,
+    authorType: row.author_type,
+    authorSlot: row.author_slot,
+    authorName: row.author_name,
+    parentId: canonicalParentId,
+    depth: row.depth ?? undefined,
+    sortPath: row.sort_path ?? undefined,
+    replyToType: canonicalParentId ? 'reply' : 'thread',
+    replyToReplyId: row.reply_to_reply_id ?? canonicalParentId,
+    replyToAuthorName: row.reply_to_author_name,
+    createdAt: row.created_at,
+  }
+}
 
 const normalizeForumContextTokenLimit = (value: number | null | undefined) => {
   if (!Number.isFinite(value)) {
@@ -1658,7 +1668,7 @@ export const fetchForumRepliesByThread = async (threadId: string): Promise<Forum
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_replies')
-    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
+    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,parent_id,reply_to_reply_id,reply_to_author_name,created_at')
     .eq('thread_id', threadId)
     .eq('user_id', userId)
     .order('created_at', { ascending: true })
@@ -1667,6 +1677,21 @@ export const fetchForumRepliesByThread = async (threadId: string): Promise<Forum
     throw error
   }
   return (data ?? []).map((row) => mapForumReplyRow(row as ForumReplyRow))
+}
+
+export const fetchForumReplyTreeByThread = async (threadId: string): Promise<ForumReply[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase.rpc('get_forum_thread_replies_tree', { p_thread_id: threadId })
+
+  if (error) {
+    throw error
+  }
+
+  const rows = (data ?? []) as ForumReplyRow[]
+  return rows.filter((row) => row.user_id === userId).map((row) => mapForumReplyRow(row))
 }
 
 export const createForumReply = async (params: {
@@ -1681,9 +1706,9 @@ export const createForumReply = async (params: {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
-  const normalizedReplyToReplyId = params.replyToType === 'thread' ? null : params.replyToReplyId ?? null
+  const normalizedParentId = params.replyToType === 'thread' ? null : params.replyToReplyId ?? null
   const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
-  const replyToAuthorName = await resolveReplyTargetAuthorName(userId, params.threadId, normalizedReplyToReplyId)
+  const replyToAuthorName = await resolveReplyTargetAuthorName(userId, params.threadId, normalizedParentId)
   const { data, error } = await supabase
     .from('forum_replies')
     .insert({
@@ -1693,10 +1718,11 @@ export const createForumReply = async (params: {
       author_type: params.authorType,
       author_slot: authorPayload.authorSlot,
       author_name: authorPayload.authorName,
-      reply_to_reply_id: normalizedReplyToReplyId,
+      parent_id: normalizedParentId,
+      reply_to_reply_id: normalizedParentId,
       reply_to_author_name: replyToAuthorName,
     })
-    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
+    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,parent_id,reply_to_reply_id,reply_to_author_name,created_at')
     .single()
 
   if (error || !data) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,9 @@ export type ForumReply = {
   authorType: ForumAuthorType
   authorSlot: number | null
   authorName: string | null
+  parentId: string | null
+  depth?: number
+  sortPath?: string
   replyToType: 'thread' | 'reply' | null
   replyToReplyId: string | null
   replyToAuthorName: string | null


### PR DESCRIPTION
### Motivation
- Introduce a canonical tree linkage field for forum replies so replies can be represented as a tree instead of only a flat chronological list.
- Keep backward compatibility with existing `reply_to_reply_id` while supporting the new RPC `get_forum_thread_replies_tree` and SQL backfilled `parent_id` column.

### Description
- Added `parentId: string | null`, optional `depth?: number`, and optional `sortPath?: string` to the `ForumReply` type in `src/types.ts` so tree metadata is available at the domain level.
- Extended the `ForumReplyRow` row type in `src/storage/supabaseSync.ts` to include `parent_id`, optional `depth`, and optional `sort_path` and updated selects to request `parent_id` where appropriate.
- Updated `mapForumReplyRow` to treat `parent_id` as canonical (falling back to `reply_to_reply_id` for compatibility) and to populate `parentId`, `depth`, and `sortPath` while preserving `replyToType`/`replyToReplyId` behavior.
- Modified `createForumReply` to compute `normalizedParentId` and insert both `parent_id` and `reply_to_reply_id` (aligned) so newly created nested replies write the canonical field while remaining compatible with older consumers.
- Added `fetchForumReplyTreeByThread(threadId)` which calls `supabase.rpc('get_forum_thread_replies_tree', { p_thread_id: threadId })` and maps the returned rows through the new mapper.
- Switched the forum thread detail page (`src/pages/ForumThreadPage.tsx`) to use `fetchForumReplyTreeByThread` for refreshing replies while keeping the older `fetchForumRepliesByThread` available for other usages.

### Testing
- Ran the production build with `npm run build` and the build completed successfully.
- The TypeScript compile step (`tsc -b`) completed as part of the build, so new types and mappings type-check in the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af80b88c48833092a9460154034a35)