### PR TITLE
Add forum content export support to Export page

### DIFF
--- a/src/pages/ExportPage.tsx
+++ b/src/pages/ExportPage.tsx
@@ -11,6 +11,7 @@ type ExportModules = {
   syzygy: boolean
   memory: boolean
   checkins: boolean
+  forum: boolean
 }
 
 type SessionRow = {
@@ -78,6 +79,27 @@ type CheckinRow = {
   created_at: string
 }
 
+type ForumThreadRow = {
+  id: string
+  title: string
+  body: string
+  author_type: string
+  author_name: string
+  created_at: string
+  updated_at: string
+}
+
+type ForumReplyRow = {
+  id: string
+  thread_id: string
+  body: string
+  author_type: string
+  author_name: string
+  created_at: string
+  parent_id: string | null
+  reply_to_reply_id: string | null
+}
+
 type ExportDataBundle = {
   sessions: SessionRow[]
   messages: MessageRow[]
@@ -87,6 +109,8 @@ type ExportDataBundle = {
   syzygyReplies: SyzygyReplyRow[]
   memoryEntries: MemoryEntryRow[]
   checkins: CheckinRow[]
+  forumThreads: ForumThreadRow[]
+  forumReplies: ForumReplyRow[]
 }
 
 const formatOptions: Array<{ value: ExportFormat; label: string }> = [
@@ -101,6 +125,7 @@ const defaultModules: ExportModules = {
   syzygy: true,
   memory: true,
   checkins: true,
+  forum: true,
 }
 
 const MESSAGE_BATCH_SIZE = 1000
@@ -137,6 +162,23 @@ const computeStreak = (checkins: CheckinRow[]) => {
 }
 
 const safeMarkdownText = (value: string) => value.replaceAll('```', '\\`\\`\\`')
+
+const renderForumReplies = (replies: ForumReplyRow[], lines: string[], parentId: string | null = null, depth = 0) => {
+  const nested = replies
+    .filter((reply) => {
+      const linkId = reply.parent_id ?? reply.reply_to_reply_id
+      return parentId === null ? !linkId : linkId === parentId
+    })
+    .sort((a, b) => a.created_at.localeCompare(b.created_at))
+
+  nested.forEach((reply) => {
+    const indent = '  '.repeat(depth)
+    lines.push(
+      `${indent}- ↳ [${reply.created_at}] (${reply.author_type}/${reply.author_name}) #${reply.id}: ${safeMarkdownText(reply.body)}`,
+    )
+    renderForumReplies(replies, lines, reply.id, depth + 1)
+  })
+}
 
 const formatDownloadStamp = (value: Date) => {
   const year = value.getFullYear()
@@ -268,6 +310,36 @@ const renderMarkdown = (
     lines.push('')
   }
 
+  if (modules.forum) {
+    lines.push('## 论坛区')
+    const sortedThreads = [...data.forumThreads].sort((a, b) => a.created_at.localeCompare(b.created_at))
+    const repliesByThread = new Map<string, ForumReplyRow[]>()
+    data.forumReplies.forEach((reply) => {
+      const list = repliesByThread.get(reply.thread_id) ?? []
+      list.push(reply)
+      repliesByThread.set(reply.thread_id, list)
+    })
+
+    sortedThreads.forEach((thread) => {
+      lines.push(`### 帖子: ${safeMarkdownText(thread.title)} (${thread.id})`)
+      lines.push(`- 作者: ${thread.author_type}/${thread.author_name}`)
+      lines.push(`- 创建: ${thread.created_at}  更新: ${thread.updated_at}`)
+      lines.push(`- 正文: ${safeMarkdownText(thread.body)}`)
+      lines.push('- 回复:')
+      const threadReplies = repliesByThread.get(thread.id) ?? []
+      const renderedLinesStart = lines.length
+      renderForumReplies(threadReplies, lines)
+      if (lines.length === renderedLinesStart) {
+        lines.push('  - (无回复)')
+      }
+      lines.push('')
+    })
+
+    if (sortedThreads.length === 0) {
+      lines.push('暂无论坛记录', '')
+    }
+  }
+
   return lines.join('\n')
 }
 
@@ -337,6 +409,8 @@ const ExportPage = ({ user }: { user: User | null }) => {
         syzygyReplies: [],
         memoryEntries: [],
         checkins: [],
+        forumThreads: [],
+        forumReplies: [],
       }
 
       if (modules.chat) {
@@ -419,6 +493,26 @@ const ExportPage = ({ user }: { user: User | null }) => {
           throw checkinError
         }
         baseData.checkins = (checkinRows ?? []) as CheckinRow[]
+      }
+
+      if (modules.forum) {
+        const [{ data: forumThreads, error: forumThreadError }, { data: forumReplies, error: forumReplyError }] = await Promise.all([
+          supabase
+            .from('forum_threads')
+            .select('id,title,body,author_type,author_name,created_at,updated_at')
+            .eq('user_id', user.id)
+            .order('created_at', { ascending: true }),
+          supabase
+            .from('forum_replies')
+            .select('id,thread_id,body,author_type,author_name,created_at,parent_id,reply_to_reply_id')
+            .eq('user_id', user.id)
+            .order('created_at', { ascending: true }),
+        ])
+        if (forumThreadError || forumReplyError) {
+          throw forumThreadError ?? forumReplyError
+        }
+        baseData.forumThreads = (forumThreads ?? []) as ForumThreadRow[]
+        baseData.forumReplies = (forumReplies ?? []) as ForumReplyRow[]
       }
 
       let fileContent = ''
@@ -517,6 +611,10 @@ const ExportPage = ({ user }: { user: User | null }) => {
           <label>
             <input type="checkbox" checked={modules.checkins} onChange={() => toggleModule('checkins')} />
             打卡（checkins）
+          </label>
+          <label>
+            <input type="checkbox" checked={modules.forum} onChange={() => toggleModule('forum')} />
+            论坛区（forum_threads + forum_replies）
           </label>
         </div>
 


### PR DESCRIPTION
### Motivation
- Provide users a way to export forum content (threads + replies) using the same export UI and pipeline as existing modules so all content can be packaged together.
- Ensure exported forum output is text-only, human-readable, and preserves reply hierarchy for downstream consumption.

### Description
- Added a new `forum` flag to `ExportModules` and enabled it in `defaultModules` so the forum module participates in the existing module-selection flow via the same UI and button.
- Introduced `ForumThreadRow` and `ForumReplyRow` types and extended `ExportDataBundle` with `forumThreads` and `forumReplies` to carry forum data through the export pipeline.
- Extended `handleExport` to fetch `forum_threads` and `forum_replies` for the current user and store them in the `baseData` bundle used for JSON and Markdown/TXT output.
- Added a forum section renderer for Markdown/TXT that emits thread metadata and body and renders replies as a nested plain-text tree, preferring `parent_id` and falling back to `reply_to_reply_id` for reply hierarchy.
- Added a checkbox entry `论坛区（forum_threads + forum_replies）` to the existing “导出模块” UI; no new page, button, or changes to other modules or RP export flow were introduced.

### Testing
- Ran `npm run build` (TypeScript + Vite) which completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the Export page renders the new forum checkbox, capturing a screenshot for inspection.
- No automated unit tests were present or modified; the change was validated by building and visually confirming the UI and that the exported JSON bundle includes the `forumThreads`/`forumReplies` fields and Markdown/TXT rendering code path was added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc48bc8b08330bc176a1ad50180cc)