### PR TITLE
Increase linked-letter model context limit and remove redundant navigation fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,14 +166,14 @@ const buildOpenAiMessages = (
   return [...systemLayers, ...history]
 }
 
-const LETTER_PREVIEW_LIMIT = 80
+const LETTER_MODEL_CONTEXT_LIMIT = 400
 
-const buildLetterPreview = (content: string) => {
+const buildLetterModelContext = (content: string) => {
   const compact = content.replace(/\s+/g, ' ').trim()
-  if (compact.length <= LETTER_PREVIEW_LIMIT) {
+  if (compact.length <= LETTER_MODEL_CONTEXT_LIMIT) {
     return compact
   }
-  return `${compact.slice(0, LETTER_PREVIEW_LIMIT)}…`
+  return `${compact.slice(0, LETTER_MODEL_CONTEXT_LIMIT)}…`
 }
 
 const buildCompactLetterEvents = (letters: LetterEntry[]) => {
@@ -182,8 +182,8 @@ const buildCompactLetterEvents = (letters: LetterEntry[]) => {
   }
   const lines = letters.map((letter) => {
     const model = letter.model?.trim() || 'unknown'
-    const preview = buildLetterPreview(letter.content)
-    return `[来信 from ${model} @ ${letter.createdAt}] ${preview}`
+    const content = buildLetterModelContext(letter.content)
+    return `[来信 from ${model} @ ${letter.createdAt}] ${content}`
   })
   return `Linked letter events in this conversation (compact summaries):\n${lines.join('\n')}`
 }

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -298,11 +298,6 @@ const LettersPage = ({
   const openChatSession = useCallback(
     (sessionId: string) => {
       navigate(`/chat/${sessionId}`)
-      window.setTimeout(() => {
-        if (window.location.pathname !== `/chat/${sessionId}`) {
-          window.location.assign(`/chat/${sessionId}`)
-        }
-      }, 0)
     },
     [navigate],
   )


### PR DESCRIPTION
### Motivation
- Improve the amount of linked-letter content sent to the model by increasing the compact context size and clarify naming, and remove a legacy navigation fallback that forced a full page redirect when opening a chat session.

### Description
- Rename `LETTER_PREVIEW_LIMIT` to `LETTER_MODEL_CONTEXT_LIMIT`, rename `buildLetterPreview` to `buildLetterModelContext`, and increase the trimming threshold from `80` to `400` so longer linked-letter context is preserved when building compact events. 
- Update `buildCompactLetterEvents` to use the new `buildLetterModelContext` naming and variable `content` for clarity. 
- Remove the `window.setTimeout` fallback that called `window.location.assign` from `openChatSession` in `LettersPage.tsx` so `navigate` is relied on exclusively.

### Testing
- Ran a TypeScript type-check/build with `yarn build` and unit tests with `yarn test`, and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1175f14c08330a2a8535c35173dc5)