### PR TITLE
Fix HashRouter-safe “转入对话” navigation in LettersPage

### DIFF
--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -298,11 +298,6 @@ const LettersPage = ({
   const openChatSession = useCallback(
     (sessionId: string) => {
       navigate(`/chat/${sessionId}`)
-      window.setTimeout(() => {
-        if (window.location.pathname !== `/chat/${sessionId}`) {
-          window.location.assign(`/chat/${sessionId}`)
-        }
-      }, 0)
     },
     [navigate],
   )


### PR DESCRIPTION
### Motivation
- The app is deployed with `HashRouter`, and the previous hard navigation fallback used a path-based URL (`/chat/:id`) which caused GitHub Pages 404s when linking a letter to a chat.

### Description
- Removed the hard `window.location.assign('/chat/:id')` fallback in `openChatSession` and rely on `navigate(`/chat/${sessionId}`)` so navigation remains HashRouter-safe while keeping all linking and Supabase write logic unchanged.

### Testing
- Ran a production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1175f14c08330a2a8535c35173dc5)