### PR TITLE
Normalize letter timestamps to local display format

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
   saveLetterReplySystemPrompt,
   updateUserSettings,
 } from './storage/userSettings'
+import { formatLocalTimestamp } from './utils/time'
 import { invokeMemoryExtraction } from './storage/memoryExtraction'
 import {
   addRemoteMessage,
@@ -183,7 +184,7 @@ const buildCompactLetterEvents = (letters: LetterEntry[]) => {
   const lines = letters.map((letter) => {
     const model = letter.model?.trim() || 'unknown'
     const content = buildLetterModelContext(letter.content)
-    return `[来信 from ${model} @ ${letter.createdAt}] ${content}`
+    return `[来信 from ${model} @ ${formatLocalTimestamp(letter.createdAt)}] ${content}`
   })
   return `Linked letter events in this conversation (compact summaries):\n${lines.join('\n')}`
 }

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -11,19 +11,19 @@ import {
   markLetterAsRead,
 } from '../storage/supabaseSync'
 import { ensureUserSettings } from '../storage/userSettings'
+import { formatLocalTimestamp } from '../utils/time'
 import './LettersPage.css'
 
 const PREVIEW_LIMIT = 30
 const LETTER_MEMORY_LIMIT = 20
 const LETTER_HELPER_INSTRUCTION = 'Write a warm check-in letter in Chinese. Keep it concise, sincere, and personal.'
 
-const formatTimestamp = (value: string) =>
-  new Date(value).toLocaleString('zh-CN', {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+const ISO_TIMESTAMP_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})/g
+
+const formatTimestamp = (value: string) => formatLocalTimestamp(value)
+
+const formatInlineTimestamps = (value: string) =>
+  value.replaceAll(ISO_TIMESTAMP_PATTERN, (match) => formatTimestamp(match))
 
 const getPreview = (content: string) => {
   const compact = content.replace(/\s+/g, ' ').trim()
@@ -38,7 +38,7 @@ const getMetaLabel = (letter: LetterEntry) => {
     return letter.module
   }
   if (letter.triggerReason) {
-    return letter.triggerReason
+    return formatInlineTimestamps(letter.triggerReason)
   }
   return letter.triggerType
 }


### PR DESCRIPTION
### Motivation
- Letter-related UI was exposing raw UTC ISO timestamps (e.g. `2026-03-11T08:04:34.876+00:00`) which are not user-friendly.
- The goal is to present readable local times in all visible letter contexts while leaving UTC storage and schema unchanged.

### Description
- Replaced ad-hoc timestamp rendering on the Letters page with the shared `formatLocalTimestamp` formatter so list and detail views show local-formatted times (`src/pages/LettersPage.tsx`).
- Added `formatInlineTimestamps` to detect and replace ISO timestamps embedded in `triggerReason` text so inline metadata no longer shows raw ISO strings (`src/pages/LettersPage.tsx`).
- Updated the compact linked-letter system-event summaries used for model context to emit local-formatted timestamps instead of raw ISO strings (`src/App.tsx`).
- This is a UI-only change; database writes continue to use UTC ISO strings and no schema changes were made.

### Testing
- Ran `npm run lint`, which completed successfully (there remains one pre-existing warning in `src/pages/CheckinPage.tsx`).
- Ran `npm run build`, which finished successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b128e36a6c8330a9df5699e9280b47)