### PR TITLE
Add bubble chat input bar component to game bottom bar

### DIFF
--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -350,6 +350,56 @@
   background: linear-gradient(180deg, #ffe5d9 0%, #f7c8bf 100%);
 }
 
+.game-bubble-input-bar {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border: 3px solid var(--game-shell-edge);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #ffe5d9 0%, #f7c8bf 100%);
+  box-shadow: inset 0 0 0 2px #fff2e9;
+}
+
+.game-bubble-input-bar__history-button {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border: 2px solid #6f4a44;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #f8d8ce 0%, #efb8ad 100%);
+  box-shadow:
+    inset 0 1px 0 #ffeae4,
+    inset 0 -2px 0 rgba(97, 64, 57, 0.5);
+  color: #5d303c;
+  font-size: 16px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.game-bubble-input-bar__input {
+  flex: 1;
+  min-width: 0;
+  height: 36px;
+  border: 2px solid var(--game-shell-edge);
+  border-radius: 8px;
+  background: #fff2e9;
+  padding: 0 10px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--game-text);
+  outline: none;
+}
+
+.game-bubble-input-bar__input::placeholder {
+  color: #a07a72;
+  font-size: 12px;
+}
+
 .game-control-button {
   width: clamp(60px, 8vw, 72px);
   height: clamp(48px, 6vw, 56px);
@@ -926,6 +976,26 @@
   .game-bottom-controls {
     gap: 6px;
     padding: 6px;
+  }
+
+  .game-bubble-input-bar {
+    gap: 6px;
+    padding: 6px;
+  }
+
+  .game-bubble-input-bar__history-button {
+    width: 32px;
+    height: 32px;
+    font-size: 14px;
+  }
+
+  .game-bubble-input-bar__input {
+    height: 32px;
+    font-size: 12px;
+  }
+
+  .game-bubble-input-bar__input::placeholder {
+    font-size: 11px;
   }
 
   .game-control-button {

--- a/src/game/ui/GameBottomBar.tsx
+++ b/src/game/ui/GameBottomBar.tsx
@@ -1,3 +1,5 @@
+import GameBubbleInputBar from './GameBubbleInputBar'
+
 type GameBottomBarProps = {
   onOpenPawMenu: () => void
   onOpenSettings: () => void
@@ -21,6 +23,8 @@ const GameBottomBar = ({ onOpenPawMenu, onOpenSettings }: GameBottomBarProps) =>
           <span className="game-dpad-button__arrow game-dpad-button__arrow--down" aria-hidden="true" />
         </button>
       </div>
+
+      <GameBubbleInputBar />
 
       <div className="game-bottom-controls" aria-label="功能控制区">
         <button type="button" className="game-control-button game-control-button--icon" onClick={onOpenSettings} aria-label="打开游戏设置">

--- a/src/game/ui/GameBubbleInputBar.tsx
+++ b/src/game/ui/GameBubbleInputBar.tsx
@@ -1,0 +1,23 @@
+const GameBubbleInputBar = () => {
+  return (
+    <div className="game-bubble-input-bar" aria-label="气泡聊天输入栏">
+      <button
+        type="button"
+        className="game-bubble-input-bar__history-button"
+        aria-label="聊天历史记录"
+      >
+        🕐
+      </button>
+
+      <input
+        type="text"
+        className="game-bubble-input-bar__input"
+        placeholder="跟 Syzygy 说点什么..."
+        readOnly
+        aria-label="气泡聊天输入框"
+      />
+    </div>
+  )
+}
+
+export default GameBubbleInputBar


### PR DESCRIPTION
## Summary
Added a new `GameBubbleInputBar` component to the game interface that displays a chat input area with a history button in the bottom bar.

## Key Changes
- **New Component**: Created `GameBubbleInputBar.tsx` with:
  - A history button (displaying 🕐 emoji) for accessing chat history
  - A read-only text input field with placeholder text "跟 Syzygy 说点什么..." (Talk to Syzygy about something...)
  - Proper accessibility labels in Chinese for screen readers

- **Styling**: Added comprehensive CSS styles in `gameHud.css`:
  - `.game-bubble-input-bar`: Main container with flexbox layout, gradient background, and border styling
  - `.game-bubble-input-bar__history-button`: Styled button with gradient background and shadow effects
  - `.game-bubble-input-bar__input`: Text input with custom styling and placeholder colors
  - Mobile responsive variants that reduce sizing and spacing on smaller screens

- **Integration**: Updated `GameBottomBar.tsx` to:
  - Import and render the new `GameBubbleInputBar` component
  - Position it between the menu section and control buttons

## Implementation Details
- The input field is currently read-only, suggesting this is a UI placeholder for future functionality
- Component uses BEM naming convention for CSS classes
- Includes proper ARIA labels for accessibility
- Responsive design with mobile breakpoint adjustments (gap, padding, and font sizes)
- Consistent styling with existing game UI using gradient backgrounds and inset shadows

https://claude.ai/code/session_01V5WhyBRt2u8cDW1xxmGhpt