### PR TITLE
Add “转入对话” flow to Letters and support opening letter via route/query

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1464,7 +1464,7 @@ const App = () => {
           path="/letters"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <LettersPage />
+              <LettersPage sessions={sessions} onCreateSession={createSessionEntry} />
             </RequireAuth>
           }
         />

--- a/src/pages/LettersPage.css
+++ b/src/pages/LettersPage.css
@@ -251,6 +251,16 @@
   font-weight: 700;
 }
 
+.letter-link {
+  border: 1px solid rgba(154, 196, 240, 0.95);
+  background: rgba(232, 245, 255, 0.9);
+  color: #35628c;
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
 .letter-delete:disabled,
 .letter-close:disabled {
   opacity: 0.7;
@@ -286,6 +296,42 @@
   line-height: 1.8;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.letter-link-picker {
+  margin-top: 14px;
+  border-top: 1px solid rgba(255, 224, 237, 0.9);
+  padding-top: 12px;
+}
+
+.letter-link-picker-title {
+  margin: 0 0 8px;
+  color: #826c78;
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.letter-link-picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.letter-link-picker-item {
+  width: 100%;
+  border: 1px solid rgba(255, 220, 235, 0.9);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.86);
+  color: #6a5561;
+  font: inherit;
+  text-align: left;
+  padding: 8px 10px;
+}
+
+.letter-link-picker-empty {
+  margin: 8px 0 0;
+  color: #ab8f9d;
+  font-size: 0.82rem;
 }
 
 @media (max-width: 640px) {

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { supabase } from '../supabase/client'
-import type { LetterEntry } from '../types'
-import { createLetter, deleteLetter, fetchAllMemoryEntries, fetchLetters, markLetterAsRead } from '../storage/supabaseSync'
+import type { ChatSession, LetterEntry } from '../types'
+import {
+  createLetter,
+  deleteLetter,
+  fetchAllMemoryEntries,
+  fetchLetters,
+  linkLetterToConversation,
+  markLetterAsRead,
+} from '../storage/supabaseSync'
 import { ensureUserSettings } from '../storage/userSettings'
 import './LettersPage.css'
 
@@ -51,7 +58,15 @@ const buildMemoryContext = async () => {
     .join('\n')
 }
 
-const LettersPage = () => {
+const LettersPage = ({
+  sessions,
+  onCreateSession,
+}: {
+  sessions: ChatSession[]
+  onCreateSession: (title?: string) => Promise<ChatSession>
+}) => {
+  const location = useLocation()
+  const navigate = useNavigate()
   const [letters, setLetters] = useState<LetterEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -62,6 +77,21 @@ const LettersPage = () => {
   const [manualError, setManualError] = useState<string | null>(null)
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [deletingLetterId, setDeletingLetterId] = useState<string | null>(null)
+  const [linkPickerOpen, setLinkPickerOpen] = useState(false)
+  const [linking, setLinking] = useState(false)
+  const [linkError, setLinkError] = useState<string | null>(null)
+
+  const routeOpenLetterId = useMemo(() => {
+    const stateOpenLetterId =
+      typeof (location.state as { openLetterId?: unknown } | null)?.openLetterId === 'string'
+        ? ((location.state as { openLetterId?: string } | null)?.openLetterId ?? null)
+        : null
+    if (stateOpenLetterId) {
+      return stateOpenLetterId
+    }
+    const searchParams = new URLSearchParams(location.search)
+    return searchParams.get('open')
+  }, [location.search, location.state])
 
   const activeLetter = useMemo(
     () => letters.find((letter) => letter.id === activeLetterId) ?? null,
@@ -85,6 +115,17 @@ const LettersPage = () => {
   useEffect(() => {
     void loadLetters()
   }, [loadLetters])
+
+  useEffect(() => {
+    if (loading || !routeOpenLetterId) {
+      return
+    }
+    const target = letters.find((letter) => letter.id === routeOpenLetterId)
+    if (!target) {
+      return
+    }
+    void handleOpenLetter(target)
+  }, [letters, loading, routeOpenLetterId])
 
   useEffect(() => {
     let active = true
@@ -118,7 +159,7 @@ const LettersPage = () => {
     }
   }, [])
 
-  const handleOpenLetter = async (letter: LetterEntry) => {
+  async function handleOpenLetter(letter: LetterEntry) {
     setActiveLetterId(letter.id)
     if (letter.isRead) {
       return
@@ -132,6 +173,11 @@ const LettersPage = () => {
       console.warn('标记已读失败', markError)
     }
   }
+
+  useEffect(() => {
+    setLinkPickerOpen(false)
+    setLinkError(null)
+  }, [activeLetterId])
 
   const handleManualGenerate = async () => {
     if (manualGenerating || !supabase) {
@@ -249,6 +295,70 @@ const LettersPage = () => {
     }
   }
 
+  const openChatSession = useCallback(
+    (sessionId: string) => {
+      navigate(`/chat/${sessionId}`)
+      window.setTimeout(() => {
+        if (window.location.pathname !== `/chat/${sessionId}`) {
+          window.location.assign(`/chat/${sessionId}`)
+        }
+      }, 0)
+    },
+    [navigate],
+  )
+
+  const handleLinkToSession = useCallback(
+    async (sessionId: string) => {
+      if (!activeLetter || linking) {
+        return
+      }
+      setLinkError(null)
+      setLinking(true)
+      try {
+        await linkLetterToConversation(activeLetter.id, sessionId)
+        setLetters((current) =>
+          current.map((letter) =>
+            letter.id === activeLetter.id ? { ...letter, conversationId: sessionId } : letter,
+          ),
+        )
+        setLinkPickerOpen(false)
+        setActiveLetterId(null)
+        openChatSession(sessionId)
+      } catch (linkActionError) {
+        console.warn('关联对话失败', linkActionError)
+        setLinkError('关联失败，请稍后重试。')
+      } finally {
+        setLinking(false)
+      }
+    },
+    [activeLetter, linking, openChatSession],
+  )
+
+  const handleCreateAndLinkSession = useCallback(async () => {
+    if (!activeLetter || linking) {
+      return
+    }
+    setLinkError(null)
+    setLinking(true)
+    try {
+      const createdSession = await onCreateSession('来自来信')
+      await linkLetterToConversation(activeLetter.id, createdSession.id)
+      setLetters((current) =>
+        current.map((letter) =>
+          letter.id === activeLetter.id ? { ...letter, conversationId: createdSession.id } : letter,
+        ),
+      )
+      setLinkPickerOpen(false)
+      setActiveLetterId(null)
+      openChatSession(createdSession.id)
+    } catch (createError) {
+      console.warn('创建并关联对话失败', createError)
+      setLinkError('转入对话失败，请稍后重试。')
+    } finally {
+      setLinking(false)
+    }
+  }, [activeLetter, linking, onCreateSession, openChatSession])
+
   return (
     <main className="letters-page app-shell">
       <header className="letters-header app-shell__header">
@@ -327,6 +437,17 @@ const LettersPage = () => {
               <div className="letter-sheet-actions">
                 <button
                   type="button"
+                  className="letter-link"
+                  onClick={() => {
+                    setLinkError(null)
+                    setLinkPickerOpen(true)
+                  }}
+                  disabled={deletingLetterId === activeLetter.id || linking}
+                >
+                  转入对话
+                </button>
+                <button
+                  type="button"
                   className="letter-delete"
                   onClick={() => void handleDeleteActiveLetter()}
                   disabled={deletingLetterId === activeLetter.id}
@@ -345,6 +466,38 @@ const LettersPage = () => {
             </header>
             <p className="letter-sheet-content">{activeLetter.content}</p>
             {deleteError ? <p className="letters-manual-error">{deleteError}</p> : null}
+            {linkError ? <p className="letters-manual-error">{linkError}</p> : null}
+
+            {linkPickerOpen ? (
+              <section className="letter-link-picker" aria-label="target conversation picker">
+                <p className="letter-link-picker-title">选择目标对话</p>
+                <button
+                  type="button"
+                  className="letter-link-picker-item"
+                  onClick={() => void handleCreateAndLinkSession()}
+                  disabled={linking}
+                >
+                  {linking ? '处理中…' : '新建对话'}
+                </button>
+                {sessions.length > 0 ? (
+                  <div className="letter-link-picker-list">
+                    {sessions.map((session) => (
+                      <button
+                        key={session.id}
+                        type="button"
+                        className="letter-link-picker-item"
+                        onClick={() => void handleLinkToSession(session.id)}
+                        disabled={linking}
+                      >
+                        {session.title}
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="letter-link-picker-empty">暂无已有会话，可直接新建。</p>
+                )}
+              </section>
+            ) : null}
           </article>
         </div>
       ) : null}


### PR DESCRIPTION
### Motivation
- Allow a letter to be attached to a chat conversation from the Letters detail view and enable jumping into that conversation directly. 
- Support deep-linking into a specific letter from routes/queries so event cards can point back into Letters later.

### Description
- Added a `转入对话` action and lightweight picker in `src/pages/LettersPage.tsx` that shows existing chat sessions and a `新建对话` option. 
- Implemented linking via `linkLetterToConversation(letterId, sessionId)` and a new-session flow that calls the app-level `onCreateSession` then links the letter; navigation to the chat uses `navigate('/chat/:id')` with a hard-navigation fallback `window.location.assign` to ensure reliability. 
- Added support for opening a specific letter from routing by reading `location.state.openLetterId` and the query param `?open=<letterId>` and auto-opening the letter after the list loads. 
- Wired `LettersPage` props in `src/App.tsx` so the page receives `sessions` and `onCreateSession`, and added UI styles in `src/pages/LettersPage.css` for the transfer button and picker.

### Testing
- Ran `npm run lint` which completed (one unrelated pre-existing warning remains in `src/pages/CheckinPage.tsx`).
- Ran `npm run build` which completed successfully.
- Launched a dev server and ran an automated Playwright smoke script that loaded `/letters` and produced a screenshot to verify the picker and navigation flows rendered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e58ac2ac833081968b14318887f2)