### PR TITLE
Center letter detail overlay away from bottom edge

### DIFF
--- a/src/pages/LettersPage.css
+++ b/src/pages/LettersPage.css
@@ -213,9 +213,9 @@
   z-index: 30;
   background: rgba(87, 56, 70, 0.32);
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
-  padding: 10px;
+  padding: calc(env(safe-area-inset-top) + 18px) 14px calc(env(safe-area-inset-bottom) + 18px);
 }
 
 .letter-sheet {
@@ -286,4 +286,16 @@
   line-height: 1.8;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+@media (max-width: 640px) {
+  .letter-sheet-backdrop {
+    align-items: center;
+    padding: calc(env(safe-area-inset-top) + 14px) 12px calc(env(safe-area-inset-bottom) + 14px);
+  }
+
+  .letter-sheet {
+    max-height: calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - 28px);
+    border-radius: 20px;
+  }
 }


### PR DESCRIPTION
### Motivation
- The letter detail overlay was positioned like a bottom sheet and felt too low when opened, reducing the reading experience.
- The goal is to make the detail view feel like opening a letter (centered/modal) while keeping the existing soft glass/pink style and comfortable spacing from device edges.

### Description
- Changed `.letter-sheet-backdrop` alignment from `align-items: flex-end` to `align-items: center` and increased safe-area-aware padding to keep the card visually centered and away from screen edges in `src/pages/LettersPage.css`.
- Preserved the existing glass/pink styling and `.letter-sheet` sizing while keeping `max-height` so long content scrolls internally rather than pushing the card off-screen.
- Added a small-screen media query (`@media (max-width: 640px)`) to maintain floating behavior, reduce border-radius slightly, and cap `max-height` with `100dvh` minus safe-area insets for stable mobile scrolling.

### Testing
- Ran `npm run lint`, which completed successfully with one pre-existing warning in `src/pages/CheckinPage.tsx` about hook dependencies.
- Started the dev server with `npm run dev` and captured visual checks via Playwright screenshots for mobile and desktop breakpoints, validating the overlay appears centered and not flush to the bottom when a letter is opened.
- No unrelated files were modified and automated checks passed as noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0239cb0e08330a5066dc8fc6e9888)