### PR TITLE
Add manual letter generation trigger to Letters page

### DIFF
--- a/src/pages/LettersPage.css
+++ b/src/pages/LettersPage.css
@@ -29,6 +29,65 @@
   padding: 14px 14px calc(20px + env(safe-area-inset-bottom));
 }
 
+
+.letters-manual-panel {
+  margin: 0 auto 10px;
+  width: min(620px, 100%);
+  padding: 10px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 236, 244, 0.9);
+  background: rgba(255, 255, 255, 0.42);
+}
+
+.letters-manual-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.letters-manual-row label {
+  color: #8a6f7d;
+  font-size: 0.84rem;
+  font-weight: 600;
+  margin-right: auto;
+}
+
+.letters-manual-row select,
+.letters-manual-row button,
+.letters-manual-panel textarea {
+  border: 1px solid rgba(255, 220, 235, 0.9);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.86);
+  color: #6a5561;
+  font: inherit;
+}
+
+.letters-manual-row select,
+.letters-manual-row button {
+  height: 34px;
+  padding: 0 10px;
+}
+
+.letters-manual-row button {
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.letters-manual-panel textarea {
+  margin-top: 8px;
+  width: 100%;
+  resize: vertical;
+  min-height: 50px;
+  padding: 8px 10px;
+  font-size: 0.84rem;
+}
+
+.letters-manual-error {
+  margin: 8px 2px 0;
+  color: #b04576;
+  font-size: 0.82rem;
+}
+
 .letters-list {
   margin: 0 auto;
   width: min(620px, 100%);

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -1,9 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { LetterEntry } from '../types'
-import { fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
+import { supabase } from '../supabase/client'
+import type { LetterEntry, LetterModel } from '../types'
+import { createLetter, fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
 import './LettersPage.css'
 
 const PREVIEW_LIMIT = 30
+
+const LETTER_MODEL_OPTIONS: Array<{ value: LetterModel; label: string; modelId: string }> = [
+  { value: 'claude', label: 'Claude', modelId: 'anthropic/claude-3.5-sonnet' },
+  { value: 'gpt', label: 'GPT', modelId: 'openai/gpt-4o-mini' },
+  { value: 'gemini', label: 'Gemini', modelId: 'google/gemini-2.0-flash-001' },
+]
 
 const formatTimestamp = (value: string) =>
   new Date(value).toLocaleString('zh-CN', {
@@ -36,6 +43,10 @@ const LettersPage = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeLetterId, setActiveLetterId] = useState<string | null>(null)
+  const [selectedModel, setSelectedModel] = useState<LetterModel>('claude')
+  const [manualPrompt, setManualPrompt] = useState('')
+  const [manualGenerating, setManualGenerating] = useState(false)
+  const [manualError, setManualError] = useState<string | null>(null)
 
   const activeLetter = useMemo(
     () => letters.find((letter) => letter.id === activeLetterId) ?? null,
@@ -75,6 +86,78 @@ const LettersPage = () => {
     }
   }
 
+  const handleManualGenerate = async () => {
+    if (manualGenerating || !supabase) {
+      return
+    }
+    setManualGenerating(true)
+    setManualError(null)
+    try {
+      const { data } = await supabase.auth.getSession()
+      const accessToken = data.session?.access_token
+      const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
+      const modelConfig = LETTER_MODEL_OPTIONS.find((item) => item.value === selectedModel)
+      if (!accessToken || !anonKey || !modelConfig) {
+        throw new Error('登录状态异常或模型配置缺失')
+      }
+
+      const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          apikey: anonKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: modelConfig.modelId,
+          modelId: modelConfig.modelId,
+          module: 'letter',
+          stream: false,
+          messages: [
+            {
+              role: 'system',
+              content:
+                'You are Syzygy writing a warm short letter to the user. Keep it personal, kind, and under 180 Chinese characters.',
+            },
+            {
+              role: 'user',
+              content: manualPrompt.trim() || 'Write a check-in style letter for today.',
+            },
+          ],
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error(await response.text())
+      }
+      const payload = (await response.json()) as Record<string, unknown>
+      const choice = (payload.choices as Record<string, unknown>[] | undefined)?.[0]
+      const message = (choice?.message as Record<string, unknown> | undefined) ?? choice
+      const content =
+        typeof message?.content === 'string'
+          ? message.content
+          : typeof choice?.text === 'string'
+            ? choice.text
+            : ''
+      const finalContent = content.trim() || '（空回复）'
+
+      const created = await createLetter({
+        model: selectedModel,
+        content: finalContent,
+        triggerType: 'manual',
+        triggerReason: null,
+        module: 'letter',
+      })
+      setLetters((current) => [created, ...current])
+      setActiveLetterId(created.id)
+    } catch (generateError) {
+      console.warn('手动生成来信失败', generateError)
+      setManualError('生成失败，请稍后重试。')
+    } finally {
+      setManualGenerating(false)
+    }
+  }
+
   return (
     <main className="letters-page app-shell">
       <header className="letters-header app-shell__header">
@@ -82,6 +165,35 @@ const LettersPage = () => {
       </header>
 
       <section className="letters-content app-shell__content" aria-label="letters list">
+        <div className="letters-manual-panel glass-card" aria-label="manual letter trigger">
+          <div className="letters-manual-row">
+            <label htmlFor="letters-model">手动生成（验证用）</label>
+            <select
+              id="letters-model"
+              value={selectedModel}
+              onChange={(event) => setSelectedModel(event.target.value as LetterModel)}
+              disabled={manualGenerating}
+            >
+              {LETTER_MODEL_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <button type="button" onClick={() => void handleManualGenerate()} disabled={manualGenerating}>
+              {manualGenerating ? '生成中…' : 'Generate Letter'}
+            </button>
+          </div>
+          <textarea
+            value={manualPrompt}
+            onChange={(event) => setManualPrompt(event.target.value)}
+            placeholder="可选：补充一条生成指令（用于手动验证）"
+            rows={2}
+            disabled={manualGenerating}
+          />
+          {manualError ? <p className="letters-manual-error">{manualError}</p> : null}
+        </div>
+
         <div className="letters-list glass-card">
           {loading ? <p className="letters-state">加载中…</p> : null}
           {!loading && error ? <p className="letters-state">{error}</p> : null}


### PR DESCRIPTION
### Motivation

- Provide a lightweight, manual entry point on the Letters page to perform end-to-end validation of model-driven letter generation during the current UI phase. 
- Keep the feature intentionally manual and non-agentic so QA can verify generation, DB insert, and UI refresh flows without scheduling or background logic. 
- Reuse existing app patterns for model calls and storage so the change is minimal and consistent with current architecture.

### Description

- Added a compact manual trigger panel on `Letters` page with a model selector for `claude` / `gpt` / `gemini`, an optional prompt textarea, and a secondary `Generate Letter` action. 
- The manual generator reuses the existing Supabase Edge Function call pattern by POSTing to the `openrouter-chat` function (same auth + anon key pattern used elsewhere). 
- On success the code calls the existing `createLetter` storage API which inserts into `public.letters` with `model`, `content`, `trigger_type: 'manual'`, `trigger_reason: null`, and `module: 'letter'`. 
- The UI prepends the created letter to the local list and opens it immediately so the new letter appears without waiting for a full refresh; styling for the manual panel was added in `src/pages/LettersPage.css` and UI code in `src/pages/LettersPage.tsx`.

### Testing

- Ran `npm run build` (TypeScript + Vite) and the build succeeded. 
- Started the dev server with `npm run dev` and validated the UI manually. 
- Captured a Playwright screenshot of `http://127.0.0.1:4173/letters` to confirm the manual trigger panel renders; these automated validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd9bad2f483308191597f4842bd4b)