### PR TITLE
Improve retro nested reply tree readability and mobile behavior

### DIFF
--- a/src/components/forum/ForumReplyTree.tsx
+++ b/src/components/forum/ForumReplyTree.tsx
@@ -61,8 +61,8 @@ const ForumReplyTree = ({
           <footer className="forum-reply-item__footer">
             <span>回复给：{getReplyTargetLabel(reply)}</span>
             {hasChildren ? (
-              <button type="button" className="btn-secondary" onClick={() => toggleNode(reply.id)}>
-                {collapsed ? `展开 ${children.length} 条子回复` : `收起 ${children.length} 条子回复`}
+              <button type="button" className="btn-secondary forum-reply-item__toggle" onClick={() => toggleNode(reply.id)}>
+                {collapsed ? `展开 ${children.length} 条回复` : `收起 ${children.length} 条回复`}
               </button>
             ) : null}
             <button type="button" className="btn-secondary" onClick={() => onToggleInlineReply(reply.id)}>

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -791,30 +791,100 @@
 }
 
 .forum-reply-tree {
+  --forum-reply-indent: 1rem;
+  --forum-reply-indent-mobile: 0.6rem;
   display: grid;
-  gap: 0.6rem;
+  gap: 0.7rem;
+  min-width: 0;
 }
 
 .forum-reply-node {
-  margin-left: calc(var(--forum-reply-depth, 0) * 1rem);
+  position: relative;
+  min-width: 0;
+  margin-left: calc(var(--forum-reply-depth, 0) * var(--forum-reply-indent));
+  padding-left: 0.5rem;
+}
+
+.forum-reply-node::before {
+  content: '';
+  position: absolute;
+  top: 0.8rem;
+  left: 0;
+  width: 0.35rem;
+  border-top: 2px solid #cdb3bf;
+}
+
+.forum-reply-node .forum-reply-item {
+  overflow: hidden;
+}
+
+.forum-reply-node .forum-bbs-card__content,
+.forum-reply-node .forum-reply-item__footer {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.forum-reply-node .forum-bbs-card__content .assistant-markdown {
+  overflow-x: auto;
+}
+
+.forum-reply-node .forum-inline-editor {
+  margin-top: 0;
+  border-top: 2px dashed #5c5c5c;
+  background: #fff6fb;
+}
+
+.forum-reply-item__toggle {
+  padding-inline: 0.58rem;
 }
 
 .forum-reply-node__children {
-  margin-top: 0.55rem;
-  margin-left: 0.45rem;
-  padding-left: 0.65rem;
-  border-left: 2px dashed #c8adb9;
+  position: relative;
+  margin-top: 0.5rem;
+  margin-left: 0.3rem;
+  padding-left: 0.8rem;
   display: grid;
-  gap: 0.55rem;
+  gap: 0.65rem;
+  border-left: 2px dashed #cdb3bf;
+}
+
+.forum-reply-node__children::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -2px;
+  width: 2px;
+  height: 0.45rem;
+  background: #fff;
 }
 
 @media (max-width: 640px) {
+  .forum-reply-tree {
+    gap: 0.55rem;
+  }
+
   .forum-reply-node {
-    margin-left: calc(var(--forum-reply-depth, 0) * 0.55rem);
+    margin-left: calc(var(--forum-reply-depth, 0) * var(--forum-reply-indent-mobile));
+    padding-left: 0.35rem;
+  }
+
+  .forum-reply-node::before {
+    top: 0.72rem;
+    width: 0.24rem;
   }
 
   .forum-reply-node__children {
-    margin-left: 0.2rem;
-    padding-left: 0.45rem;
+    margin-left: 0.18rem;
+    padding-left: 0.5rem;
+    gap: 0.5rem;
+  }
+
+  .forum-reply-node .forum-reply-item__footer {
+    gap: 0.25rem;
+  }
+
+  .forum-reply-node .forum-reply-item__footer .btn-secondary {
+    max-width: 100%;
+    white-space: normal;
   }
 }


### PR DESCRIPTION
### Motivation
- Make nested replies easier to scan while preserving the forum's retro/pixel BBS aesthetic. 
- Ensure deep nesting remains usable on small screens and that the inline reply editor stays visually attached to its reply node.

### Description
- Adjusted `ForumReplyTree` toggle copy to a compact Chinese format and added `forum-reply-item__toggle` for targeted styling.  
- Reworked nested-reply CSS in `src/pages/ForumPage.css` to add depth-based indentation variables, connector-like branch accents, clearer child-block grouping, and improved sibling spacing.  
- Tuned the inline editor visuals so it reads as part of the parent node (dashed separator and themed background).  
- Improved mobile behavior by reducing per-depth indentation, tightening gaps, and preventing horizontal overflow for long content and action rows.

### Testing
- Built the app with `npm run build`, which completed successfully.  
- Launched a dev server and captured an automated screenshot of the forum page to validate nested-reply presentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af87d9d2588330bd0152d47e779cd3)