### PR TITLE
Use app default model for Letters generation

### DIFF
--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '../supabase/client'
-import type { LetterEntry, LetterModel } from '../types'
+import type { LetterEntry } from '../types'
 import { createLetter, deleteLetter, fetchAllMemoryEntries, fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
 import { ensureUserSettings } from '../storage/userSettings'
 import './LettersPage.css'
@@ -9,12 +9,6 @@ import './LettersPage.css'
 const PREVIEW_LIMIT = 30
 const LETTER_MEMORY_LIMIT = 20
 const LETTER_HELPER_INSTRUCTION = 'Write a warm check-in letter in Chinese. Keep it concise, sincere, and personal.'
-
-const LETTER_MODEL_OPTIONS: Array<{ value: LetterModel; label: string; modelId: string }> = [
-  { value: 'claude', label: 'Claude', modelId: 'anthropic/claude-3.5-sonnet' },
-  { value: 'gpt', label: 'GPT', modelId: 'openai/gpt-4o-mini' },
-  { value: 'gemini', label: 'Gemini', modelId: 'google/gemini-2.0-flash-001' },
-]
 
 const formatTimestamp = (value: string) =>
   new Date(value).toLocaleString('zh-CN', {
@@ -62,7 +56,7 @@ const LettersPage = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeLetterId, setActiveLetterId] = useState<string | null>(null)
-  const [selectedModel, setSelectedModel] = useState<LetterModel>('claude')
+  const [defaultModelId, setDefaultModelId] = useState('openrouter/auto')
   const [manualPrompt, setManualPrompt] = useState('')
   const [manualGenerating, setManualGenerating] = useState(false)
   const [manualError, setManualError] = useState<string | null>(null)
@@ -91,6 +85,38 @@ const LettersPage = () => {
   useEffect(() => {
     void loadLetters()
   }, [loadLetters])
+
+  useEffect(() => {
+    let active = true
+    const client = supabase
+    if (!client) {
+      return () => {
+        active = false
+      }
+    }
+
+    const loadDefaultModel = async () => {
+      try {
+        const { data, error } = await client.auth.getUser()
+        if (error || !data.user) {
+          return
+        }
+        const settings = await ensureUserSettings(data.user.id)
+        if (!active) {
+          return
+        }
+        setDefaultModelId(settings.defaultModel.trim() || 'openrouter/auto')
+      } catch (settingsError) {
+        console.warn('加载默认模型失败', settingsError)
+      }
+    }
+
+    void loadDefaultModel()
+
+    return () => {
+      active = false
+    }
+  }, [])
 
   const handleOpenLetter = async (letter: LetterEntry) => {
     setActiveLetterId(letter.id)
@@ -121,9 +147,8 @@ const LettersPage = () => {
       const accessToken = data.session?.access_token
       const user = userData.user
       const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
-      const modelConfig = LETTER_MODEL_OPTIONS.find((item) => item.value === selectedModel)
-      if (!accessToken || !anonKey || !modelConfig || userError || !user) {
-        throw new Error('登录状态异常或模型配置缺失')
+      if (!accessToken || !anonKey || userError || !user) {
+        throw new Error('登录状态异常')
       }
 
       const [settings, memoryContext] = await Promise.all([
@@ -132,6 +157,8 @@ const LettersPage = () => {
       ])
       const appSystemPrompt = settings.systemPrompt.trim()
       const letterReplyPrompt = settings.letterReplySystemPrompt.trim()
+      const modelId = settings.defaultModel.trim() || 'openrouter/auto'
+      setDefaultModelId(modelId)
 
       const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`, {
         method: 'POST',
@@ -141,8 +168,8 @@ const LettersPage = () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          model: modelConfig.modelId,
-          modelId: modelConfig.modelId,
+          model: modelId,
+          modelId: modelId,
           module: 'letter',
           stream: false,
           messages: [
@@ -183,7 +210,7 @@ const LettersPage = () => {
       const finalContent = content.trim() || '（空回复）'
 
       const created = await createLetter({
-        model: selectedModel,
+        model: modelId,
         content: finalContent,
         triggerType: 'manual',
         triggerReason: null,
@@ -234,23 +261,12 @@ const LettersPage = () => {
       <section className="letters-content app-shell__content" aria-label="letters list">
         <div className="letters-manual-panel glass-card" aria-label="manual letter trigger">
           <div className="letters-manual-row">
-            <label htmlFor="letters-model">手动生成（验证用）</label>
-            <select
-              id="letters-model"
-              value={selectedModel}
-              onChange={(event) => setSelectedModel(event.target.value as LetterModel)}
-              disabled={manualGenerating}
-            >
-              {LETTER_MODEL_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+            <label>手动生成（验证用）</label>
             <button type="button" onClick={() => void handleManualGenerate()} disabled={manualGenerating}>
               {manualGenerating ? '生成中…' : 'Generate Letter'}
             </button>
           </div>
+          <p className="letters-manual-hint">当前默认模型：{defaultModelId}</p>
           <textarea
             value={manualPrompt}
             onChange={(event) => setManualPrompt(event.target.value)}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -7,7 +7,6 @@ import type {
   ForumThread,
   ForumAuthorType,
   LetterEntry,
-  LetterModel,
   LetterTriggerType,
   MemoryEntry,
   MemoryStatus,
@@ -197,7 +196,7 @@ type ForumAiProfileRow = {
 type LetterRow = {
   id: string
   user_id: string
-  model: LetterModel
+  model: string
   content: string
   trigger_type: LetterTriggerType
   trigger_reason: string | null
@@ -460,7 +459,7 @@ export const fetchLetters = async (): Promise<LetterEntry[]> => {
 
 export const createLetter = async (
   input: {
-    model: LetterModel
+    model: string
     content: string
     triggerType?: LetterTriggerType
     triggerReason?: string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,14 +219,12 @@ export type ForumAiProfile = {
   updatedAt: string
 }
 
-export type LetterModel = 'claude' | 'gpt' | 'gemini'
-
 export type LetterTriggerType = 'manual' | 'scheduled' | 'event'
 
 export type LetterEntry = {
   id: string
   userId: string
-  model: LetterModel
+  model: string
   content: string
   triggerType: LetterTriggerType
   triggerReason: string | null


### PR DESCRIPTION
### Motivation
- The Letters page previously maintained its own Claude/GPT/Gemini selector which duplicates model selection logic and diverges from the app-wide model library.
- Letters should use the single source of truth `user_settings.default_model` so behavior matches the rest of the app.
- Persist actual model id strings for letters (e.g. `openai/gpt-5.4`) instead of a coarse enum to support the model catalog.

### Description
- Removed the dedicated `LETTER_MODEL_OPTIONS` and the per-letter dropdown UI from `src/pages/LettersPage.tsx`, replacing it with a minimal manual panel: textarea + generate button + a passive hint `当前默认模型：{...}`.
- Load user settings on page load via `ensureUserSettings` and use `settings.defaultModel` (exact model id) when calling the `openrouter-chat` function and when creating letters in `handleManualGenerate` in `src/pages/LettersPage.tsx`.
- Updated the letters data model to store the real model id string by changing `LetterEntry.model` to `string` in `src/types.ts` and adjusted Supabase row typing/mapping and `createLetter`/`fetchLetters` signatures in `src/storage/supabaseSync.ts` to read/write `letters.model` as a string.
- Kept all other Letters UI and behaviors unchanged and ensured the same model id is supplied to the API as both `model` and `modelId` in the request body.

### Testing
- Ran `npm run build` (TypeScript + Vite build) and the build completed successfully.
- Ran `npm run lint` and ESLint completed successfully (one pre-existing warning reported in `src/pages/CheckinPage.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c9ebdc7883308a1dc761666bebb4)