### PR TITLE
Render linked letters as timeline event cards in chat

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -682,3 +682,71 @@
   font-size: 12px;
   color: #64748b;
 }
+
+.timeline-letter-card {
+  align-self: stretch;
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  background: linear-gradient(135deg, rgba(255, 251, 235, 0.95), rgba(254, 243, 199, 0.72));
+  border-radius: 14px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 8px 24px rgba(180, 83, 9, 0.12);
+}
+
+.timeline-letter-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.timeline-letter-card__avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(252, 211, 77, 0.45);
+}
+
+.timeline-letter-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.timeline-letter-card__model {
+  font-size: 12px;
+  font-weight: 700;
+  color: #78350f;
+}
+
+.timeline-letter-card__time {
+  font-size: 11px;
+  color: #92400e;
+}
+
+.timeline-letter-card__preview {
+  margin: 0;
+  color: #451a03;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.timeline-letter-card__action {
+  align-self: flex-start;
+  border: 1px solid rgba(146, 64, 14, 0.25);
+  background: rgba(255, 255, 255, 0.72);
+  color: #78350f;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.timeline-letter-card__action:hover {
+  background: rgba(255, 255, 255, 0.95);
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -3,10 +3,11 @@ import { createPortal } from 'react-dom'
 import type { FormEvent } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { useNavigate } from 'react-router-dom'
-import type { ChatMessage, ChatSession } from '../types'
+import type { ChatMessage, ChatSession, ChatTimelineItem, LetterEntry } from '../types'
 import ConfirmDialog from '../components/ConfirmDialog'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import ReasoningPanel from '../components/ReasoningPanel'
+import { fetchLettersByConversation } from '../storage/supabaseSync'
 import './ChatPage.css'
 
 export type ChatPageProps = {
@@ -30,6 +31,16 @@ const formatTime = (timestamp: string) =>
     hour: '2-digit',
     minute: '2-digit',
   })
+
+const normalizeMessageSortTime = (message: ChatMessage) => message.clientCreatedAt ?? message.createdAt
+
+const buildLetterPreview = (content: string) => {
+  const compact = content.replace(/\s+/g, ' ').trim()
+  if (compact.length <= 50) {
+    return compact
+  }
+  return `${compact.slice(0, 50)}…`
+}
 
 const MESSAGE_ACTIONS_MENU_WIDTH = 140
 const MESSAGE_ACTIONS_MENU_HEIGHT = 84
@@ -56,6 +67,7 @@ const ChatPage = ({
   const [openHeaderMenu, setOpenHeaderMenu] = useState(false)
   const [headerMenuPosition, setHeaderMenuPosition] = useState({ top: 0, right: 0 })
   const [pendingDelete, setPendingDelete] = useState<ChatMessage | null>(null)
+  const [letters, setLetters] = useState<LetterEntry[]>([])
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const actionsMenuRef = useRef<HTMLDivElement | null>(null)
   const actionTriggerRefs = useRef<Record<string, HTMLButtonElement | null>>({})
@@ -120,9 +132,60 @@ const ChatPage = ({
     return Array.from(unique)
   }, [defaultModel, enabledModels, sessionOverride])
 
+
+  useEffect(() => {
+    let active = true
+    const loadLetters = async () => {
+      try {
+        const linkedLetters = await fetchLettersByConversation(session.id)
+        if (!active) {
+          return
+        }
+        setLetters(linkedLetters)
+      } catch (error) {
+        console.warn('无法加载关联来信', error)
+        if (active) {
+          setLetters([])
+        }
+      }
+    }
+    void loadLetters()
+    return () => {
+      active = false
+    }
+  }, [session.id])
+
+  const timelineItems = useMemo<ChatTimelineItem[]>(() => {
+    const messageItems: ChatTimelineItem[] = messages.map((message) => ({
+      type: 'message',
+      id: message.id,
+      sortTime: normalizeMessageSortTime(message),
+      message,
+    }))
+    const letterItems: ChatTimelineItem[] = letters.map((letter) => ({
+      type: 'letter',
+      id: letter.id,
+      sortTime: letter.createdAt,
+      letter,
+    }))
+    return [...messageItems, ...letterItems].sort((a, b) => {
+      const primary = new Date(a.sortTime).getTime() - new Date(b.sortTime).getTime()
+      if (primary !== 0) {
+        return primary
+      }
+      if (a.type === 'message' && b.type === 'message') {
+        return new Date(a.message.createdAt).getTime() - new Date(b.message.createdAt).getTime()
+      }
+      if (a.type === 'letter' && b.type === 'letter') {
+        return new Date(a.letter.createdAt).getTime() - new Date(b.letter.createdAt).getTime()
+      }
+      return a.type === 'message' ? -1 : 1
+    })
+  }, [letters, messages])
+
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages.length])
+  }, [timelineItems.length])
 
   useEffect(() => {
     document.body.classList.add('chat-page-active')
@@ -332,60 +395,87 @@ const ChatPage = ({
         </div>
       </header>
       <main className="chat-messages glass-panel">
-        {messages.length === 0 ? (
+        {timelineItems.length === 0 ? (
           <div className="empty-state">
             <p>暂无消息，开始聊点什么吧。</p>
           </div>
         ) : (
-          messages.map((message) => (
-            <div
-              key={message.id}
-              className={`message ${message.role === 'user' ? 'out' : 'in'}`}
-            >
-              <div className="bubble">
-                {(() => {
-                  const reasoningText =
-                    message.meta?.reasoning_text?.trim() ?? message.meta?.reasoning?.trim()
-                  return reasoningText ? <ReasoningPanel reasoning={reasoningText} /> : null
-                })()}
-                {message.role === 'assistant' ? (
-                  <div className="assistant-markdown">
-                    <MarkdownRenderer content={message.content} />
-                  </div>
-                ) : (
-                  <p>{message.content}</p>
-                )}
-                {message.role === 'assistant' && message.meta?.model ? (
-                  <div className="message-footer">
-                    <span className="model-tag">
-                      {message.meta.model === 'mock-model' ? '模拟模型' : message.meta.model}
+          timelineItems.map((item) => {
+            if (item.type === 'letter') {
+              return (
+                <div key={`letter-${item.id}`} className="timeline-letter-card">
+                  <div className="timeline-letter-card__header">
+                    <span className="timeline-letter-card__avatar" aria-hidden="true">
+                      💌
                     </span>
+                    <div className="timeline-letter-card__meta">
+                      <span className="timeline-letter-card__model">{item.letter.model}</span>
+                      <span className="timeline-letter-card__time">{formatTime(item.letter.createdAt)}</span>
+                    </div>
                   </div>
-                ) : null}
-              </div>
-              <div className="bubble-meta">
-                <span className="timestamp">{formatTime(message.createdAt)}</span>
-                <div className="message-actions">
+                  <p className="timeline-letter-card__preview">{buildLetterPreview(item.letter.content)}</p>
                   <button
-                    ref={(node) => {
-                      actionTriggerRefs.current[message.id] = node
-                    }}
                     type="button"
-                    className="ghost action-trigger"
-                    aria-expanded={openActionsId === message.id}
-                    aria-label={actionsLabel}
-                    onClick={() =>
-                      setOpenActionsId((current) =>
-                        current === message.id ? null : message.id,
-                      )
-                    }
+                    className="timeline-letter-card__action"
+                    onClick={() => navigate('/letters')}
                   >
-                    •••
+                    查看来信
                   </button>
                 </div>
+              )
+            }
+
+            const message = item.message
+            return (
+              <div
+                key={message.id}
+                className={`message ${message.role === 'user' ? 'out' : 'in'}`}
+              >
+                <div className="bubble">
+                  {(() => {
+                    const reasoningText =
+                      message.meta?.reasoning_text?.trim() ?? message.meta?.reasoning?.trim()
+                    return reasoningText ? <ReasoningPanel reasoning={reasoningText} /> : null
+                  })()}
+                  {message.role === 'assistant' ? (
+                    <div className="assistant-markdown">
+                      <MarkdownRenderer content={message.content} />
+                    </div>
+                  ) : (
+                    <p>{message.content}</p>
+                  )}
+                  {message.role === 'assistant' && message.meta?.model ? (
+                    <div className="message-footer">
+                      <span className="model-tag">
+                        {message.meta.model === 'mock-model' ? '模拟模型' : message.meta.model}
+                      </span>
+                    </div>
+                  ) : null}
+                </div>
+                <div className="bubble-meta">
+                  <span className="timestamp">{formatTime(message.createdAt)}</span>
+                  <div className="message-actions">
+                    <button
+                      ref={(node) => {
+                        actionTriggerRefs.current[message.id] = node
+                      }}
+                      type="button"
+                      className="ghost action-trigger"
+                      aria-expanded={openActionsId === message.id}
+                      aria-label={actionsLabel}
+                      onClick={() =>
+                        setOpenActionsId((current) =>
+                          current === message.id ? null : message.id,
+                        )
+                      }
+                    >
+                      •••
+                    </button>
+                  </div>
+                </div>
               </div>
-            </div>
-          ))
+            )
+          })
         )}
         <div ref={bottomRef} />
       </main>

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,3 +234,19 @@ export type LetterEntry = {
   module: string | null
   metadata: Record<string, unknown> | null
 }
+
+export type ChatTimelineMessageItem = {
+  type: 'message'
+  id: string
+  sortTime: string
+  message: ChatMessage
+}
+
+export type ChatTimelineLetterItem = {
+  type: 'letter'
+  id: string
+  sortTime: string
+  letter: LetterEntry
+}
+
+export type ChatTimelineItem = ChatTimelineMessageItem | ChatTimelineLetterItem


### PR DESCRIPTION
### Motivation
- Show letter events in the chat timeline for conversations that have linked letters so the timeline reflects both chat activity and external letter events. 
- Keep ordinary chat message rendering unchanged while making letter events visually distinct and not injecting full letter bodies into message bubbles. 

### Description
- Added a timeline union type `ChatTimelineItem` with `message` and `letter` variants in `src/types.ts` to represent mixed timeline entries. 
- In `src/pages/ChatPage.tsx` fetch linked letters with `fetchLettersByConversation(session.id)` and store them in component state. 
- Merge `messages` and `letters` into a single `timelineItems` array and sort by a normalized `sortTime` (`clientCreatedAt ?? createdAt` for messages, `createdAt` for letters). 
- Render the merged timeline in `ChatPage` so messages continue to render as before and letters render as distinct event cards with model/avatar, created time, a ~50-char preview (no full body), and a `查看来信` button; added styling in `src/pages/ChatPage.css`. 

### Testing
- Ran `npm run build` to verify the app compiles successfully (build succeeded). 
- Ran `npm run lint` which completed; it reports one pre-existing warning in `src/pages/CheckinPage.tsx`. 
- Launched the dev server and ran an automated Playwright script to load `/chat` and capture a screenshot showing letter cards in the timeline (screenshot generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b107d05fdc8330b70cc1fd335f48d6)