### PR TITLE
refactor: center system popups for settings and paw menu, keep character interaction contextual

### DIFF
--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -1,54 +1,65 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import type { User } from '@supabase/supabase-js'
-import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload } from './EventBus'
-import GameHud from './ui/GameHud'
-import type { GameFeatureId } from './ui/GameMenuOverlay'
-import GameSettingsOverlay from './ui/GameSettingsOverlay'
-import GameFeatureShell from './ui/GameFeatureShell'
-import SnacksPage from '../pages/SnacksPage'
-import SyzygyFeedPage from '../pages/SyzygyFeedPage'
-import CheckinPage from '../pages/CheckinPage'
-import ExportPage from '../pages/ExportPage'
-import './gameHud.css'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { User } from "@supabase/supabase-js";
+import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload } from "./EventBus";
+import GameHud from "./ui/GameHud";
+import GameMenuOverlay, { type GameFeatureId } from "./ui/GameMenuOverlay";
+import GameSettingsOverlay from "./ui/GameSettingsOverlay";
+import GameFeatureShell from "./ui/GameFeatureShell";
+import SnacksPage from "../pages/SnacksPage";
+import SyzygyFeedPage from "../pages/SyzygyFeedPage";
+import CheckinPage from "../pages/CheckinPage";
+import ExportPage from "../pages/ExportPage";
+import "./gameHud.css";
 
 type SharedSnackAiConfig = {
-  model: string
-  reasoning: boolean
-  temperature: number
-  topP: number
-  maxTokens: number
-  systemPrompt: string
-  snackSystemOverlay: string
-  syzygyPostSystemPrompt: string
-  syzygyReplySystemPrompt: string
-}
+  model: string;
+  reasoning: boolean;
+  temperature: number;
+  topP: number;
+  maxTokens: number;
+  systemPrompt: string;
+  snackSystemOverlay: string;
+  syzygyPostSystemPrompt: string;
+  syzygyReplySystemPrompt: string;
+};
 
 type GameModeShellProps = {
-  onSwitchToPhoneMode: () => void
-  onOpenSharedSettings: () => void
-  onOpenChat: (npcId: OpenNpcActionsPayload['npcId']) => void
-  user: User | null
-  snackAiConfig: SharedSnackAiConfig
-  syzygyAiConfig: SharedSnackAiConfig
-}
+  onSwitchToPhoneMode: () => void;
+  onOpenSharedSettings: () => void;
+  onOpenChat: (npcId: OpenNpcActionsPayload["npcId"]) => void;
+  user: User | null;
+  snackAiConfig: SharedSnackAiConfig;
+  syzygyAiConfig: SharedSnackAiConfig;
+};
 
-type ActiveNpcMenu = OpenNpcActionsPayload
+type ActiveNpcMenu = OpenNpcActionsPayload;
 
-const GAME_FEATURE_META: Record<GameFeatureId, { title: string; subtitle: string }> = {
-  snacks: { title: '零食罐罐区', subtitle: '游戏模式面板 · 零食管理与投喂' },
-  syzygy: { title: '仓鼠观察日志', subtitle: '游戏模式面板 · 观察记录' },
-  checkin: { title: '打卡', subtitle: '游戏模式面板 · 每日陪伴打卡' },
-  export: { title: '数据导出', subtitle: '游戏模式面板 · 导出数据包' },
-}
+const GAME_FEATURE_META: Record<
+  GameFeatureId,
+  { title: string; subtitle: string }
+> = {
+  snacks: { title: "零食罐罐区", subtitle: "游戏模式面板 · 零食管理与投喂" },
+  syzygy: { title: "仓鼠观察日志", subtitle: "游戏模式面板 · 观察记录" },
+  checkin: { title: "打卡", subtitle: "游戏模式面板 · 每日陪伴打卡" },
+  export: { title: "数据导出", subtitle: "游戏模式面板 · 导出数据包" },
+};
 
-const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value))
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
 
 const NPC_MENU_LAYOUT = {
   width: 176,
   estimatedHeight: 170,
   anchorOffset: 18,
   edgePadding: 12,
-} as const
+} as const;
 
 const GameModeShell = ({
   onSwitchToPhoneMode,
@@ -58,140 +69,171 @@ const GameModeShell = ({
   snackAiConfig,
   syzygyAiConfig,
 }: GameModeShellProps) => {
-  const [activeNpcMenu, setActiveNpcMenu] = useState<ActiveNpcMenu | null>(null)
-  const [isPawMenuOpen, setIsPawMenuOpen] = useState(false)
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
-  const [activeFeature, setActiveFeature] = useState<GameFeatureId | null>(null)
-  const npcMenuRef = useRef<HTMLDivElement | null>(null)
-  const [npcMenuSize, setNpcMenuSize] = useState<{ width: number; height: number }>({
+  const [activeNpcMenu, setActiveNpcMenu] = useState<ActiveNpcMenu | null>(
+    null,
+  );
+  const [isPawMenuOpen, setIsPawMenuOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [activeFeature, setActiveFeature] = useState<GameFeatureId | null>(
+    null,
+  );
+  const npcMenuRef = useRef<HTMLDivElement | null>(null);
+  const [npcMenuSize, setNpcMenuSize] = useState<{
+    width: number;
+    height: number;
+  }>({
     width: NPC_MENU_LAYOUT.width,
     height: NPC_MENU_LAYOUT.estimatedHeight,
-  })
+  });
 
   const handleOpenNpcActions = useCallback((payload: OpenNpcActionsPayload) => {
-    setActiveNpcMenu(payload)
-  }, [])
+    setActiveNpcMenu(payload);
+  }, []);
 
   const handleCloseNpcActions = useCallback(() => {
-    setActiveNpcMenu(null)
-  }, [])
+    setActiveNpcMenu(null);
+  }, []);
 
   const handleOpenChat = useCallback(() => {
     if (!activeNpcMenu) {
-      return
+      return;
     }
-    onOpenChat(activeNpcMenu.npcId)
-    setActiveNpcMenu(null)
-  }, [activeNpcMenu, onOpenChat])
+    onOpenChat(activeNpcMenu.npcId);
+    setActiveNpcMenu(null);
+  }, [activeNpcMenu, onOpenChat]);
 
   const handleOpenFeature = useCallback((featureId: GameFeatureId) => {
-    setIsPawMenuOpen(false)
-    setActiveFeature(featureId)
-  }, [])
+    setIsPawMenuOpen(false);
+    setActiveFeature(featureId);
+  }, []);
 
   useEffect(() => {
-    EventBus.on(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions)
+    EventBus.on(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions);
 
     return () => {
-      EventBus.off(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions)
-    }
-  }, [handleOpenNpcActions])
+      EventBus.off(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions);
+    };
+  }, [handleOpenNpcActions]);
 
   useEffect(() => {
     if (!activeNpcMenu) {
-      return
+      return;
     }
 
     const handlePointerDown = (event: PointerEvent) => {
-      const menuElement = npcMenuRef.current
+      const menuElement = npcMenuRef.current;
       if (!menuElement) {
-        return
+        return;
       }
       if (event.target instanceof Node && menuElement.contains(event.target)) {
-        return
+        return;
       }
-      setActiveNpcMenu(null)
-    }
+      setActiveNpcMenu(null);
+    };
 
-    window.addEventListener('pointerdown', handlePointerDown)
+    window.addEventListener("pointerdown", handlePointerDown);
     return () => {
-      window.removeEventListener('pointerdown', handlePointerDown)
-    }
-  }, [activeNpcMenu])
-
+      window.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [activeNpcMenu]);
 
   useLayoutEffect(() => {
     if (!activeNpcMenu) {
-      return
+      return;
     }
 
-    const menuElement = npcMenuRef.current
+    const menuElement = npcMenuRef.current;
     if (!menuElement) {
-      return
+      return;
     }
 
-    const rect = menuElement.getBoundingClientRect()
+    const rect = menuElement.getBoundingClientRect();
     if (!rect.width || !rect.height) {
-      return
+      return;
     }
 
     setNpcMenuSize((prev) =>
       prev.width === rect.width && prev.height === rect.height
         ? prev
         : { width: rect.width, height: rect.height },
-    )
-  }, [activeNpcMenu])
+    );
+  }, [activeNpcMenu]);
 
   const npcMenuPosition = useMemo(() => {
     if (!activeNpcMenu) {
-      return null
+      return null;
     }
 
-    const { edgePadding, anchorOffset } = NPC_MENU_LAYOUT
-    const menuWidth = npcMenuSize.width
-    const menuHeight = npcMenuSize.height
+    const { edgePadding, anchorOffset } = NPC_MENU_LAYOUT;
+    const menuWidth = npcMenuSize.width;
+    const menuHeight = npcMenuSize.height;
 
     const candidatePositions = [
-      { left: activeNpcMenu.anchor.x + anchorOffset, top: activeNpcMenu.anchor.y - menuHeight - anchorOffset },
-      { left: activeNpcMenu.anchor.x + anchorOffset, top: activeNpcMenu.anchor.y + anchorOffset },
-      { left: activeNpcMenu.anchor.x - menuWidth - anchorOffset, top: activeNpcMenu.anchor.y - menuHeight - anchorOffset },
-      { left: activeNpcMenu.anchor.x - menuWidth - anchorOffset, top: activeNpcMenu.anchor.y + anchorOffset },
-    ]
+      {
+        left: activeNpcMenu.anchor.x + anchorOffset,
+        top: activeNpcMenu.anchor.y - menuHeight - anchorOffset,
+      },
+      {
+        left: activeNpcMenu.anchor.x + anchorOffset,
+        top: activeNpcMenu.anchor.y + anchorOffset,
+      },
+      {
+        left: activeNpcMenu.anchor.x - menuWidth - anchorOffset,
+        top: activeNpcMenu.anchor.y - menuHeight - anchorOffset,
+      },
+      {
+        left: activeNpcMenu.anchor.x - menuWidth - anchorOffset,
+        top: activeNpcMenu.anchor.y + anchorOffset,
+      },
+    ];
 
-    const viewportWidth = window.innerWidth
-    const viewportHeight = window.innerHeight
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
 
     const findBestPosition = () => {
       for (const position of candidatePositions) {
         const fitsHorizontally =
-          position.left >= edgePadding && position.left + menuWidth <= viewportWidth - edgePadding
+          position.left >= edgePadding &&
+          position.left + menuWidth <= viewportWidth - edgePadding;
         const fitsVertically =
-          position.top >= edgePadding && position.top + menuHeight <= viewportHeight - edgePadding
+          position.top >= edgePadding &&
+          position.top + menuHeight <= viewportHeight - edgePadding;
         if (fitsHorizontally && fitsVertically) {
-          return position
+          return position;
         }
       }
 
       return {
-        left: clamp(activeNpcMenu.anchor.x + anchorOffset, edgePadding, viewportWidth - edgePadding - menuWidth),
-        top: clamp(activeNpcMenu.anchor.y - menuHeight - anchorOffset, edgePadding, viewportHeight - edgePadding - menuHeight),
-      }
-    }
+        left: clamp(
+          activeNpcMenu.anchor.x + anchorOffset,
+          edgePadding,
+          viewportWidth - edgePadding - menuWidth,
+        ),
+        top: clamp(
+          activeNpcMenu.anchor.y - menuHeight - anchorOffset,
+          edgePadding,
+          viewportHeight - edgePadding - menuHeight,
+        ),
+      };
+    };
 
-    const position = findBestPosition()
+    const position = findBestPosition();
 
     return {
       left: `${position.left}px`,
       top: `${position.top}px`,
-    }
-  }, [activeNpcMenu, npcMenuSize.height, npcMenuSize.width])
+    };
+  }, [activeNpcMenu, npcMenuSize.height, npcMenuSize.width]);
 
-  const featureMeta = activeFeature ? GAME_FEATURE_META[activeFeature] : null
+  const featureMeta = activeFeature ? GAME_FEATURE_META[activeFeature] : null;
 
   return (
     <div className="app-shell game-mode-shell">
       <div className="game-mode-container">
-        <GameHud onOpenPawMenu={() => setIsPawMenuOpen((open) => !open)} onOpenSettings={() => setIsSettingsOpen(true)} />
+        <GameHud
+          onOpenPawMenu={() => setIsPawMenuOpen((open) => !open)}
+          onOpenSettings={() => setIsSettingsOpen(true)}
+        />
 
         {activeNpcMenu && npcMenuPosition ? (
           <div className="npc-actions-layer" role="presentation">
@@ -202,13 +244,25 @@ const GameModeShell = ({
               aria-label="仓鼠互动菜单"
               style={npcMenuPosition}
             >
-              <button type="button" className="npc-actions-menu__button npc-actions-menu__button--chat" onClick={handleOpenChat}>
+              <button
+                type="button"
+                className="npc-actions-menu__button npc-actions-menu__button--chat"
+                onClick={handleOpenChat}
+              >
                 聊天
               </button>
-              <button type="button" className="npc-actions-menu__button npc-actions-menu__button--close" onClick={handleCloseNpcActions}>
+              <button
+                type="button"
+                className="npc-actions-menu__button npc-actions-menu__button--close"
+                onClick={handleCloseNpcActions}
+              >
                 关闭
               </button>
-              <button type="button" className="npc-actions-menu__button npc-actions-menu__button--disabled" disabled>
+              <button
+                type="button"
+                className="npc-actions-menu__button npc-actions-menu__button--disabled"
+                disabled
+              >
                 互动（即将开放）
               </button>
             </div>
@@ -216,28 +270,10 @@ const GameModeShell = ({
         ) : null}
 
         {isPawMenuOpen ? (
-          <div className="game-paw-menu-backdrop" role="presentation" onClick={() => setIsPawMenuOpen(false)}>
-            <section
-              className="game-paw-menu-panel"
-              role="dialog"
-              aria-modal="true"
-              aria-label="系统功能菜单"
-              onClick={(event) => event.stopPropagation()}
-            >
-              <button type="button" className="game-paw-menu-item" onClick={() => handleOpenFeature('snacks')}>
-                零食罐罐区
-              </button>
-              <button type="button" className="game-paw-menu-item" onClick={() => handleOpenFeature('syzygy')}>
-                仓鼠观察日志
-              </button>
-              <button type="button" className="game-paw-menu-item" onClick={() => handleOpenFeature('checkin')}>
-                打卡
-              </button>
-              <button type="button" className="game-paw-menu-item" onClick={() => handleOpenFeature('export')}>
-                数据导出
-              </button>
-            </section>
-          </div>
+          <GameMenuOverlay
+            onClose={() => setIsPawMenuOpen(false)}
+            onOpenFeature={handleOpenFeature}
+          />
         ) : null}
 
         {isSettingsOpen ? (
@@ -255,16 +291,32 @@ const GameModeShell = ({
               subtitle={featureMeta.subtitle}
               onBackToGame={() => setActiveFeature(null)}
             >
-              {activeFeature === 'snacks' ? <SnacksPage user={user} snackAiConfig={snackAiConfig} entryMode="game" /> : null}
-              {activeFeature === 'syzygy' ? <SyzygyFeedPage user={user} snackAiConfig={syzygyAiConfig} entryMode="game" /> : null}
-              {activeFeature === 'checkin' ? <CheckinPage user={user} entryMode="game" /> : null}
-              {activeFeature === 'export' ? <ExportPage user={user} entryMode="game" /> : null}
+              {activeFeature === "snacks" ? (
+                <SnacksPage
+                  user={user}
+                  snackAiConfig={snackAiConfig}
+                  entryMode="game"
+                />
+              ) : null}
+              {activeFeature === "syzygy" ? (
+                <SyzygyFeedPage
+                  user={user}
+                  snackAiConfig={syzygyAiConfig}
+                  entryMode="game"
+                />
+              ) : null}
+              {activeFeature === "checkin" ? (
+                <CheckinPage user={user} entryMode="game" />
+              ) : null}
+              {activeFeature === "export" ? (
+                <ExportPage user={user} entryMode="game" />
+              ) : null}
             </GameFeatureShell>
           </div>
         ) : null}
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default GameModeShell
+export default GameModeShell;

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -38,8 +38,7 @@
   padding: clamp(10px, 2vw, 18px);
   border: 4px solid var(--game-shell-edge);
   border-radius: 24px;
-  background:
-    linear-gradient(180deg, #eec9bf 0%, #d7ada4 100%);
+  background: linear-gradient(180deg, #eec9bf 0%, #d7ada4 100%);
   box-shadow:
     inset 0 0 0 3px var(--game-shell-light),
     inset 0 -6px 0 var(--game-shell-shadow),
@@ -52,7 +51,6 @@
 .game-top-bar,
 .game-bottom-bar,
 .game-viewport-shell,
-.game-paw-menu-panel,
 .game-overlay-panel,
 .game-feature-shell {
   border: 3px solid var(--game-shell-edge);
@@ -85,7 +83,9 @@
   place-items: center;
 }
 
-.game-avatar-chip__emoji { font-size: clamp(26px, 4vw, 34px); }
+.game-avatar-chip__emoji {
+  font-size: clamp(26px, 4vw, 34px);
+}
 
 .game-player-panel {
   border: 3px solid var(--game-shell-edge);
@@ -288,25 +288,55 @@
   border: 2px solid #68433d;
   border-radius: 6px;
   background: linear-gradient(180deg, #f6cec8 0%, #e7a9a6 100%);
-  box-shadow: inset 0 2px 0 #fce5e2, inset 0 -2px 0 #bf7d76;
+  box-shadow:
+    inset 0 2px 0 #fce5e2,
+    inset 0 -2px 0 #bf7d76;
   display: grid;
   place-items: center;
   padding: 0;
 }
 
-.game-dpad-button[disabled] { opacity: 1; }
+.game-dpad-button[disabled] {
+  opacity: 1;
+}
 
-.game-dpad-button__arrow { width: 0; height: 0; border-style: solid; }
-.game-dpad-button__arrow--up { border-width: 0 7px 10px; border-color: transparent transparent #6d4c45 transparent; }
-.game-dpad-button__arrow--down { border-width: 10px 7px 0; border-color: #6d4c45 transparent transparent transparent; }
-.game-dpad-button__arrow--left { border-width: 7px 10px 7px 0; border-color: transparent #6d4c45 transparent transparent; }
-.game-dpad-button__arrow--right { border-width: 7px 0 7px 10px; border-color: transparent transparent transparent #6d4c45; }
+.game-dpad-button__arrow {
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+.game-dpad-button__arrow--up {
+  border-width: 0 7px 10px;
+  border-color: transparent transparent #6d4c45 transparent;
+}
+.game-dpad-button__arrow--down {
+  border-width: 10px 7px 0;
+  border-color: #6d4c45 transparent transparent transparent;
+}
+.game-dpad-button__arrow--left {
+  border-width: 7px 10px 7px 0;
+  border-color: transparent #6d4c45 transparent transparent;
+}
+.game-dpad-button__arrow--right {
+  border-width: 7px 0 7px 10px;
+  border-color: transparent transparent transparent #6d4c45;
+}
 
-.game-dpad-button--up { grid-area: 1 / 2; }
-.game-dpad-button--left { grid-area: 2 / 1; }
-.game-dpad-button--center { grid-area: 2 / 2; }
-.game-dpad-button--right { grid-area: 2 / 3; }
-.game-dpad-button--down { grid-area: 3 / 2; }
+.game-dpad-button--up {
+  grid-area: 1 / 2;
+}
+.game-dpad-button--left {
+  grid-area: 2 / 1;
+}
+.game-dpad-button--center {
+  grid-area: 2 / 2;
+}
+.game-dpad-button--right {
+  grid-area: 2 / 3;
+}
+.game-dpad-button--down {
+  grid-area: 3 / 2;
+}
 
 .game-bottom-controls {
   display: flex;
@@ -326,7 +356,9 @@
   border: 3px solid #724b44;
   border-radius: 14px;
   background: linear-gradient(180deg, #ffd8de 0%, #ef9fb0 100%);
-  box-shadow: inset 0 2px 0 #ffeef1, inset 0 -2px 0 #c56d81;
+  box-shadow:
+    inset 0 2px 0 #ffeef1,
+    inset 0 -2px 0 #c56d81;
   color: #6c3f4b;
   font-size: clamp(22px, 3vw, 26px);
   padding: 0;
@@ -335,7 +367,6 @@
 .game-control-button--paw {
   width: clamp(66px, 9vw, 76px);
 }
-
 
 .npc-actions-layer {
   position: fixed;
@@ -353,7 +384,10 @@
   border: 3px solid var(--game-shell-edge);
   border-radius: 12px;
   background: linear-gradient(180deg, #ffeade 0%, #f3c7b8 100%);
-  box-shadow: inset 0 0 0 2px #fff4ec, inset 0 -4px 0 rgba(117, 75, 68, 0.35), 0 6px 0 rgba(89, 56, 53, 0.25);
+  box-shadow:
+    inset 0 0 0 2px #fff4ec,
+    inset 0 -4px 0 rgba(117, 75, 68, 0.35),
+    0 6px 0 rgba(89, 56, 53, 0.25);
   pointer-events: auto;
 }
 
@@ -361,7 +395,9 @@
   min-height: 40px;
   border: 2px solid #6f4a44;
   border-radius: 10px;
-  box-shadow: inset 0 1px 0 #ffe9df, inset 0 -2px 0 rgba(97, 64, 57, 0.5);
+  box-shadow:
+    inset 0 1px 0 #ffe9df,
+    inset 0 -2px 0 rgba(97, 64, 57, 0.5);
   color: var(--game-text);
   font-size: 13px;
   font-weight: 700;
@@ -383,26 +419,15 @@
   opacity: 0.88;
 }
 
-.game-paw-menu-backdrop {
+.game-overlay-backdrop {
   position: absolute;
   inset: 0;
   z-index: 25;
-  pointer-events: none;
-}
-
-.game-paw-menu-panel {
-  position: absolute;
-  right: 10px;
-  bottom: 94px;
-  width: min(270px, calc(100% - 20px));
-  padding: 10px;
-  display: grid;
-  gap: 8px;
-  border: 3px solid var(--game-shell-edge);
-  border-radius: 12px;
-  background: linear-gradient(180deg, #ffe9dd 0%, #f3c9ba 100%);
-  box-shadow: inset 0 0 0 2px #fff4ed, inset 0 -5px 0 rgba(117, 75, 68, 0.35), 0 6px 0 rgba(89, 56, 53, 0.28);
-  pointer-events: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(12px, 2.8vw, 24px);
+  background: rgba(33, 23, 23, 0.24);
 }
 
 .game-paw-menu-item {
@@ -410,14 +435,15 @@
   border: 2px solid var(--game-shell-edge);
   border-radius: 10px;
   background: linear-gradient(180deg, #ffe0d8 0%, #f5bfb0 100%);
-  box-shadow: inset 0 1px 0 #fff0e9, inset 0 -2px 0 rgba(113, 72, 66, 0.45);
+  box-shadow:
+    inset 0 1px 0 #fff0e9,
+    inset 0 -2px 0 rgba(113, 72, 66, 0.45);
   color: var(--game-text);
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
 }
 
-.game-overlay-backdrop,
 .game-feature-shell-backdrop {
   position: fixed;
   inset: 0;
@@ -441,7 +467,9 @@
     0 10px 0 rgba(89, 56, 53, 0.35);
 }
 
-.game-overlay-panel--narrow { width: min(380px, 100%); }
+.game-overlay-panel--narrow {
+  width: min(380px, 100%);
+}
 
 .game-overlay-header {
   display: flex;
@@ -460,7 +488,9 @@
   border: 2px solid var(--game-shell-edge);
   border-radius: 8px;
   background: linear-gradient(180deg, #f9d6d2 0%, #efb5b1 100%);
-  box-shadow: inset 0 1px 0 #ffece8, inset 0 -2px 0 #c17f76;
+  box-shadow:
+    inset 0 1px 0 #ffece8,
+    inset 0 -2px 0 #c17f76;
   color: var(--game-text);
   padding: 4px 10px;
   font-size: 12px;
@@ -576,7 +606,9 @@
   min-height: 40px;
   border: 2px solid #6f4a44;
   border-radius: 9px;
-  box-shadow: inset 0 1px 0 #ffe7e0, inset 0 -2px 0 rgba(97, 64, 57, 0.6);
+  box-shadow:
+    inset 0 1px 0 #ffe7e0,
+    inset 0 -2px 0 rgba(97, 64, 57, 0.6);
   color: var(--game-text);
   font-size: 12px;
   font-weight: 800;
@@ -591,7 +623,6 @@
   background: linear-gradient(180deg, #ffd7dd 0%, #f09aae 100%);
   color: #5d303c;
 }
-
 
 .game-feature-shell-backdrop {
   align-items: stretch;
@@ -651,11 +682,6 @@
   .game-control-button {
     min-width: 56px;
     min-height: 46px;
-  }
-
-  .game-paw-menu-panel {
-    right: 8px;
-    bottom: 88px;
   }
 
   .npc-actions-menu {


### PR DESCRIPTION
### Motivation
- The UI used mixed popup positioning where the NPC interaction menu needed to remain contextual near characters while system-level panels (settings, paw menu) were anchored to buttons and appeared visually detached. 
- The paw menu in particular appeared too far from its trigger and felt disconnected from the game shell. 
- The goal is to standardize behavior so contextual menus remain character-adjacent and system menus open centered in the game shell with a shared visual shell style. 

### Description
- Replaced the paw-button anchored panel with the shared centered overlay by using `GameMenuOverlay` for the paw menu flow so it now opens as a centered system panel (keeps the same menu items and behavior). 
- Updated the overlay/backdrop styles by centralizing the system backdrop (`.game-overlay-backdrop`) and removing the old anchored `.game-paw-menu-panel` positioning so settings and paw menu share the same centered system-popup look. 
- Preserved the NPC interaction menu logic and anchor-position calculation (no changes to the contextual `npc-actions-menu` positioning algorithm). 
- Primary files changed are `src/game/GameModeShell.tsx` and `src/game/gameHud.css` with the paw menu now rendered via `src/game/ui/GameMenuOverlay.tsx` and settings continuing to use `src/game/ui/GameSettingsOverlay.tsx`. 

### Testing
- Ran `npm run build`, which completed successfully and produced the production build. 
- Ran `npm run lint`, which completed with a single pre-existing `react-hooks/exhaustive-deps` warning in `src/pages/CheckinPage.tsx` and reported no new lint errors. 
- Verified there are no new console/lint errors introduced by these changes during the build/lint run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba4cee22788330abd9a218afb18f40)