### PR TITLE
refactor: unify paw-menu popup with settings popup shell, size, and panel quality

### DIFF
--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -456,10 +456,9 @@
 }
 
 .game-overlay-panel {
-  width: min(540px, 100%);
+  width: min(420px, 100%);
   max-height: min(78vh, 700px);
-  overflow: auto;
-  padding: 14px;
+  padding: 16px;
   background: linear-gradient(180deg, #ffece2 0%, #f4cfc5 100%);
   box-shadow:
     inset 0 0 0 2px #fff5ef,
@@ -467,8 +466,10 @@
     0 10px 0 rgba(89, 56, 53, 0.35);
 }
 
-.game-overlay-panel--narrow {
-  width: min(380px, 100%);
+.game-system-modal {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 10px;
 }
 
 .game-overlay-header {
@@ -484,7 +485,7 @@
 }
 
 .game-overlay-close {
-  min-height: 34px;
+  min-height: 36px;
   border: 2px solid var(--game-shell-edge);
   border-radius: 8px;
   background: linear-gradient(180deg, #f9d6d2 0%, #efb5b1 100%);
@@ -492,9 +493,27 @@
     inset 0 1px 0 #ffece8,
     inset 0 -2px 0 #c17f76;
   color: var(--game-text);
-  padding: 4px 10px;
+  padding: 4px 12px;
   font-size: 12px;
   font-weight: 700;
+}
+
+.game-system-modal__header {
+  align-items: flex-start;
+}
+
+.game-system-modal__title-stack {
+  display: grid;
+  gap: 3px;
+}
+
+.game-system-modal__eyebrow {
+  margin: 0;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #7c5650;
 }
 
 .game-overlay-subtitle {
@@ -507,27 +526,114 @@
   line-height: 1.4;
 }
 
-.game-overlay-list {
-  margin-top: 10px;
+.game-system-modal__subtitle {
+  margin-top: 0;
+}
+
+.game-system-modal__content {
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 3px;
+}
+
+.game-system-modal__content--settings {
+  display: block;
+}
+
+.game-system-modal__content--menu {
+  display: block;
+}
+
+.game-system-modal__content::-webkit-scrollbar,
+.game-overlay-list--scrollable::-webkit-scrollbar {
+  width: 10px;
+}
+
+.game-system-modal__content::-webkit-scrollbar-thumb,
+.game-overlay-list--scrollable::-webkit-scrollbar-thumb {
+  border: 2px solid #f9dfd5;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #efb5b1 0%, #d78682 100%);
+}
+
+.game-system-modal__content::-webkit-scrollbar-track,
+.game-overlay-list--scrollable::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(126, 86, 78, 0.12);
+}
+
+.game-system-modal__footer {
+  border: 3px solid var(--game-shell-edge);
+  border-radius: 10px;
+  padding: 9px;
+  background: linear-gradient(180deg, #ffdacc 0%, #f0beb2 100%);
+  box-shadow: inset 0 0 0 2px #ffece3;
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
+}
+
+.game-overlay-list {
+  display: grid;
+  gap: 10px;
+}
+
+.game-overlay-list--scrollable {
+  min-height: 0;
 }
 
 .game-overlay-card,
 .game-shared-settings-entry {
-  border: 2px solid var(--game-shell-edge);
-  border-radius: 8px;
+  border: 3px solid var(--game-shell-edge);
+  border-radius: 10px;
   padding: 10px;
-  background: var(--game-panel-light);
+  background: linear-gradient(180deg, #ffe9de 0%, #f8d4ca 100%);
+  box-shadow:
+    inset 0 0 0 2px #fff6ef,
+    inset 0 -4px 0 rgba(126, 86, 78, 0.22);
+}
+
+.game-overlay-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.game-overlay-card__body {
+  display: grid;
+  gap: 6px;
+}
+
+.game-overlay-card h3,
+.game-overlay-card p {
+  margin: 0;
+}
+
+.game-overlay-card h3 {
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+}
+
+.game-overlay-card p {
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .game-overlay-card__button {
-  width: 100%;
+  min-width: 88px;
   min-height: 40px;
-  border-radius: 8px;
-  border: 2px solid var(--game-shell-edge);
-  background: var(--game-panel-mid);
-  color: var(--game-text);
+  border-radius: 9px;
+  border: 2px solid #6f4a44;
+  background: linear-gradient(180deg, #ffd8de 0%, #ef9fb0 100%);
+  box-shadow:
+    inset 0 1px 0 #ffe7ec,
+    inset 0 -2px 0 rgba(97, 64, 57, 0.6);
+  color: #5e3340;
+  font-size: 12px;
+  font-weight: 800;
+  padding: 7px 12px;
 }
 
 .game-settings-layout {
@@ -589,17 +695,6 @@
   margin: 8px 0 0;
   font-size: 12px;
   line-height: 1.45;
-}
-
-.game-settings-footer {
-  border: 3px solid var(--game-shell-edge);
-  border-radius: 10px;
-  padding: 9px;
-  background: linear-gradient(180deg, #ffdacc 0%, #f0beb2 100%);
-  box-shadow: inset 0 0 0 2px #ffece3;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
 }
 
 .game-settings-action {

--- a/src/game/ui/GameMenuOverlay.tsx
+++ b/src/game/ui/GameMenuOverlay.tsx
@@ -1,3 +1,5 @@
+import GameSystemModal from './GameSystemModal'
+
 export type GameFeatureId = 'snacks' | 'syzygy' | 'checkin' | 'export'
 
 type MenuEntry = {
@@ -20,34 +22,27 @@ const GAME_MENU_ENTRIES: MenuEntry[] = [
 
 const GameMenuOverlay = ({ onClose, onOpenFeature }: GameMenuOverlayProps) => {
   return (
-    <div className="game-overlay-backdrop" role="presentation" onClick={onClose}>
-      <section
-        className="game-overlay-panel"
-        role="dialog"
-        aria-modal="true"
-        aria-label="游戏菜单"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <header className="game-overlay-header">
-          <h2 className="ui-title">游戏菜单</h2>
-          <button type="button" className="ghost" onClick={onClose}>
-            关闭
-          </button>
-        </header>
-        <p className="game-overlay-subtitle">以下入口延续“共享能力 + 游戏模式外壳”的体验。</p>
-        <div className="game-overlay-list">
-          {GAME_MENU_ENTRIES.map((entry) => (
-            <article key={entry.id} className="game-overlay-card">
+    <GameSystemModal
+      title="游戏菜单"
+      ariaLabel="游戏菜单"
+      subtitle="以下入口延续“共享能力 + 游戏模式外壳”的体验。"
+      onClose={onClose}
+      contentClassName="game-system-modal__content--menu"
+    >
+      <div className="game-overlay-list game-overlay-list--scrollable">
+        {GAME_MENU_ENTRIES.map((entry) => (
+          <article key={entry.id} className="game-overlay-card">
+            <div className="game-overlay-card__body">
               <h3>{entry.title}</h3>
               <p>{entry.description}</p>
-              <button type="button" className="game-overlay-card__button" onClick={() => onOpenFeature(entry.id)}>
-                打开
-              </button>
-            </article>
-          ))}
-        </div>
-      </section>
-    </div>
+            </div>
+            <button type="button" className="game-overlay-card__button" onClick={() => onOpenFeature(entry.id)}>
+              打开
+            </button>
+          </article>
+        ))}
+      </div>
+    </GameSystemModal>
   )
 }
 

--- a/src/game/ui/GameSettingsOverlay.tsx
+++ b/src/game/ui/GameSettingsOverlay.tsx
@@ -1,3 +1,5 @@
+import GameSystemModal from './GameSystemModal'
+
 type GameSettingsOverlayProps = {
   onClose: () => void
   onSwitchToPhoneMode: () => void
@@ -8,54 +10,45 @@ const GameSettingsOverlay = ({ onClose, onSwitchToPhoneMode, onOpenSharedSetting
   const placeholderSettings = ['HUD 显示偏好（占位）', '操作方式偏好（占位）', '游戏音效开关（占位）']
 
   return (
-    <div className="game-overlay-backdrop" role="presentation" onClick={onClose}>
-      <section
-        className="game-overlay-panel game-overlay-panel--narrow"
-        role="dialog"
-        aria-modal="true"
-        aria-label="游戏设置"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <header className="game-overlay-header">
-          <h2 className="ui-title">游戏设置</h2>
-          <button type="button" className="game-overlay-close" onClick={onClose}>
-            关闭
+    <GameSystemModal
+      title="游戏设置"
+      ariaLabel="游戏设置"
+      subtitle="这里仅包含游戏侧显示与操作偏好，不包含 AI / 模型 / Prompt 配置。"
+      onClose={onClose}
+      contentClassName="game-system-modal__content--settings"
+      footer={
+        <>
+          <button type="button" className="game-settings-action game-settings-action--secondary" onClick={onClose}>
+            关闭面板
           </button>
-        </header>
-        <p className="game-overlay-subtitle">这里仅包含游戏侧显示与操作偏好，不包含 AI / 模型 / Prompt 配置。</p>
-
-        <div className="game-settings-layout">
-          <section className="game-settings-section" aria-label="游戏侧设置">
-            <p className="game-settings-section__title">游戏侧设置（占位）</p>
-            <div className="game-settings-placeholder-list">
-              {placeholderSettings.map((setting) => (
-                <div key={setting} className="game-settings-placeholder-item" role="presentation">
-                  <span>{setting}</span>
-                  <span className="game-settings-placeholder-item__badge">未开放</span>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="game-settings-section game-settings-section--shared" aria-label="通用设置说明">
-            <p className="game-settings-section__title">通用设置说明</p>
-            <p className="game-shared-settings-entry__text">AI、模型与 Prompt 相关配置继续维护在「通用设置」，本面板不做重复实现。</p>
-            <button type="button" className="game-settings-action game-settings-action--secondary" onClick={onOpenSharedSettings}>
-              前往通用设置
-            </button>
-          </section>
-
-          <div className="game-settings-footer">
-            <button type="button" className="game-settings-action game-settings-action--secondary" onClick={onClose}>
-              关闭面板
-            </button>
-            <button type="button" className="game-settings-action game-settings-action--primary" onClick={onSwitchToPhoneMode}>
-              返回手机模式
-            </button>
+          <button type="button" className="game-settings-action game-settings-action--primary" onClick={onSwitchToPhoneMode}>
+            返回手机模式
+          </button>
+        </>
+      }
+    >
+      <div className="game-settings-layout">
+        <section className="game-settings-section" aria-label="游戏侧设置">
+          <p className="game-settings-section__title">游戏侧设置（占位）</p>
+          <div className="game-settings-placeholder-list">
+            {placeholderSettings.map((setting) => (
+              <div key={setting} className="game-settings-placeholder-item" role="presentation">
+                <span>{setting}</span>
+                <span className="game-settings-placeholder-item__badge">未开放</span>
+              </div>
+            ))}
           </div>
-        </div>
-      </section>
-    </div>
+        </section>
+
+        <section className="game-settings-section game-settings-section--shared" aria-label="通用设置说明">
+          <p className="game-settings-section__title">通用设置说明</p>
+          <p className="game-shared-settings-entry__text">AI、模型与 Prompt 相关配置继续维护在「通用设置」，本面板不做重复实现。</p>
+          <button type="button" className="game-settings-action game-settings-action--secondary" onClick={onOpenSharedSettings}>
+            前往通用设置
+          </button>
+        </section>
+      </div>
+    </GameSystemModal>
   )
 }
 

--- a/src/game/ui/GameSystemModal.tsx
+++ b/src/game/ui/GameSystemModal.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react'
+
+type GameSystemModalProps = {
+  title: string
+  subtitle?: string
+  ariaLabel: string
+  onClose: () => void
+  children: ReactNode
+  footer?: ReactNode
+  contentClassName?: string
+}
+
+const GameSystemModal = ({
+  title,
+  subtitle,
+  ariaLabel,
+  onClose,
+  children,
+  footer,
+  contentClassName,
+}: GameSystemModalProps) => {
+  const contentClasses = ['game-system-modal__content', contentClassName].filter(Boolean).join(' ')
+
+  return (
+    <div className="game-overlay-backdrop" role="presentation" onClick={onClose}>
+      <section
+        className="game-overlay-panel game-system-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="game-overlay-header game-system-modal__header">
+          <div className="game-system-modal__title-stack">
+            <p className="game-system-modal__eyebrow">系统面板</p>
+            <h2 className="ui-title">{title}</h2>
+          </div>
+          <button type="button" className="game-overlay-close" onClick={onClose}>
+            关闭
+          </button>
+        </header>
+        {subtitle ? <p className="game-overlay-subtitle game-system-modal__subtitle">{subtitle}</p> : null}
+        <div className={contentClasses}>{children}</div>
+        {footer ? <footer className="game-system-modal__footer">{footer}</footer> : null}
+      </section>
+    </div>
+  )
+}
+
+export default GameSystemModal


### PR DESCRIPTION
### Motivation
- System-level popups (settings and paw-menu) were visually and spatially inconsistent; both should read as the same UI family while keeping existing behavior and centering intact. 
- The goal is to reuse a single modal shell so both popups share the same shell/panel quality, footprint, and header/close/button rhythm while overflowing content scrolls internally.

### Description
- Added a shared modal shell component at `src/game/ui/GameSystemModal.tsx` and migrated both popups to render inside it so they share the same header, eyebrow/title rhythm, close treatment, content region, and optional footer. 
- Updated `src/game/ui/GameSettingsOverlay.tsx` and `src/game/ui/GameMenuOverlay.tsx` to use `GameSystemModal` and preserved their existing content and feature logic. 
- Unified visual and layout CSS in `src/game/gameHud.css` (modal width changed to `min(420px, 100%)`, consistent shell density/border/shadow, scroll styling, footer/grid, and upgraded card/button styles) so paw-menu matches the settings panel in polish and spacing. 
- Kept centering behavior, NPC contextual menu logic, feature entry behavior, and phone-mode behavior unchanged; overflow now uses an internal scroll region (`.game-system-modal__content`) so the modal size stays stable.

### Testing
- Ran the production build via `npm run build` (which runs `tsc` and `vite build`) and the build completed successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba5777d5b083309034413ad791339c)