### PR TITLE
Support multi-target letter-to-conversation linking via junction table

### DIFF
--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -207,6 +207,11 @@ type LetterRow = {
   metadata: Record<string, unknown> | null
 }
 
+type LetterConversationRow = {
+  letter_id: string
+  conversation_id: string
+}
+
 
 const mapSnackPostRow = (row: SnackPostRow): SnackPost => ({
   id: row.id,
@@ -462,14 +467,33 @@ export const fetchLettersByConversation = async (sessionId: string): Promise<Let
     return []
   }
   const userId = await requireAuthenticatedUserId()
-  const { data, error } = await supabase
+  const { data: links, error: linkError } = await supabase
+    .from('letter_conversations')
+    .select('letter_id,conversation_id')
+    .eq('conversation_id', sessionId)
+  if (linkError) {
+    throw linkError
+  }
+
+  const linkedLetterIds = Array.from(
+    new Set((links ?? []).map((row) => (row as LetterConversationRow).letter_id).filter(Boolean)),
+  )
+
+  let query = supabase
     .from('letters')
     .select(
       'id,user_id,model,content,trigger_type,trigger_reason,created_at,is_read,conversation_id,module,metadata',
     )
     .eq('user_id', userId)
-    .eq('conversation_id', sessionId)
     .order('created_at', { ascending: true })
+
+  if (linkedLetterIds.length > 0) {
+    query = query.in('id', linkedLetterIds)
+  } else {
+    query = query.eq('conversation_id', sessionId)
+  }
+
+  const { data, error } = await query
   if (error) {
     throw error
   }
@@ -537,13 +561,30 @@ export const linkLetterToConversation = async (letterId: string, conversationId:
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
-  const { error } = await supabase
+  const { error: linkError } = await supabase
+    .from('letter_conversations')
+    .upsert(
+      {
+        letter_id: letterId,
+        conversation_id: conversationId,
+      },
+      {
+        onConflict: 'letter_id,conversation_id',
+        ignoreDuplicates: true,
+      },
+    )
+  if (linkError) {
+    throw linkError
+  }
+
+  const { error: legacyError } = await supabase
     .from('letters')
     .update({ conversation_id: conversationId })
     .eq('id', letterId)
     .eq('user_id', userId)
-  if (error) {
-    throw error
+    .is('conversation_id', null)
+  if (legacyError) {
+    throw legacyError
   }
 }
 


### PR DESCRIPTION
### Motivation
- Letters previously stored a single `conversation_id` which caused a new link to overwrite any existing link, preventing a letter from being attached to multiple chat sessions.
- Introduce use of the backfilled `letter_conversations` junction table so a single letter can be associated with multiple conversations while preserving legacy compatibility.

### Description
- Changed conversation-based letter loading to query `letter_conversations` for `letter_id`s and then fetch full `letters` rows by those ids, falling back to `letters.conversation_id` if no junction rows exist. (modified `src/storage/supabaseSync.ts`)
- Implemented `linkLetterToConversation` to `upsert` into `letter_conversations` with an ignore-on-duplicate policy so linking a letter to an additional session does not remove prior links. (modified `src/storage/supabaseSync.ts`)
- Retained a legacy/back-compat write to `letters.conversation_id` only when that field is currently `null`, avoiding overwriting existing single-link values. (modified `src/storage/supabaseSync.ts`)
- Added a `LetterConversationRow` type to represent junction rows in the storage layer; no UI redesigns were required and existing pages continue to call the same storage functions.

### Testing
- Ran the production build with `npm run build` and the build completed successfully (Vite emitted a chunk-size warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11d5beaa08330926a2205d4626f27)