### PR TITLE
fix: remove first-row special padding and align display mode row with other settings items

### DIFF
--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -479,11 +479,6 @@
 }
 
 
-.settings-page .settings-section:first-child {
-  padding: 14px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-}
-
 .display-mode-switch {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
### Motivation
- The first settings section used a special outer padding and border via `.settings-page .settings-section:first-child` which caused the "Display Mode" row to be inset and visually misaligned from other settings rows.

### Description
- Remove the `.settings-page .settings-section:first-child` rule from `src/pages/SettingsPage.css` so the Display Mode row relies on the common `.collapse-header` layout and baseline, preserving collapse behavior, right-side mode summary, and mode-switch functionality while eliminating the extra container inset.

### Testing
- Ran `npm run build` which completed successfully, and verified the Settings page visually with a screenshot saved to `artifacts/settings-display-mode-alignment.png` showing the Display Mode row aligned with neighboring rows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3cfdabf7c8330b7d706e916333d4a)