### PR TITLE
Add dedicated Letters prompt section to API Settings

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -92,6 +92,7 @@ const SettingsPage = ({
   const [showUnsavedPromptDialog, setShowUnsavedPromptDialog] = useState(false)
   const [snackSectionExpanded, setSnackSectionExpanded] = useState(false)
   const [syzygySectionExpanded, setSyzygySectionExpanded] = useState(false)
+  const [letterSectionExpanded, setLetterSectionExpanded] = useState(false)
   const [errors, setErrors] = useState<{ temperature?: string; topP?: string; maxTokens?: string; compressionRatio?: string; compressionKeepRecent?: string }>(
     {},
   )
@@ -1356,12 +1357,26 @@ const SettingsPage = ({
               </button>
               {syzygyReplyStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
             </div>
+          </div>
+        ) : null}
+      </section>
 
-
-            <div className="section-title nested-prompt-title">
-              <h2 className="ui-title">来信回复风格（Letter Reply Prompt）</h2>
-              <p>控制来信模块回复时的语气与长度。</p>
-            </div>
+      <section className="settings-section" role="listitem">
+        <button
+          type="button"
+          className="collapse-header"
+          onClick={() => setLetterSectionExpanded((current) => !current)}
+          aria-expanded={letterSectionExpanded}
+        >
+          <span className="section-title">
+            <span className="section-icon" aria-hidden="true">💌</span>
+            <h2 className="ui-title">来信</h2>
+            <p>控制来信生成时的语气、长度与表达方式。</p>
+          </span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
+        </button>
+        {letterSectionExpanded ? (
+          <div className="accordion-content">
             <textarea
               className="system-prompt"
               value={draftLetterReplyPrompt}
@@ -1379,6 +1394,7 @@ const SettingsPage = ({
               <button type="button" className="ghost" onClick={handleResetLetterReplyPrompt}>
                 恢复默认
               </button>
+              {hasUnsavedLetterReplyPrompt ? <span className="system-prompt-status">有未保存修改</span> : null}
               {letterReplyStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Provide a dedicated, module-specific prompt area for the Letters feature so letter generation can have its own instruction layer separate from other modules. 
- Keep the UI and interaction consistent with the existing module-specific prompt sections (系统提示词 / Snack Feed / 仓鼠观察日志) to avoid redesigning the settings page.

### Description
- Added a new collapsible section titled `来信` with description `控制来信生成时的语气、长度与表达方式。` to the API Settings page in `src/pages/SettingsPage.tsx`.
- Introduced a `letterSectionExpanded` state and moved the Letters prompt editor UI into the new section while preserving the same accordion structure and visual family as other prompt sections.
- Wired the textarea to `draftLetterReplyPrompt` and reused the existing handlers `handleLetterReplyPromptChange`, `handleSaveLetterReplyPrompt`, and `handleResetLetterReplyPrompt`, and preserved saved/unsaved status indicators (`有未保存修改` / `已保存`).
- No unrelated settings UI was changed and existing prompt save/reset/unsaved logic was preserved.

### Testing
- `npm run build` completed successfully (TypeScript compilation and Vite build succeeded).
- Started the dev server (`npm run dev`) and the server came up (Vite ready), indicating the front-end runs without compile errors.
- Attempted a Playwright screenshot to visually validate the page, but the headless Chromium process crashed (SIGSEGV) in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02f82fe98833097244806712f9d99)