### PR TITLE
Add letters-to-conversation helpers in Supabase storage layer

### DIFF
--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -457,6 +457,25 @@ export const fetchLetters = async (): Promise<LetterEntry[]> => {
   return (data ?? []).map((row) => mapLetterRow(row as LetterRow))
 }
 
+export const fetchLettersByConversation = async (sessionId: string): Promise<LetterEntry[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('letters')
+    .select(
+      'id,user_id,model,content,trigger_type,trigger_reason,created_at,is_read,conversation_id,module,metadata',
+    )
+    .eq('user_id', userId)
+    .eq('conversation_id', sessionId)
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapLetterRow(row as LetterRow))
+}
+
 export const createLetter = async (
   input: {
     model: string
@@ -506,6 +525,21 @@ export const markLetterAsRead = async (letterId: string): Promise<void> => {
   const { error } = await supabase
     .from('letters')
     .update({ is_read: true })
+    .eq('id', letterId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
+export const linkLetterToConversation = async (letterId: string, conversationId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('letters')
+    .update({ conversation_id: conversationId })
     .eq('id', letterId)
     .eq('user_id', userId)
   if (error) {


### PR DESCRIPTION
### Motivation
- Allow letters to be associated with chat sessions so they can appear as event cards in a conversation timeline.
- Provide a dedicated helper to fetch all letters for a specific conversation scoped to the current user.
- Provide a helper to link/update a single letter's `conversation_id` while preserving existing auth scoping and mappings.

### Description
- Added `fetchLettersByConversation(sessionId: string): Promise<LetterEntry[]>` in `src/storage/supabaseSync.ts` which scopes results to the authenticated user, filters by `conversation_id = sessionId`, and returns rows ordered by `created_at` ascending.
- Added `linkLetterToConversation(letterId: string, conversationId: string): Promise<void>` in `src/storage/supabaseSync.ts` which updates a letter's `conversation_id` and scopes the update to the authenticated user via `requireAuthenticatedUserId`.
- Reused existing row mapping (`mapLetterRow`) and authentication pattern (`requireAuthenticatedUserId`) and kept the `LetterEntry` type unchanged in `src/types.ts`.

### Testing
- Ran the TypeScript and Vite build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0de447fe08330acbc0fbfbf81a834)