### PR TITLE
Add nested forum reply tree UI and backend mapping for threaded replies

### DIFF
--- a/src/components/forum/ForumReplyTree.tsx
+++ b/src/components/forum/ForumReplyTree.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useState, type CSSProperties, type ReactNode } from 'react'
+import MarkdownRenderer from '../MarkdownRenderer'
+import type { ForumReply } from '../../types'
+import type { ForumReplyTreeNode } from '../../utils/forumReplyTree'
+
+type ForumReplyTreeProps = {
+  nodes: ForumReplyTreeNode[]
+  activeInlineReplyId: string | null
+  deletingReplyId: string | null
+  getAuthorLabel: (reply: ForumReply) => string
+  getReplyTargetLabel: (reply: ForumReply) => string
+  formatTime: (value: string) => string
+  onToggleInlineReply: (replyId: string) => void
+  onDeleteReply: (replyId: string) => void
+  renderInlineEditor: (reply: ForumReply) => ReactNode
+}
+
+const ForumReplyTree = ({
+  nodes,
+  activeInlineReplyId,
+  deletingReplyId,
+  getAuthorLabel,
+  getReplyTargetLabel,
+  formatTime,
+  onToggleInlineReply,
+  onDeleteReply,
+  renderInlineEditor,
+}: ForumReplyTreeProps) => {
+  const [collapsedNodeIds, setCollapsedNodeIds] = useState<Set<string>>(new Set())
+
+  const toggleNode = useCallback((replyId: string) => {
+    setCollapsedNodeIds((current) => {
+      const next = new Set(current)
+      if (next.has(replyId)) {
+        next.delete(replyId)
+      } else {
+        next.add(replyId)
+      }
+      return next
+    })
+  }, [])
+
+  const renderNode = (node: ForumReplyTreeNode, depth: number): ReactNode => {
+    const { reply, children } = node
+    const hasChildren = children.length > 0
+    const collapsed = hasChildren ? collapsedNodeIds.has(reply.id) : false
+    const style = { '--forum-reply-depth': depth } as CSSProperties
+
+    return (
+      <div className="forum-reply-node" key={reply.id} style={style}>
+        <article className="forum-reply-item">
+          <header className="forum-bbs-card__author forum-bbs-card__author--reply">
+            <strong>{getAuthorLabel(reply)}</strong>
+            <small>{formatTime(reply.createdAt)}</small>
+          </header>
+          <div className="forum-bbs-card__content forum-bbs-card__content--reply">
+            <div className="assistant-markdown">
+              <MarkdownRenderer content={reply.content} />
+            </div>
+          </div>
+          <footer className="forum-reply-item__footer">
+            <span>回复给：{getReplyTargetLabel(reply)}</span>
+            {hasChildren ? (
+              <button type="button" className="btn-secondary" onClick={() => toggleNode(reply.id)}>
+                {collapsed ? `展开 ${children.length} 条子回复` : `收起 ${children.length} 条子回复`}
+              </button>
+            ) : null}
+            <button type="button" className="btn-secondary" onClick={() => onToggleInlineReply(reply.id)}>
+              {activeInlineReplyId === reply.id ? '收起回复' : '回复'}
+            </button>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => onDeleteReply(reply.id)}
+              disabled={deletingReplyId === reply.id}
+            >
+              {deletingReplyId === reply.id ? '删除中…' : '删除'}
+            </button>
+          </footer>
+          {activeInlineReplyId === reply.id ? renderInlineEditor(reply) : null}
+        </article>
+        {hasChildren && !collapsed ? (
+          <div className="forum-reply-node__children">{children.map((child) => renderNode(child, depth + 1))}</div>
+        ) : null}
+      </div>
+    )
+  }
+
+  return <div className="forum-reply-tree">{nodes.map((node) => renderNode(node, 0))}</div>
+}
+
+export default ForumReplyTree

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -783,3 +783,38 @@
     padding-right: 0.72rem;
   }
 }
+
+.forum-thread-list__empty {
+  margin: 0;
+  color: #5c5c5c;
+  font-family: var(--font-sans);
+}
+
+.forum-reply-tree {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.forum-reply-node {
+  margin-left: calc(var(--forum-reply-depth, 0) * 1rem);
+}
+
+.forum-reply-node__children {
+  margin-top: 0.55rem;
+  margin-left: 0.45rem;
+  padding-left: 0.65rem;
+  border-left: 2px dashed #c8adb9;
+  display: grid;
+  gap: 0.55rem;
+}
+
+@media (max-width: 640px) {
+  .forum-reply-node {
+    margin-left: calc(var(--forum-reply-depth, 0) * 0.55rem);
+  }
+
+  .forum-reply-node__children {
+    margin-left: 0.2rem;
+    padding-left: 0.45rem;
+  }
+}

--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -7,13 +7,15 @@ import {
   deleteForumThread,
   fetchAllMemoryEntries,
   fetchForumAiProfiles,
-  fetchForumRepliesByThread,
+  fetchForumReplyTreeByThread,
   fetchForumThreadById,
 } from '../storage/supabaseSync'
 import ConfirmDialog from '../components/ConfirmDialog'
 import MarkdownRenderer from '../components/MarkdownRenderer'
+import ForumReplyTree from '../components/forum/ForumReplyTree'
 import { FORUM_AI_SLOTS, defaultForumProfile, getForumAuthorLabel, loadForumGlobalAiConfig, requestForumAiContent, type ForumGlobalAiConfig } from './forumShared'
 import './ForumPage.css'
+import { buildForumReplyTree } from '../utils/forumReplyTree'
 
 const formatTime = (value: string) =>
   new Date(value).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
@@ -48,7 +50,7 @@ const ForumThreadPage = () => {
     try {
       const [threadData, replyData, profileData, globalConfig] = await Promise.all([
         fetchForumThreadById(id),
-        fetchForumRepliesByThread(id),
+        fetchForumReplyTreeByThread(id),
         fetchForumAiProfiles(),
         loadForumGlobalAiConfig(),
       ])
@@ -115,18 +117,26 @@ const ForumThreadPage = () => {
     return map
   }, [profiles])
 
+  const replyMap = useMemo(() => {
+    const map = new Map<string, ForumReply>()
+    replies.forEach((reply) => map.set(reply.id, reply))
+    return map
+  }, [replies])
+
+  const replyTree = useMemo(() => buildForumReplyTree(replies), [replies])
+
   const getReplyTargetLabel = useCallback(
     (targetReplyId: string | null) => {
       if (!targetReplyId) {
         return '主题帖'
       }
-      const target = replies.find((reply) => reply.id === targetReplyId)
+      const target = replyMap.get(targetReplyId)
       if (!target) {
         return '主题帖'
       }
       return `${getForumAuthorLabel(target.authorType, target.authorSlot, profiles, target.authorName)} 的回复`
     },
-    [profiles, replies],
+    [profiles, replyMap],
   )
 
   const rootTargetLabel = useMemo(() => {
@@ -211,6 +221,89 @@ const ForumThreadPage = () => {
     }
   }
 
+  const getReplyTargetNameForReply = useCallback((reply: ForumReply) => {
+    if (!thread) {
+      return '主题帖'
+    }
+    if (!reply.parentId) {
+      return getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)
+    }
+    const target = replyMap.get(reply.parentId)
+    if (!target) {
+      return '未知目标'
+    }
+    return getForumAuthorLabel(target.authorType, target.authorSlot, profiles, target.authorName)
+  }, [profiles, replyMap, thread])
+
+  const renderInlineEditor = (reply: ForumReply) => (
+    <div className="forum-inline-editor">
+      <p className="forum-inline-editor__target">
+        回复给：{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}
+      </p>
+      <label>
+        内容 / AI 指令
+        <div className="forum-terminal-field">
+          <textarea
+            className="textarea-glass"
+            rows={4}
+            value={inlineReplyContent}
+            onChange={(event) => setInlineReplyContent(event.target.value)}
+            placeholder="输入对该回复的内容；也可填写给 AI 的指令后点击下方按钮。"
+          />
+        </div>
+      </label>
+      <div className="forum-editor__actions">
+        <button
+          type="button"
+          className="btn-primary"
+          disabled={submitting}
+          onClick={() =>
+            void handleSubmitReply({
+              content: inlineReplyContent,
+              targetReplyId: reply.id,
+              onSuccess: () => {
+                setInlineReplyContent('')
+                setActiveInlineReplyId(null)
+              },
+            })
+          }
+        >
+          发布用户回复
+        </button>
+        {FORUM_AI_SLOTS.map((slot) => {
+          const profile = profileMap.get(slot) ?? {
+            ...defaultForumProfile(slot),
+            id: `slot-${slot}`,
+            userId: '',
+            createdAt: '',
+            updatedAt: '',
+          }
+          return (
+            <button
+              key={`${reply.id}-${slot}`}
+              type="button"
+              className="btn-secondary"
+              disabled={Boolean(generatingSlot) || !profile.enabled || !globalAiConfig}
+              onClick={() =>
+                void handleGenerateAiReply({
+                  slot,
+                  content: inlineReplyContent,
+                  targetReplyId: reply.id,
+                  onSuccess: () => {
+                    setInlineReplyContent('')
+                    setActiveInlineReplyId(null)
+                  },
+                })
+              }
+            >
+              {generatingSlot === slot ? '生成中…' : `${profile.displayName} 生成回复`}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+
   if (loading) {
     return <div className="forum-page app-shell__content forum-loading">加载中…</div>
   }
@@ -257,123 +350,27 @@ const ForumThreadPage = () => {
       </article>
 
       <section className="glass-card forum-thread-list">
-        <h3 className="ui-title">回复（按时间顺序）</h3>
-        <div className="forum-thread-list__items">
-          {replies.map((reply) => {
-            const target =
-              reply.replyToType === 'reply' ? replies.find((item) => item.id === reply.replyToReplyId) : null
-            const targetName =
-              reply.replyToType === 'thread'
-                ? getForumAuthorLabel(thread.authorType, thread.authorSlot, profiles, thread.authorName)
-                : target
-                  ? getForumAuthorLabel(target.authorType, target.authorSlot, profiles, target.authorName)
-                  : '未知目标'
-            return (
-              <article className="forum-reply-item" key={reply.id}>
-                <header className="forum-bbs-card__author forum-bbs-card__author--reply">
-                  <strong>{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}</strong>
-                  <small>{formatTime(reply.createdAt)}</small>
-                </header>
-                <div className="forum-bbs-card__content forum-bbs-card__content--reply">
-                  <div className="assistant-markdown">
-                    <MarkdownRenderer content={reply.content} />
-                  </div>
-                </div>
-                <footer className="forum-reply-item__footer">
-                  <span>回复给：{targetName}</span>
-                  <button
-                    type="button"
-                    className="btn-secondary"
-                    onClick={() => {
-                      setError(null)
-                      setSuccessMessage(null)
-                      setInlineReplyContent('')
-                      setActiveInlineReplyId((current) => (current === reply.id ? null : reply.id))
-                    }}
-                  >
-                    {activeInlineReplyId === reply.id ? '收起回复' : '回复'}
-                  </button>
-                  <button
-                    type="button"
-                    className="btn-secondary"
-                    onClick={() => setPendingDeleteReplyId(reply.id)}
-                    disabled={deletingReplyId === reply.id}
-                  >
-                    {deletingReplyId === reply.id ? '删除中…' : '删除'}
-                  </button>
-                </footer>
-                {activeInlineReplyId === reply.id ? (
-                  <div className="forum-inline-editor">
-                    <p className="forum-inline-editor__target">
-                      回复给：{getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}
-                    </p>
-                    <label>
-                      内容 / AI 指令
-                      <div className="forum-terminal-field">
-                        <textarea
-                          className="textarea-glass"
-                          rows={4}
-                          value={inlineReplyContent}
-                          onChange={(event) => setInlineReplyContent(event.target.value)}
-                          placeholder="输入对该回复的内容；也可填写给 AI 的指令后点击下方按钮。"
-                        />
-                      </div>
-                    </label>
-                    <div className="forum-editor__actions">
-                      <button
-                        type="button"
-                        className="btn-primary"
-                        disabled={submitting}
-                        onClick={() =>
-                          void handleSubmitReply({
-                            content: inlineReplyContent,
-                            targetReplyId: reply.id,
-                            onSuccess: () => {
-                              setInlineReplyContent('')
-                              setActiveInlineReplyId(null)
-                            },
-                          })
-                        }
-                      >
-                        发布用户回复
-                      </button>
-                      {FORUM_AI_SLOTS.map((slot) => {
-                        const profile = profileMap.get(slot) ?? {
-                          ...defaultForumProfile(slot),
-                          id: `slot-${slot}`,
-                          userId: '',
-                          createdAt: '',
-                          updatedAt: '',
-                        }
-                        return (
-                          <button
-                            key={`${reply.id}-${slot}`}
-                            type="button"
-                            className="btn-secondary"
-                            disabled={Boolean(generatingSlot) || !profile.enabled || !globalAiConfig}
-                            onClick={() =>
-                              void handleGenerateAiReply({
-                                slot,
-                                content: inlineReplyContent,
-                                targetReplyId: reply.id,
-                                onSuccess: () => {
-                                  setInlineReplyContent('')
-                                  setActiveInlineReplyId(null)
-                                },
-                              })
-                            }
-                          >
-                            {generatingSlot === slot ? '生成中…' : `${profile.displayName} 生成回复`}
-                          </button>
-                        )
-                      })}
-                    </div>
-                  </div>
-                ) : null}
-              </article>
-            )
-          })}
-        </div>
+        <h3 className="ui-title">回复（嵌套树）</h3>
+        {replyTree.length ? (
+          <ForumReplyTree
+            nodes={replyTree}
+            activeInlineReplyId={activeInlineReplyId}
+            deletingReplyId={deletingReplyId}
+            getAuthorLabel={(reply) => getForumAuthorLabel(reply.authorType, reply.authorSlot, profiles, reply.authorName)}
+            getReplyTargetLabel={getReplyTargetNameForReply}
+            formatTime={formatTime}
+            onToggleInlineReply={(replyId) => {
+              setError(null)
+              setSuccessMessage(null)
+              setInlineReplyContent('')
+              setActiveInlineReplyId((current) => (current === replyId ? null : replyId))
+            }}
+            onDeleteReply={(replyId) => setPendingDeleteReplyId(replyId)}
+            renderInlineEditor={renderInlineEditor}
+          />
+        ) : (
+          <p className="forum-thread-list__empty">还没有回复，来抢沙发吧。</p>
+        )}
       </section>
 
       <section className="glass-card forum-editor">

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -167,8 +167,11 @@ type ForumReplyRow = {
   author_type: ForumAuthorType
   author_slot: number | null
   author_name: string | null
+  parent_id: string | null
   reply_to_reply_id: string | null
   reply_to_author_name: string | null
+  depth?: number | null
+  sort_path?: string | null
   created_at: string
 }
 
@@ -320,19 +323,26 @@ const mapForumThreadRow = (row: ForumThreadRow): ForumThread => ({
   updatedAt: row.updated_at,
 })
 
-const mapForumReplyRow = (row: ForumReplyRow): ForumReply => ({
-  id: row.id,
-  threadId: row.thread_id,
-  userId: row.user_id,
-  content: row.body,
-  authorType: row.author_type,
-  authorSlot: row.author_slot,
-  authorName: row.author_name,
-  replyToType: row.reply_to_reply_id ? 'reply' : 'thread',
-  replyToReplyId: row.reply_to_reply_id,
-  replyToAuthorName: row.reply_to_author_name,
-  createdAt: row.created_at,
-})
+const mapForumReplyRow = (row: ForumReplyRow): ForumReply => {
+  const canonicalParentId = row.parent_id ?? row.reply_to_reply_id
+
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    userId: row.user_id,
+    content: row.body,
+    authorType: row.author_type,
+    authorSlot: row.author_slot,
+    authorName: row.author_name,
+    parentId: canonicalParentId,
+    depth: row.depth ?? undefined,
+    sortPath: row.sort_path ?? undefined,
+    replyToType: canonicalParentId ? 'reply' : 'thread',
+    replyToReplyId: row.reply_to_reply_id ?? canonicalParentId,
+    replyToAuthorName: row.reply_to_author_name,
+    createdAt: row.created_at,
+  }
+}
 
 const normalizeForumContextTokenLimit = (value: number | null | undefined) => {
   if (!Number.isFinite(value)) {
@@ -1658,7 +1668,7 @@ export const fetchForumRepliesByThread = async (threadId: string): Promise<Forum
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('forum_replies')
-    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
+    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,parent_id,reply_to_reply_id,reply_to_author_name,created_at')
     .eq('thread_id', threadId)
     .eq('user_id', userId)
     .order('created_at', { ascending: true })
@@ -1667,6 +1677,21 @@ export const fetchForumRepliesByThread = async (threadId: string): Promise<Forum
     throw error
   }
   return (data ?? []).map((row) => mapForumReplyRow(row as ForumReplyRow))
+}
+
+export const fetchForumReplyTreeByThread = async (threadId: string): Promise<ForumReply[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase.rpc('get_forum_thread_replies_tree', { p_thread_id: threadId })
+
+  if (error) {
+    throw error
+  }
+
+  const rows = (data ?? []) as ForumReplyRow[]
+  return rows.filter((row) => row.user_id === userId).map((row) => mapForumReplyRow(row))
 }
 
 export const createForumReply = async (params: {
@@ -1681,9 +1706,9 @@ export const createForumReply = async (params: {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
-  const normalizedReplyToReplyId = params.replyToType === 'thread' ? null : params.replyToReplyId ?? null
+  const normalizedParentId = params.replyToType === 'thread' ? null : params.replyToReplyId ?? null
   const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
-  const replyToAuthorName = await resolveReplyTargetAuthorName(userId, params.threadId, normalizedReplyToReplyId)
+  const replyToAuthorName = await resolveReplyTargetAuthorName(userId, params.threadId, normalizedParentId)
   const { data, error } = await supabase
     .from('forum_replies')
     .insert({
@@ -1693,10 +1718,11 @@ export const createForumReply = async (params: {
       author_type: params.authorType,
       author_slot: authorPayload.authorSlot,
       author_name: authorPayload.authorName,
-      reply_to_reply_id: normalizedReplyToReplyId,
+      parent_id: normalizedParentId,
+      reply_to_reply_id: normalizedParentId,
       reply_to_author_name: replyToAuthorName,
     })
-    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,reply_to_reply_id,reply_to_author_name,created_at')
+    .select('id,thread_id,user_id,body,author_type,author_slot,author_name,parent_id,reply_to_reply_id,reply_to_author_name,created_at')
     .single()
 
   if (error || !data) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,9 @@ export type ForumReply = {
   authorType: ForumAuthorType
   authorSlot: number | null
   authorName: string | null
+  parentId: string | null
+  depth?: number
+  sortPath?: string
   replyToType: 'thread' | 'reply' | null
   replyToReplyId: string | null
   replyToAuthorName: string | null

--- a/src/utils/forumReplyTree.ts
+++ b/src/utils/forumReplyTree.ts
@@ -1,0 +1,53 @@
+import type { ForumReply } from '../types'
+
+export type ForumReplyTreeNode = {
+  reply: ForumReply
+  children: ForumReplyTreeNode[]
+}
+
+const compareReplies = (a: ForumReply, b: ForumReply) => {
+  const createdAtCompare = a.createdAt.localeCompare(b.createdAt)
+  if (createdAtCompare !== 0) {
+    return createdAtCompare
+  }
+  return a.id.localeCompare(b.id)
+}
+
+const sortTreeNodes = (nodes: ForumReplyTreeNode[]): ForumReplyTreeNode[] => {
+  const sorted = [...nodes].sort((left, right) => compareReplies(left.reply, right.reply))
+  sorted.forEach((node) => {
+    node.children = sortTreeNodes(node.children)
+  })
+  return sorted
+}
+
+export const buildForumReplyTree = (replies: ForumReply[]): ForumReplyTreeNode[] => {
+  const nodeMap = new Map<string, ForumReplyTreeNode>()
+  replies.forEach((reply) => {
+    nodeMap.set(reply.id, { reply, children: [] })
+  })
+
+  const roots: ForumReplyTreeNode[] = []
+
+  replies.forEach((reply) => {
+    const node = nodeMap.get(reply.id)
+    if (!node) {
+      return
+    }
+
+    if (!reply.parentId) {
+      roots.push(node)
+      return
+    }
+
+    const parentNode = nodeMap.get(reply.parentId)
+    if (!parentNode) {
+      roots.push(node)
+      return
+    }
+
+    parentNode.children.push(node)
+  })
+
+  return sortTreeNodes(roots)
+}


### PR DESCRIPTION
### Motivation

- Support threaded (nested) replies in the forum UI instead of a flat chronological list to make reply relationships clearer.
- Ensure reply rows from the database can represent parent-child relationships and be consumed as a canonical tree structure. 
- Provide a reusable renderer for nested replies with inline reply editor and collapse/expand behavior. 

### Description

- Added a new React component `ForumReplyTree` for rendering nested reply nodes with collapse/expand, inline reply toggle, delete buttons, and markdown rendering. 
- Introduced `buildForumReplyTree` utility that converts a flat `ForumReply[]` into a sorted tree of `ForumReplyTreeNode`s and used it in `ForumThreadPage`. 
- Extended the `ForumReply` type with `parentId`, optional `depth`, and optional `sortPath`, and updated `mapForumReplyRow` to canonicalize `parent_id`/`reply_to_reply_id` into `parentId` as well as expose `depth` and `sortPath`. 
- Updated supabase sync functions: added `fetchForumReplyTreeByThread` (RPC wrapper for server-side tree retrieval), included `parent_id` in reply queries, and changed `createForumReply` to write `parent_id` alongside `reply_to_reply_id`. 
- Replaced flat reply rendering in `ForumThreadPage` with the nested tree view, added helper `replyMap` and `getReplyTargetNameForReply`, and pulled inline editor rendering into a `renderInlineEditor` function passed to `ForumReplyTree`. 
- Added CSS rules in `ForumPage.css` to style the nested reply tree, node indentation, and child container borders. 

### Testing

- Ran TypeScript type checking and a local build to validate the new types and imports (`tsc` / `npm run build`) and both succeeded. 
- Verified the forum thread page loads and renders the nested reply tree in the development environment with the updated Supabase RPC data shape.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af80b88c48833092a9460154034a35)