### PR TITLE
Build Letters page as iOS-glass style message list UI

### DIFF
--- a/src/pages/LettersPage.css
+++ b/src/pages/LettersPage.css
@@ -1,0 +1,186 @@
+.letters-page {
+  background:
+    radial-gradient(circle at 8% 12%, rgba(255, 214, 231, 0.5) 0 2px, transparent 2px),
+    radial-gradient(circle at 88% 22%, rgba(255, 214, 231, 0.38) 0 1.6px, transparent 1.6px),
+    var(--page-bg);
+  background-size:
+    24px 24px,
+    20px 20px,
+    auto;
+}
+
+.letters-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(env(safe-area-inset-top) + 16px) 16px 14px;
+  border-bottom: 1px solid rgba(255, 231, 242, 0.85);
+  background: rgba(255, 255, 255, 0.62);
+  backdrop-filter: blur(14px);
+}
+
+.letters-header .ui-title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #6b5561;
+}
+
+.letters-content {
+  padding: 14px 14px calc(20px + env(safe-area-inset-bottom));
+}
+
+.letters-list {
+  margin: 0 auto;
+  width: min(620px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 26px;
+  border: 1px solid rgba(255, 240, 246, 0.95);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.letter-row {
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 18px;
+  padding: 11px 12px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 11px;
+  align-items: center;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.letter-row:hover {
+  background: rgba(255, 252, 254, 0.96);
+  border-color: rgba(255, 226, 238, 0.8);
+}
+
+.letter-row.is-unread {
+  border-color: rgba(255, 221, 236, 0.95);
+  box-shadow: 0 8px 20px rgba(255, 191, 219, 0.14);
+}
+
+.letter-row.is-read {
+  opacity: 0.88;
+}
+
+.letter-avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  background: #ff7faf;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 1rem;
+  box-shadow: inset 0 -6px 12px rgba(0, 0, 0, 0.08);
+  flex-shrink: 0;
+}
+
+.letter-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.letter-preview {
+  color: #5e4f59;
+  font-size: 0.95rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.letter-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: #ab8f9d;
+  font-size: 0.77rem;
+}
+
+.letter-meta > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.letter-meta-dot {
+  opacity: 0.6;
+}
+
+.letters-state {
+  margin: 12px;
+  text-align: center;
+  color: #907682;
+  font-size: 0.92rem;
+}
+
+.letter-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: rgba(87, 56, 70, 0.32);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 10px;
+}
+
+.letter-sheet {
+  width: min(680px, 100%);
+  max-height: min(80vh, 760px);
+  overflow: auto;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.93);
+  border: 1px solid rgba(255, 224, 237, 0.95);
+  box-shadow: 0 22px 36px rgba(48, 30, 40, 0.2);
+}
+
+.letter-sheet-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.letter-sheet-title {
+  margin: 0;
+  color: #5d4b55;
+  font-size: 1.02rem;
+}
+
+.letter-sheet-meta {
+  margin: 2px 0 0;
+  color: #ab8f9d;
+  font-size: 0.8rem;
+}
+
+.letter-close {
+  border: 1px solid rgba(255, 214, 231, 0.95);
+  background: rgba(255, 240, 246, 0.9);
+  color: #7a6170;
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.letter-sheet-content {
+  margin: 14px 2px 0;
+  color: #493c45;
+  font-size: 0.96rem;
+  line-height: 1.8;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -1,10 +1,144 @@
-const LettersPage = () => (
-  <main className="app-shell" style={{ padding: "1rem" }}>
-    <section className="glass-card" style={{ maxWidth: 560, margin: "0 auto", padding: "1rem" }}>
-      <h1 className="ui-title">Letters</h1>
-      <p>Letters 页面正在建设中，当前为可安全跳转的占位页。</p>
-    </section>
-  </main>
-);
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { LetterEntry } from '../types'
+import { fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
+import './LettersPage.css'
 
-export default LettersPage;
+const PREVIEW_LIMIT = 30
+
+const formatTimestamp = (value: string) =>
+  new Date(value).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+const getPreview = (content: string) => {
+  const compact = content.replace(/\s+/g, ' ').trim()
+  if (compact.length <= PREVIEW_LIMIT) {
+    return compact
+  }
+  return `${compact.slice(0, PREVIEW_LIMIT)}…`
+}
+
+const getMetaLabel = (letter: LetterEntry) => {
+  if (letter.module) {
+    return letter.module
+  }
+  if (letter.triggerReason) {
+    return letter.triggerReason
+  }
+  return letter.triggerType
+}
+
+const LettersPage = () => {
+  const [letters, setLetters] = useState<LetterEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [activeLetterId, setActiveLetterId] = useState<string | null>(null)
+
+  const activeLetter = useMemo(
+    () => letters.find((letter) => letter.id === activeLetterId) ?? null,
+    [activeLetterId, letters],
+  )
+
+  const loadLetters = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await fetchLetters()
+      setLetters(list)
+    } catch (loadError) {
+      console.warn('加载来信失败', loadError)
+      setError('加载失败，请稍后重试。')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadLetters()
+  }, [loadLetters])
+
+  const handleOpenLetter = async (letter: LetterEntry) => {
+    setActiveLetterId(letter.id)
+    if (letter.isRead) {
+      return
+    }
+    setLetters((current) =>
+      current.map((item) => (item.id === letter.id ? { ...item, isRead: true } : item)),
+    )
+    try {
+      await markLetterAsRead(letter.id)
+    } catch (markError) {
+      console.warn('标记已读失败', markError)
+    }
+  }
+
+  return (
+    <main className="letters-page app-shell">
+      <header className="letters-header app-shell__header">
+        <h1 className="ui-title">Letters</h1>
+      </header>
+
+      <section className="letters-content app-shell__content" aria-label="letters list">
+        <div className="letters-list glass-card">
+          {loading ? <p className="letters-state">加载中…</p> : null}
+          {!loading && error ? <p className="letters-state">{error}</p> : null}
+          {!loading && !error && letters.length === 0 ? (
+            <p className="letters-state">暂时还没有来信。</p>
+          ) : null}
+
+          {!loading && !error
+            ? letters.map((letter) => (
+                <button
+                  key={letter.id}
+                  type="button"
+                  className={`letter-row ${letter.isRead ? 'is-read' : 'is-unread'}`}
+                  onClick={() => void handleOpenLetter(letter)}
+                >
+                  <span className="letter-avatar" aria-hidden>
+                    S
+                  </span>
+                  <span className="letter-body">
+                    <span className="letter-preview">{getPreview(letter.content)}</span>
+                    <span className="letter-meta">
+                      <span>{formatTimestamp(letter.createdAt)}</span>
+                      <span className="letter-meta-dot">·</span>
+                      <span>{getMetaLabel(letter)}</span>
+                    </span>
+                  </span>
+                </button>
+              ))
+            : null}
+        </div>
+      </section>
+
+      {activeLetter ? (
+        <div className="letter-sheet-backdrop" onClick={() => setActiveLetterId(null)}>
+          <article
+            className="letter-sheet glass-card"
+            onClick={(event) => event.stopPropagation()}
+            aria-label="letter detail"
+          >
+            <header className="letter-sheet-header">
+              <span className="letter-avatar" aria-hidden>
+                S
+              </span>
+              <div>
+                <p className="letter-sheet-title ui-title">Syzygy</p>
+                <p className="letter-sheet-meta">{formatTimestamp(activeLetter.createdAt)}</p>
+              </div>
+              <button type="button" className="letter-close" onClick={() => setActiveLetterId(null)}>
+                关闭
+              </button>
+            </header>
+            <p className="letter-sheet-content">{activeLetter.content}</p>
+          </article>
+        </div>
+      ) : null}
+    </main>
+  )
+}
+
+export default LettersPage


### PR DESCRIPTION
### Motivation
- Replace the placeholder Letters page with an inbox-style message list that matches the app's soft glass/iOS aesthetic rather than the forum pixel look.
- Provide a straightforward UI shell that lists letters newest-first, shows a short preview, and allows reading full content while persisting read state.

### Description
- Replaced `src/pages/LettersPage.tsx` with a React component that loads letters via `fetchLetters`, renders newest-first rows, and uses `markLetterAsRead` when a letter is opened.
- Each row includes a pink circular avatar with a white `S`, a right-side content area, a preview truncated to ~30 characters, and a lighter timestamp/source meta label, with no time-group headings.
- Added subtle read/unread differentiation via `is-unread` / `is-read` classes and implemented a sheet-style detail view to show full text when a row is clicked.
- Added `src/pages/LettersPage.css` implementing rounded glass cards, a soft pink/white/gray palette, light translucent panels, and optional dotted accents while avoiding forum styling.

### Testing
- Ran `npm run lint`, which completed successfully with one pre-existing unrelated warning in `CheckinPage.tsx`.
- Ran `npm run build`, which completed successfully.
- Started the dev server and ran a headless Playwright script to capture a screenshot; the server started and the screenshot artifact was produced but the environment redirected to authentication so the letters list itself was not visible in the capture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd6af2b6883308fcd640bc4a60964)