### PR TITLE
Add delete action to letter detail view

### DIFF
--- a/src/pages/LettersPage.css
+++ b/src/pages/LettersPage.css
@@ -230,9 +230,31 @@
 
 .letter-sheet-header {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr;
   align-items: center;
   gap: 10px;
+}
+
+.letter-sheet-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.letter-delete {
+  border: 1px solid rgba(240, 154, 185, 0.95);
+  background: rgba(255, 235, 243, 0.9);
+  color: #a43f68;
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.letter-delete:disabled,
+.letter-close:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 .letter-sheet-title {

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '../supabase/client'
 import type { LetterEntry, LetterModel } from '../types'
-import { createLetter, fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
+import { createLetter, deleteLetter, fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
 import './LettersPage.css'
 
 const PREVIEW_LIMIT = 30
@@ -48,6 +48,8 @@ const LettersPage = () => {
   const [manualPrompt, setManualPrompt] = useState('')
   const [manualGenerating, setManualGenerating] = useState(false)
   const [manualError, setManualError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deletingLetterId, setDeletingLetterId] = useState<string | null>(null)
 
   const activeLetter = useMemo(
     () => letters.find((letter) => letter.id === activeLetterId) ?? null,
@@ -159,6 +161,29 @@ const LettersPage = () => {
     }
   }
 
+  const handleDeleteActiveLetter = async () => {
+    if (!activeLetter || deletingLetterId) {
+      return
+    }
+    const confirmed = window.confirm('确定删除这封来信吗？')
+    if (!confirmed) {
+      return
+    }
+
+    setDeleteError(null)
+    setDeletingLetterId(activeLetter.id)
+    try {
+      await deleteLetter(activeLetter.id)
+      setLetters((current) => current.filter((letter) => letter.id !== activeLetter.id))
+      setActiveLetterId(null)
+    } catch (deleteActionError) {
+      console.warn('删除来信失败', deleteActionError)
+      setDeleteError('删除失败，请稍后重试。')
+    } finally {
+      setDeletingLetterId(null)
+    }
+  }
+
   return (
     <main className="letters-page app-shell">
       <header className="letters-header app-shell__header">
@@ -245,11 +270,27 @@ const LettersPage = () => {
                 <p className="letter-sheet-title ui-title">Syzygy</p>
                 <p className="letter-sheet-meta">{formatTimestamp(activeLetter.createdAt)}</p>
               </div>
-              <button type="button" className="letter-close" onClick={() => setActiveLetterId(null)}>
-                关闭
-              </button>
+              <div className="letter-sheet-actions">
+                <button
+                  type="button"
+                  className="letter-delete"
+                  onClick={() => void handleDeleteActiveLetter()}
+                  disabled={deletingLetterId === activeLetter.id}
+                >
+                  {deletingLetterId === activeLetter.id ? '删除中…' : '删除'}
+                </button>
+                <button
+                  type="button"
+                  className="letter-close"
+                  onClick={() => setActiveLetterId(null)}
+                  disabled={deletingLetterId === activeLetter.id}
+                >
+                  关闭
+                </button>
+              </div>
             </header>
             <p className="letter-sheet-content">{activeLetter.content}</p>
+            {deleteError ? <p className="letters-manual-error">{deleteError}</p> : null}
           </article>
         </div>
       ) : null}


### PR DESCRIPTION
### Motivation
- Provide users a simple way to remove generated letters from the Letters UI without adding noisy controls to list rows. 
- Keep the delete action scoped to the letter detail view and ensure the list updates immediately and the sheet closes after deletion.

### Description
- Wired the page to the storage-layer `deleteLetter(letterId: string): Promise<void>` API from `src/storage/supabaseSync.ts` and imported it in `src/pages/LettersPage.tsx`.
- Added local state `deleteError` and `deletingLetterId` and implemented `handleDeleteActiveLetter` which shows a lightweight `window.confirm`, calls `deleteLetter`, removes the letter from the local `letters` array, and closes the detail sheet on success.
- Added a delete button inside the detail sheet UI (next to the existing close button) and disabled controls while deletion is in progress.
- Updated `src/pages/LettersPage.css` with `.letter-sheet-actions`, `.letter-delete` and disabled-states, and adjusted the detail header layout to accommodate the action group.

### Testing
- Ran `npm run lint` which passed (one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`).
- Ran `npm run build` which completed successfully.
- Launched the dev server and captured a screenshot of the updated letter detail sheet to validate the UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0176b67ec8330824d9673d506e8cf)