### PR TITLE
fix: load Phaser public assets with Vite BASE_URL for GitHub Pages deployment

### DIFF
--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -10,9 +10,13 @@ export class HomeScene extends Phaser.Scene {
   }
 
   preload() {
-    this.load.image(FLOOR_KEY, '/assets/game/floor_tile.png')
-    this.load.image(CHUAN_KEY, '/assets/game/chuan1.png')
-    this.load.image(SYZYGY_KEY, '/assets/game/syzygy1.png')
+    const baseUrl = import.meta.env.BASE_URL
+    const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+    const assetBase = `${normalizedBaseUrl}assets/game/`
+
+    this.load.image(FLOOR_KEY, `${assetBase}floor_tile.png`)
+    this.load.image(CHUAN_KEY, `${assetBase}chuan1.png`)
+    this.load.image(SYZYGY_KEY, `${assetBase}syzygy1.png`)
   }
 
   create() {


### PR DESCRIPTION
### Motivation
- GitHub Pages serves the site under a repository subpath so root‑relative `/assets/...` requests returned 404s in deployed game mode, therefore asset URLs must respect Vite's base path via `import.meta.env.BASE_URL`.

### Description
- Changed `src/game/scenes/HomeScene.ts` to construct asset URLs from `import.meta.env.BASE_URL`, normalize the trailing slash, set `assetBase = `${normalizedBaseUrl}assets/game/``, and load the three images via `${assetBase}...png`, while keeping filenames and scene layout/logic unchanged.

### Testing
- Ran `npm install` and `npm run build`, and the production build completed successfully with no TypeScript or bundling errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5345c19788330a03b87c19cc2d7f0)