### PR TITLE
Open linked letter from chat timeline card

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -417,7 +417,11 @@ const ChatPage = ({
                   <button
                     type="button"
                     className="timeline-letter-card__action"
-                    onClick={() => navigate('/letters')}
+                    onClick={() =>
+                      navigate('/letters', {
+                        state: { openLetterId: item.letter.id },
+                      })
+                    }
                   >
                     查看来信
                   </button>


### PR DESCRIPTION
### Motivation
- The chat timeline letter card navigated to `/letters` without telling `LettersPage` which letter to open, forcing users to locate the letter manually.

### Description
- Updated `src/pages/ChatPage.tsx` to pass the target letter id via route state when navigating using `navigate('/letters', { state: { openLetterId: item.letter.id } })`.
- This change reuses the existing `LettersPage` `routeOpenLetterId` handling so the specified letter opens automatically without redesigning the card.

### Testing
- Ran `npm run lint`, which completed successfully and reported one pre-existing warning in `src/pages/CheckinPage.tsx`.
- No lint errors or other automated test failures were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11fe9d3508330966f4d1e4bfed368)