### PR TITLE
feat: add EventBus and open existing chat window when clicking Syzygy NPC

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -502,6 +502,20 @@ const App = () => {
     [applySnapshot, user],
   )
 
+  const openChatFromGameMode = useCallback(() => {
+    const latest = selectMostRecentSession(sessionsRef.current)
+    if (latest) {
+      navigate(`/chat/${latest.id}`)
+      setDisplayMode('phone')
+      return
+    }
+
+    void createSessionEntry().then((session) => {
+      navigate(`/chat/${session.id}`)
+      setDisplayMode('phone')
+    })
+  }, [createSessionEntry, navigate])
+
   const renameSessionEntry = useCallback(
     async (sessionId: string, title: string) => {
       if (user && supabase) {
@@ -1428,7 +1442,10 @@ const App = () => {
           </div>
         }
       >
-        <GameModeShell onSwitchToPhoneMode={() => setDisplayMode('phone')} />
+        <GameModeShell
+          onSwitchToPhoneMode={() => setDisplayMode('phone')}
+          onOpenChat={openChatFromGameMode}
+        />
       </Suspense>
     )
   }

--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -1,0 +1,8 @@
+import Phaser from 'phaser'
+
+export const GAME_EVENTS = {
+  OPEN_CHAT_WITH_SYZYGY: 'open-chat-with-syzygy',
+} as const
+
+export const EventBus = new Phaser.Events.EventEmitter()
+

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -1,10 +1,25 @@
+import { useEffect } from 'react'
 import GameContainer from './GameContainer'
+import { EventBus, GAME_EVENTS } from './EventBus'
 
 type GameModeShellProps = {
   onSwitchToPhoneMode: () => void
+  onOpenChat: () => void
 }
 
-const GameModeShell = ({ onSwitchToPhoneMode }: GameModeShellProps) => {
+const GameModeShell = ({ onSwitchToPhoneMode, onOpenChat }: GameModeShellProps) => {
+  useEffect(() => {
+    const handleOpenChat = () => {
+      onOpenChat()
+    }
+
+    EventBus.on(GAME_EVENTS.OPEN_CHAT_WITH_SYZYGY, handleOpenChat)
+
+    return () => {
+      EventBus.off(GAME_EVENTS.OPEN_CHAT_WITH_SYZYGY, handleOpenChat)
+    }
+  }, [onOpenChat])
+
   return (
     <div className="app-shell game-mode-shell">
       <div className="game-mode-container">

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -1,10 +1,13 @@
 import Phaser from 'phaser'
+import { EventBus, GAME_EVENTS } from '../EventBus'
 
 const FLOOR_KEY = 'floor_tile'
 const CHUAN_KEY = 'chuan1'
 const SYZYGY_KEY = 'syzygy1'
 
 export class HomeScene extends Phaser.Scene {
+  private syzygySprite?: Phaser.GameObjects.Image
+
   constructor() {
     super('HomeScene')
   }
@@ -33,9 +36,20 @@ export class HomeScene extends Phaser.Scene {
       .setOrigin(0.5, 1)
       .setScale(2)
 
-    this.add
+    this.syzygySprite = this.add
       .image(centerX + spacing, baseY, SYZYGY_KEY)
       .setOrigin(0.5, 1)
       .setScale(2)
+
+    this.syzygySprite.setInteractive({ useHandCursor: true })
+    this.syzygySprite.on('pointerover', () => {
+      this.syzygySprite?.setTint(0xdbeafe)
+    })
+    this.syzygySprite.on('pointerout', () => {
+      this.syzygySprite?.clearTint()
+    })
+    this.syzygySprite.on('pointerdown', () => {
+      EventBus.emit(GAME_EVENTS.OPEN_CHAT_WITH_SYZYGY)
+    })
   }
 }


### PR DESCRIPTION
### Motivation
- Enable a first game-to-app interaction so clicking the Syzygy NPC in game mode opens the existing chat UI without coupling Phaser scenes to React components. 
- Provide a minimal, standalone event bridge so Phaser can emit intent events and React decides how to render the chat UI. 
- Keep phone-mode/chat logic unchanged and avoid adding player movement, new NPCs, or styling changes in this PR. 

### Description
- Added a lightweight shared event module `src/game/EventBus.ts` that exports a Phaser `EventEmitter` singleton and a typed `GAME_EVENTS` map (event: `OPEN_CHAT_WITH_SYZYGY`).
- Updated `src/game/scenes/HomeScene.ts` to keep a reference to the Syzygy sprite, call `setInteractive()`, add optional hover tint/cursor feedback, and emit `GAME_EVENTS.OPEN_CHAT_WITH_SYZYGY` on pointer down.
- Updated `src/game/GameModeShell.tsx` to subscribe to the EventBus in `useEffect` and unsubscribe on cleanup so listeners do not leak or duplicate across mounts.
- Wired the React app in `src/App.tsx` with an `openChatFromGameMode` callback that navigates to the most recent chat session (or creates one) and switches the UI back to phone mode so the existing chat component is reused unmodified.
- Files changed: `src/game/EventBus.ts`, `src/game/scenes/HomeScene.ts`, `src/game/GameModeShell.tsx`, and `src/App.tsx`.
- EventBus design and decoupling: Phaser emits only an intent (`open-chat-with-syzygy`) via a shared EventBus, and React subscribes/unsubscribes and decides routing/UI behavior, preserving strict separation between game objects and React DOM. 

### Testing
- Fixed a TypeScript ordering issue encountered during an initial build attempt, after which `npm run build` completed successfully. 
- Started the dev server with `npm run dev` and confirmed it served the app successfully. 
- Captured a Playwright screenshot of the running app to assist manual verification (artifact produced). 
- Automated steps passed (build/dev/run); listener lifecycle is implemented with `useEffect` cleanup to prevent leaks or duplicate firings during repeated mode switching.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b536c93d108330b7cb519fd4fa36c2)