### PR TITLE
Refine nested reply footer layout and compact action buttons

### DIFF
--- a/src/components/forum/ForumReplyTree.tsx
+++ b/src/components/forum/ForumReplyTree.tsx
@@ -59,23 +59,25 @@ const ForumReplyTree = ({
             </div>
           </div>
           <footer className="forum-reply-item__footer">
-            <span>回复给：{getReplyTargetLabel(reply)}</span>
-            {hasChildren ? (
-              <button type="button" className="btn-secondary forum-reply-item__toggle" onClick={() => toggleNode(reply.id)}>
-                {collapsed ? `展开 ${children.length} 条回复` : `收起 ${children.length} 条回复`}
+            <div className="forum-reply-item__meta">回复给：{getReplyTargetLabel(reply)}</div>
+            <div className="forum-reply-item__actions">
+              {hasChildren ? (
+                <button type="button" className="btn-secondary forum-btn--compact forum-reply-item__toggle" onClick={() => toggleNode(reply.id)}>
+                  {collapsed ? `展开 ${children.length} 条回复` : `收起 ${children.length} 条回复`}
+                </button>
+              ) : null}
+              <button type="button" className="btn-secondary forum-btn--compact" onClick={() => onToggleInlineReply(reply.id)}>
+                {activeInlineReplyId === reply.id ? '收起回复' : '回复'}
               </button>
-            ) : null}
-            <button type="button" className="btn-secondary" onClick={() => onToggleInlineReply(reply.id)}>
-              {activeInlineReplyId === reply.id ? '收起回复' : '回复'}
-            </button>
-            <button
-              type="button"
-              className="btn-secondary"
-              onClick={() => onDeleteReply(reply.id)}
-              disabled={deletingReplyId === reply.id}
-            >
-              {deletingReplyId === reply.id ? '删除中…' : '删除'}
-            </button>
+              <button
+                type="button"
+                className="btn-secondary forum-btn--compact"
+                onClick={() => onDeleteReply(reply.id)}
+                disabled={deletingReplyId === reply.id}
+              >
+                {deletingReplyId === reply.id ? '删除中…' : '删除'}
+              </button>
+            </div>
           </footer>
           {activeInlineReplyId === reply.id ? renderInlineEditor(reply) : null}
         </article>

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -573,7 +573,7 @@
 
 .forum-bbs-card__author strong,
 .forum-bbs-card__author small,
-.forum-reply-item__footer span,
+.forum-reply-item__meta,
 .forum-thread-page .forum-editor__target,
 .forum-thread-page .forum-inline-editor__target,
 .forum-thread-page .btn-primary,
@@ -656,14 +656,38 @@
 
 .forum-thread-page .forum-reply-item__footer,
 .forum-thread-page .forum-root-post footer {
-  display: flex;
   width: 100%;
+  padding: 0.5rem 0.65rem;
+  border-top: 2px solid #5c5c5c;
+}
+
+.forum-thread-page .forum-root-post footer {
+  display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
   gap: 0.35rem;
-  padding: 0.5rem 0.65rem;
-  border-top: 2px solid #5c5c5c;
+}
+
+.forum-thread-page .forum-reply-item__footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.35rem;
+}
+
+.forum-reply-item__meta {
+  min-width: 0;
+  font-size: 1rem;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.forum-reply-item__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+  min-width: 0;
 }
 
 .forum-thread-page .forum-root-post footer {
@@ -727,6 +751,19 @@
   background: #ffd6e7;
   box-shadow: 3px 3px 0 0 #5c5c5c;
   color: #5c5c5c;
+}
+
+.forum-thread-page .forum-reply-item__actions .forum-btn--compact {
+  padding: 0.12rem 0.46rem;
+  font-size: 0.9rem;
+  line-height: 1.15;
+  box-shadow: 2px 2px 0 0 #5c5c5c;
+  white-space: nowrap;
+}
+
+.forum-thread-page .forum-reply-item__actions .forum-btn--compact:active {
+  transform: translate(2px, 2px);
+  box-shadow: 0 0 0 0 #5c5c5c;
 }
 
 .forum-thread-page .btn-primary:active,
@@ -838,6 +875,10 @@
   padding-inline: 0.58rem;
 }
 
+.forum-thread-page .forum-reply-item__actions .forum-reply-item__toggle {
+  padding-inline: 0.42rem;
+}
+
 .forum-reply-node__children {
   position: relative;
   margin-top: 0.5rem;
@@ -880,11 +921,14 @@
   }
 
   .forum-reply-node .forum-reply-item__footer {
+    gap: 0.28rem;
+  }
+
+  .forum-reply-node .forum-reply-item__actions {
     gap: 0.25rem;
   }
 
-  .forum-reply-node .forum-reply-item__footer .btn-secondary {
-    max-width: 100%;
+  .forum-thread-page .forum-reply-item__actions .forum-btn--compact {
     white-space: normal;
   }
 }


### PR DESCRIPTION
### Motivation
- Nested reply footers felt cramped because the target label and action buttons shared a single row, making replies hard to scan in threaded views.
- We want a compact, two-row layout that preserves the retro/pixel aesthetic while keeping action buttons smaller and confined to their own row.

### Description
- Split the reply footer into two semantic parts by updating `src/components/forum/ForumReplyTree.tsx` to render a meta row (`.forum-reply-item__meta`) containing the `回复给：...` label and an actions row (`.forum-reply-item__actions`) containing collapse/expand, reply, and delete controls.
- Added a compact modifier class `forum-btn--compact` and related styles in `src/pages/ForumPage.css` to reduce vertical/horizontal padding, slightly lower `font-size`, and reduce box-shadow for nested action buttons while keeping the pixel look.
- Converted `.forum-reply-item__footer` to a grid-based two-row layout and adjusted responsive rules so the target label never mixes with action buttons and wrapping is limited to the action row.
- Updated font-family selector to include `.forum-reply-item__meta` so typography remains consistent with the forum style.

### Testing
- Ran the production build with `npm run build`, which completed successfully.
- Started the dev server with `npm run dev` and executed a Playwright script to navigate to the forum route and capture a screenshot, which completed and produced a capture of the page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8a5b749c8330b4e1e3bd126afa7c)