### PR TITLE
Use settings-driven prompt layering for manual Letters generation

### DIFF
--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -8,6 +8,7 @@ import './LettersPage.css'
 
 const PREVIEW_LIMIT = 30
 const LETTER_MEMORY_LIMIT = 20
+const LETTER_HELPER_INSTRUCTION = 'Write a warm check-in letter in Chinese. Keep it concise, sincere, and personal.'
 
 const LETTER_MODEL_OPTIONS: Array<{ value: LetterModel; label: string; modelId: string }> = [
   { value: 'claude', label: 'Claude', modelId: 'anthropic/claude-3.5-sonnet' },
@@ -130,6 +131,7 @@ const LettersPage = () => {
         buildMemoryContext(),
       ])
       const appSystemPrompt = settings.systemPrompt.trim()
+      const letterReplyPrompt = settings.letterReplySystemPrompt.trim()
 
       const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`, {
         method: 'POST',
@@ -149,12 +151,14 @@ const LettersPage = () => {
               : []),
             {
               role: 'system',
-              content:
-                'You are Syzygy writing a warm and concise letter to the user. Keep it personal, kind, and under 180 Chinese characters.',
+              content: `Memory context (latest user memory entries):\n${memoryContext}`,
             },
+            ...(letterReplyPrompt
+              ? [{ role: 'system' as const, content: letterReplyPrompt }]
+              : []),
             {
               role: 'system',
-              content: `Memory context (latest user memory entries):\n${memoryContext}`,
+              content: LETTER_HELPER_INSTRUCTION,
             },
             {
               role: 'user',


### PR DESCRIPTION
### Motivation
- The manual Letters flow previously relied on a hardcoded inline system persona message; the intent is to make manual letter generation honor the user-configured system identity plus memory and a dedicated letter reply prompt.

### Description
- Updated `src/pages/LettersPage.tsx` to load `systemPrompt` and `letterReplySystemPrompt` via `ensureUserSettings` and to include memory entries via the existing `buildMemoryContext` (which uses `fetchAllMemoryEntries`).
- Assembled the model `messages` payload so the request stack is: global `systemPrompt` → memory context block → `letterReplySystemPrompt` → a short helper instruction (`LETTER_HELPER_INSTRUCTION`) → the manual user prompt, and removed the old hardcoded persona as the primary behavior source.
- Kept the manual-only generation path and preserved the manual prompt textarea as the user-level instruction override.

### Testing
- Ran `npm run lint`, which completed successfully; there is one unrelated pre-existing `react-hooks/exhaustive-deps` warning in `src/pages/CheckinPage.tsx` but no new lint errors from this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b031344284833099edefa62289bb2c)