### PR TITLE
Align forum new-thread page with settings-page layout pattern

### DIFF
--- a/src/pages/ForumNewThreadPage.tsx
+++ b/src/pages/ForumNewThreadPage.tsx
@@ -182,79 +182,83 @@ const ForumNewThreadPage = () => {
   }
 
   return (
-    <div className="forum-page forum-thread-page forum-new-thread-page app-shell__content">
-      <header className="forum-header forum-header--thread glass-card">
-        <button type="button" className="btn-secondary forum-header__back-btn" onClick={() => navigate('/forum')}>
-          返回列表
-        </button>
-        <h1 className="ui-title">新建主题</h1>
-      </header>
+    <div className="forum-page forum-new-thread-page app-shell__content">
+      <div className="forum-page__wrapper forum-new-thread-shell">
+        <header className="forum-header forum-header--index forum-settings-header forum-new-thread-header">
+          <button type="button" className="forum-pixel-btn" onClick={() => navigate('/forum')}>
+            返回论坛
+          </button>
+          <h1 className="ui-title">新建主题</h1>
+          <span className="forum-settings-header__spacer" aria-hidden="true" />
+        </header>
 
-      <section className="glass-card forum-editor forum-new-thread-card">
-        {loading ? <p className="forum-new-thread-status">加载 AI 档案中…</p> : null}
-        {authorIsAi ? (
-          <p className="forum-settings-summary forum-new-thread-helper">标题将由 AI 自动生成</p>
-        ) : (
-          <label>
-            标题
-            <div className="forum-terminal-field">
-              <input className="input-glass" value={title} onChange={(event) => setTitle(event.target.value)} />
+        <section className="forum-thread-list forum-settings-content forum-new-thread-content">
+          <section className="forum-settings-editor forum-new-thread-panel">
+            {loading ? <p className="forum-new-thread-status">加载 AI 档案中…</p> : null}
+            {authorIsAi ? (
+              <p className="forum-settings-summary forum-new-thread-helper">标题将由 AI 自动生成</p>
+            ) : (
+              <label>
+                <span>标题</span>
+                <input className="input-glass" value={title} onChange={(event) => setTitle(event.target.value)} />
+              </label>
+            )}
+            <label>
+              <span>作者</span>
+              <select
+                className="input-glass"
+                value={authorDraft}
+                onChange={(event) => setAuthorDraft(event.target.value as AuthorDraft)}
+              >
+                <option value="user">我（直接发布）</option>
+                {FORUM_AI_SLOTS.map((slot) => {
+                  const profile = profileLookup.get(slot) ?? {
+                    ...defaultForumProfile(slot),
+                    id: `slot-${slot}`,
+                    userId: '',
+                    createdAt: '',
+                    updatedAt: '',
+                  }
+                  return (
+                    <option key={slot} value={`ai-${slot}`}>
+                      {profile.displayName}（AI Slot {slot}）
+                    </option>
+                  )
+                })}
+              </select>
+            </label>
+            <label>
+              <span>{authorIsAi ? '写作方向（可选）' : '正文'}</span>
+              <textarea
+                className="textarea-glass"
+                rows={8}
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                placeholder={authorIsAi ? '可填写 AI 写作方向。' : '输入你要发的主题内容。'}
+              />
+            </label>
+            {error ? <p className="forum-error forum-new-thread-error">{error}</p> : null}
+            <div className="forum-editor__actions forum-new-thread-actions">
+              <button
+                type="button"
+                className="forum-pixel-btn forum-pixel-btn--primary"
+                disabled={submitting || generating}
+                onClick={handleCreate}
+              >
+                直接发布（用户）
+              </button>
+              <button
+                type="button"
+                className="forum-pixel-btn"
+                disabled={submitting || generating}
+                onClick={handleGenerateAiThread}
+              >
+                {generating ? 'AI 生成中…' : '生成 AI 主题'}
+              </button>
             </div>
-          </label>
-        )}
-        <label>
-          作者
-          <div className="forum-terminal-field forum-terminal-field--select">
-            <select
-              className="input-glass"
-              value={authorDraft}
-              onChange={(event) => setAuthorDraft(event.target.value as AuthorDraft)}
-            >
-              <option value="user">我（直接发布）</option>
-              {FORUM_AI_SLOTS.map((slot) => {
-                const profile = profileLookup.get(slot) ?? {
-                  ...defaultForumProfile(slot),
-                  id: `slot-${slot}`,
-                  userId: '',
-                  createdAt: '',
-                  updatedAt: '',
-                }
-                return (
-                  <option key={slot} value={`ai-${slot}`}>
-                    {profile.displayName}（AI Slot {slot}）
-                  </option>
-                )
-              })}
-            </select>
-          </div>
-        </label>
-        <label>
-          {authorIsAi ? '写作方向（可选）' : '正文'}
-          <div className="forum-terminal-field">
-            <textarea
-              className="textarea-glass"
-              rows={8}
-              value={content}
-              onChange={(event) => setContent(event.target.value)}
-              placeholder={authorIsAi ? '可填写 AI 写作方向。' : '输入你要发的主题内容。'}
-            />
-          </div>
-        </label>
-        {error ? <p className="forum-error forum-new-thread-error">{error}</p> : null}
-        <div className="forum-editor__actions">
-          <button type="button" className="btn-primary" disabled={submitting || generating} onClick={handleCreate}>
-            直接发布（用户）
-          </button>
-          <button
-            type="button"
-            className="btn-secondary"
-            disabled={submitting || generating}
-            onClick={handleGenerateAiThread}
-          >
-            {generating ? 'AI 生成中…' : '生成 AI 主题'}
-          </button>
-        </div>
-      </section>
+          </section>
+        </section>
+      </div>
     </div>
   )
 }

--- a/src/pages/ForumPage.css
+++ b/src/pages/ForumPage.css
@@ -774,68 +774,70 @@
 
 
 .forum-new-thread-page {
-  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 100%;
+  min-height: 100%;
+}
+
+.forum-new-thread-shell {
+  width: 100%;
+  max-width: 560px;
   margin: 0 auto;
+  border: none;
+  box-shadow: none;
+  background: transparent;
+  gap: 0.55rem;
+}
+
+.forum-new-thread-content {
   display: grid;
-  gap: 0.7rem;
+  gap: 0.55rem;
+  padding: 0;
 }
 
-.forum-thread-page .forum-new-thread-card {
-  padding: 0.85rem;
-  border-width: 3px;
-  box-shadow: 6px 6px 0 0 #ffd6e7;
-  background: #fffdf8;
-  gap: 0.7rem;
+.forum-new-thread-panel {
+  gap: 0.6rem;
 }
 
-.forum-thread-page.forum-new-thread-page .forum-editor label {
+.forum-new-thread-panel label {
   color: #5c5c5c;
   font-family: 'DotGothic16', 'VT323', monospace;
   font-size: 0.95rem;
 }
 
-.forum-thread-page.forum-new-thread-page .input-glass,
-.forum-thread-page.forum-new-thread-page .textarea-glass,
-.forum-thread-page.forum-new-thread-page select.input-glass {
+.forum-new-thread-panel .input-glass,
+.forum-new-thread-panel .textarea-glass,
+.forum-new-thread-panel select.input-glass {
   width: 100%;
   border-radius: 0;
-  border: 3px solid #5c5c5c;
-  box-shadow: inset 0 0 0 2px #fff;
+  border: 2px solid #5c5c5c;
+  box-shadow: inset 0 0 0 1px #fff;
   background: #fff;
   color: #334155;
   font-family: var(--font-sans);
 }
 
-.forum-thread-page.forum-new-thread-page .input-glass,
-.forum-thread-page.forum-new-thread-page select.input-glass {
-  min-height: 2.6rem;
+.forum-new-thread-panel .input-glass,
+.forum-new-thread-panel select.input-glass {
+  min-height: 2.4rem;
 }
 
-.forum-thread-page.forum-new-thread-page select.input-glass {
-  appearance: none;
-  background-image: linear-gradient(45deg, transparent 50%, #5c5c5c 50%), linear-gradient(135deg, #5c5c5c 50%, transparent 50%);
-  background-position: calc(100% - 18px) calc(1.2rem), calc(100% - 11px) calc(1.2rem);
-  background-size: 7px 7px, 7px 7px;
-  background-repeat: no-repeat;
-  padding-right: 2.1rem;
-}
-
-.forum-thread-page.forum-new-thread-page .textarea-glass {
+.forum-new-thread-panel .textarea-glass {
   min-height: 10.5rem;
   resize: vertical;
-}
-
-.forum-thread-page.forum-new-thread-page .forum-terminal-field--select::after {
-  display: none;
+  white-space: pre-wrap;
 }
 
 .forum-new-thread-status,
 .forum-new-thread-helper {
-  border: 2px solid #5c5c5c;
-  background: #ffeaf2;
-  color: #5c5c5c;
-  box-shadow: 3px 3px 0 0 #ffd6e7;
+  border: 2px solid #d2bdc8;
+  background: #fff5fa;
+  color: #7a7078;
+  box-shadow: 2px 2px 0 0 #f2d6e4;
   padding: 0.3rem 0.55rem;
+  margin: 0;
 }
 
 .forum-new-thread-error {
@@ -845,8 +847,18 @@
   padding: 0.3rem 0.55rem;
 }
 
-.forum-thread-page.forum-new-thread-page .forum-editor__actions {
-  padding-top: 0.1rem;
+.forum-new-thread-actions {
+  justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  .forum-new-thread-page {
+    padding-inline: 0.75rem;
+  }
+
+  .forum-new-thread-actions {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
### Motivation
- The new-thread page was using the thread-detail layout reference and rendered as a narrow vertical strip with a heavy dark header; it should visually match the Forum AI Settings page family instead. 
- The goal is purely visual: restore full forum background, a centered wrapper/card with a comfortable max width, and a light retro pixel panel structure while preserving all existing behavior.

### Description
- Reworked `ForumNewThreadPage.tsx` to use the same outer structure as the settings page by adding a centered wrapper (`forum-page__wrapper forum-new-thread-shell`), a compact settings-style header, and a single main content panel for the form; the original handlers and logic were not changed. 
- Replaced thread-detail-specific markup and classes with settings-style classes and new page-scoped classes: `forum-new-thread-page`, `forum-new-thread-shell`, `forum-new-thread-header`, `forum-new-thread-content`, `forum-new-thread-panel`, and `forum-new-thread-actions`. 
- Switched action buttons and header button to the settings-style pixel button variants for consistent visuals with `ForumSettingsPage`. 
- Updated `src/pages/ForumPage.css` to remove the previous `.forum-thread-page`-scoped new-thread overrides and add minimal, scoped CSS for the new-thread classes to control width, panel styling, inputs, spacing and responsive behavior while keeping the full forum background. 

### Testing
- Ran `npm run build` and the build completed successfully. 
- Started the dev server and loaded `/forum/new-thread` and captured a UI screenshot to validate layout changes (screenshot captured during validation). 
- No runtime logic, validation, AI generation, or submit flow was modified, and existing form handlers were preserved and exercised during manual layout validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af961cb83c83309c1deaba2575c2ce)