### PR TITLE
fix: anchor NPC interaction menu to sprite screen position instead of viewport top area

### DIFF
--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -32,10 +32,7 @@ type GameModeShellProps = {
   syzygyAiConfig: SharedSnackAiConfig
 }
 
-type ActiveNpcMenu = {
-  npcId: OpenNpcActionsPayload['npcId']
-  anchor: OpenNpcActionsPayload['anchor']
-}
+type ActiveNpcMenu = OpenNpcActionsPayload
 
 const GAME_FEATURE_META: Record<GameFeatureId, { title: string; subtitle: string }> = {
   snacks: { title: '零食罐罐区', subtitle: '游戏模式面板 · 零食管理与投喂' },
@@ -72,7 +69,7 @@ const GameModeShell = ({
   })
 
   const handleOpenNpcActions = useCallback((payload: OpenNpcActionsPayload) => {
-    setActiveNpcMenu({ npcId: payload.npcId, anchor: payload.anchor })
+    setActiveNpcMenu(payload)
   }, [])
 
   const handleCloseNpcActions = useCallback(() => {

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -8,6 +8,19 @@ const SYZYGY_KEY = 'syzygy1'
 export class HomeScene extends Phaser.Scene {
   private syzygySprite?: Phaser.GameObjects.Image
 
+  private getSpriteScreenAnchor(sprite: Phaser.GameObjects.Image) {
+    const bounds = sprite.getBounds()
+    const canvas = this.game.canvas
+    const canvasRect = canvas.getBoundingClientRect()
+    const scaleX = canvasRect.width / this.scale.width
+    const scaleY = canvasRect.height / this.scale.height
+
+    return {
+      x: canvasRect.left + bounds.right * scaleX,
+      y: canvasRect.top + (bounds.top + bounds.height * 0.45) * scaleY,
+    }
+  }
+
   constructor() {
     super('HomeScene')
   }
@@ -53,13 +66,9 @@ export class HomeScene extends Phaser.Scene {
         return
       }
 
-      const bounds = this.syzygySprite.getBounds()
       EventBus.emit(GAME_EVENTS.OPEN_NPC_ACTIONS, {
         npcId: 'syzygy',
-        anchor: {
-          x: bounds.right,
-          y: bounds.top + bounds.height * 0.45,
-        },
+        anchor: this.getSpriteScreenAnchor(this.syzygySprite),
       })
     })
   }


### PR DESCRIPTION
### Motivation
- The NPC interaction menu was positioned using incorrect reference coordinates and opened detached near the top of the viewport instead of adjacent to the clicked sprite.
- The goal is to anchor the menu to the clicked character sprite by converting the Phaser/world position into UI/DOM screen coordinates while preserving the current visual style and behavior.

### Description
- Added `getSpriteScreenAnchor` to `src/game/scenes/HomeScene.ts` which computes screen-space `x`/`y` from the sprite's `getBounds()` and the game canvas `getBoundingClientRect()` plus scale factors, and used it when emitting `GAME_EVENTS.OPEN_NPC_ACTIONS`.
- Kept the React-side placement logic intact in `src/game/GameModeShell.tsx` and simplified the `ActiveNpcMenu` type to use the existing `OpenNpcActionsPayload` and set state directly from the emitted payload so the corrected anchor drives the existing edge-aware placement.
- No UI style, chat opening, paw menu behavior, or overall shell layout were changed.

### Testing
- Ran `npm run build` and the production build completed successfully without errors.
- Ran `npm run lint` which completed; it reported one pre-existing warning in `src/pages/CheckinPage.tsx` unrelated to this change.
- Verified the changed files compile and the updated anchor flows through `OPEN_NPC_ACTIONS` to the existing menu placement logic (no console errors during build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba40fb5bf483308d2364af6ec93241)