### PR TITLE
Add return-home button to Letters page header

### DIFF
--- a/src/pages/LettersPage.css
+++ b/src/pages/LettersPage.css
@@ -10,6 +10,7 @@
 }
 
 .letters-header {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,6 +18,27 @@
   border-bottom: 1px solid rgba(255, 231, 242, 0.85);
   background: rgba(255, 255, 255, 0.62);
   backdrop-filter: blur(14px);
+}
+
+.letters-home-btn {
+  position: absolute;
+  left: 16px;
+  bottom: 10px;
+  border: 1px solid rgba(255, 214, 231, 0.95);
+  background: rgba(255, 240, 246, 0.9);
+  color: #7a6170;
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  line-height: 1;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.letters-home-btn:hover {
+  background: rgba(255, 246, 250, 0.98);
+  border-color: rgba(255, 205, 224, 0.95);
 }
 
 .letters-header .ui-title {

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { supabase } from '../supabase/client'
 import type { LetterEntry, LetterModel } from '../types'
 import { createLetter, fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
@@ -161,6 +162,9 @@ const LettersPage = () => {
   return (
     <main className="letters-page app-shell">
       <header className="letters-header app-shell__header">
+        <Link to="/" className="letters-home-btn">
+          返回首页
+        </Link>
         <h1 className="ui-title">Letters</h1>
       </header>
 


### PR DESCRIPTION
### Motivation
- Provide a clear navigation affordance from the Letters page back to the app home while keeping the current page structure and visual language unchanged.

### Description
- Import `Link` from `react-router-dom` and render a pill-shaped button labeled `返回首页` in the header that navigates to `/` in `src/pages/LettersPage.tsx`.
- Add scoped styles (`.letters-home-btn`) and set the header to `position: relative` in `src/pages/LettersPage.css` to position the button without restructuring the header or other page layout.

### Testing
- Ran `npm run build` successfully to validate the bundling step.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and visually verified the button on `/letters` and that it navigates to `/` by capturing a screenshot (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0151725b88330b7e361788ff9733f)