### PR TITLE
refactor: make display mode setting collapsible in settings panel

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -182,6 +182,18 @@
   flex: 1;
 }
 
+.collapse-header-aside {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.collapse-summary {
+  font-size: 13px;
+  color: #8c8c8c;
+  font-weight: 600;
+}
+
 .collapse-indicator {
   color: rgba(17, 24, 39, 0.35);
   font-size: 24px;
@@ -436,7 +448,6 @@
 }
 
 .display-mode-switch {
-  margin-top: 12px;
   display: grid;
   gap: 8px;
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -64,6 +64,7 @@ const SettingsPage = ({
   const [compressionRatioInput, setCompressionRatioInput] = useState('0.65')
   const [compressionKeepRecentInput, setCompressionKeepRecentInput] = useState('20')
   const [draftSummarizerModel, setDraftSummarizerModel] = useState<string | null>(null)
+  const [displayModeSectionExpanded, setDisplayModeSectionExpanded] = useState(false)
   const [modelSectionExpanded, setModelSectionExpanded] = useState(false)
   const [generationSectionExpanded, setGenerationSectionExpanded] = useState(false)
   const [reasoningSectionExpanded, setReasoningSectionExpanded] = useState(false)
@@ -778,6 +779,8 @@ const SettingsPage = ({
       ? defaultModelId
       : draftEnabledModels[0] ?? draftDefaultModel ?? defaultModelId
 
+  const displayModeLabel = displayMode === 'phone' ? 'Phone Mode' : 'Game Mode'
+
   if (!ready || !settings) {
     return (
       <div className="settings-shell app-shell">
@@ -825,35 +828,50 @@ const SettingsPage = ({
           <span className="settings-ribbon-line" />
         </div>
         <div className="settings-group" role="list">
-      <section className="settings-section" role="listitem">
-        <div className="section-title">
-          <span className="section-icon" aria-hidden="true">📱</span>
-          <h2 className="ui-title">显示模式</h2>
-          <p>Phone Mode 会保留当前完整功能；Game Mode 目前仅提供占位骨架。</p>
-        </div>
-        <div className="display-mode-switch" role="radiogroup" aria-label="Display mode">
-          <label className="display-mode-option">
-            <input
-              type="radio"
-              name="displayMode"
-              value="phone"
-              checked={displayMode === 'phone'}
-              onChange={() => onDisplayModeChange('phone')}
-            />
-            <span>Phone Mode</span>
-          </label>
-          <label className="display-mode-option">
-            <input
-              type="radio"
-              name="displayMode"
-              value="game"
-              checked={displayMode === 'game'}
-              onChange={() => onDisplayModeChange('game')}
-            />
-            <span>Game Mode</span>
-          </label>
-        </div>
-      </section>
+          <section className="settings-section" role="listitem">
+            <button
+              type="button"
+              className="collapse-header"
+              onClick={() => setDisplayModeSectionExpanded((current) => !current)}
+              aria-expanded={displayModeSectionExpanded}
+            >
+              <span className="section-title">
+                <span className="section-icon" aria-hidden="true">📱</span>
+                <h2 className="ui-title">显示模式</h2>
+                <p>{displayModeLabel} · Phone Mode 保留完整功能，Game Mode 为骨架预览。</p>
+              </span>
+              <span className="collapse-header-aside">
+                <span className="collapse-summary">{displayModeLabel}</span>
+                <span className="collapse-indicator" aria-hidden="true">›</span>
+              </span>
+            </button>
+            {displayModeSectionExpanded ? (
+              <div className="accordion-content">
+                <div className="display-mode-switch" role="radiogroup" aria-label="Display mode">
+                  <label className="display-mode-option">
+                    <input
+                      type="radio"
+                      name="displayMode"
+                      value="phone"
+                      checked={displayMode === 'phone'}
+                      onChange={() => onDisplayModeChange('phone')}
+                    />
+                    <span>Phone Mode</span>
+                  </label>
+                  <label className="display-mode-option">
+                    <input
+                      type="radio"
+                      name="displayMode"
+                      value="game"
+                      checked={displayMode === 'game'}
+                      onChange={() => onDisplayModeChange('game')}
+                    />
+                    <span>Game Mode</span>
+                  </label>
+                </div>
+              </div>
+            ) : null}
+          </section>
       <section className="settings-section" role="listitem">
         <button
           type="button"


### PR DESCRIPTION
### Motivation
- Polish the settings page UX by making the `显示模式` (Display Mode) section match the collapsible/accordion interaction used by other settings rows.
- Keep this change strictly UI-focused so that existing display-mode state, persistence, and rendering behavior remain unchanged.

### Description
- Replaced the inline radio group with a collapsible row using a `collapse-header` button and `accordion-content` so radios are shown only when expanded, controlled by a new `displayModeSectionExpanded` state.
- Added a collapsed-state summary that shows the current selection via `displayModeLabel` so the selected mode remains visible when collapsed.
- Introduced minimal CSS (`.collapse-header-aside`, `.collapse-summary`) and reused existing section styles to match nearby settings rows and keep visual consistency.
- Preserved existing wiring to `onDisplayModeChange` and did not modify persistence or display-mode logic (UI-only change in `src/pages/SettingsPage.tsx` and `src/pages/SettingsPage.css`).

### Testing
- Ran `npm run lint` which passed (one pre-existing warning in `CheckinPage.tsx` remains).
- Built the app with `npm run build` which succeeded without errors.
- Launched the dev server with `npm run dev` and performed manual UI verification on `http://127.0.0.1:4173/settings`.
- Captured Playwright screenshots to verify collapsed and expanded states and confirmed expanding/collapsing, switching modes, and persistence after refresh all behaved as expected (manual verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c488af008330855cdf1e84cb4e6c)