### PR TITLE
feat: fix player display name to 串串 and wire game-menu feature entries to game-mode wrappers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1476,6 +1476,9 @@ const App = () => {
             navigate('/settings')
           }}
           onOpenChat={openChatFromGameMode}
+          user={user}
+          snackAiConfig={snackAiConfig}
+          syzygyAiConfig={syzygyAiConfig}
         />
       </Suspense>
     )

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -1,21 +1,57 @@
 import { useCallback, useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
 import GameContainer from './GameContainer'
 import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload } from './EventBus'
 import GameHud from './ui/GameHud'
-import GameMenuOverlay from './ui/GameMenuOverlay'
+import GameMenuOverlay, { type GameFeatureId } from './ui/GameMenuOverlay'
 import GameSettingsOverlay from './ui/GameSettingsOverlay'
+import GameFeatureShell from './ui/GameFeatureShell'
+import SnacksPage from '../pages/SnacksPage'
+import SyzygyFeedPage from '../pages/SyzygyFeedPage'
+import CheckinPage from '../pages/CheckinPage'
+import ExportPage from '../pages/ExportPage'
 import './gameHud.css'
+
+type SharedSnackAiConfig = {
+  model: string
+  reasoning: boolean
+  temperature: number
+  topP: number
+  maxTokens: number
+  systemPrompt: string
+  snackSystemOverlay: string
+  syzygyPostSystemPrompt: string
+  syzygyReplySystemPrompt: string
+}
 
 type GameModeShellProps = {
   onSwitchToPhoneMode: () => void
   onOpenSharedSettings: () => void
   onOpenChat: (npcId: OpenNpcActionsPayload['npcId']) => void
+  user: User | null
+  snackAiConfig: SharedSnackAiConfig
+  syzygyAiConfig: SharedSnackAiConfig
 }
 
-const GameModeShell = ({ onSwitchToPhoneMode, onOpenSharedSettings, onOpenChat }: GameModeShellProps) => {
+const GAME_FEATURE_META: Record<GameFeatureId, { title: string; subtitle: string }> = {
+  snacks: { title: '零食罐罐区', subtitle: '游戏模式面板 · 零食管理与投喂' },
+  syzygy: { title: '仓鼠观察日志', subtitle: '游戏模式面板 · 观察记录' },
+  checkin: { title: '打卡', subtitle: '游戏模式面板 · 每日陪伴打卡' },
+  export: { title: '数据导出', subtitle: '游戏模式面板 · 导出数据包' },
+}
+
+const GameModeShell = ({
+  onSwitchToPhoneMode,
+  onOpenSharedSettings,
+  onOpenChat,
+  user,
+  snackAiConfig,
+  syzygyAiConfig,
+}: GameModeShellProps) => {
   const [activeNpcId, setActiveNpcId] = useState<OpenNpcActionsPayload['npcId'] | null>(null)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [activeFeature, setActiveFeature] = useState<GameFeatureId | null>(null)
   const [actionHint, setActionHint] = useState<string | null>(null)
 
   const handleOpenNpcActions = useCallback((payload: OpenNpcActionsPayload) => {
@@ -41,6 +77,11 @@ const GameModeShell = ({ onSwitchToPhoneMode, onOpenSharedSettings, onOpenChat }
     }, 1600)
   }, [])
 
+  const handleOpenFeature = useCallback((featureId: GameFeatureId) => {
+    setIsMenuOpen(false)
+    setActiveFeature(featureId)
+  }, [])
+
   useEffect(() => {
     EventBus.on(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions)
 
@@ -48,6 +89,8 @@ const GameModeShell = ({ onSwitchToPhoneMode, onOpenSharedSettings, onOpenChat }
       EventBus.off(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions)
     }
   }, [handleOpenNpcActions])
+
+  const featureMeta = activeFeature ? GAME_FEATURE_META[activeFeature] : null
 
   return (
     <div className="app-shell game-mode-shell">
@@ -86,13 +129,28 @@ const GameModeShell = ({ onSwitchToPhoneMode, onOpenSharedSettings, onOpenChat }
           </div>
         ) : null}
 
-        {isMenuOpen ? <GameMenuOverlay onClose={() => setIsMenuOpen(false)} /> : null}
+        {isMenuOpen ? <GameMenuOverlay onClose={() => setIsMenuOpen(false)} onOpenFeature={handleOpenFeature} /> : null}
         {isSettingsOpen ? (
           <GameSettingsOverlay
             onClose={() => setIsSettingsOpen(false)}
             onSwitchToPhoneMode={onSwitchToPhoneMode}
             onOpenSharedSettings={onOpenSharedSettings}
           />
+        ) : null}
+
+        {activeFeature && featureMeta ? (
+          <div className="game-feature-shell-backdrop">
+            <GameFeatureShell
+              title={featureMeta.title}
+              subtitle={featureMeta.subtitle}
+              onBackToGame={() => setActiveFeature(null)}
+            >
+              {activeFeature === 'snacks' ? <SnacksPage user={user} snackAiConfig={snackAiConfig} entryMode="game" /> : null}
+              {activeFeature === 'syzygy' ? <SyzygyFeedPage user={user} snackAiConfig={syzygyAiConfig} entryMode="game" /> : null}
+              {activeFeature === 'checkin' ? <CheckinPage user={user} entryMode="game" /> : null}
+              {activeFeature === 'export' ? <ExportPage user={user} entryMode="game" /> : null}
+            </GameFeatureShell>
+          </div>
         ) : null}
       </div>
     </div>

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -363,3 +363,67 @@
     width: min(300px, calc(100% - 18px));
   }
 }
+
+.game-feature-shell-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 26;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: 12px;
+  pointer-events: auto;
+}
+
+.game-feature-shell {
+  width: min(980px, 100%);
+  height: 100%;
+  border-radius: 18px;
+  border: 1px solid rgba(56, 189, 248, 0.55);
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.97), rgba(15, 23, 42, 0.97));
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.6);
+}
+
+.game-feature-shell__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.game-feature-shell__titles {
+  text-align: center;
+}
+
+.game-feature-shell__titles h2 {
+  margin: 0;
+}
+
+.game-feature-shell__titles p {
+  margin: 2px 0 0;
+  color: #94a3b8;
+  font-size: 12px;
+}
+
+.game-feature-shell__content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px;
+}
+
+.game-feature-page {
+  background: transparent;
+}
+
+.game-feature-page .snacks-header-spacer {
+  width: 76px;
+  display: inline-block;
+}

--- a/src/game/ui/GameFeatureShell.tsx
+++ b/src/game/ui/GameFeatureShell.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+
+type GameFeatureShellProps = {
+  title: string
+  subtitle: string
+  onBackToGame: () => void
+  children: ReactNode
+}
+
+const GameFeatureShell = ({ title, subtitle, onBackToGame, children }: GameFeatureShellProps) => {
+  return (
+    <div className="game-feature-shell" role="dialog" aria-modal="true" aria-label={`${title} 游戏面板`}>
+      <header className="game-feature-shell__header">
+        <button type="button" className="ghost" onClick={onBackToGame}>
+          返回游戏
+        </button>
+        <div className="game-feature-shell__titles">
+          <h2 className="ui-title">{title}</h2>
+          <p>{subtitle}</p>
+        </div>
+        <button type="button" className="primary" onClick={onBackToGame}>
+          关闭
+        </button>
+      </header>
+
+      <div className="game-feature-shell__content">{children}</div>
+    </div>
+  )
+}
+
+export default GameFeatureShell

--- a/src/game/ui/GameMenuOverlay.tsx
+++ b/src/game/ui/GameMenuOverlay.tsx
@@ -1,11 +1,14 @@
+export type GameFeatureId = 'snacks' | 'syzygy' | 'checkin' | 'export'
+
 type MenuEntry = {
-  id: string
+  id: GameFeatureId
   title: string
   description: string
 }
 
 type GameMenuOverlayProps = {
   onClose: () => void
+  onOpenFeature: (featureId: GameFeatureId) => void
 }
 
 const GAME_MENU_ENTRIES: MenuEntry[] = [
@@ -15,7 +18,7 @@ const GAME_MENU_ENTRIES: MenuEntry[] = [
   { id: 'export', title: '数据导出', description: '以游戏模式外壳进入数据导出功能。' },
 ]
 
-const GameMenuOverlay = ({ onClose }: GameMenuOverlayProps) => {
+const GameMenuOverlay = ({ onClose, onOpenFeature }: GameMenuOverlayProps) => {
   return (
     <div className="game-overlay-backdrop" role="presentation" onClick={onClose}>
       <section
@@ -37,8 +40,8 @@ const GameMenuOverlay = ({ onClose }: GameMenuOverlayProps) => {
             <article key={entry.id} className="game-overlay-card">
               <h3>{entry.title}</h3>
               <p>{entry.description}</p>
-              <button type="button" className="game-overlay-card__button" disabled aria-disabled="true">
-                打开（占位）
+              <button type="button" className="game-overlay-card__button" onClick={() => onOpenFeature(entry.id)}>
+                打开
               </button>
             </article>
           ))}

--- a/src/game/ui/GameTopBar.tsx
+++ b/src/game/ui/GameTopBar.tsx
@@ -35,7 +35,7 @@ const GameTopBar = ({ stamina, maxStamina, level, coins }: GameTopBarProps) => {
           🐹
         </span>
         <div>
-          <p className="game-avatar-chip__name">川川</p>
+          <p className="game-avatar-chip__name">串串</p>
           <p className="game-avatar-chip__sub">等级 {level}</p>
         </div>
       </div>

--- a/src/pages/CheckinPage.tsx
+++ b/src/pages/CheckinPage.tsx
@@ -7,6 +7,7 @@ import './CheckinPage.css'
 
 export type CheckinPageProps = {
   user: User | null
+  entryMode?: 'phone' | 'game'
 }
 
 const formatDateKey = (date: Date) => {
@@ -66,7 +67,7 @@ const getMonthCalendarCells = (monthDate: Date) => {
   return cells
 }
 
-const CheckinPage = ({ user }: CheckinPageProps) => {
+const CheckinPage = ({ user, entryMode = 'phone' }: CheckinPageProps) => {
   const [recentCheckins, setRecentCheckins] = useState<CheckinEntry[]>([])
   const [checkinTotal, setCheckinTotal] = useState(0)
   const [checkinLoading, setCheckinLoading] = useState(false)
@@ -138,10 +139,11 @@ const CheckinPage = ({ user }: CheckinPageProps) => {
   }
 
   return (
-    <div className="checkin-page">
-      <header className="checkin-page-header">
-        <div className="checkin-nav-actions">
-          {navTabs.map((tab) => {
+    <div className={`checkin-page ${entryMode === 'game' ? 'game-feature-page' : ''}`}>
+      {entryMode === 'phone' ? (
+        <header className="checkin-page-header">
+          <div className="checkin-nav-actions">
+            {navTabs.map((tab) => {
             const isActive = tab.path === '/checkin'
             return (
               <button
@@ -154,9 +156,10 @@ const CheckinPage = ({ user }: CheckinPageProps) => {
                 {tab.label}
               </button>
             )
-          })}
-        </div>
-      </header>
+            })}
+          </div>
+        </header>
+      ) : null}
 
       <section className="checkin-card standalone">
         <div className="checkin-header">

--- a/src/pages/ExportPage.tsx
+++ b/src/pages/ExportPage.tsx
@@ -343,7 +343,7 @@ const renderMarkdown = (
   return lines.join('\n')
 }
 
-const ExportPage = ({ user }: { user: User | null }) => {
+const ExportPage = ({ user, entryMode = 'phone' }: { user: User | null; entryMode?: 'phone' | 'game' }) => {
   const navigate = useNavigate()
   const [format, setFormat] = useState<ExportFormat>('markdown')
   const [modules, setModules] = useState<ExportModules>(defaultModules)
@@ -553,16 +553,18 @@ const ExportPage = ({ user }: { user: User | null }) => {
   }
 
   return (
-    <div className="export-page">
-      <header className="export-header">
-        <button type="button" className="ghost" onClick={() => navigate(-1)}>
-          返回
-        </button>
+    <div className={`export-page ${entryMode === 'game' ? 'game-feature-page' : ''}`}>
+      {entryMode === 'phone' ? (
+        <header className="export-header">
+          <button type="button" className="ghost" onClick={() => navigate(-1)}>
+            返回
+          </button>
         <h1 className="ui-title">数据导出</h1>
-        <button type="button" className="ghost" onClick={() => navigate('/')}>
-          聊天
-        </button>
-      </header>
+          <button type="button" className="ghost" onClick={() => navigate('/')}>
+            聊天
+          </button>
+        </header>
+      ) : null}
 
       <section className="export-card export-package-card">
         <span className="export-washi-tape" aria-hidden="true" />

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -28,6 +28,7 @@ import './SnacksPage.css'
 
 type SnacksPageProps = {
   user: User | null
+  entryMode?: 'phone' | 'game'
   snackAiConfig: {
     model: string
     reasoning: boolean
@@ -61,7 +62,7 @@ const getReplyPreview = (reply: SnackReply | undefined) => {
   return reply.content.length > 30 ? `${reply.content.slice(0, 30)}…` : reply.content
 }
 
-const SnacksPage = ({ user, snackAiConfig }: SnacksPageProps) => {
+const SnacksPage = ({ user, snackAiConfig, entryMode = 'phone' }: SnacksPageProps) => {
   const navigate = useNavigate()
   const [draft, setDraft] = useState('')
   const [posts, setPosts] = useState<SnackPost[]>([])
@@ -572,11 +573,15 @@ const SnacksPage = ({ user, snackAiConfig }: SnacksPageProps) => {
   }
 
   return (
-    <div className="snacks-page app-shell__content">
+    <div className={`snacks-page app-shell__content ${entryMode === 'game' ? 'game-feature-page' : ''}`}>
       <header className="snacks-header">
-        <button type="button" className="ghost" onClick={() => navigate('/')}>
-          返回聊天
-        </button>
+        {entryMode === 'phone' ? (
+          <button type="button" className="ghost" onClick={() => navigate('/')}>
+            返回聊天
+          </button>
+        ) : (
+          <span className="snacks-header-spacer" aria-hidden="true" />
+        )}
         <h1 className="ui-title">{showTrash ? '零食回收站' : '零食罐罐区'}</h1>
         <button
           type="button"

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -30,6 +30,7 @@ import './SnacksPage.css'
 
 type SyzygyFeedPageProps = {
   user: User | null
+  entryMode?: 'phone' | 'game'
   snackAiConfig: {
     model: string
     reasoning: boolean
@@ -67,7 +68,7 @@ const getReplyPreview = (reply: SyzygyReply | undefined) => {
   return reply.content.length > 30 ? `${reply.content.slice(0, 30)}…` : reply.content
 }
 
-const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
+const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeedPageProps) => {
   const navigate = useNavigate()
   const [draft, setDraft] = useState('')
   const [posts, setPosts] = useState<SyzygyPost[]>([])
@@ -605,11 +606,15 @@ const SyzygyFeedPage = ({ user, snackAiConfig }: SyzygyFeedPageProps) => {
   }
 
   return (
-    <div className="snacks-page app-shell__content">
+    <div className={`snacks-page app-shell__content ${entryMode === 'game' ? 'game-feature-page' : ''}`}>
       <header className="snacks-header">
-        <button type="button" className="ghost" onClick={() => navigate('/')}>
-          返回聊天
-        </button>
+        {entryMode === 'phone' ? (
+          <button type="button" className="ghost" onClick={() => navigate('/')}>
+            返回聊天
+          </button>
+        ) : (
+          <span className="snacks-header-spacer" aria-hidden="true" />
+        )}
         <h1 className="ui-title">{showTrash ? '观察日志回收站' : '仓鼠观察日志'}</h1>
         <button
           type="button"


### PR DESCRIPTION
### Motivation
- The game HUD currently shows the wrong hard-coded player name and needs to display the fixed name "串串" for Phase 1 without adding profile or DB work. 
- The in-game menu contained placeholder (disabled) entries for four feature areas that should be navigable from game mode and render inside a distinct game-mode UI. 
- The goal is to open existing feature pages inside a simple game-mode wrapper while reusing existing logic and keeping phone-mode UI unchanged.

### Description
- Fixed the HUD player display name to the literal string `串串` in `src/game/ui/GameTopBar.tsx` so the top bar shows the intended fixed name for now. 
- Replaced placeholder menu buttons with clickable entries by adding a typed `GameFeatureId` model and `onOpenFeature` handler in `src/game/ui/GameMenuOverlay.tsx`. 
- Added a reusable `GameFeatureShell` component at `src/game/ui/GameFeatureShell.tsx` and game-mode shell wiring in `src/game/GameModeShell.tsx` to render the four features in a game-mode wrapper (title/toolbar/back-to-game) and passed `user`, `snackAiConfig`, and `syzygyAiConfig` from `App` into game mode to reuse feature logic. 
- Kept phone-mode routes unchanged and added `entryMode?: 'phone' | 'game'` to `SnacksPage`, `SyzygyFeedPage`, `CheckinPage`, and `ExportPage` so the same pages can hide phone-specific chrome when opened from game mode; added game-shell CSS in `src/game/gameHud.css` for distinct visual treatment. 
- This PR intentionally does not add any editable profile or SQL/schema work; the HUD name is deliberately hard-coded to `串串` for now.

Manual verification summary: open game mode, confirm the HUD reads `串串`, open game menu, click each of the four entries (零食罐罐区 / 仓鼠观察日志 / 打卡 / 数据导出) and confirm each opens inside a visually distinct game-mode panel with a clear return-to-game action, and verify phone-mode versions still render via their normal routes.

### Testing
- Ran `git diff --check` which succeeded with no whitespace errors. 
- Ran the repository linters (`eslint`) which produced no actionable errors in the changed files in this environment. 
- Attempted a full TypeScript/Vite build via `npm run build` but the job did not complete within the environment timeout (300s) and therefore did not produce a final build result; no TypeScript/Vite error output was produced before timeout. 
- Attempted an automated Playwright screenshot of the running dev server but the page returned `net::ERR_EMPTY_RESPONSE` in this environment so the end-to-end screenshot check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ff4ce48c8330acf38bcc4c57317b)