### PR TITLE
Restyle forum new-thread page to match retro thread aesthetic

### DIFF
--- a/src/pages/ForumNewThreadPage.tsx
+++ b/src/pages/ForumNewThreadPage.tsx
@@ -182,59 +182,65 @@ const ForumNewThreadPage = () => {
   }
 
   return (
-    <div className="forum-page app-shell__content">
-      <header className="forum-header glass-card">
-        <button type="button" className="btn-secondary" onClick={() => navigate('/forum')}>
+    <div className="forum-page forum-thread-page forum-new-thread-page app-shell__content">
+      <header className="forum-header forum-header--thread glass-card">
+        <button type="button" className="btn-secondary forum-header__back-btn" onClick={() => navigate('/forum')}>
           返回列表
         </button>
         <h1 className="ui-title">新建主题</h1>
       </header>
 
-      <section className="glass-card forum-editor">
-        {loading ? <p>加载 AI 档案中…</p> : null}
+      <section className="glass-card forum-editor forum-new-thread-card">
+        {loading ? <p className="forum-new-thread-status">加载 AI 档案中…</p> : null}
         {authorIsAi ? (
-          <p className="forum-settings-summary">标题将由 AI 自动生成</p>
+          <p className="forum-settings-summary forum-new-thread-helper">标题将由 AI 自动生成</p>
         ) : (
           <label>
             标题
-            <input className="input-glass" value={title} onChange={(event) => setTitle(event.target.value)} />
+            <div className="forum-terminal-field">
+              <input className="input-glass" value={title} onChange={(event) => setTitle(event.target.value)} />
+            </div>
           </label>
         )}
         <label>
           作者
-          <select
-            className="input-glass"
-            value={authorDraft}
-            onChange={(event) => setAuthorDraft(event.target.value as AuthorDraft)}
-          >
-            <option value="user">我（直接发布）</option>
-            {FORUM_AI_SLOTS.map((slot) => {
-              const profile = profileLookup.get(slot) ?? {
-                ...defaultForumProfile(slot),
-                id: `slot-${slot}`,
-                userId: '',
-                createdAt: '',
-                updatedAt: '',
-              }
-              return (
-                <option key={slot} value={`ai-${slot}`}>
-                  {profile.displayName}（AI Slot {slot}）
-                </option>
-              )
-            })}
-          </select>
+          <div className="forum-terminal-field forum-terminal-field--select">
+            <select
+              className="input-glass"
+              value={authorDraft}
+              onChange={(event) => setAuthorDraft(event.target.value as AuthorDraft)}
+            >
+              <option value="user">我（直接发布）</option>
+              {FORUM_AI_SLOTS.map((slot) => {
+                const profile = profileLookup.get(slot) ?? {
+                  ...defaultForumProfile(slot),
+                  id: `slot-${slot}`,
+                  userId: '',
+                  createdAt: '',
+                  updatedAt: '',
+                }
+                return (
+                  <option key={slot} value={`ai-${slot}`}>
+                    {profile.displayName}（AI Slot {slot}）
+                  </option>
+                )
+              })}
+            </select>
+          </div>
         </label>
         <label>
           {authorIsAi ? '写作方向（可选）' : '正文'}
-          <textarea
-            className="textarea-glass"
-            rows={8}
-            value={content}
-            onChange={(event) => setContent(event.target.value)}
-            placeholder={authorIsAi ? '可填写 AI 写作方向。' : '输入你要发的主题内容。'}
-          />
+          <div className="forum-terminal-field">
+            <textarea
+              className="textarea-glass"
+              rows={8}
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              placeholder={authorIsAi ? '可填写 AI 写作方向。' : '输入你要发的主题内容。'}
+            />
+          </div>
         </label>
-        {error ? <p className="forum-error">{error}</p> : null}
+        {error ? <p className="forum-error forum-new-thread-error">{error}</p> : null}
         <div className="forum-editor__actions">
           <button type="button" className="btn-primary" disabled={submitting || generating} onClick={handleCreate}>
             直接发布（用户）

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -772,6 +772,83 @@
   box-shadow: 0 0 0 0 #5c5c5c;
 }
 
+
+.forum-new-thread-page {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.forum-thread-page .forum-new-thread-card {
+  padding: 0.85rem;
+  border-width: 3px;
+  box-shadow: 6px 6px 0 0 #ffd6e7;
+  background: #fffdf8;
+  gap: 0.7rem;
+}
+
+.forum-thread-page.forum-new-thread-page .forum-editor label {
+  color: #5c5c5c;
+  font-family: 'DotGothic16', 'VT323', monospace;
+  font-size: 0.95rem;
+}
+
+.forum-thread-page.forum-new-thread-page .input-glass,
+.forum-thread-page.forum-new-thread-page .textarea-glass,
+.forum-thread-page.forum-new-thread-page select.input-glass {
+  width: 100%;
+  border-radius: 0;
+  border: 3px solid #5c5c5c;
+  box-shadow: inset 0 0 0 2px #fff;
+  background: #fff;
+  color: #334155;
+  font-family: var(--font-sans);
+}
+
+.forum-thread-page.forum-new-thread-page .input-glass,
+.forum-thread-page.forum-new-thread-page select.input-glass {
+  min-height: 2.6rem;
+}
+
+.forum-thread-page.forum-new-thread-page select.input-glass {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #5c5c5c 50%), linear-gradient(135deg, #5c5c5c 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(1.2rem), calc(100% - 11px) calc(1.2rem);
+  background-size: 7px 7px, 7px 7px;
+  background-repeat: no-repeat;
+  padding-right: 2.1rem;
+}
+
+.forum-thread-page.forum-new-thread-page .textarea-glass {
+  min-height: 10.5rem;
+  resize: vertical;
+}
+
+.forum-thread-page.forum-new-thread-page .forum-terminal-field--select::after {
+  display: none;
+}
+
+.forum-new-thread-status,
+.forum-new-thread-helper {
+  border: 2px solid #5c5c5c;
+  background: #ffeaf2;
+  color: #5c5c5c;
+  box-shadow: 3px 3px 0 0 #ffd6e7;
+  padding: 0.3rem 0.55rem;
+}
+
+.forum-new-thread-error {
+  border: 2px solid #b91c1c;
+  background: #fff1f2;
+  box-shadow: 3px 3px 0 0 #fecdd3;
+  padding: 0.3rem 0.55rem;
+}
+
+.forum-thread-page.forum-new-thread-page .forum-editor__actions {
+  padding-top: 0.1rem;
+}
+
 @media (max-width: 720px) {
   .forum-header--index,
   .forum-thread-item__main {


### PR DESCRIPTION
### Motivation
- Make the forum "new thread" page visually match the retro pixel aesthetic used by the thread/detail pages while keeping all existing behavior intact.

### Description
- Updated the page container and header classes in `src/pages/ForumNewThreadPage.tsx` to reuse the thread-detail visual language (`forum-thread-page`, `forum-header--thread`, `forum-header__back-btn`) so the top area matches the BBS style.
- Restyled form markup in `ForumNewThreadPage.tsx` by wrapping title/select/textarea fields with `forum-terminal-field`, adding scoped helper/loading/error classes, and leaving all conditional logic (user vs AI author) unchanged.
- Added minimal, scoped CSS in `src/pages/ForumPage.css` under `.forum-new-thread-page` to provide square corners, stronger pixel borders, terminal-like inputs/selects/textareas, pixel-like buttons/status blocks, and the retro pink/white palette.
- All changes are UI-only and no business logic, validation, state flow, AI generation flow, or submit behavior was modified.

### Testing
- Built the app with `npm run build` and the build completed successfully.
- Ran the dev server with `npm run dev` and loaded the page to validate styles applied successfully.
- Captured a Playwright screenshot of `http://127.0.0.1:4173/forum/new-thread` to verify the visual result; the script ran and produced the artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af925f45dc83309e4fb24e24c763f9)