### PR TITLE
refactor: restyle game-mode daily chat and session drawer to match the retro handheld game UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1947,6 +1947,7 @@ const ChatRoute = ({
       />
       <SessionsDrawer
         open={drawerOpen}
+        theme={chatTheme}
         sessions={sessions}
         messageCounts={messageCounts}
         activeSessionId={activeSession.id}

--- a/src/components/SessionsDrawer.css
+++ b/src/components/SessionsDrawer.css
@@ -245,3 +245,183 @@
     gap: 2px;
   }
 }
+
+
+.drawer-scrim--pixel {
+  background: rgba(61, 39, 34, 0.26);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
+.sessions-drawer--pixel {
+  background: linear-gradient(180deg, rgba(255, 241, 232, 0.98) 0%, rgba(246, 212, 202, 0.98) 100%);
+  border-right: 3px solid #714842;
+  border-top-right-radius: 18px;
+  border-bottom-right-radius: 18px;
+  box-shadow:
+    inset 0 0 0 2px #fff7f2,
+    inset 0 0 0 6px rgba(255, 227, 214, 0.72),
+    inset -7px 0 0 rgba(126, 86, 78, 0.28),
+    0 12px 0 rgba(89, 56, 53, 0.32),
+    0 18px 34px rgba(56, 33, 30, 0.2);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.sessions-drawer--pixel::before {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0)),
+    repeating-linear-gradient(
+      180deg,
+      rgba(242, 141, 160, 0.08) 0,
+      rgba(242, 141, 160, 0.08) 12px,
+      rgba(255, 233, 223, 0.08) 12px,
+      rgba(255, 233, 223, 0.08) 24px
+    );
+  opacity: 0.9;
+  filter: none;
+}
+
+.sessions-drawer--pixel .drawer-header {
+  border: 3px solid #7e564e;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, #ffeade 0%, #f6d8ca 100%);
+  box-shadow: inset 0 0 0 2px #fff2e9;
+}
+
+.sessions-drawer--pixel .drawer-header h2 {
+  font-size: 19px;
+}
+
+.sessions-drawer--pixel .syncing {
+  color: #7c5650;
+  font-weight: 700;
+}
+
+.sessions-drawer--pixel .drawer-tabs {
+  gap: 8px;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.sessions-drawer--pixel .drawer-tabs button,
+.sessions-drawer--pixel button.primary,
+.sessions-drawer--pixel button.ghost,
+.sessions-drawer--pixel button.danger,
+.sessions-drawer--pixel .inline-actions button {
+  min-height: 38px;
+  border: 2px solid #6f4a44;
+  border-radius: 9px;
+  box-shadow:
+    inset 0 1px 0 #ffe7e0,
+    inset 0 -2px 0 rgba(97, 64, 57, 0.6);
+  font-weight: 800;
+}
+
+.sessions-drawer--pixel .drawer-tabs button {
+  background: linear-gradient(180deg, #f8ddd4 0%, #edb8af 100%);
+  color: #4a312d;
+  padding: 7px 10px;
+}
+
+.sessions-drawer--pixel .drawer-tabs button.active,
+.sessions-drawer--pixel button.primary {
+  background: linear-gradient(180deg, #ffd7dd 0%, #f09aae 100%);
+  color: #5d303c;
+  border-color: #6f4a44;
+}
+
+.sessions-drawer--pixel button.primary {
+  box-shadow:
+    inset 0 1px 0 #fff0f3,
+    inset 0 -2px 0 rgba(164, 88, 107, 0.55);
+}
+
+.sessions-drawer--pixel .search-input,
+.sessions-drawer--pixel .rename-row input {
+  border: 3px solid #7e564e;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, #fff1e8 0%, #f7d5ca 100%);
+  box-shadow: inset 0 0 0 2px #fff7f2;
+  color: #2f2322;
+}
+
+.sessions-drawer--pixel .search-input:focus,
+.sessions-drawer--pixel .rename-row input:focus {
+  border-color: #cb5f7b;
+  box-shadow: inset 0 0 0 2px #fff7f2, 0 0 0 3px rgba(242, 141, 160, 0.22);
+}
+
+.sessions-drawer--pixel .sessions-list {
+  padding-right: 6px;
+}
+
+.sessions-drawer--pixel .session-row {
+  border: 3px solid #7e564e;
+  border-radius: 12px;
+  padding: 12px;
+  background: linear-gradient(180deg, #ffe9de 0%, #f8d4ca 100%);
+  box-shadow:
+    inset 0 0 0 2px #fff6ef,
+    inset 0 -4px 0 rgba(126, 86, 78, 0.22);
+}
+
+.sessions-drawer--pixel .session-row.active {
+  background: linear-gradient(180deg, #ffe0e5 0%, #f5b2bf 100%);
+  border-color: #714842;
+}
+
+.sessions-drawer--pixel .session-select {
+  align-items: flex-start;
+  color: #2f2322;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sessions-drawer--pixel .session-select span:first-child {
+  width: 100%;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.sessions-drawer--pixel .session-select .count,
+.sessions-drawer--pixel .empty {
+  color: #7c5650;
+}
+
+.sessions-drawer--pixel button.ghost,
+.sessions-drawer--pixel .inline-actions button {
+  background: linear-gradient(180deg, #ffe6dc 0%, #f2c1b7 100%);
+  color: #5a3d37;
+}
+
+.sessions-drawer--pixel button.danger {
+  background: linear-gradient(180deg, #ffd8df 0%, #ef9db0 100%);
+  color: #6d2235;
+}
+
+.sessions-drawer--pixel .sessions-list::-webkit-scrollbar {
+  width: 10px;
+}
+
+.sessions-drawer--pixel .sessions-list::-webkit-scrollbar-thumb {
+  border: 2px solid #f9dfd5;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #efb5b1 0%, #d78682 100%);
+}
+
+.sessions-drawer--pixel .sessions-list::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(126, 86, 78, 0.12);
+}
+
+@media (max-width: 560px) {
+  .sessions-drawer--pixel {
+    width: 94vw;
+    border-top-right-radius: 16px;
+    border-bottom-right-radius: 16px;
+  }
+}

--- a/src/components/SessionsDrawer.tsx
+++ b/src/components/SessionsDrawer.tsx
@@ -5,6 +5,7 @@ import './SessionsDrawer.css'
 
 export type SessionsDrawerProps = {
   open: boolean
+  theme?: 'ios' | 'pixel'
   sessions: ChatSession[]
   messageCounts: Record<string, number>
   activeSessionId?: string
@@ -121,6 +122,7 @@ const SessionsDrawer = ({
   onRenameSession,
   onDeleteSession,
   onArchiveSession,
+  theme = 'ios',
 }: SessionsDrawerProps) => {
   const [search, setSearch] = useState('')
   const [archiveView, setArchiveView] = useState<'active' | 'archived'>('active')
@@ -198,8 +200,8 @@ const SessionsDrawer = ({
 
   return (
     <>
-      <div className={`drawer-scrim ${open ? 'open' : ''}`} onClick={onClose} />
-      <aside className={`sessions-drawer ${open ? 'open' : ''}`}>
+      <div className={`drawer-scrim drawer-scrim--${theme} ${open ? 'open' : ''}`} onClick={onClose} />
+      <aside className={`sessions-drawer sessions-drawer--${theme} ${open ? 'open' : ''}`}>
         <div className="sessions-drawer-content">
           <div className="drawer-header">
             <h2 className="ui-title">会话</h2>

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -758,185 +758,262 @@
 }
 
 .chat-page--pixel {
-  --pixel-border: #334155;
-  --pixel-surface: rgba(15, 23, 42, 0.92);
-  --pixel-panel: rgba(30, 41, 59, 0.92);
-  --pixel-text: #e2e8f0;
-  --pixel-subtle: #94a3b8;
-  background: linear-gradient(180deg, #020617 0%, #0f172a 100%);
+  --pixel-border: #7e564e;
+  --pixel-shadow: #9e6f66;
+  --pixel-panel: linear-gradient(180deg, #fff1e8 0%, #f7d5ca 100%);
+  --pixel-panel-strong: linear-gradient(180deg, #ffe9de 0%, #f8d4ca 100%);
+  --pixel-panel-accent: linear-gradient(180deg, #ffd8df 0%, #ef9db0 100%);
+  --pixel-panel-user: linear-gradient(180deg, #f8d7cb 0%, #f2c0b8 100%);
+  --pixel-text: #2f2322;
+  --pixel-subtle: #7c5650;
+  --pixel-cream: #fff7f2;
+  background:
+    radial-gradient(circle at 12% 0%, #e7c9bf 0%, transparent 32%),
+    radial-gradient(circle at 90% 12%, #f3ddd5 0%, transparent 30%),
+    #d2b0ab;
   color: var(--pixel-text);
 }
 
 .chat-page--pixel .chat-header {
-  border-bottom: 2px solid rgba(71, 85, 105, 0.72);
   padding-bottom: 10px;
 }
 
 .chat-page--pixel .app-shell__header {
-  background: rgba(15, 23, 42, 0.9) !important;
-  backdrop-filter: blur(2px);
+  background: linear-gradient(180deg, #ffeade 0%, #f6d8ca 100%) !important;
+  border-bottom: 3px solid var(--pixel-border);
+  box-shadow: inset 0 0 0 2px #fff2e9;
 }
 
 .chat-page--pixel .chat-header .ghost,
 .chat-page--pixel .return-to-game-button {
-  border-radius: 4px;
-  border: 1px solid rgba(100, 116, 139, 0.7);
-  background: rgba(15, 23, 42, 0.36);
-  color: #dbeafe;
+  min-height: 36px;
+  border-radius: 9px;
+  border: 2px solid #6f4a44;
+  background: linear-gradient(180deg, #ffe6dc 0%, #f2c1b7 100%);
+  box-shadow:
+    inset 0 1px 0 #fff1eb,
+    inset 0 -2px 0 rgba(113, 72, 66, 0.45);
+  color: var(--pixel-text);
+  font-weight: 800;
 }
 
 .chat-page--pixel .chat-header .ghost:hover,
 .chat-page--pixel .return-to-game-button:hover {
-  background: rgba(30, 41, 59, 0.9);
+  background: linear-gradient(180deg, #fff0e6 0%, #f7d0c5 100%);
 }
 
 .chat-page--pixel .header-title .subtitle,
 .chat-page--pixel .model-hint,
 .chat-page--pixel .composer-toggle .toggle-hint,
-.chat-page--pixel .chip-label {
+.chat-page--pixel .chip-label,
+.chat-page--pixel .empty-state,
+.chat-page--pixel .message.in .bubble-meta,
+.chat-page--pixel .message.out .bubble-meta,
+.chat-page--pixel .streaming-status {
   color: var(--pixel-subtle);
+}
+
+.chat-page--pixel .header-menu,
+.chat-page--pixel .actions-menu {
+  background: linear-gradient(180deg, #fff1e8 0%, #f6d4ca 100%);
+  border: 3px solid #714842;
+  border-radius: 12px;
+  box-shadow:
+    inset 0 0 0 2px #fff7f2,
+    inset 0 -6px 0 rgba(126, 86, 78, 0.26),
+    0 12px 22px rgba(56, 33, 30, 0.16);
+}
+
+.chat-page--pixel .actions-menu button,
+.chat-page--pixel .header-menu button {
+  color: var(--pixel-text);
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.chat-page--pixel .actions-menu button:hover,
+.chat-page--pixel .header-menu button:hover {
+  background: rgba(242, 141, 160, 0.16);
 }
 
 .chat-page--pixel .chat-messages {
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82) 0%, rgba(15, 23, 42, 0.95) 100%);
-  border: 1px solid rgba(71, 85, 105, 0.8);
-  border-radius: 8px;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.65);
-}
-
-.chat-page--pixel .empty-state,
-.chat-page--pixel .message.in .bubble-meta,
-.chat-page--pixel .message.out .bubble-meta {
-  color: var(--pixel-subtle);
+  background: linear-gradient(180deg, #d6b4ad 0%, #bf938a 100%);
+  border: 3px solid #714842;
+  border-radius: 18px;
+  box-shadow:
+    inset 0 0 0 3px #6f5b55,
+    inset 0 0 0 6px #a57e75,
+    inset 0 0 0 9px rgba(247, 244, 206, 0.45),
+    0 10px 18px rgba(89, 56, 53, 0.16);
+  padding: 12px 12px calc(18px + env(safe-area-inset-bottom));
 }
 
 .chat-page--pixel .message .bubble {
-  background: var(--pixel-panel);
-  border: 1px solid rgba(100, 116, 139, 0.7);
-  border-radius: 6px;
-  box-shadow: none;
+  max-width: min(78%, 560px);
+  background: var(--pixel-panel-strong);
+  border: 3px solid var(--pixel-border);
+  border-radius: 12px;
+  box-shadow:
+    inset 0 0 0 2px #fff6ef,
+    inset 0 -4px 0 rgba(126, 86, 78, 0.22);
+  color: var(--pixel-text);
 }
 
 .chat-page--pixel .message.out .bubble {
-  background: rgba(30, 58, 138, 0.78);
-  border-color: rgba(147, 197, 253, 0.6);
+  background: var(--pixel-panel-user);
 }
 
 .chat-page--pixel .assistant-markdown,
 .chat-page--pixel .message .bubble p {
-  color: #e2e8f0;
+  color: var(--pixel-text);
 }
 
 .chat-page--pixel .assistant-markdown a,
 .chat-page--pixel .message.out .bubble a {
-  color: #93c5fd;
+  color: #9d3d5a;
+}
+
+.chat-page--pixel .assistant-markdown code {
+  background: rgba(126, 86, 78, 0.12);
+}
+
+.chat-page--pixel .assistant-markdown pre {
+  background: #6f5b55;
+  color: #fff7f2;
 }
 
 .chat-page--pixel .model-tag {
-  color: #bfdbfe;
-  background: rgba(59, 130, 246, 0.2);
-  border-radius: 4px;
+  color: #6d2235;
+  background: rgba(242, 141, 160, 0.18);
+  border: 1px solid rgba(203, 95, 123, 0.25);
+  border-radius: 999px;
 }
 
 .chat-page--pixel .message.out .action-trigger,
 .chat-page--pixel .message .action-trigger {
-  color: #cbd5e1;
+  color: #6e4d48;
 }
 
 .chat-page--pixel .message:hover .action-trigger,
 .chat-page--pixel .message:active .action-trigger,
 .chat-page--pixel .message:focus-within .action-trigger,
 .chat-page--pixel .message .action-trigger[aria-expanded='true'] {
-  background: rgba(30, 41, 59, 0.8);
-  border-color: rgba(100, 116, 139, 0.8);
-}
-
-.chat-page--pixel .actions-menu,
-.chat-page--pixel .header-menu {
-  background: rgba(15, 23, 42, 0.97);
-  border: 1px solid rgba(100, 116, 139, 0.85);
-  border-radius: 6px;
-}
-
-.chat-page--pixel .actions-menu button,
-.chat-page--pixel .header-menu button {
-  color: #e2e8f0;
-  border-radius: 4px;
-}
-
-.chat-page--pixel .actions-menu button:hover,
-.chat-page--pixel .header-menu button:hover {
-  background: rgba(30, 41, 59, 0.95);
+  background: rgba(242, 141, 160, 0.14);
+  border-color: rgba(126, 86, 78, 0.24);
 }
 
 .chat-page--pixel .chat-composer {
-  background: rgba(15, 23, 42, 0.92);
-  border: 1px solid rgba(100, 116, 139, 0.8);
-  border-radius: 8px;
-  box-shadow: none;
-}
-
-.chat-page--pixel .streaming-status {
-  color: var(--pixel-subtle);
+  background: linear-gradient(180deg, rgba(255, 241, 232, 0.98) 0%, rgba(246, 212, 202, 0.98) 100%);
+  border: 3px solid #714842;
+  border-radius: 16px;
+  box-shadow:
+    inset 0 0 0 2px #fff7f2,
+    inset 0 0 0 6px rgba(255, 227, 214, 0.72),
+    inset 0 -7px 0 rgba(126, 86, 78, 0.28),
+    0 10px 20px rgba(56, 33, 30, 0.16);
 }
 
 .chat-page--pixel .model-selector,
 .chat-page--pixel .composer-toggle {
-  border-radius: 4px;
-  border: 1px solid rgba(100, 116, 139, 0.8);
-  background: rgba(30, 41, 59, 0.85);
-  color: #e2e8f0;
+  min-height: 34px;
+  border-radius: 9px;
+  border: 2px solid #6f4a44;
+  background: linear-gradient(180deg, #ffe6dc 0%, #f2c1b7 100%);
+  color: var(--pixel-text);
+  box-shadow:
+    inset 0 1px 0 #fff1eb,
+    inset 0 -2px 0 rgba(113, 72, 66, 0.45);
 }
 
 .chat-page--pixel .model-selector:hover,
 .chat-page--pixel .composer-toggle:hover,
 .chat-page--pixel .model-selector:focus-within,
 .chat-page--pixel .composer-toggle:active {
-  background: rgba(51, 65, 85, 0.9);
+  background: linear-gradient(180deg, #fff0e6 0%, #f7d0c5 100%);
 }
 
 .chat-page--pixel .composer-toggle input {
-  border-color: rgba(148, 163, 184, 0.8);
-  background: rgba(15, 23, 42, 0.9);
+  border-color: #8f6b63;
+  background: rgba(255, 247, 242, 0.9);
 }
 
 .chat-page--pixel .composer-toggle input:checked {
-  background: rgba(30, 64, 175, 0.9);
-  border-color: rgba(96, 165, 250, 0.95);
+  background: rgba(240, 157, 176, 0.9);
+  border-color: #cb5f7b;
 }
 
 .chat-page--pixel .composer-toggle input:checked::after {
-  background: #bfdbfe;
+  background: #fff7f2;
 }
 
 .chat-page--pixel .composer-toggle:has(input:checked) {
-  background: rgba(30, 58, 138, 0.65);
-  border-color: rgba(147, 197, 253, 0.9);
+  background: linear-gradient(180deg, #ffdce3 0%, #f5bcc8 100%);
+  border-color: #cb5f7b;
 }
 
 .chat-page--pixel .textarea-glass {
-  border-radius: 4px;
-  border: 1px solid rgba(100, 116, 139, 0.85);
-  background: rgba(15, 23, 42, 0.95);
-  color: #e2e8f0;
+  border-radius: 10px;
+  border: 3px solid var(--pixel-border);
+  background: var(--pixel-panel);
+  box-shadow: inset 0 0 0 2px var(--pixel-cream);
+  color: var(--pixel-text);
 }
 
 .chat-page--pixel .textarea-glass::placeholder {
-  color: #94a3b8;
+  color: #957069;
 }
 
 .chat-page--pixel .btn-primary {
-  border-radius: 4px;
-  border: 1px solid rgba(147, 197, 253, 0.8);
-  background: linear-gradient(180deg, #2563eb 0%, #1d4ed8 100%);
+  min-height: 46px;
+  border-radius: 10px;
+  border: 2px solid #6f4a44;
+  background: linear-gradient(180deg, #ffd7dd 0%, #f09aae 100%);
+  color: #5d303c;
+  box-shadow:
+    inset 0 1px 0 #fff0f3,
+    inset 0 -2px 0 rgba(164, 88, 107, 0.55);
 }
 
 .chat-page--pixel .timeline-letter-card {
-  background: rgba(15, 23, 42, 0.84);
-  border-color: rgba(100, 116, 139, 0.7);
+  border: 3px solid #7e564e;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fff0e5 0%, #f7d1c5 100%);
+  box-shadow:
+    inset 0 0 0 2px #fff8f2,
+    inset 0 -4px 0 rgba(126, 86, 78, 0.22);
 }
 
+.chat-page--pixel .timeline-letter-card__avatar {
+  background: rgba(242, 141, 160, 0.22);
+}
+
+.chat-page--pixel .timeline-letter-card__model,
 .chat-page--pixel .timeline-letter-card__preview,
 .chat-page--pixel .timeline-letter-card__time {
-  color: #cbd5e1;
+  color: #694a45;
+}
+
+.chat-page--pixel .timeline-letter-card__action {
+  border: 2px solid #6f4a44;
+  background: linear-gradient(180deg, #ffe6dc 0%, #f2c1b7 100%);
+  box-shadow:
+    inset 0 1px 0 #fff1eb,
+    inset 0 -2px 0 rgba(113, 72, 66, 0.45);
+  color: var(--pixel-text);
+}
+
+@media (max-width: 560px) {
+  .chat-page--pixel .chat-messages {
+    border-radius: 16px;
+    padding: 10px 10px calc(14px + env(safe-area-inset-bottom));
+  }
+
+  .chat-page--pixel .message .bubble {
+    max-width: 90%;
+    border-radius: 10px;
+  }
+
+  .chat-page--pixel .chat-composer {
+    border-radius: 14px;
+  }
 }


### PR DESCRIPTION
### Motivation
- The game-mode daily chat UI and left session drawer were still using an older dark-blue/pixel treatment that visually mismatched the new retro handheld game shell. 
- This change aims to complete the Phase 1 visual pass by restyling only the game-mode chat/drawer to match the handheld/pixel UI while preserving all existing chat and session behavior. 

### Description
- Added an optional `theme?: 'ios' | 'pixel'` prop to `SessionsDrawer` and passed the active `chatTheme` from the chat route so presentation changes are scoped to game mode only. 
- Reworked the `chat-page--pixel` rules in `src/pages/ChatPage.css` to replace the dark-blue pixel look with the handheld pink/beige palette, thicker retro borders, framed message area, updated composer, and matching popovers/buttons. 
- Introduced `sessions-drawer--pixel` and `drawer-scrim--pixel` variants in `src/components/SessionsDrawer.css` to restyle the drawer shell, header, tabs, search, session rows, active highlight, actions, and mobile sizing so the drawer reads as part of the same in-game UI family. 
- All chat/session logic (message history, send/streaming flow, model switching, session create/delete/rename/archive, and phone-mode styling) was preserved and only presentation for game-mode was changed. 
- Manual verification summary: on desktop opened daily chat from the character and confirmed the old dark-blue UI is gone and the chat visually matches the handheld shell; opened the left session drawer in game mode, verified the drawer visuals and new-session flow match the game UI and session switching works; on mobile confirmed the game-mode chat/drawer remain readable and touch-friendly and that phone-mode chat/drawer remain unchanged. 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` which finished with no new errors but surfaced a pre-existing warning in `src/pages/CheckinPage.tsx` about a missing `useEffect` dependency. 
- No automated tests were added or changed; this PR is a UI/theming refactor scoped to game-mode presentation only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab62dd7b0833086211c6afccee54b)