### PR TITLE
Add per-user letter reply system prompt setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
   saveMemoryExtractModel,
   saveSyzygyPostSystemPrompt,
   saveSyzygyReplySystemPrompt,
+  saveLetterReplySystemPrompt,
   updateUserSettings,
 } from './storage/userSettings'
 import { invokeMemoryExtraction } from './storage/memoryExtraction'
@@ -62,6 +63,7 @@ import {
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
   resolveSyzygyReplyPrompt,
+  resolveLetterReplyPrompt,
 } from './constants/aiOverlays'
 import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
 
@@ -218,6 +220,7 @@ const App = () => {
     snackSystemOverlay: resolveSnackSystemOverlay(activeSettings.snackSystemOverlay),
     syzygyPostSystemPrompt: resolveSyzygyPostPrompt(activeSettings.syzygyPostSystemPrompt),
     syzygyReplySystemPrompt: resolveSyzygyReplyPrompt(activeSettings.syzygyReplySystemPrompt),
+    letterReplySystemPrompt: resolveLetterReplyPrompt(activeSettings.letterReplySystemPrompt),
   }), [activeSettings, latestSession])
   const snackAiConfig = useMemo(() => ({
     ...feedAiConfigBase,
@@ -1270,6 +1273,23 @@ const App = () => {
     setUserSettings(nextSettings)
   }, [user])
 
+
+  const handleSaveLetterReplySystemPrompt = useCallback(async (nextPrompt: string) => {
+    if (!user) {
+      return
+    }
+    const nextSettings = {
+      ...(settingsRef.current ?? createDefaultSettings(user.id)),
+      userId: user.id,
+      letterReplySystemPrompt: nextPrompt,
+      updatedAt: new Date().toISOString(),
+    }
+    if (supabase) {
+      await saveLetterReplySystemPrompt(user.id, nextPrompt)
+    }
+    setUserSettings(nextSettings)
+  }, [user])
+
   const handleToggleMemoryAutoExtract = useCallback(async (enabled: boolean) => {
     if (!user) {
       return
@@ -1533,6 +1553,7 @@ const App = () => {
                 onSaveSnackSystemPrompt={handleSaveSnackSystemPrompt}
                 onSaveSyzygyPostPrompt={handleSaveSyzygyPostSystemPrompt}
                 onSaveSyzygyReplyPrompt={handleSaveSyzygyReplySystemPrompt}
+                onSaveLetterReplyPrompt={handleSaveLetterReplySystemPrompt}
               />
             </RequireAuth>
           }

--- a/src/constants/aiOverlays.ts
+++ b/src/constants/aiOverlays.ts
@@ -15,6 +15,13 @@ export const DEFAULT_SYZYGY_REPLY_PROMPT = `中文，像社交平台下的简短
 不要长分析，不要分点，不要复述整段内容。
 语气亲近自然，轻轻回应情绪即可。`
 
+export const DEFAULT_LETTER_REPLY_PROMPT = `你正在回复一封写给用户的来信。
+要求：
+- 用中文，语气温柔、真诚、贴近对方。
+- 以简短回信为主：2-4 句，总字数尽量不超过 180 字。
+- 优先回应对方情绪与近况，避免空泛说教和模板化鸡汤。
+- 不要分点，不要使用夸张符号堆叠。`
+
 export const resolveSnackSystemOverlay = (overlay: string | null | undefined) => {
   const trimmed = overlay?.trim()
   return trimmed && trimmed.length > 0 ? overlay ?? '' : DEFAULT_SNACK_SYSTEM_OVERLAY
@@ -28,4 +35,10 @@ export const resolveSyzygyPostPrompt = (prompt: string | null | undefined) => {
 export const resolveSyzygyReplyPrompt = (prompt: string | null | undefined) => {
   const trimmed = prompt?.trim()
   return trimmed && trimmed.length > 0 ? prompt ?? '' : DEFAULT_SYZYGY_REPLY_PROMPT
+}
+
+
+export const resolveLetterReplyPrompt = (prompt: string | null | undefined) => {
+  const trimmed = prompt?.trim()
+  return trimmed && trimmed.length > 0 ? prompt ?? '' : DEFAULT_LETTER_REPLY_PROMPT
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,9 +8,11 @@ import {
   DEFAULT_SNACK_SYSTEM_OVERLAY,
   DEFAULT_SYZYGY_POST_PROMPT,
   DEFAULT_SYZYGY_REPLY_PROMPT,
+  DEFAULT_LETTER_REPLY_PROMPT,
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
   resolveSyzygyReplyPrompt,
+  resolveLetterReplyPrompt,
 } from '../constants/aiOverlays'
 import './SettingsPage.css'
 
@@ -29,6 +31,7 @@ type SettingsPageProps = {
   onSaveSnackSystemPrompt: (value: string) => Promise<void>
   onSaveSyzygyPostPrompt: (value: string) => Promise<void>
   onSaveSyzygyReplyPrompt: (value: string) => Promise<void>
+  onSaveLetterReplyPrompt: (value: string) => Promise<void>
 }
 
 const defaultModelId = 'openrouter/auto'
@@ -42,6 +45,7 @@ const SettingsPage = ({
   onSaveSnackSystemPrompt,
   onSaveSyzygyPostPrompt,
   onSaveSyzygyReplyPrompt,
+  onSaveLetterReplyPrompt,
 }: SettingsPageProps) => {
   const navigate = useNavigate()
   const [searchTerm, setSearchTerm] = useState('')
@@ -83,6 +87,8 @@ const SettingsPage = ({
   const [draftSyzygyReplyPrompt, setDraftSyzygyReplyPrompt] = useState(DEFAULT_SYZYGY_REPLY_PROMPT)
   const [syzygyPostStatus, setSyzygyPostStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [syzygyReplyStatus, setSyzygyReplyStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [draftLetterReplyPrompt, setDraftLetterReplyPrompt] = useState(DEFAULT_LETTER_REPLY_PROMPT)
+  const [letterReplyStatus, setLetterReplyStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [showUnsavedPromptDialog, setShowUnsavedPromptDialog] = useState(false)
   const [snackSectionExpanded, setSnackSectionExpanded] = useState(false)
   const [syzygySectionExpanded, setSyzygySectionExpanded] = useState(false)
@@ -158,6 +164,7 @@ const SettingsPage = ({
     const timer = window.setTimeout(() => {
       setDraftSyzygyPostPrompt(resolveSyzygyPostPrompt(settings.syzygyPostSystemPrompt))
       setDraftSyzygyReplyPrompt(resolveSyzygyReplyPrompt(settings.syzygyReplySystemPrompt))
+      setDraftLetterReplyPrompt(resolveLetterReplyPrompt(settings.letterReplySystemPrompt))
     }, 0)
     return () => {
       window.clearTimeout(timer)
@@ -174,7 +181,7 @@ const SettingsPage = ({
       try {
         const { data, error } = await client
           .from('user_settings')
-          .select('syzygy_post_system_prompt,syzygy_reply_system_prompt')
+          .select('syzygy_post_system_prompt,syzygy_reply_system_prompt,letter_reply_system_prompt')
           .eq('user_id', user.id)
           .maybeSingle()
         if (!active || error) {
@@ -182,6 +189,7 @@ const SettingsPage = ({
         }
         setDraftSyzygyPostPrompt(resolveSyzygyPostPrompt(data?.syzygy_post_system_prompt))
         setDraftSyzygyReplyPrompt(resolveSyzygyReplyPrompt(data?.syzygy_reply_system_prompt))
+        setDraftLetterReplyPrompt(resolveLetterReplyPrompt(data?.letter_reply_system_prompt))
       } catch {
         // ignore and keep local fallback
       }
@@ -303,6 +311,9 @@ const SettingsPage = ({
   const hasUnsavedSyzygyReplyPrompt = settings
     ? draftSyzygyReplyPrompt !== resolveSyzygyReplyPrompt(settings.syzygyReplySystemPrompt)
     : false
+  const hasUnsavedLetterReplyPrompt = settings
+    ? draftLetterReplyPrompt !== resolveLetterReplyPrompt(settings.letterReplySystemPrompt)
+    : false
   const hasUnsavedExtractModel =
     (settings?.memoryExtractModel ?? '') !== (draftMemoryExtractModel ?? '')
   const hasUnsavedPrompt =
@@ -310,6 +321,7 @@ const SettingsPage = ({
     hasUnsavedSnackOverlay ||
     hasUnsavedSyzygyPostPrompt ||
     hasUnsavedSyzygyReplyPrompt ||
+    hasUnsavedLetterReplyPrompt ||
     hasUnsavedExtractModel ||
     hasUnsavedModelSettings ||
     hasUnsavedGeneration
@@ -649,6 +661,34 @@ const SettingsPage = ({
     setSyzygyReplyStatus('idle')
   }
 
+  const handleLetterReplyPromptChange = (value: string) => {
+    setDraftLetterReplyPrompt(value)
+    if (letterReplyStatus !== 'idle') {
+      setLetterReplyStatus('idle')
+    }
+  }
+
+  const handleSaveLetterReplyPrompt = async () => {
+    if (!settings || !hasUnsavedLetterReplyPrompt) {
+      return
+    }
+    const nextPrompt = resolveLetterReplyPrompt(draftLetterReplyPrompt)
+    setDraftLetterReplyPrompt(nextPrompt)
+    setLetterReplyStatus('saving')
+    try {
+      await onSaveLetterReplyPrompt(nextPrompt)
+      setLetterReplyStatus('saved')
+    } catch (error) {
+      console.warn('保存来信回复提示词失败', error)
+      setLetterReplyStatus('error')
+    }
+  }
+
+  const handleResetLetterReplyPrompt = () => {
+    setDraftLetterReplyPrompt(DEFAULT_LETTER_REPLY_PROMPT)
+    setLetterReplyStatus('idle')
+  }
+
   const requestNavigation = (action: () => void) => {
     if (!hasUnsavedPrompt) {
       action()
@@ -685,8 +725,10 @@ const SettingsPage = ({
       setSnackOverlayStatus('idle')
       setDraftSyzygyPostPrompt(resolveSyzygyPostPrompt(settings.syzygyPostSystemPrompt))
       setDraftSyzygyReplyPrompt(resolveSyzygyReplyPrompt(settings.syzygyReplySystemPrompt))
+      setDraftLetterReplyPrompt(resolveLetterReplyPrompt(settings.letterReplySystemPrompt))
       setSyzygyPostStatus('idle')
       setSyzygyReplyStatus('idle')
+      setLetterReplyStatus('idle')
     }
     setShowUnsavedPromptDialog(false)
     const pendingAction = pendingNavigationRef.current
@@ -715,6 +757,9 @@ const SettingsPage = ({
     }
     if (hasUnsavedSyzygyReplyPrompt) {
       void handleSaveSyzygyReplyPrompt()
+    }
+    if (hasUnsavedLetterReplyPrompt) {
+      void handleSaveLetterReplyPrompt()
     }
     setShowUnsavedPromptDialog(false)
     const pendingAction = pendingNavigationRef.current
@@ -1310,6 +1355,31 @@ const SettingsPage = ({
                 恢复默认
               </button>
               {syzygyReplyStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
+            </div>
+
+
+            <div className="section-title nested-prompt-title">
+              <h2 className="ui-title">来信回复风格（Letter Reply Prompt）</h2>
+              <p>控制来信模块回复时的语气与长度。</p>
+            </div>
+            <textarea
+              className="system-prompt"
+              value={draftLetterReplyPrompt}
+              onChange={(event) => handleLetterReplyPromptChange(event.target.value)}
+            />
+            <div className="system-prompt-actions">
+              <button
+                type="button"
+                className="primary"
+                disabled={!hasUnsavedLetterReplyPrompt}
+                onClick={() => void handleSaveLetterReplyPrompt()}
+              >
+                保存
+              </button>
+              <button type="button" className="ghost" onClick={handleResetLetterReplyPrompt}>
+                恢复默认
+              </button>
+              {letterReplyStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
             </div>
           </div>
         ) : null}

--- a/src/storage/userSettings.ts
+++ b/src/storage/userSettings.ts
@@ -4,9 +4,11 @@ import {
   DEFAULT_SNACK_SYSTEM_OVERLAY,
   DEFAULT_SYZYGY_POST_PROMPT,
   DEFAULT_SYZYGY_REPLY_PROMPT,
+  DEFAULT_LETTER_REPLY_PROMPT,
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
   resolveSyzygyReplyPrompt,
+  resolveLetterReplyPrompt,
 } from '../constants/aiOverlays'
 
 type UserSettingsRow = {
@@ -27,6 +29,7 @@ type UserSettingsRow = {
   snack_system_prompt: string | null
   syzygy_post_system_prompt: string | null
   syzygy_reply_system_prompt: string | null
+  letter_reply_system_prompt: string | null
   enable_reasoning: boolean | null
   chat_reasoning_enabled: boolean | null
   rp_reasoning_enabled: boolean | null
@@ -96,6 +99,7 @@ export const createDefaultSettings = (userId: string): UserSettings => ({
   snackSystemOverlay: DEFAULT_SNACK_SYSTEM_OVERLAY,
   syzygyPostSystemPrompt: DEFAULT_SYZYGY_POST_PROMPT,
   syzygyReplySystemPrompt: DEFAULT_SYZYGY_REPLY_PROMPT,
+  letterReplySystemPrompt: DEFAULT_LETTER_REPLY_PROMPT,
   chatReasoningEnabled: true,
   rpReasoningEnabled: false,
   chatHighThinkingEnabled: false,
@@ -123,6 +127,7 @@ const mapSettingsRow = (row: UserSettingsRow): UserSettings => {
   snackSystemOverlay: resolveSnackSystemOverlay(row.snack_system_prompt),
   syzygyPostSystemPrompt: resolveSyzygyPostPrompt(row.syzygy_post_system_prompt),
   syzygyReplySystemPrompt: resolveSyzygyReplyPrompt(row.syzygy_reply_system_prompt),
+  letterReplySystemPrompt: resolveLetterReplyPrompt(row.letter_reply_system_prompt),
   chatReasoningEnabled: row.chat_reasoning_enabled ?? row.enable_reasoning ?? true,
   rpReasoningEnabled: row.rp_reasoning_enabled ?? false,
   chatHighThinkingEnabled: localHighThinking.chatHighThinkingEnabled,
@@ -138,7 +143,7 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
   const { data, error } = await supabase
     .from('user_settings')
     .select(
-      'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
+      'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,letter_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
     )
     .eq('user_id', userId)
     .maybeSingle()
@@ -168,13 +173,14 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
         snack_system_prompt: defaults.snackSystemOverlay,
         syzygy_post_system_prompt: defaults.syzygyPostSystemPrompt,
         syzygy_reply_system_prompt: defaults.syzygyReplySystemPrompt,
+        letter_reply_system_prompt: defaults.letterReplySystemPrompt,
         enable_reasoning: defaults.chatReasoningEnabled,
         chat_reasoning_enabled: defaults.chatReasoningEnabled,
         rp_reasoning_enabled: defaults.rpReasoningEnabled,
         updated_at: now,
       })
       .select(
-        'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
+        'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,letter_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
       )
       .single()
     if (insertError || !inserted) {
@@ -209,6 +215,7 @@ export const updateUserSettings = async (settings: UserSettings): Promise<void> 
       snack_system_prompt: settings.snackSystemOverlay,
       syzygy_post_system_prompt: settings.syzygyPostSystemPrompt,
       syzygy_reply_system_prompt: settings.syzygyReplySystemPrompt,
+      letter_reply_system_prompt: settings.letterReplySystemPrompt,
       enable_reasoning: settings.chatReasoningEnabled,
       chat_reasoning_enabled: settings.chatReasoningEnabled,
       rp_reasoning_enabled: settings.rpReasoningEnabled,
@@ -340,6 +347,24 @@ export const saveSyzygyReplySystemPrompt = async (userId: string, value: string)
     .from('user_settings')
     .update({
       syzygy_reply_system_prompt: value,
+      updated_at: now,
+    })
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
+
+export const saveLetterReplySystemPrompt = async (userId: string, value: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const now = new Date().toISOString()
+  const { error } = await supabase
+    .from('user_settings')
+    .update({
+      letter_reply_system_prompt: value,
       updated_at: now,
     })
     .eq('user_id', userId)

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export type UserSettings = {
   snackSystemOverlay: string
   syzygyPostSystemPrompt: string
   syzygyReplySystemPrompt: string
+  letterReplySystemPrompt: string
   chatReasoningEnabled: boolean
   rpReasoningEnabled: boolean
   chatHighThinkingEnabled: boolean


### PR DESCRIPTION
### Motivation
- Provide a dedicated, per-user system prompt for the Letters module following the existing module-specific prompt pattern. 
- Keep prompt behavior consistent with `snack`/`syzygy` flows so letters can be customized, persisted, and resolved with a sensible default.

### Description
- Add `letterReplySystemPrompt: string` to the `UserSettings` type in `src/types.ts` so the setting is fully typed. 
- Introduce `DEFAULT_LETTER_REPLY_PROMPT` and `resolveLetterReplyPrompt(...)` in `src/constants/aiOverlays.ts` following the same resolver pattern as other prompts. 
- Extend `src/storage/userSettings.ts` to include `letter_reply_system_prompt` in the DB row type, load it in `ensureUserSettings`, include it in default settings and `updateUserSettings`, map it into `letterReplySystemPrompt`, and add `saveLetterReplySystemPrompt(userId, value)` helper. 
- Wire a new `handleSaveLetterReplySystemPrompt` in `src/App.tsx` and pass `onSaveLetterReplyPrompt` into `SettingsPage`, and update `src/pages/SettingsPage.tsx` to provide draft/status state, load/save/reset handlers, unsaved-change tracking, and UI for editing the new prompt.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Started the dev server with `npm run dev` and captured a screenshot of the updated Settings UI showing the new Letter Reply Prompt editor. 
- TypeScript checks and the app compiled without type errors after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02cc925b08330b3ed646405086125)