### PR TITLE
feat: add dual chat themes for phone mode and game mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1592,6 +1592,7 @@ const App = () => {
                 onActiveSessionChange={setActiveChatSessionId}
                 user={user}
                 onReturnToGame={isChatOpenedFromGameMode ? handleReturnToGameFromChat : undefined}
+                chatTheme={isChatOpenedFromGameMode ? 'pixel' : 'ios'}
               />
             </RequireAuth>
           }
@@ -1784,6 +1785,7 @@ const ChatRoute = ({
   onActiveSessionChange,
   user,
   onReturnToGame,
+  chatTheme,
 }: {
   sessions: ChatSession[]
   messages: ChatMessage[]
@@ -1809,6 +1811,7 @@ const ChatRoute = ({
   onActiveSessionChange: (sessionId: string) => void
   user: User | null
   onReturnToGame?: () => void
+  chatTheme: 'ios' | 'pixel'
 }) => {
   const { sessionId } = useParams()
   const navigate = useNavigate()
@@ -1916,6 +1919,7 @@ const ChatRoute = ({
         }
         user={user}
         onReturnToGame={onReturnToGame}
+        theme={chatTheme}
       />
       <SessionsDrawer
         open={drawerOpen}

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -750,3 +750,187 @@
 .timeline-letter-card__action:hover {
   background: rgba(255, 255, 255, 0.95);
 }
+
+.chat-page--pixel {
+  --pixel-border: #334155;
+  --pixel-surface: rgba(15, 23, 42, 0.92);
+  --pixel-panel: rgba(30, 41, 59, 0.92);
+  --pixel-text: #e2e8f0;
+  --pixel-subtle: #94a3b8;
+  background: linear-gradient(180deg, #020617 0%, #0f172a 100%);
+  color: var(--pixel-text);
+}
+
+.chat-page--pixel .chat-header {
+  border-bottom: 2px solid rgba(71, 85, 105, 0.72);
+  padding-bottom: 10px;
+}
+
+.chat-page--pixel .app-shell__header {
+  background: rgba(15, 23, 42, 0.9) !important;
+  backdrop-filter: blur(2px);
+}
+
+.chat-page--pixel .chat-header .ghost,
+.chat-page--pixel .return-to-game-button {
+  border-radius: 4px;
+  border: 1px solid rgba(100, 116, 139, 0.7);
+  background: rgba(15, 23, 42, 0.36);
+  color: #dbeafe;
+}
+
+.chat-page--pixel .chat-header .ghost:hover,
+.chat-page--pixel .return-to-game-button:hover {
+  background: rgba(30, 41, 59, 0.9);
+}
+
+.chat-page--pixel .header-title .subtitle,
+.chat-page--pixel .model-hint,
+.chat-page--pixel .composer-toggle .toggle-hint,
+.chat-page--pixel .chip-label {
+  color: var(--pixel-subtle);
+}
+
+.chat-page--pixel .chat-messages {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82) 0%, rgba(15, 23, 42, 0.95) 100%);
+  border: 1px solid rgba(71, 85, 105, 0.8);
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.65);
+}
+
+.chat-page--pixel .empty-state,
+.chat-page--pixel .message.in .bubble-meta,
+.chat-page--pixel .message.out .bubble-meta {
+  color: var(--pixel-subtle);
+}
+
+.chat-page--pixel .message .bubble {
+  background: var(--pixel-panel);
+  border: 1px solid rgba(100, 116, 139, 0.7);
+  border-radius: 6px;
+  box-shadow: none;
+}
+
+.chat-page--pixel .message.out .bubble {
+  background: rgba(30, 58, 138, 0.78);
+  border-color: rgba(147, 197, 253, 0.6);
+}
+
+.chat-page--pixel .assistant-markdown,
+.chat-page--pixel .message .bubble p {
+  color: #e2e8f0;
+}
+
+.chat-page--pixel .assistant-markdown a,
+.chat-page--pixel .message.out .bubble a {
+  color: #93c5fd;
+}
+
+.chat-page--pixel .model-tag {
+  color: #bfdbfe;
+  background: rgba(59, 130, 246, 0.2);
+  border-radius: 4px;
+}
+
+.chat-page--pixel .message.out .action-trigger,
+.chat-page--pixel .message .action-trigger {
+  color: #cbd5e1;
+}
+
+.chat-page--pixel .message:hover .action-trigger,
+.chat-page--pixel .message:active .action-trigger,
+.chat-page--pixel .message:focus-within .action-trigger,
+.chat-page--pixel .message .action-trigger[aria-expanded='true'] {
+  background: rgba(30, 41, 59, 0.8);
+  border-color: rgba(100, 116, 139, 0.8);
+}
+
+.chat-page--pixel .actions-menu,
+.chat-page--pixel .header-menu {
+  background: rgba(15, 23, 42, 0.97);
+  border: 1px solid rgba(100, 116, 139, 0.85);
+  border-radius: 6px;
+}
+
+.chat-page--pixel .actions-menu button,
+.chat-page--pixel .header-menu button {
+  color: #e2e8f0;
+  border-radius: 4px;
+}
+
+.chat-page--pixel .actions-menu button:hover,
+.chat-page--pixel .header-menu button:hover {
+  background: rgba(30, 41, 59, 0.95);
+}
+
+.chat-page--pixel .chat-composer {
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(100, 116, 139, 0.8);
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.chat-page--pixel .streaming-status {
+  color: var(--pixel-subtle);
+}
+
+.chat-page--pixel .model-selector,
+.chat-page--pixel .composer-toggle {
+  border-radius: 4px;
+  border: 1px solid rgba(100, 116, 139, 0.8);
+  background: rgba(30, 41, 59, 0.85);
+  color: #e2e8f0;
+}
+
+.chat-page--pixel .model-selector:hover,
+.chat-page--pixel .composer-toggle:hover,
+.chat-page--pixel .model-selector:focus-within,
+.chat-page--pixel .composer-toggle:active {
+  background: rgba(51, 65, 85, 0.9);
+}
+
+.chat-page--pixel .composer-toggle input {
+  border-color: rgba(148, 163, 184, 0.8);
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.chat-page--pixel .composer-toggle input:checked {
+  background: rgba(30, 64, 175, 0.9);
+  border-color: rgba(96, 165, 250, 0.95);
+}
+
+.chat-page--pixel .composer-toggle input:checked::after {
+  background: #bfdbfe;
+}
+
+.chat-page--pixel .composer-toggle:has(input:checked) {
+  background: rgba(30, 58, 138, 0.65);
+  border-color: rgba(147, 197, 253, 0.9);
+}
+
+.chat-page--pixel .textarea-glass {
+  border-radius: 4px;
+  border: 1px solid rgba(100, 116, 139, 0.85);
+  background: rgba(15, 23, 42, 0.95);
+  color: #e2e8f0;
+}
+
+.chat-page--pixel .textarea-glass::placeholder {
+  color: #94a3b8;
+}
+
+.chat-page--pixel .btn-primary {
+  border-radius: 4px;
+  border: 1px solid rgba(147, 197, 253, 0.8);
+  background: linear-gradient(180deg, #2563eb 0%, #1d4ed8 100%);
+}
+
+.chat-page--pixel .timeline-letter-card {
+  background: rgba(15, 23, 42, 0.84);
+  border-color: rgba(100, 116, 139, 0.7);
+}
+
+.chat-page--pixel .timeline-letter-card__preview,
+.chat-page--pixel .timeline-letter-card__time {
+  color: #cbd5e1;
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -13,6 +13,7 @@ import './ChatPage.css'
 export type ChatPageProps = {
   session: ChatSession
   messages: ChatMessage[]
+  theme?: 'ios' | 'pixel'
   onOpenDrawer: () => void
   onSendMessage: (text: string) => Promise<void>
   onDeleteMessage: (messageId: string) => void | Promise<void>
@@ -51,6 +52,7 @@ const POPOVER_GAP = 6
 const ChatPage = ({
   session,
   messages,
+  theme = 'ios',
   onOpenDrawer,
   onSendMessage,
   onDeleteMessage,
@@ -299,7 +301,10 @@ const ChatPage = ({
   }, [openHeaderMenu])
 
   return (
-    <div className="chat-page chat-polka-dots">
+    <div
+      className={`chat-page chat-page--${theme}${theme === 'ios' ? ' chat-polka-dots' : ''}`}
+      data-theme={theme}
+    >
       <header className="chat-header top-nav app-shell__header">
         <button type="button" className="ghost" onClick={onOpenDrawer}>
           会话
@@ -310,7 +315,7 @@ const ChatPage = ({
         </div>
         <div className="header-actions" ref={headerMenuRef}>
           {onReturnToGame ? (
-            <button type="button" className="ghost" onClick={onReturnToGame}>
+            <button type="button" className="ghost return-to-game-button" onClick={onReturnToGame}>
               Return to Game
             </button>
           ) : null}


### PR DESCRIPTION
### Motivation
- Provide a presentation-only way to render the existing shared chat UI with two visual themes so chat opened from the phone keeps the current iOS look while chat opened from the game renders a pixel/game-themed skin.
- Keep all chat business logic (session/message flow, streaming, model/reasoning controls, persistence, return-to-game wiring) unchanged and shared across both themes.
- Make the theming minimal-risk and extensible by scoping style variants to the presentation layer only.

### Description
- Added an optional prop `theme?: 'ios' | 'pixel'` to `ChatPage` and applied wrapper class `chat-page--<theme>` plus `data-theme` so the same component tree can render two visual variants while preserving behavior.
- Wired theme selection at the route level so `App`/`ChatRoute` compute and forward `chatTheme` (game-opened chat uses `'pixel'`, otherwise `'ios'`) and pass it to `ChatPage` as `theme` (`theme={chatTheme}`).
- Implemented a first-pass pixel/game skin in `src/pages/ChatPage.css` scoped under `.chat-page--pixel` (header, message panel and bubbles, menus, composer, action buttons, letter cards, and a `return-to-game` button class) while leaving the iOS/default styles intact.
- Presentation-only change: no message/session/streaming/model logic was changed and the return-to-game control remains wired through the existing `onReturnToGame` callback.

### Testing
- Ran `npm run build` (TypeScript compile + Vite build), which completed successfully.
- Started the dev server with `npm run dev` (Vite) which started and served the app successfully.
- Executed an automated Playwright script to snapshot `http://127.0.0.1:4173/chat`, which produced a screenshot but the app redirected to `#/auth` in this environment (no authenticated session), so in-session visual verification of the chat view was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53ddf6aac83309bedaab64f8809fa)