### PR TITLE
feat: install Phaser and add React bridge container for game mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",
+        "phaser": "^3.90.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
@@ -2531,6 +2532,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4040,6 +4047,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/phaser": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
+      "integrity": "sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",
+    "phaser": "^3.90.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",

--- a/src/App.css
+++ b/src/App.css
@@ -29,16 +29,36 @@ button {
 
 
 .game-mode-shell {
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
+  background: #020617;
 }
 
-.game-mode-placeholder {
-  width: min(560px, 100%);
-  border: 1px dashed #cbd5e1;
-  border-radius: 16px;
-  padding: 28px;
-  background: rgba(255, 255, 255, 0.8);
-  text-align: center;
+.game-mode-loading {
+  margin: auto;
+  color: #e2e8f0;
+}
+
+.game-mode-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.game-mode-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  color: #e2e8f0;
+}
+
+.game-mode-toolbar h1 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.game-canvas-container {
+  flex: 1;
+  min-height: 0;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { Navigate, Route, Routes, useNavigate, useParams } from 'react-router-dom'
 import ChatPage from './pages/ChatPage'
@@ -125,6 +125,8 @@ const AUTO_EXTRACT_USER_TURN_INTERVAL = 12
 const AUTO_EXTRACT_COOLDOWN_MS = 10 * 60 * 1000
 const MEMORY_EXTRACT_RECENT_MESSAGES = 24
 const AUTO_EXTRACT_PENDING_LIMIT = 50
+
+const GameModeShell = lazy(() => import('./game/GameModeShell'))
 
 const updateMessage = (messages: ChatMessage[], next: ChatMessage) =>
   sortMessages(
@@ -1419,9 +1421,15 @@ const App = () => {
 
   if (displayMode === 'game') {
     return (
-      <GameModePlaceholder
-        onSwitchToPhoneMode={() => setDisplayMode('phone')}
-      />
+      <Suspense
+        fallback={
+          <div className="app-shell game-mode-shell">
+            <div className="game-mode-loading">Loading game mode...</div>
+          </div>
+        }
+      >
+        <GameModeShell onSwitchToPhoneMode={() => setDisplayMode('phone')} />
+      </Suspense>
     )
   }
 
@@ -1655,24 +1663,6 @@ const App = () => {
         />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
-    </div>
-  )
-}
-
-const GameModePlaceholder = ({
-  onSwitchToPhoneMode,
-}: {
-  onSwitchToPhoneMode: () => void
-}) => {
-  return (
-    <div className="app-shell game-mode-shell">
-      <div className="game-mode-placeholder">
-        <h1>Game mode placeholder</h1>
-        <p>Phase 0 skeleton only</p>
-        <button type="button" className="primary" onClick={onSwitchToPhoneMode}>
-          Back to Phone Mode
-        </button>
-      </div>
     </div>
   )
 }

--- a/src/game/GameContainer.tsx
+++ b/src/game/GameContainer.tsx
@@ -1,0 +1,30 @@
+import { useLayoutEffect, useRef } from 'react'
+import Phaser from 'phaser'
+import { createGameConfig } from './config'
+
+const GameContainer = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const gameRef = useRef<Phaser.Game | null>(null)
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container || gameRef.current) {
+      return
+    }
+
+    gameRef.current = new Phaser.Game(createGameConfig(container))
+
+    return () => {
+      if (gameRef.current) {
+        gameRef.current.destroy(true)
+        gameRef.current = null
+      }
+      container.innerHTML = ''
+      containerRef.current = null
+    }
+  }, [])
+
+  return <div ref={containerRef} className="game-canvas-container" aria-label="Hamster Nest game canvas" />
+}
+
+export default GameContainer

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -1,0 +1,23 @@
+import GameContainer from './GameContainer'
+
+type GameModeShellProps = {
+  onSwitchToPhoneMode: () => void
+}
+
+const GameModeShell = ({ onSwitchToPhoneMode }: GameModeShellProps) => {
+  return (
+    <div className="app-shell game-mode-shell">
+      <div className="game-mode-container">
+        <div className="game-mode-toolbar">
+          <h1>Game Mode</h1>
+          <button type="button" className="primary" onClick={onSwitchToPhoneMode}>
+            Back to Phone Mode
+          </button>
+        </div>
+        <GameContainer />
+      </div>
+    </div>
+  )
+}
+
+export default GameModeShell

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,0 +1,16 @@
+import Phaser from 'phaser'
+import { BootScene } from './scenes/BootScene'
+
+export const createGameConfig = (parent: HTMLElement): Phaser.Types.Core.GameConfig => ({
+  type: Phaser.AUTO,
+  parent,
+  transparent: false,
+  backgroundColor: '#0f172a',
+  scene: [BootScene],
+  scale: {
+    mode: Phaser.Scale.RESIZE,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: '100%',
+    height: '100%',
+  },
+})

--- a/src/game/scenes/BootScene.ts
+++ b/src/game/scenes/BootScene.ts
@@ -1,0 +1,20 @@
+import Phaser from 'phaser'
+
+export class BootScene extends Phaser.Scene {
+  constructor() {
+    super('BootScene')
+  }
+
+  create() {
+    const { width, height } = this.scale
+
+    this.add
+      .text(width / 2, height / 2, 'Hamster-Nest Game Mode', {
+        color: '#e2e8f0',
+        fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, sans-serif',
+        fontSize: '24px',
+        fontStyle: '600',
+      })
+      .setOrigin(0.5)
+  }
+}


### PR DESCRIPTION
### Motivation
- Add safe, lazy-loaded Phaser integration so the app can enter a new game mode without affecting the existing phone-mode experience.
- Provide a minimal, future-proof bridge pattern where React owns lifecycle and Phaser owns rendering inside a container div.
- Ensure entering/leaving game mode mounts and fully destroys the Phaser instance to prevent orphaned canvases or duplicate renderers.

### Description
- Install `phaser` and wire it into `package.json` so the runtime is available when game mode is requested.
- Add a lazy-loaded `GameModeShell` and wire `App.tsx` to `React.lazy` + `Suspense` so Phaser code is only loaded when `displayMode === 'game'`.
- Add `src/game/GameContainer.tsx` which uses `useLayoutEffect` and `useRef` to create exactly one `Phaser.Game` with `parent` set to a container div and which calls `game.destroy(true)` and clears refs/DOM on unmount.
- Add minimal Phaser infra (`src/game/config.ts` + `src/game/scenes/BootScene.ts`) and small CSS updates for the game shell, rendering a blank/placeholder scene that shows "Hamster-Nest Game Mode".

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` which passed with one unrelated pre-existing warning in `src/pages/CheckinPage.tsx`.
- Started the dev server (`vite`) and it launched successfully for manual testing.
- Executed an automated Playwright smoke script to load the app in game mode and capture a screenshot, which completed successfully, and verified that switching to game mode mounts a Phaser canvas and switching back destroys it with no duplicate canvases or console errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51c89b780833087084f9eb4b671de)