### PR TITLE
refactor: unify paw-menu popup with settings popup shell, size, and panel quality

### DIFF
--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -456,14 +456,19 @@
 }
 
 .game-overlay-panel {
-  width: min(420px, 100%);
+  width: min(448px, calc(100vw - 24px));
+  min-height: min(560px, calc(100vh - 32px));
   max-height: min(78vh, 700px);
   padding: 16px;
-  background: linear-gradient(180deg, #ffece2 0%, #f4cfc5 100%);
+  border: 3px solid #714842;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #fff1e8 0%, #f6d4ca 100%);
   box-shadow:
-    inset 0 0 0 2px #fff5ef,
-    inset 0 -6px 0 rgba(126, 86, 78, 0.42),
-    0 10px 0 rgba(89, 56, 53, 0.35);
+    inset 0 0 0 2px #fff7f2,
+    inset 0 0 0 6px rgba(255, 227, 214, 0.72),
+    inset 0 -7px 0 rgba(126, 86, 78, 0.4),
+    0 12px 0 rgba(89, 56, 53, 0.35),
+    0 16px 32px rgba(56, 33, 30, 0.18);
 }
 
 .game-system-modal {
@@ -534,14 +539,18 @@
   min-height: 0;
   overflow-y: auto;
   padding-right: 3px;
+  overscroll-behavior: contain;
 }
 
-.game-system-modal__content--settings {
-  display: block;
-}
-
+.game-system-modal__content--settings,
 .game-system-modal__content--menu {
   display: block;
+}
+
+.game-system-modal__content-shell {
+  display: grid;
+  gap: 10px;
+  padding: 2px 3px 2px 0;
 }
 
 .game-system-modal__content::-webkit-scrollbar,
@@ -600,6 +609,13 @@
   align-items: center;
 }
 
+.game-overlay-card--menu {
+  background: linear-gradient(180deg, #fff0e5 0%, #f7d1c5 100%);
+  box-shadow:
+    inset 0 0 0 2px #fff8f2,
+    inset 0 -4px 0 rgba(126, 86, 78, 0.26);
+}
+
 .game-overlay-card__body {
   display: grid;
   gap: 6px;
@@ -624,16 +640,6 @@
 .game-overlay-card__button {
   min-width: 88px;
   min-height: 40px;
-  border-radius: 9px;
-  border: 2px solid #6f4a44;
-  background: linear-gradient(180deg, #ffd8de 0%, #ef9fb0 100%);
-  box-shadow:
-    inset 0 1px 0 #ffe7ec,
-    inset 0 -2px 0 rgba(97, 64, 57, 0.6);
-  color: #5e3340;
-  font-size: 12px;
-  font-weight: 800;
-  padding: 7px 12px;
 }
 
 .game-settings-layout {
@@ -697,7 +703,8 @@
   line-height: 1.45;
 }
 
-.game-settings-action {
+.game-settings-action,
+.game-overlay-card__button {
   min-height: 40px;
   border: 2px solid #6f4a44;
   border-radius: 9px;
@@ -714,9 +721,24 @@
   background: linear-gradient(180deg, #f8ddd4 0%, #edb8af 100%);
 }
 
-.game-settings-action--primary {
+.game-settings-action--primary,
+.game-overlay-card__button {
   background: linear-gradient(180deg, #ffd7dd 0%, #f09aae 100%);
   color: #5d303c;
+}
+
+.game-menu-section__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.game-menu-section__hint {
+  margin: 8px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #6e4d48;
 }
 
 .game-feature-shell-backdrop {
@@ -792,6 +814,8 @@
   }
 
   .game-overlay-panel {
+    width: min(448px, calc(100vw - 16px));
+    min-height: min(520px, calc(100vh - 16px));
     max-height: min(82vh, 700px);
     padding: 12px;
   }

--- a/src/game/ui/GameMenuOverlay.tsx
+++ b/src/game/ui/GameMenuOverlay.tsx
@@ -29,18 +29,25 @@ const GameMenuOverlay = ({ onClose, onOpenFeature }: GameMenuOverlayProps) => {
       onClose={onClose}
       contentClassName="game-system-modal__content--menu"
     >
-      <div className="game-overlay-list game-overlay-list--scrollable">
-        {GAME_MENU_ENTRIES.map((entry) => (
-          <article key={entry.id} className="game-overlay-card">
-            <div className="game-overlay-card__body">
-              <h3>{entry.title}</h3>
-              <p>{entry.description}</p>
-            </div>
-            <button type="button" className="game-overlay-card__button" onClick={() => onOpenFeature(entry.id)}>
-              打开
-            </button>
-          </article>
-        ))}
+      <div className="game-system-modal__content-shell">
+        <section className="game-settings-section" aria-label="游戏菜单入口">
+          <p className="game-menu-section__title">系统功能入口</p>
+          <p className="game-menu-section__hint">与游戏设置共享同一系统弹窗外壳，保留稳定尺寸，并在内容较多时于内部滚动。</p>
+        </section>
+
+        <div className="game-overlay-list game-overlay-list--scrollable">
+          {GAME_MENU_ENTRIES.map((entry) => (
+            <article key={entry.id} className="game-overlay-card game-overlay-card--menu">
+              <div className="game-overlay-card__body">
+                <h3>{entry.title}</h3>
+                <p>{entry.description}</p>
+              </div>
+              <button type="button" className="game-overlay-card__button" onClick={() => onOpenFeature(entry.id)}>
+                打开
+              </button>
+            </article>
+          ))}
+        </div>
       </div>
     </GameSystemModal>
   )

--- a/src/game/ui/GameSettingsOverlay.tsx
+++ b/src/game/ui/GameSettingsOverlay.tsx
@@ -27,7 +27,7 @@ const GameSettingsOverlay = ({ onClose, onSwitchToPhoneMode, onOpenSharedSetting
         </>
       }
     >
-      <div className="game-settings-layout">
+      <div className="game-system-modal__content-shell game-settings-layout">
         <section className="game-settings-section" aria-label="游戏侧设置">
           <p className="game-settings-section__title">游戏侧设置（占位）</p>
           <div className="game-settings-placeholder-list">


### PR DESCRIPTION
### Motivation
- Unify the visual treatment and modal footprint of the two system-level panels so settings and paw-menu feel like the same UI family. 
- Keep current centering and interaction logic but prevent paw-menu content from changing modal size unexpectedly. 
- Provide a shared internal scroll region so overflow is readable while the modal size remains stable.

### Description
- Updated modal shell styling in `src/game/gameHud.css` to tighten the shell density and visual polish and to set a consistent centered modal footprint (`.game-overlay-panel` sizing, border, radius, shadow and responsive adjustments). 
- Introduced a shared internal content wrapper (`.game-system-modal__content-shell`) and inert-scroll behavior so both overlays keep spacing rhythm while their content can scroll internally. 
- Aligned button and card treatment so paw-menu entries match settings actions (merged action styles into `.game-settings-action, .game-overlay-card__button` and added `.game-overlay-card--menu`) and gave paw-menu an intro section for parity. 
- Changed the paw-menu component `src/game/ui/GameMenuOverlay.tsx` to use the shared content shell and menu card variant while keeping the existing feature entry handlers, and updated `src/game/ui/GameSettingsOverlay.tsx` to wrap its layout with the same content-shell for consistent rhythm. 
- Short notes: settings and paw-menu now both use the same `GameSystemModal` shell; popup size/footprint is unified; overflow uses an internal scroll region; manual checks compared both popups for size, polish, scrolling, and action behavior.

### Testing
- Ran `npm run build`, which completed successfully (Vite reported chunk-size warnings but produced a working build). 
- Ran `npm run lint`, which completed with an existing warning in `src/pages/CheckinPage.tsx:122` about a missing React Hook dependency and no new lint errors introduced by this change. 
- No automated test suites failed related to these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba614eb94c8330a86aab074876583c)