### PR TITLE
fix: tighten display mode row layout and align icon/text/value in settings

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -106,13 +106,14 @@
 
 .section-title {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   grid-template-areas:
     'icon title'
     'icon subtitle';
   column-gap: 10px;
   row-gap: 2px;
   align-items: center;
+  min-width: 0;
 }
 
 .section-icon {
@@ -141,6 +142,13 @@
   margin: 0;
   color: #8c8c8c;
   font-size: 13px;
+}
+
+.display-mode-subtitle {
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .settings-page .collapse-header {
@@ -180,6 +188,35 @@
 
 .settings-page .collapse-header .section-title {
   flex: 1;
+}
+
+.settings-page .display-mode-collapse-header {
+  min-height: 52px;
+  padding-block: 10px;
+}
+
+.settings-page .display-mode-collapse-header .section-title {
+  min-width: 0;
+  row-gap: 1px;
+}
+
+.settings-page .display-mode-collapse-header .section-icon {
+  align-self: center;
+}
+
+.settings-page .display-mode-collapse-header .collapse-header-aside {
+  flex-shrink: 0;
+  min-width: fit-content;
+  gap: 6px;
+}
+
+.settings-page .display-mode-collapse-header .collapse-summary {
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.settings-page .display-mode-collapse-header .collapse-indicator {
+  font-size: 21px;
 }
 
 .collapse-header-aside {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -831,14 +831,14 @@ const SettingsPage = ({
           <section className="settings-section" role="listitem">
             <button
               type="button"
-              className="collapse-header"
+              className="collapse-header display-mode-collapse-header"
               onClick={() => setDisplayModeSectionExpanded((current) => !current)}
               aria-expanded={displayModeSectionExpanded}
             >
               <span className="section-title">
                 <span className="section-icon" aria-hidden="true">📱</span>
                 <h2 className="ui-title">显示模式</h2>
-                <p>{displayModeLabel} · Phone Mode 保留完整功能，Game Mode 为骨架预览。</p>
+                <p className="display-mode-subtitle">Phone Mode 保留完整功能，Game Mode 为像素模式。</p>
               </span>
               <span className="collapse-header-aside">
                 <span className="collapse-summary">{displayModeLabel}</span>


### PR DESCRIPTION
### Motivation
- Polish the collapsed “Display Mode” settings row so it visually matches other rows by reducing height, tightening title/subtitle spacing, and aligning the left icon with nearby items.
- Prevent long helper text from wrapping into multiple lines in the collapsed state and keep the selected mode + chevron stable and vertically centered on the right.
- Ensure the row remains stable at narrower widths and under common browser zoom levels without changing behavior or persistence logic.

### Description
- Added a display-mode-specific class to the collapse header (`display-mode-collapse-header`) and a dedicated subtitle class (`display-mode-subtitle`) in `src/pages/SettingsPage.tsx` and replaced the long helper copy with a concise single-line message.
- Updated `src/pages/SettingsPage.css` to use `grid-template-columns: auto minmax(0, 1fr)` and `min-width: 0` for the text column so it can shrink and truncate reliably.
- Added focused CSS overrides for `.display-mode-collapse-header` and `.display-mode-subtitle` to reduce min-height/padding, tighten row-gap, force single-line ellipsis truncation, and keep the right-side `collapse-summary` + chevron as a compact, vertically centered cluster.
- No changes to mode switching, persistence, or expand/collapse logic; this is a layout-only polish.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and it passed; one pre-existing warning in `src/pages/CheckinPage.tsx` remains unrelated to this change.
- Automated visual verification script using Playwright ran against the running dev server and produced screenshots at 390px and 1280px: `artifacts/display-mode-row-narrow.png` and `artifacts/display-mode-row-desktop.png`, demonstrating expected collapsed layout behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c8f5918c8330bab111549e27cf33)