### PR TITLE
refactor: polish game HUD layout, localize UI to Chinese, and separate game settings from shared AI settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1461,7 +1461,7 @@ const App = () => {
       <Suspense
         fallback={
           <div className="app-shell game-mode-shell">
-            <div className="game-mode-loading">Loading game mode...</div>
+            <div className="game-mode-loading">游戏模式加载中...</div>
           </div>
         }
       >
@@ -1469,6 +1469,11 @@ const App = () => {
           onSwitchToPhoneMode={() => {
             setIsChatOpenedFromGameMode(false)
             setDisplayMode('phone')
+          }}
+          onOpenSharedSettings={() => {
+            setIsChatOpenedFromGameMode(false)
+            setDisplayMode('phone')
+            navigate('/settings')
           }}
           onOpenChat={openChatFromGameMode}
         />

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -8,10 +8,11 @@ import './gameHud.css'
 
 type GameModeShellProps = {
   onSwitchToPhoneMode: () => void
+  onOpenSharedSettings: () => void
   onOpenChat: (npcId: OpenNpcActionsPayload['npcId']) => void
 }
 
-const GameModeShell = ({ onSwitchToPhoneMode, onOpenChat }: GameModeShellProps) => {
+const GameModeShell = ({ onSwitchToPhoneMode, onOpenSharedSettings, onOpenChat }: GameModeShellProps) => {
   const [activeNpcId, setActiveNpcId] = useState<OpenNpcActionsPayload['npcId'] | null>(null)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
@@ -34,7 +35,7 @@ const GameModeShell = ({ onSwitchToPhoneMode, onOpenChat }: GameModeShellProps) 
   }, [activeNpcId, onOpenChat])
 
   const handleActionClick = useCallback(() => {
-    setActionHint('Action system is coming in a future phase.')
+    setActionHint('动作系统将在后续阶段开放。')
     window.setTimeout(() => {
       setActionHint(null)
     }, 1600)
@@ -65,21 +66,21 @@ const GameModeShell = ({ onSwitchToPhoneMode, onOpenChat }: GameModeShellProps) 
             <div
               className="npc-actions-panel game-overlay-panel game-overlay-panel--narrow"
               role="dialog"
-              aria-label="Syzygy interaction menu"
+              aria-label="仓鼠互动菜单"
               onClick={(event) => event.stopPropagation()}
             >
-              <h2 className="ui-title npc-actions-title">Syzygy</h2>
-              <p className="npc-actions-subtitle">Choose an interaction</p>
+              <h2 className="ui-title npc-actions-title">仓鼠互动</h2>
+              <p className="npc-actions-subtitle">请选择互动方式</p>
               <div className="npc-actions-list">
                 <button type="button" className="primary" onClick={handleOpenChat}>
-                  Chat
+                  聊天
                 </button>
                 <button type="button" className="ghost" disabled aria-disabled="true">
-                  Action · Coming soon
+                  动作 · 即将开放
                 </button>
               </div>
               <button type="button" className="ghost npc-actions-close" onClick={handleCloseNpcActions}>
-                Close
+                关闭
               </button>
             </div>
           </div>
@@ -87,7 +88,11 @@ const GameModeShell = ({ onSwitchToPhoneMode, onOpenChat }: GameModeShellProps) 
 
         {isMenuOpen ? <GameMenuOverlay onClose={() => setIsMenuOpen(false)} /> : null}
         {isSettingsOpen ? (
-          <GameSettingsOverlay onClose={() => setIsSettingsOpen(false)} onSwitchToPhoneMode={onSwitchToPhoneMode} />
+          <GameSettingsOverlay
+            onClose={() => setIsSettingsOpen(false)}
+            onSwitchToPhoneMode={onSwitchToPhoneMode}
+            onOpenSharedSettings={onOpenSharedSettings}
+          />
         ) : null}
       </div>
     </div>

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -119,6 +119,10 @@
   gap: 12px;
 }
 
+.game-bottom-bar > .game-control-actions {
+  flex: 1;
+}
+
 .game-direction-pad {
   width: 118px;
   height: 118px;
@@ -259,6 +263,19 @@
   gap: 10px;
 }
 
+.game-shared-settings-entry {
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.game-shared-settings-entry p {
+  margin: 0 0 8px;
+  color: #cbd5e1;
+  font-size: 13px;
+}
+
 .npc-actions-title,
 .npc-actions-subtitle {
   color: inherit;
@@ -320,19 +337,20 @@
   }
 
   .game-bottom-bar {
-    flex-direction: column;
+    flex-direction: row;
     align-items: stretch;
   }
 
   .game-direction-pad {
-    align-self: flex-start;
+    align-self: flex-end;
     width: 108px;
     height: 108px;
   }
 
   .game-control-actions {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-content: end;
   }
 
   .game-control-button {

--- a/src/game/ui/GameBottomBar.tsx
+++ b/src/game/ui/GameBottomBar.tsx
@@ -6,31 +6,31 @@ type GameBottomBarProps = {
 
 const GameBottomBar = ({ onOpenMenu, onOpenSettings, onAction }: GameBottomBarProps) => {
   return (
-    <footer className="game-bottom-bar" aria-label="Game controls">
-      <div className="game-direction-pad" aria-label="Directional controls placeholder">
-        <button type="button" className="game-dpad-button game-dpad-button--up" aria-label="Move up" disabled>
-          ▲
+    <footer className="game-bottom-bar" aria-label="游戏操作栏">
+      <div className="game-control-actions">
+        <button type="button" className="game-control-button" onClick={onOpenSettings}>
+          游戏设置
         </button>
-        <button type="button" className="game-dpad-button game-dpad-button--left" aria-label="Move left" disabled>
-          ◀
+        <button type="button" className="game-control-button" onClick={onOpenMenu}>
+          菜单
         </button>
-        <button type="button" className="game-dpad-button game-dpad-button--right" aria-label="Move right" disabled>
-          ▶
-        </button>
-        <button type="button" className="game-dpad-button game-dpad-button--down" aria-label="Move down" disabled>
-          ▼
+        <button type="button" className="game-control-button game-control-button--action" onClick={onAction}>
+          动作
         </button>
       </div>
 
-      <div className="game-control-actions">
-        <button type="button" className="game-control-button" onClick={onOpenSettings}>
-          Settings
+      <div className="game-direction-pad" aria-label="方向控制（占位）">
+        <button type="button" className="game-dpad-button game-dpad-button--up" aria-label="向上移动" disabled>
+          ▲
         </button>
-        <button type="button" className="game-control-button" onClick={onOpenMenu}>
-          Menu
+        <button type="button" className="game-dpad-button game-dpad-button--left" aria-label="向左移动" disabled>
+          ◀
         </button>
-        <button type="button" className="game-control-button game-control-button--action" onClick={onAction}>
-          Action
+        <button type="button" className="game-dpad-button game-dpad-button--right" aria-label="向右移动" disabled>
+          ▶
+        </button>
+        <button type="button" className="game-dpad-button game-dpad-button--down" aria-label="向下移动" disabled>
+          ▼
         </button>
       </div>
     </footer>

--- a/src/game/ui/GameMenuOverlay.tsx
+++ b/src/game/ui/GameMenuOverlay.tsx
@@ -9,10 +9,10 @@ type GameMenuOverlayProps = {
 }
 
 const GAME_MENU_ENTRIES: MenuEntry[] = [
-  { id: 'snacks', title: 'Snacks', description: 'Manage food and feeding actions in game shell mode.' },
-  { id: 'syzygy', title: 'Syzygy Feed / Observation Log', description: 'Open your hamster observations from game mode.' },
-  { id: 'checkin', title: 'Check-in', description: 'Review daily check-ins with game-mode UI wrappers.' },
-  { id: 'export', title: 'Export', description: 'Export data from a game-mode entry point.' },
+  { id: 'snacks', title: '零食罐罐区', description: '以游戏模式外壳进入零食管理与投喂功能。' },
+  { id: 'syzygy', title: '仓鼠观察日志', description: '以游戏模式外壳查看你的仓鼠观察记录。' },
+  { id: 'checkin', title: '打卡', description: '以游戏模式外壳查看与管理每日打卡。' },
+  { id: 'export', title: '数据导出', description: '以游戏模式外壳进入数据导出功能。' },
 ]
 
 const GameMenuOverlay = ({ onClose }: GameMenuOverlayProps) => {
@@ -22,23 +22,23 @@ const GameMenuOverlay = ({ onClose }: GameMenuOverlayProps) => {
         className="game-overlay-panel"
         role="dialog"
         aria-modal="true"
-        aria-label="Game menu"
+        aria-label="游戏菜单"
         onClick={(event) => event.stopPropagation()}
       >
         <header className="game-overlay-header">
-          <h2 className="ui-title">Game Menu</h2>
+          <h2 className="ui-title">游戏菜单</h2>
           <button type="button" className="ghost" onClick={onClose}>
-            Close
+            关闭
           </button>
         </header>
-        <p className="game-overlay-subtitle">Feature entry points that stay in game-mode styling.</p>
+        <p className="game-overlay-subtitle">以下入口延续“共享能力 + 游戏模式外壳”的体验。</p>
         <div className="game-overlay-list">
           {GAME_MENU_ENTRIES.map((entry) => (
             <article key={entry.id} className="game-overlay-card">
               <h3>{entry.title}</h3>
               <p>{entry.description}</p>
               <button type="button" className="game-overlay-card__button" disabled aria-disabled="true">
-                Open (placeholder)
+                打开（占位）
               </button>
             </article>
           ))}

--- a/src/game/ui/GameSettingsOverlay.tsx
+++ b/src/game/ui/GameSettingsOverlay.tsx
@@ -1,33 +1,44 @@
 type GameSettingsOverlayProps = {
   onClose: () => void
   onSwitchToPhoneMode: () => void
+  onOpenSharedSettings: () => void
 }
 
-const GameSettingsOverlay = ({ onClose, onSwitchToPhoneMode }: GameSettingsOverlayProps) => {
+const GameSettingsOverlay = ({ onClose, onSwitchToPhoneMode, onOpenSharedSettings }: GameSettingsOverlayProps) => {
   return (
     <div className="game-overlay-backdrop" role="presentation" onClick={onClose}>
       <section
         className="game-overlay-panel game-overlay-panel--narrow"
         role="dialog"
         aria-modal="true"
-        aria-label="Game settings"
+        aria-label="游戏设置"
         onClick={(event) => event.stopPropagation()}
       >
         <header className="game-overlay-header">
-          <h2 className="ui-title">Game Settings</h2>
+          <h2 className="ui-title">游戏设置</h2>
           <button type="button" className="ghost" onClick={onClose}>
-            Close
+            关闭
           </button>
         </header>
+        <p className="game-overlay-subtitle">这里仅包含游戏侧显示与操作偏好，不包含 AI / 模型 / Prompt 配置。</p>
         <div className="game-settings-stack">
           <button type="button" className="game-control-button" disabled aria-disabled="true">
-            Audio (placeholder)
+            HUD 显示偏好（占位）
           </button>
           <button type="button" className="game-control-button" disabled aria-disabled="true">
-            Controls (placeholder)
+            操作方式偏好（占位）
           </button>
+          <button type="button" className="game-control-button" disabled aria-disabled="true">
+            游戏音效开关（占位）
+          </button>
+          <div className="game-shared-settings-entry">
+            <p>AI 与模型等通用设置请前往「通用设置」，此处不重复实现。</p>
+            <button type="button" className="ghost" onClick={onOpenSharedSettings}>
+              前往通用设置
+            </button>
+          </div>
           <button type="button" className="primary" onClick={onSwitchToPhoneMode}>
-            Back to Phone Mode
+            返回手机模式
           </button>
         </div>
       </section>

--- a/src/game/ui/GameTopBar.tsx
+++ b/src/game/ui/GameTopBar.tsx
@@ -8,7 +8,7 @@ type GameTopBarProps = {
 }
 
 const formatClock = (value: Date) =>
-  new Intl.DateTimeFormat(undefined, {
+  new Intl.DateTimeFormat('zh-CN', {
     hour: '2-digit',
     minute: '2-digit',
   }).format(value)
@@ -29,20 +29,20 @@ const GameTopBar = ({ stamina, maxStamina, level, coins }: GameTopBarProps) => {
   }, [stamina, maxStamina])
 
   return (
-    <header className="game-top-bar" aria-label="Game HUD status bar">
-      <div className="game-avatar-chip" aria-label="Player avatar placeholder">
+    <header className="game-top-bar" aria-label="游戏 HUD 状态栏">
+      <div className="game-avatar-chip" aria-label="玩家头像占位">
         <span className="game-avatar-chip__emoji" aria-hidden="true">
           🐹
         </span>
         <div>
-          <p className="game-avatar-chip__name">Chuan</p>
-          <p className="game-avatar-chip__sub">Lv.{level}</p>
+          <p className="game-avatar-chip__name">川川</p>
+          <p className="game-avatar-chip__sub">等级 {level}</p>
         </div>
       </div>
 
-      <div className="game-stat-block" aria-label="Stamina">
+      <div className="game-stat-block" aria-label="体力">
         <div className="game-stat-block__label-row">
-          <span>Stamina</span>
+          <span>体力</span>
           <span>
             {stamina}/{maxStamina}
           </span>
@@ -53,8 +53,8 @@ const GameTopBar = ({ stamina, maxStamina, level, coins }: GameTopBarProps) => {
       </div>
 
       <div className="game-meta-stats">
-        <p className="game-chip">🪙 {coins}</p>
-        <p className="game-chip game-clock" aria-live="polite">
+        <p className="game-chip" aria-label="金币">🪙 {coins}</p>
+        <p className="game-chip game-clock" aria-live="polite" aria-label="当前时间">
           🕒 {formatClock(time)}
         </p>
       </div>


### PR DESCRIPTION
### Motivation
- Move the on-screen directional pad to a right-hand default position and make bottom controls feel natural for right-hand play. 
- Localize all visible game-mode HUD/menu/overlay copy to Chinese to match product language. 
- Make the boundary between game-only settings and shared AI/system settings explicit so game mode does not duplicate global model/prompt controls.

### Description
- Repositioned bottom HUD elements so primary action buttons are grouped on the left and the directional pad is rendered on the right by updating DOM order in `src/game/ui/GameBottomBar.tsx` and layout tweaks in `src/game/gameHud.css`. 
- Localized visible game-mode copy (top HUD, bottom controls, menu overlay, settings overlay, NPC interaction overlay, and loading text) into Chinese and added Chinese ARIA labels across `src/game/ui/GameTopBar.tsx`, `src/game/ui/GameMenuOverlay.tsx`, `src/game/GameModeShell.tsx`, `src/App.tsx`, and related files. 
- Clarified settings ownership by changing `GameSettingsOverlay` to show only game-side placeholders (HUD/controls/sound/visual preferences) and adding an explicit note plus a “前往通用设置” entry that navigates to the shared settings page; the overlay now accepts an `onOpenSharedSettings` handler and the app passes a route to `/settings`. 
- Preserved the existing game-mode wrapper entry pattern for the four feature entry points (零食罐罐区, 仓鼠观察日志, 打卡, 数据导出) and did not duplicate any shared AI/model/prompt/reasoning controls or state in the game layer. 
- Responsive adjustments ensure the new right-side pad and left-side action buttons behave on narrow/mobile viewports by modifying CSS media rules in `src/game/gameHud.css`.
- Included small copy polish for action hint text and NPC interaction strings to match Chinese-first product rules.
- Manual verification summary: on desktop the game HUD shows the directional pad on the right and controls on the left while overlays and labels render in Chinese; on narrow/mobile viewport the layout remains responsive and the right-side directional pad remains usable.

### Testing
- Ran a production build with `npm run build` and the build completed successfully. 
- Ran lint with `npm run lint` which passed; there is one pre-existing lint warning in `src/pages/CheckinPage.tsx` unrelated to these changes. 
- Started the dev server and captured a smoke-check screenshot to confirm the game HUD renders as expected in a browser session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f9f3e3648330a40b3c8d0157e2cb)