### PR TITLE
fix: rebuild paw feature areas as true game feature modals and restore internal content scrolling

### DIFF
--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -748,10 +748,142 @@
 
 .game-feature-shell {
   width: min(980px, 100%);
-  height: 100%;
+  max-width: min(980px, calc(100vw - 24px));
+  height: min(760px, calc(100vh - 24px));
+  max-height: calc(100vh - 24px);
   display: flex;
   flex-direction: column;
+  gap: 10px;
+  padding: 14px;
   overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 245, 238, 0.98) 0%, rgba(247, 208, 197, 0.98) 100%);
+  box-shadow:
+    inset 0 0 0 2px #fff7f2,
+    inset 0 0 0 7px rgba(255, 229, 218, 0.75),
+    inset 0 -8px 0 rgba(126, 86, 78, 0.32),
+    0 12px 0 rgba(89, 56, 53, 0.35),
+    0 24px 44px rgba(56, 33, 30, 0.24);
+}
+
+.game-feature-shell__utility-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.game-feature-shell__utility-button,
+.game-feature-shell__close-button {
+  min-height: 38px;
+  border: 2px solid var(--game-shell-edge);
+  border-radius: 9px;
+  background: linear-gradient(180deg, #ffe6dc 0%, #f2c1b7 100%);
+  box-shadow:
+    inset 0 1px 0 #fff1eb,
+    inset 0 -2px 0 rgba(113, 72, 66, 0.45);
+  color: var(--game-text);
+  font-size: 12px;
+  font-weight: 800;
+  padding: 7px 12px;
+}
+
+.game-feature-shell__close-button {
+  background: linear-gradient(180deg, #ffd8df 0%, #ef9db0 100%);
+  color: #5d303c;
+}
+
+.game-feature-shell__utility-tag {
+  border: 2px solid #8b665f;
+  border-radius: 999px;
+  background: rgba(255, 240, 233, 0.92);
+  padding: 6px 10px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  color: #7c5650;
+}
+
+.game-feature-shell__header,
+.game-feature-shell__body {
+  min-height: 0;
+  border: 3px solid var(--game-shell-edge);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fff1e8 0%, #f7d5ca 100%);
+  box-shadow:
+    inset 0 0 0 2px #fff7f2,
+    inset 0 -4px 0 rgba(126, 86, 78, 0.18);
+}
+
+.game-feature-shell__header {
+  padding: 14px 16px 12px;
+}
+
+.game-feature-shell__titles {
+  display: grid;
+  gap: 8px;
+}
+
+.game-feature-shell__eyebrow {
+  margin: 0;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #7c5650;
+}
+
+.game-feature-shell__title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.game-feature-shell__title-row .ui-title {
+  margin: 0;
+  font-size: clamp(21px, 3vw, 28px);
+}
+
+.game-feature-shell__subtitle {
+  margin: 0;
+  padding: 10px 12px;
+  border: 2px solid #9a7067;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #ffe4da 0%, #f8cfc5 100%);
+  font-size: 12px;
+  line-height: 1.45;
+  color: #694a45;
+}
+
+.game-feature-shell__body {
+  flex: 1;
+  min-height: 0;
+  padding: 12px;
+  overflow: hidden;
+}
+
+.game-feature-shell__content {
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
+}
+
+.game-feature-shell__content::-webkit-scrollbar {
+  width: 10px;
+}
+
+.game-feature-shell__content::-webkit-scrollbar-thumb {
+  border: 2px solid #f9dfd5;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #efb5b1 0%, #d78682 100%);
+}
+
+.game-feature-shell__content::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(126, 86, 78, 0.12);
 }
 
 @media (max-width: 760px) {
@@ -822,5 +954,30 @@
 
   .game-settings-footer {
     grid-template-columns: 1fr;
+  }
+
+  .game-feature-shell-backdrop {
+    padding: 8px;
+  }
+
+  .game-feature-shell {
+    max-width: calc(100vw - 16px);
+    height: min(100%, calc(100vh - 16px));
+    max-height: calc(100vh - 16px);
+    gap: 8px;
+    padding: 10px;
+  }
+
+  .game-feature-shell__utility-row,
+  .game-feature-shell__title-row {
+    flex-wrap: wrap;
+  }
+
+  .game-feature-shell__header {
+    padding: 12px;
+  }
+
+  .game-feature-shell__body {
+    padding: 9px;
   }
 }

--- a/src/game/ui/GameFeatureShell.tsx
+++ b/src/game/ui/GameFeatureShell.tsx
@@ -10,20 +10,29 @@ type GameFeatureShellProps = {
 const GameFeatureShell = ({ title, subtitle, onBackToGame, children }: GameFeatureShellProps) => {
   return (
     <div className="game-feature-shell" role="dialog" aria-modal="true" aria-label={`${title} 游戏面板`}>
-      <header className="game-feature-shell__header">
-        <button type="button" className="ghost" onClick={onBackToGame}>
+      <div className="game-feature-shell__utility-row">
+        <button type="button" className="game-feature-shell__utility-button" onClick={onBackToGame}>
           返回游戏
         </button>
+        <span className="game-feature-shell__utility-tag">PAW MENU FEATURE AREA</span>
+      </div>
+
+      <header className="game-feature-shell__header">
         <div className="game-feature-shell__titles">
-          <h2 className="ui-title">{title}</h2>
-          <p>{subtitle}</p>
+          <p className="game-feature-shell__eyebrow">系统功能面板</p>
+          <div className="game-feature-shell__title-row">
+            <h2 className="ui-title">{title}</h2>
+            <button type="button" className="game-feature-shell__close-button" onClick={onBackToGame}>
+              关闭
+            </button>
+          </div>
+          <p className="game-feature-shell__subtitle">{subtitle}</p>
         </div>
-        <button type="button" className="primary" onClick={onBackToGame}>
-          关闭
-        </button>
       </header>
 
-      <div className="game-feature-shell__content">{children}</div>
+      <div className="game-feature-shell__body">
+        <div className="game-feature-shell__content">{children}</div>
+      </div>
     </div>
   )
 }

--- a/src/pages/CheckinPage.css
+++ b/src/pages/CheckinPage.css
@@ -9,6 +9,13 @@
   gap: 1rem;
 }
 
+.checkin-page.game-feature-page {
+  min-height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
 .checkin-page-header {
   padding-block: 0.55rem;
 }
@@ -59,6 +66,10 @@
   width: min(760px, 100%);
 }
 
+.checkin-page.game-feature-page .checkin-card.standalone {
+  width: 100%;
+}
+
 .checkin-card {
   border: 1px solid #ffd6e7;
   border-radius: 24px;
@@ -71,6 +82,16 @@
   );
   background-size: 12px 12px;
   box-shadow: 0 20px 35px rgba(92, 92, 92, 0.12);
+}
+
+.checkin-page.game-feature-page .checkin-card {
+  border: 2px solid #8c665e;
+  border-radius: 20px;
+  background:
+    linear-gradient(180deg, rgba(255, 247, 242, 0.96) 0%, rgba(248, 222, 213, 0.96) 100%);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 251, 248, 0.9),
+    inset 0 -5px 0 rgba(126, 86, 78, 0.16);
 }
 
 .checkin-header {
@@ -173,6 +194,12 @@
   background: rgba(255, 255, 255, 0.72);
   border-radius: 18px;
   border: 1px solid rgba(255, 214, 231, 0.8);
+}
+
+.checkin-page.game-feature-page .calendar-panel,
+.checkin-page.game-feature-page .metric-card {
+  border-color: #c99a90;
+  background: rgba(255, 250, 247, 0.9);
 }
 
 .calendar-panel h3 {

--- a/src/pages/ExportPage.css
+++ b/src/pages/ExportPage.css
@@ -7,6 +7,12 @@
   gap: 16px;
 }
 
+.export-page.game-feature-page {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
 .export-header {
   display: flex;
   align-items: center;
@@ -31,6 +37,23 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+}
+
+.export-page.game-feature-page .export-package-card {
+  border: 2px solid #8c665e;
+  border-radius: 20px;
+  background:
+    linear-gradient(180deg, rgba(255, 247, 242, 0.96) 0%, rgba(248, 222, 213, 0.96) 100%);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 251, 248, 0.9),
+    inset 0 -5px 0 rgba(126, 86, 78, 0.16);
+}
+
+.export-page.game-feature-page .export-subsection {
+  padding: 12px;
+  border: 2px solid #c99a90;
+  border-radius: 16px;
+  background: rgba(255, 250, 247, 0.9);
 }
 
 .export-package-card h2 {

--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -10,6 +10,15 @@
   gap: 18px;
 }
 
+.snacks-page.game-feature-page {
+  min-height: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  gap: 14px;
+  background: transparent;
+}
+
 .snacks-header {
   display: flex;
   align-items: center;
@@ -21,6 +30,14 @@
   margin: 0;
 }
 
+.snacks-page.game-feature-page .snacks-header {
+  padding: 4px 2px 0;
+}
+
+.snacks-page.game-feature-page .snacks-header h1 {
+  font-size: 1rem;
+}
+
 
 .profile-header-card {
   position: relative;
@@ -30,6 +47,17 @@
   background: #fff;
   padding: 0 16px 16px;
   box-shadow: 0 10px 24px rgba(255, 214, 231, 0.25);
+}
+
+.snacks-page.game-feature-page .profile-header-card {
+  margin-top: 0;
+  border: 2px solid #8c665e;
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 244, 238, 0.92) 0%, rgba(248, 217, 206, 0.92) 100%);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 250, 247, 0.86),
+    inset 0 -4px 0 rgba(126, 86, 78, 0.14);
 }
 
 .profile-cover-banner {
@@ -93,6 +121,17 @@
   margin-top: 6px;
 }
 
+.snacks-page.game-feature-page .snacks-composer,
+.snacks-page.game-feature-page .snacks-feed {
+  border: 2px solid #8c665e;
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 248, 244, 0.96) 0%, rgba(248, 225, 216, 0.96) 100%);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 251, 248, 0.92),
+    inset 0 -4px 0 rgba(126, 86, 78, 0.16);
+}
+
 .snacks-composer textarea {
   width: 100%;
   resize: vertical;
@@ -140,6 +179,46 @@
     radial-gradient(circle at 1px 1px, #ffd6e7 1.5px, transparent 1.5px),
     radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 1px);
   background-size: 20px 20px, 10px 10px;
+}
+
+.snacks-page.game-feature-page .snacks-feed {
+  margin-top: 0;
+  padding: 14px;
+}
+
+.snacks-page.game-feature-page .post-card {
+  border: 2px solid #8c665e;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #fff8f4 0%, #f8ddd2 100%);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 251, 248, 0.88),
+    inset 0 -4px 0 rgba(126, 86, 78, 0.16);
+}
+
+.snacks-page.game-feature-page .reply-toggle,
+.snacks-page.game-feature-page .reply-composer textarea {
+  border-color: #c99a90;
+  background: rgba(255, 249, 246, 0.94);
+}
+
+.snacks-page.game-feature-page .tips,
+.snacks-page.game-feature-page .error {
+  margin: 0;
+  padding: 10px 12px;
+  border: 2px solid #c99a90;
+  border-radius: 12px;
+  background: rgba(255, 246, 241, 0.9);
+}
+
+@media (max-width: 760px) {
+  .snacks-page.game-feature-page {
+    gap: 12px;
+  }
+
+  .snacks-page.game-feature-page .snacks-feed,
+  .snacks-page.game-feature-page .snacks-composer {
+    padding: 12px;
+  }
 }
 
 .post-card {

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -660,17 +660,26 @@ const SnacksPage = ({ user, snackAiConfig, entryMode = 'phone' }: SnacksPageProp
         </main>
       ) : (
         <>
-          <section className="profile-header-card" aria-label="串串主页头部">
-            <div className="profile-cover-banner" />
-            <div className="profile-avatar-surrogate" aria-hidden="true">
-              <span className="profile-avatar-letter">C</span>
-              <span className="profile-avatar-accent">🐾</span>
-            </div>
-            <div className="profile-meta">
-              <h2 className="profile-title">串串的零食罐罐</h2>
-              <p className="profile-bio">专属于某只小仓鼠的加餐记录</p>
-            </div>
-          </section>
+          {entryMode === 'phone' ? (
+            <section className="profile-header-card" aria-label="串串主页头部">
+              <div className="profile-cover-banner" />
+              <div className="profile-avatar-surrogate" aria-hidden="true">
+                <span className="profile-avatar-letter">C</span>
+                <span className="profile-avatar-accent">🐾</span>
+              </div>
+              <div className="profile-meta">
+                <h2 className="profile-title">串串的零食罐罐</h2>
+                <p className="profile-bio">专属于某只小仓鼠的加餐记录</p>
+              </div>
+            </section>
+          ) : (
+            <section className="profile-header-card" aria-label="零食罐罐功能说明">
+              <div className="profile-meta">
+                <h2 className="profile-title">零食管理站</h2>
+                <p className="profile-bio">在这里记录投喂、回复互动，并在需要时切换到回收站。</p>
+              </div>
+            </section>
+          )}
 
           <section className="snacks-composer">
             <textarea

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -710,17 +710,26 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
         </main>
       ) : (
         <>
-          <section className="profile-header-card" aria-label="Syzygy主页头部">
-            <div className="profile-cover-banner" />
-            <div className="profile-avatar-surrogate" aria-hidden="true">
-              <span className="profile-avatar-letter">S</span>
-              <span className="profile-avatar-accent">❤</span>
-            </div>
-            <div className="profile-meta">
-              <h2 className="profile-title">Syzygy的观察日志</h2>
-              <p className="profile-bio">专属于某只小仓鼠的饲养记录</p>
-            </div>
-          </section>
+          {entryMode === 'phone' ? (
+            <section className="profile-header-card" aria-label="Syzygy主页头部">
+              <div className="profile-cover-banner" />
+              <div className="profile-avatar-surrogate" aria-hidden="true">
+                <span className="profile-avatar-letter">S</span>
+                <span className="profile-avatar-accent">❤</span>
+              </div>
+              <div className="profile-meta">
+                <h2 className="profile-title">Syzygy的观察日志</h2>
+                <p className="profile-bio">专属于某只小仓鼠的饲养记录</p>
+              </div>
+            </section>
+          ) : (
+            <section className="profile-header-card" aria-label="仓鼠观察日志功能说明">
+              <div className="profile-meta">
+                <h2 className="profile-title">观察记录站</h2>
+                <p className="profile-bio">集中发布日志、生成动态，并在同一面板中查看全部回复。</p>
+              </div>
+            </section>
+          )}
 
           <section className="snacks-composer">
             <textarea


### PR DESCRIPTION
### Motivation
- Paw-menu feature areas were opening as large centered panels but still looked like full pages embedded inside a shell and relied on page scrolling, so the UI felt inconsistent with the retro handheld game modal language and long content could not scroll inside the modal.
- The goal is to provide a single shared large game-feature modal shell with unified styling and a stable, scrollable inner content region so feature content feels native to the game shell and internal vertical scrolling works reliably.

### Description
- Rebuilt the shared feature shell layout in `GameFeatureShell` so the modal has a utility row, title row, subtitle, explicit close control, a boxed body and a dedicated scrollable inner content region (`.game-feature-shell__content`).
- Implemented CSS for the large game feature modal in `src/game/gameHud.css` to enforce stable centered sizing, constrained height/max-height, handheld retro palette, and inner `overflow-y: auto` with `min-height: 0`/`flex` constraints to enable internal scrolling.
- Adapted the four paw-menu feature pages (`零食罐罐区`, `仓鼠观察日志`, `打卡`, `数据导出`) so they use the shared shell in game mode by removing redundant outer page chrome and adding `game-feature-page` specific styles in `src/pages/*.{css,tsx}` so content sits naturally inside the modal while preserving phone-mode UI and underlying logic.
- Short notes requested: feature areas were rebuilt as true game feature modals; internal scrolling was fixed at the content-region level; manual verification performed on desktop and narrow/mobile viewports to confirm centered modal, consistent retro shell styling, and internal vertical scrolling for long content in all four features.

### Testing
- Ran the production build via `npm run build`, which runs `tsc` and `vite build`, and the build completed successfully (no type/build errors).
- The build produced normal warnings about chunk size but no failing errors, and automated build steps passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baae86dc58833094db4f0b4bba41bb)