### PR TITLE
Refactor ForumThreadPage to use nested reply tree interactions

### DIFF
--- a/src/pages/ForumThreadPage.tsx
+++ b/src/pages/ForumThreadPage.tsx
@@ -99,7 +99,8 @@ const ForumThreadPage = () => {
     setSuccessMessage(null)
     try {
       await deleteForumReply(pendingDeleteReplyId, thread.id)
-      setReplies((current) => current.filter((item) => item.id !== pendingDeleteReplyId))
+      const refreshedReplies = await fetchForumReplyTreeByThread(thread.id)
+      setReplies(refreshedReplies)
       setActiveInlineReplyId((current) => (current === pendingDeleteReplyId ? null : current))
       setSuccessMessage('回复已删除。')
       setPendingDeleteReplyId(null)
@@ -161,6 +162,7 @@ const ForumThreadPage = () => {
         threadId: thread.id,
         content: params.content.trim(),
         authorType: 'user',
+        parentId: params.targetReplyId,
         replyToType: params.targetReplyId ? 'reply' : 'thread',
         replyToReplyId: params.targetReplyId,
       })
@@ -208,6 +210,7 @@ const ForumThreadPage = () => {
         content: generated,
         authorType: 'ai',
         authorSlot: params.slot,
+        parentId: params.targetReplyId,
         replyToType: params.targetReplyId ? 'reply' : 'thread',
         replyToReplyId: params.targetReplyId,
       })
@@ -350,7 +353,7 @@ const ForumThreadPage = () => {
       </article>
 
       <section className="glass-card forum-thread-list">
-        <h3 className="ui-title">回复（嵌套树）</h3>
+        <h3 className="ui-title">回复</h3>
         {replyTree.length ? (
           <ForumReplyTree
             nodes={replyTree}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1699,6 +1699,7 @@ export const createForumReply = async (params: {
   content: string
   authorType: ForumAuthorType
   authorSlot?: number | null
+  parentId?: string | null
   replyToType?: 'thread' | 'reply' | null
   replyToReplyId?: string | null
 }): Promise<ForumReply> => {
@@ -1706,7 +1707,9 @@ export const createForumReply = async (params: {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
-  const normalizedParentId = params.replyToType === 'thread' ? null : params.replyToReplyId ?? null
+  const normalizedParentId = params.replyToType === 'thread'
+    ? null
+    : params.parentId ?? params.replyToReplyId ?? null
   const authorPayload = await resolveForumAuthorPayload(userId, params.authorType, params.authorSlot)
   const replyToAuthorName = await resolveReplyTargetAuthorName(userId, params.threadId, normalizedParentId)
   const { data, error } = await supabase


### PR DESCRIPTION
### Motivation
- Switch the thread reply UI from a flat chronological list to the nested reply tree while keeping the existing UX (root composer + per-reply inline editor).
- Ensure nested replies are created with the correct parent targeting so both user and AI replies target the intended node.
- Make deletion safe for parent replies by preventing orphaned descendants from remaining visible in UI after database cascade deletes.

### Description
- Updated `createForumReply` in `src/storage/supabaseSync.ts` to accept an explicit `parentId` and normalize parent selection with fallback to `replyToReplyId` so parent-based creation is supported while remaining compatible. (`createForumReply` normalization logic updated)
- Changed `src/pages/ForumThreadPage.tsx` to pass `parentId` when creating user and AI replies so nested replies are stored under the intended parent. (calls to `createForumReply` now include `parentId`)
- Modified reply delete handling in `src/pages/ForumThreadPage.tsx` to refetch the full reply tree via `fetchForumReplyTreeByThread` after successful delete so cascaded subtree removals are immediately reflected in UI. (replaces single-id filter with a refresh)
- Removed the wording that implied a transitional flat list by changing the heading text from `回复（嵌套树）` to `回复`, and preserved rendering with the `ForumReplyTree` component and existing inline editor behavior. (`ForumReplyTree` usage retained)

### Testing
- Ran `npm run lint`, which completed successfully (one pre-existing warning remains in `src/pages/CheckinPage.tsx`).
- Ran `npm run build`, which completed successfully and produced the production bundle without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af85546d308330a6fd1d9808fadec6)