### PR TITLE
feat: add initial HomeScene and render placeholder game assets

### DIFF
--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,12 +1,13 @@
 import Phaser from 'phaser'
-import { BootScene } from './scenes/BootScene'
+import { HomeScene } from './scenes/HomeScene'
 
 export const createGameConfig = (parent: HTMLElement): Phaser.Types.Core.GameConfig => ({
   type: Phaser.AUTO,
   parent,
   transparent: false,
   backgroundColor: '#0f172a',
-  scene: [BootScene],
+  pixelArt: true,
+  scene: [HomeScene],
   scale: {
     mode: Phaser.Scale.RESIZE,
     autoCenter: Phaser.Scale.CENTER_BOTH,

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -1,0 +1,37 @@
+import Phaser from 'phaser'
+
+const FLOOR_KEY = 'floor_tile'
+const CHUAN_KEY = 'chuan1'
+const SYZYGY_KEY = 'syzygy1'
+
+export class HomeScene extends Phaser.Scene {
+  constructor() {
+    super('HomeScene')
+  }
+
+  preload() {
+    this.load.image(FLOOR_KEY, '/assets/game/floor_tile.png')
+    this.load.image(CHUAN_KEY, '/assets/game/chuan1.png')
+    this.load.image(SYZYGY_KEY, '/assets/game/syzygy1.png')
+  }
+
+  create() {
+    const { width, height } = this.scale
+
+    this.add.tileSprite(0, 0, width, height, FLOOR_KEY).setOrigin(0, 0)
+
+    const baseY = Math.round(height * 0.72)
+    const spacing = Math.round(Math.min(220, width * 0.18))
+    const centerX = Math.round(width * 0.5)
+
+    this.add
+      .image(centerX - spacing, baseY, CHUAN_KEY)
+      .setOrigin(0.5, 1)
+      .setScale(2)
+
+    this.add
+      .image(centerX + spacing, baseY, SYZYGY_KEY)
+      .setOrigin(0.5, 1)
+      .setScale(2)
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, playable-looking prototype scene for game mode using the supplied placeholder assets so game mode is no longer a blank placeholder. 
- Keep the implementation small and stable so future PRs can add interactions, EventBus, and UI without reworking rendering.

### Description
- Added a new Phaser scene `HomeScene` at `src/game/scenes/HomeScene.ts` that uses the standard `preload()` and `create()` lifecycle to load and render assets. 
- Loaded assets with `this.load.image(...)` from the exact public paths: `/assets/game/floor_tile.png`, `/assets/game/chuan1.png`, and `/assets/game/syzygy1.png`. 
- Rendered the room floor by tiling `floor_tile.png` across the viewport with `tileSprite`, and placed `chuan1.png` and `syzygy1.png` above the floor with stable spacing and non-overlapping positions near the lower center of the scene. 
- Updated game config (`src/game/config.ts`) to boot into `HomeScene` and enabled `pixelArt: true` so pixel art is rendered crisply without smoothing. 

### Testing
- Ran `npm run build` which completed successfully and produced a production bundle. 
- Ran `npm run lint` which completed and reported an existing unrelated warning in `src/pages/CheckinPage.tsx` but no new lint errors from this change. 
- Started the dev server and executed an automated Playwright script that attempted to open game mode and produced a saved screenshot artifact for manual inspection (artifact available in CI/dev artifacts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b530ed030083309b67c6be9db06c30)