### PR TITLE
feat: add NPC action menu skeleton and return-to-game entry from chat overlay

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -62,3 +62,40 @@ button {
   flex: 1;
   min-height: 0;
 }
+
+.npc-actions-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(2, 6, 23, 0.56);
+  z-index: 20;
+}
+
+.npc-actions-panel {
+  width: min(360px, 100%);
+  padding: 16px;
+  border-radius: 16px;
+}
+
+.npc-actions-title {
+  margin: 0;
+}
+
+.npc-actions-subtitle {
+  margin: 6px 0 14px;
+  color: #475569;
+  font-size: 14px;
+}
+
+.npc-actions-list {
+  display: grid;
+  gap: 10px;
+}
+
+.npc-actions-close {
+  margin-top: 10px;
+  width: 100%;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -232,6 +232,7 @@ const App = () => {
   const [sessionsReady, setSessionsReady] = useState(false)
   const [activeChatSessionId, setActiveChatSessionId] = useState<string | null>(null)
   const [displayMode, setDisplayMode] = useState<AppDisplayMode>(loadInitialDisplayMode)
+  const [isChatOpenedFromGameMode, setIsChatOpenedFromGameMode] = useState(false)
   const sessionsRef = useRef(sessions)
   const messagesRef = useRef(messages)
   const streamingControllerRef = useRef<AbortController | null>(null)
@@ -502,7 +503,8 @@ const App = () => {
     [applySnapshot, user],
   )
 
-  const openChatFromGameMode = useCallback(() => {
+  const openChatFromGameMode = useCallback((_npcId: 'syzygy') => {
+    setIsChatOpenedFromGameMode(true)
     const latest = selectMostRecentSession(sessionsRef.current)
     if (latest) {
       navigate(`/chat/${latest.id}`)
@@ -515,6 +517,11 @@ const App = () => {
       setDisplayMode('phone')
     })
   }, [createSessionEntry, navigate])
+
+  const handleReturnToGameFromChat = useCallback(() => {
+    setIsChatOpenedFromGameMode(false)
+    setDisplayMode('game')
+  }, [])
 
   const renameSessionEntry = useCallback(
     async (sessionId: string, title: string) => {
@@ -1443,7 +1450,10 @@ const App = () => {
         }
       >
         <GameModeShell
-          onSwitchToPhoneMode={() => setDisplayMode('phone')}
+          onSwitchToPhoneMode={() => {
+            setIsChatOpenedFromGameMode(false)
+            setDisplayMode('phone')
+          }}
           onOpenChat={openChatFromGameMode}
         />
       </Suspense>
@@ -1581,6 +1591,7 @@ const App = () => {
                 onArchiveSession={handleSessionArchiveStateChange}
                 onActiveSessionChange={setActiveChatSessionId}
                 user={user}
+                onReturnToGame={isChatOpenedFromGameMode ? handleReturnToGameFromChat : undefined}
               />
             </RequireAuth>
           }
@@ -1772,6 +1783,7 @@ const ChatRoute = ({
   onArchiveSession,
   onActiveSessionChange,
   user,
+  onReturnToGame,
 }: {
   sessions: ChatSession[]
   messages: ChatMessage[]
@@ -1796,6 +1808,7 @@ const ChatRoute = ({
   onArchiveSession: (sessionId: string, isArchived: boolean) => Promise<void>
   onActiveSessionChange: (sessionId: string) => void
   user: User | null
+  onReturnToGame?: () => void
 }) => {
   const { sessionId } = useParams()
   const navigate = useNavigate()
@@ -1902,6 +1915,7 @@ const ChatRoute = ({
           onSelectReasoning(activeSession.id, reasoning)
         }
         user={user}
+        onReturnToGame={onReturnToGame}
       />
       <SessionsDrawer
         open={drawerOpen}

--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -1,8 +1,11 @@
 import Phaser from 'phaser'
 
 export const GAME_EVENTS = {
-  OPEN_CHAT_WITH_SYZYGY: 'open-chat-with-syzygy',
+  OPEN_NPC_ACTIONS: 'open-npc-actions',
 } as const
 
-export const EventBus = new Phaser.Events.EventEmitter()
+export type OpenNpcActionsPayload = {
+  npcId: 'syzygy'
+}
 
+export const EventBus = new Phaser.Events.EventEmitter()

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -1,24 +1,38 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import GameContainer from './GameContainer'
-import { EventBus, GAME_EVENTS } from './EventBus'
+import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload } from './EventBus'
 
 type GameModeShellProps = {
   onSwitchToPhoneMode: () => void
-  onOpenChat: () => void
+  onOpenChat: (npcId: OpenNpcActionsPayload['npcId']) => void
 }
 
 const GameModeShell = ({ onSwitchToPhoneMode, onOpenChat }: GameModeShellProps) => {
-  useEffect(() => {
-    const handleOpenChat = () => {
-      onOpenChat()
-    }
+  const [activeNpcId, setActiveNpcId] = useState<OpenNpcActionsPayload['npcId'] | null>(null)
 
-    EventBus.on(GAME_EVENTS.OPEN_CHAT_WITH_SYZYGY, handleOpenChat)
+  const handleOpenNpcActions = useCallback((payload: OpenNpcActionsPayload) => {
+    setActiveNpcId(payload.npcId)
+  }, [])
+
+  const handleCloseNpcActions = useCallback(() => {
+    setActiveNpcId(null)
+  }, [])
+
+  const handleOpenChat = useCallback(() => {
+    if (!activeNpcId) {
+      return
+    }
+    onOpenChat(activeNpcId)
+    setActiveNpcId(null)
+  }, [activeNpcId, onOpenChat])
+
+  useEffect(() => {
+    EventBus.on(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions)
 
     return () => {
-      EventBus.off(GAME_EVENTS.OPEN_CHAT_WITH_SYZYGY, handleOpenChat)
+      EventBus.off(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions)
     }
-  }, [onOpenChat])
+  }, [handleOpenNpcActions])
 
   return (
     <div className="app-shell game-mode-shell">
@@ -30,6 +44,30 @@ const GameModeShell = ({ onSwitchToPhoneMode, onOpenChat }: GameModeShellProps) 
           </button>
         </div>
         <GameContainer />
+        {activeNpcId ? (
+          <div className="npc-actions-overlay" role="presentation" onClick={handleCloseNpcActions}>
+            <div
+              className="npc-actions-panel glass-panel"
+              role="dialog"
+              aria-label="Syzygy interaction menu"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <h2 className="ui-title npc-actions-title">Syzygy</h2>
+              <p className="npc-actions-subtitle">Choose an interaction</p>
+              <div className="npc-actions-list">
+                <button type="button" className="primary" onClick={handleOpenChat}>
+                  Chat
+                </button>
+                <button type="button" className="ghost" disabled aria-disabled="true">
+                  Action · Coming soon
+                </button>
+              </div>
+              <button type="button" className="ghost npc-actions-close" onClick={handleCloseNpcActions}>
+                Close
+              </button>
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -49,7 +49,7 @@ export class HomeScene extends Phaser.Scene {
       this.syzygySprite?.clearTint()
     })
     this.syzygySprite.on('pointerdown', () => {
-      EventBus.emit(GAME_EVENTS.OPEN_CHAT_WITH_SYZYGY)
+      EventBus.emit(GAME_EVENTS.OPEN_NPC_ACTIONS, { npcId: 'syzygy' })
     })
   }
 }

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ export type ChatPageProps = {
   defaultReasoning: boolean
   onSelectReasoning: (reasoning: boolean | null) => void
   user: User | null
+  onReturnToGame?: () => void
 }
 
 const formatTime = (timestamp: string) =>
@@ -60,6 +61,7 @@ const ChatPage = ({
   onSelectModel,
   defaultReasoning,
   onSelectReasoning,
+  onReturnToGame,
 }: ChatPageProps) => {
   const [draft, setDraft] = useState('')
   const [openActionsId, setOpenActionsId] = useState<string | null>(null)
@@ -307,6 +309,11 @@ const ChatPage = ({
           <span className="subtitle">单聊</span>
         </div>
         <div className="header-actions" ref={headerMenuRef}>
+          {onReturnToGame ? (
+            <button type="button" className="ghost" onClick={onReturnToGame}>
+              Return to Game
+            </button>
+          ) : null}
           <button
             ref={headerMenuButtonRef}
             type="button"


### PR DESCRIPTION
### Motivation
- Clicking the in-world Syzygy NPC previously opened chat directly; this change future-proofs the flow by introducing a generic NPC interaction entry point and a clear path back to the game from chat opened in game mode.  
- The intent is to add only the minimal entry-layer and UI skeleton for future NPC actions (e.g. Action), not to implement the action system yet.  
- Short interaction summary: click Syzygy → open small NPC action menu (Chat + disabled Action placeholder) → selecting Chat opens existing chat UI → chat opened from game mode shows a “Return to Game” control that returns to the game scene.

### Description
- Replace chat-specific event with a general NPC action event by adding `open-npc-actions` and payload typing `{ npcId: 'syzygy' }` in `src/game/EventBus.ts`.  
- Emit the new event from the game world by updating Syzygy click handling in `src/game/scenes/HomeScene.ts` to `EventBus.emit(GAME_EVENTS.OPEN_NPC_ACTIONS, { npcId: 'syzygy' })`.  
- Add a lightweight NPC actions overlay in `src/game/GameModeShell.tsx` that displays a minimal panel with an active **Chat** button and a disabled **Action · Coming soon** placeholder, plus open/close handling and listener cleanup.  
- Wire game-origin chat state in `src/App.tsx` (`isChatOpenedFromGameMode`) and route the Chat selection to the existing chat UI while providing a callback `onReturnToGame` to restore `displayMode: 'game'`; inject a conditional `Return to Game` button into the chat header only when chat was opened from game mode via `src/pages/ChatPage.tsx`.  
- Add minimal styling for the new overlay in `src/App.css`.  
- Notes: the action item is intentionally non-functional (placeholder/disabled) to reserve the structure for future actions, and phone-mode chat behavior is unchanged (the `Return to Game` control is not injected for normal phone-mode chat).

### Testing
- Built the app successfully with `npm run build` and confirmed the build completed without errors. (Succeeded)  
- Started the dev server (`npm run dev`) and executed an automated Playwright script to open the app and capture a screenshot of the game-mode NPC action overlay flow, producing `artifacts/game-mode-chat-entry.png`. (Succeeded)  
- Manual verification checklist exercised during the rollout: open game mode → click Syzygy → NPC action menu appears → Chat opens existing chat UI → Action placeholder is visible and disabled → Return to Game appears in game-origin chat and returns cleanly to the game scene; phone-mode chat remains unchanged. (Manual checks passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53a82bf648330a6eb5657cf266df1)