### PR TITLE
Add speech bubble chat system with Syzygy NPC

### DIFF
--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser'
 
 export const GAME_EVENTS = {
   OPEN_NPC_ACTIONS: 'open-npc-actions',
+  SYZYGY_POSITION_UPDATE: 'syzygy-position-update',
 } as const
 
 export type OpenNpcActionsPayload = {
@@ -10,6 +11,11 @@ export type OpenNpcActionsPayload = {
     x: number
     y: number
   }
+}
+
+export type SyzygyPositionPayload = {
+  x: number
+  y: number
 }
 
 export const EventBus = new Phaser.Events.EventEmitter()

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -7,15 +7,18 @@ import {
   useState,
 } from "react";
 import type { User } from "@supabase/supabase-js";
-import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload } from "./EventBus";
+import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload, type SyzygyPositionPayload } from "./EventBus";
 import GameHud from "./ui/GameHud";
 import GameMenuOverlay, { type GameFeatureId } from "./ui/GameMenuOverlay";
 import GameSettingsOverlay from "./ui/GameSettingsOverlay";
 import GameFeatureShell from "./ui/GameFeatureShell";
+import SpeechBubbleOverlay from "./ui/SpeechBubbleOverlay";
 import SnacksPage from "../pages/SnacksPage";
 import SyzygyFeedPage from "../pages/SyzygyFeedPage";
 import CheckinPage from "../pages/CheckinPage";
 import ExportPage from "../pages/ExportPage";
+import { supabase } from "../supabase/client";
+import { parseBubbleReply } from "./utils/parseBubbleReply";
 import "./gameHud.css";
 
 type SharedSnackAiConfig = {
@@ -50,6 +53,12 @@ const GAME_FEATURE_META: Record<
   checkin: { title: "打卡", subtitle: "游戏模式面板 · 每日陪伴打卡" },
   export: { title: "数据导出", subtitle: "游戏模式面板 · 导出数据包" },
 };
+
+const BUBBLE_CHAT_SYSTEM_PROMPT = `你是 Syzygy，一只住在仓鼠小窝里的仓鼠伙伴。
+用中文回复，语气温柔、简短、口语化。
+每条回复控制在 1-2 句话，总字数不超过 60 字。
+不要使用 markdown 格式。不要分点。
+如果想表达多个想法，用 ||| 分隔成多条气泡。`
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
@@ -86,6 +95,12 @@ const GameModeShell = ({
     height: NPC_MENU_LAYOUT.estimatedHeight,
   });
 
+  // Bubble chat state
+  const [bubbleSending, setBubbleSending] = useState(false);
+  const [bubbleSegments, setBubbleSegments] = useState<string[]>([]);
+  const [syzygyPos, setSyzygyPos] = useState<SyzygyPositionPayload | null>(null);
+  const bubbleChatHistoryRef = useRef<Array<{ role: 'user' | 'assistant'; content: string }>>([]);
+
   const handleOpenNpcActions = useCallback((payload: OpenNpcActionsPayload) => {
     setActiveNpcMenu(payload);
   }, []);
@@ -107,13 +122,95 @@ const GameModeShell = ({
     setActiveFeature(featureId);
   }, []);
 
+  const handleSyzygyPositionUpdate = useCallback((pos: SyzygyPositionPayload) => {
+    setSyzygyPos(pos);
+  }, []);
+
+  const handleBubbleSend = useCallback(async (text: string) => {
+    if (bubbleSending || !user || !supabase) {
+      return;
+    }
+    setBubbleSending(true);
+    try {
+      const { data } = await supabase.auth.getSession();
+      const accessToken = data.session?.access_token;
+      if (!accessToken) {
+        return;
+      }
+      const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+      if (!anonKey) {
+        return;
+      }
+
+      bubbleChatHistoryRef.current = [
+        ...bubbleChatHistoryRef.current.slice(-10),
+        { role: 'user' as const, content: text },
+      ];
+
+      const response = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            apikey: anonKey,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: snackAiConfig.model,
+            modelId: snackAiConfig.model,
+            module: 'bubble-chat',
+            messages: [
+              { role: 'system', content: BUBBLE_CHAT_SYSTEM_PROMPT },
+              ...bubbleChatHistoryRef.current,
+            ],
+            temperature: 0.8,
+            max_tokens: 200,
+            stream: false,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        console.warn('Bubble chat request failed', response.status);
+        return;
+      }
+
+      const payload = await response.json();
+      const choice = payload?.choices?.[0];
+      const message = choice?.message ?? choice ?? {};
+      const content = typeof message?.content === 'string' ? message.content : '';
+
+      if (content) {
+        bubbleChatHistoryRef.current = [
+          ...bubbleChatHistoryRef.current,
+          { role: 'assistant' as const, content },
+        ];
+        const segments = parseBubbleReply(content);
+        if (segments.length > 0) {
+          setBubbleSegments(segments);
+        }
+      }
+    } catch (error) {
+      console.warn('Bubble chat error', error);
+    } finally {
+      setBubbleSending(false);
+    }
+  }, [bubbleSending, user, snackAiConfig.model]);
+
+  const handleBubbleDismiss = useCallback(() => {
+    setBubbleSegments([]);
+  }, []);
+
   useEffect(() => {
     EventBus.on(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions);
+    EventBus.on(GAME_EVENTS.SYZYGY_POSITION_UPDATE, handleSyzygyPositionUpdate);
 
     return () => {
       EventBus.off(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions);
+      EventBus.off(GAME_EVENTS.SYZYGY_POSITION_UPDATE, handleSyzygyPositionUpdate);
     };
-  }, [handleOpenNpcActions]);
+  }, [handleOpenNpcActions, handleSyzygyPositionUpdate]);
 
   useEffect(() => {
     if (!activeNpcMenu) {
@@ -233,7 +330,18 @@ const GameModeShell = ({
         <GameHud
           onOpenPawMenu={() => setIsPawMenuOpen((open) => !open)}
           onOpenSettings={() => setIsSettingsOpen(true)}
+          onBubbleSend={handleBubbleSend}
+          bubbleSending={bubbleSending}
         />
+
+        {bubbleSegments.length > 0 && syzygyPos ? (
+          <SpeechBubbleOverlay
+            segments={bubbleSegments}
+            anchorX={syzygyPos.x}
+            anchorY={syzygyPos.y}
+            onDismiss={handleBubbleDismiss}
+          />
+        ) : null}
 
         {activeNpcMenu && npcMenuPosition ? (
           <div className="npc-actions-layer" role="presentation">

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -1051,3 +1051,123 @@
     padding: 9px;
   }
 }
+
+/* ── Send button in bubble input bar ── */
+
+.game-bubble-input-bar__send-button {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border: 2px solid #6f4a44;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #ffd8de 0%, #f29fb2 100%);
+  box-shadow:
+    inset 0 1px 0 #ffeae4,
+    inset 0 -2px 0 rgba(97, 64, 57, 0.5);
+  color: #5d303c;
+  font-size: 16px;
+  font-weight: 700;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.game-bubble-input-bar__send-button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+/* ── Speech bubble overlay ── */
+
+.speech-bubble-overlay {
+  position: fixed;
+  z-index: 35;
+  transform: translate(-50%, -100%);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: min(280px, calc(100vw - 32px));
+  animation: bubble-appear 0.25s ease-out;
+}
+
+.speech-bubble {
+  position: relative;
+  padding: 10px 14px;
+  border: 3px solid var(--game-shell-edge);
+  border-radius: 14px;
+  background: linear-gradient(180deg, #fff5ee 0%, #f8ddd4 100%);
+  box-shadow:
+    inset 0 0 0 2px #fff9f4,
+    0 4px 8px rgba(56, 33, 30, 0.18);
+  color: var(--game-text);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+  text-align: center;
+  word-break: break-word;
+}
+
+.speech-bubble__text {
+  display: block;
+}
+
+.speech-bubble__counter {
+  display: block;
+  margin-top: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  color: #9a7067;
+  letter-spacing: 0.06em;
+}
+
+.speech-bubble__tail {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 10px 8px 0;
+  border-color: var(--game-shell-edge) transparent transparent transparent;
+  position: relative;
+}
+
+.speech-bubble__tail::after {
+  content: '';
+  position: absolute;
+  top: -13px;
+  left: -6px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 8px 6px 0;
+  border-color: #f8ddd4 transparent transparent transparent;
+}
+
+@keyframes bubble-appear {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -90%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -100%);
+  }
+}
+
+@media (max-width: 760px) {
+  .game-bubble-input-bar__send-button {
+    width: 32px;
+    height: 32px;
+    font-size: 14px;
+  }
+
+  .speech-bubble-overlay {
+    max-width: min(220px, calc(100vw - 24px));
+  }
+
+  .speech-bubble {
+    padding: 8px 10px;
+    font-size: 12px;
+    border-radius: 11px;
+  }
+}

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -35,6 +35,22 @@ export class HomeScene extends Phaser.Scene {
     this.load.image(SYZYGY_KEY, `${assetBase}syzygy1.png`)
   }
 
+  private emitSyzygyPosition() {
+    if (!this.syzygySprite) {
+      return
+    }
+    const bounds = this.syzygySprite.getBounds()
+    const canvas = this.game.canvas
+    const canvasRect = canvas.getBoundingClientRect()
+    const scaleX = canvasRect.width / this.scale.width
+    const scaleY = canvasRect.height / this.scale.height
+
+    EventBus.emit(GAME_EVENTS.SYZYGY_POSITION_UPDATE, {
+      x: canvasRect.left + (bounds.x + bounds.width * 0.5) * scaleX,
+      y: canvasRect.top + bounds.top * scaleY,
+    })
+  }
+
   create() {
     const { width, height } = this.scale
 
@@ -71,5 +87,8 @@ export class HomeScene extends Phaser.Scene {
         anchor: this.getSpriteScreenAnchor(this.syzygySprite),
       })
     })
+
+    this.emitSyzygyPosition()
+    this.scale.on('resize', () => this.emitSyzygyPosition())
   }
 }

--- a/src/game/ui/GameBottomBar.tsx
+++ b/src/game/ui/GameBottomBar.tsx
@@ -3,9 +3,11 @@ import GameBubbleInputBar from './GameBubbleInputBar'
 type GameBottomBarProps = {
   onOpenPawMenu: () => void
   onOpenSettings: () => void
+  onBubbleSend: (text: string) => void
+  bubbleSending: boolean
 }
 
-const GameBottomBar = ({ onOpenPawMenu, onOpenSettings }: GameBottomBarProps) => {
+const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, bubbleSending }: GameBottomBarProps) => {
   return (
     <footer className="game-bottom-bar" aria-label="游戏操作栏">
       <div className="game-direction-pad" aria-label="方向控制（占位）">
@@ -24,7 +26,7 @@ const GameBottomBar = ({ onOpenPawMenu, onOpenSettings }: GameBottomBarProps) =>
         </button>
       </div>
 
-      <GameBubbleInputBar />
+      <GameBubbleInputBar onSend={onBubbleSend} disabled={bubbleSending} />
 
       <div className="game-bottom-controls" aria-label="功能控制区">
         <button type="button" className="game-control-button game-control-button--icon" onClick={onOpenSettings} aria-label="打开游戏设置">

--- a/src/game/ui/GameBubbleInputBar.tsx
+++ b/src/game/ui/GameBubbleInputBar.tsx
@@ -1,10 +1,48 @@
-const GameBubbleInputBar = () => {
+import { useState, type FormEvent, type KeyboardEvent } from 'react'
+
+type GameBubbleInputBarProps = {
+  onSend: (text: string) => void
+  disabled?: boolean
+}
+
+const GameBubbleInputBar = ({ onSend, disabled }: GameBubbleInputBarProps) => {
+  const [draft, setDraft] = useState('')
+
+  const submit = () => {
+    const trimmed = draft.trim()
+    if (!trimmed || disabled) {
+      return
+    }
+    onSend(trimmed)
+    setDraft('')
+  }
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    submit()
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) {
+      return
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      submit()
+    }
+  }
+
   return (
-    <div className="game-bubble-input-bar" aria-label="气泡聊天输入栏">
+    <form
+      className="game-bubble-input-bar"
+      aria-label="气泡聊天输入栏"
+      onSubmit={handleSubmit}
+    >
       <button
         type="button"
         className="game-bubble-input-bar__history-button"
         aria-label="聊天历史记录"
+        disabled
       >
         🕐
       </button>
@@ -13,10 +51,22 @@ const GameBubbleInputBar = () => {
         type="text"
         className="game-bubble-input-bar__input"
         placeholder="跟 Syzygy 说点什么..."
-        readOnly
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
         aria-label="气泡聊天输入框"
       />
-    </div>
+
+      <button
+        type="submit"
+        className="game-bubble-input-bar__send-button"
+        disabled={disabled || !draft.trim()}
+        aria-label="发送消息"
+      >
+        {disabled ? '…' : '→'}
+      </button>
+    </form>
   )
 }
 

--- a/src/game/ui/GameHud.tsx
+++ b/src/game/ui/GameHud.tsx
@@ -5,9 +5,11 @@ import GameTopBar from './GameTopBar'
 type GameHudProps = {
   onOpenPawMenu: () => void
   onOpenSettings: () => void
+  onBubbleSend: (text: string) => void
+  bubbleSending: boolean
 }
 
-const GameHud = ({ onOpenPawMenu, onOpenSettings }: GameHudProps) => {
+const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, bubbleSending }: GameHudProps) => {
   return (
     <div className="game-hud-layout" aria-label="游戏模式主布局">
       <GameTopBar stamina={30} maxStamina={100} level={1} exp={45} maxExp={100} />
@@ -16,7 +18,12 @@ const GameHud = ({ onOpenPawMenu, onOpenSettings }: GameHudProps) => {
           <GameContainer />
         </div>
       </section>
-      <GameBottomBar onOpenPawMenu={onOpenPawMenu} onOpenSettings={onOpenSettings} />
+      <GameBottomBar
+        onOpenPawMenu={onOpenPawMenu}
+        onOpenSettings={onOpenSettings}
+        onBubbleSend={onBubbleSend}
+        bubbleSending={bubbleSending}
+      />
     </div>
   )
 }

--- a/src/game/ui/SpeechBubbleOverlay.tsx
+++ b/src/game/ui/SpeechBubbleOverlay.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useState } from 'react'
+
+type SpeechBubbleOverlayProps = {
+  segments: string[]
+  anchorX: number
+  anchorY: number
+  onDismiss: () => void
+}
+
+const BUBBLE_DISPLAY_MS = 4000
+const BUBBLE_PER_CHAR_MS = 80
+const MIN_DISPLAY_MS = 2500
+
+const computeDisplayTime = (text: string) =>
+  Math.max(MIN_DISPLAY_MS, BUBBLE_DISPLAY_MS + text.length * BUBBLE_PER_CHAR_MS)
+
+const SpeechBubbleSequence = ({
+  segments,
+  onDismiss,
+}: {
+  segments: string[]
+  onDismiss: () => void
+}) => {
+  const [visibleIndex, setVisibleIndex] = useState(0)
+
+  useEffect(() => {
+    if (segments.length === 0) {
+      return
+    }
+    if (visibleIndex >= segments.length) {
+      onDismiss()
+      return
+    }
+    const duration = computeDisplayTime(segments[visibleIndex])
+    const timer = window.setTimeout(() => {
+      setVisibleIndex((i) => i + 1)
+    }, duration)
+    return () => window.clearTimeout(timer)
+  }, [segments, visibleIndex, onDismiss])
+
+  if (segments.length === 0 || visibleIndex >= segments.length) {
+    return null
+  }
+
+  const currentText = segments[visibleIndex]
+
+  return (
+    <>
+      <div className="speech-bubble">
+        <span className="speech-bubble__text">{currentText}</span>
+        {segments.length > 1 ? (
+          <span className="speech-bubble__counter">
+            {visibleIndex + 1}/{segments.length}
+          </span>
+        ) : null}
+      </div>
+      <div className="speech-bubble__tail" aria-hidden="true" />
+    </>
+  )
+}
+
+const SpeechBubbleOverlay = ({
+  segments,
+  anchorX,
+  anchorY,
+  onDismiss,
+}: SpeechBubbleOverlayProps) => {
+  const sequenceKey = useMemo(() => segments.join('\n'), [segments])
+
+  if (segments.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className="speech-bubble-overlay"
+      style={{
+        left: `${anchorX}px`,
+        top: `${anchorY}px`,
+      }}
+      role="status"
+      aria-live="polite"
+      aria-label="Syzygy 的回复"
+    >
+      <SpeechBubbleSequence
+        key={sequenceKey}
+        segments={segments}
+        onDismiss={onDismiss}
+      />
+    </div>
+  )
+}
+
+export default SpeechBubbleOverlay

--- a/src/game/utils/parseBubbleReply.ts
+++ b/src/game/utils/parseBubbleReply.ts
@@ -1,0 +1,15 @@
+const ACTION_TAG_PATTERN = /\[action:\s*[^\]]*\]/gi
+
+export const parseBubbleReply = (raw: string): string[] => {
+  const stripped = raw.replace(ACTION_TAG_PATTERN, '').trim()
+  if (!stripped) {
+    return []
+  }
+  if (!stripped.includes('|||')) {
+    return [stripped]
+  }
+  return stripped
+    .split('|||')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+}


### PR DESCRIPTION
## Summary
Implements an interactive speech bubble chat system that allows players to communicate with Syzygy, the hamster NPC. Messages are sent to an AI backend (OpenRouter) and responses are displayed as animated speech bubbles positioned above the character.

## Key Changes

- **Speech Bubble UI Components**
  - Added `SpeechBubbleOverlay.tsx` component that displays AI responses in styled speech bubbles with tail pointer
  - Implements sequential display of multi-segment responses with configurable timing (base 4s + 80ms per character)
  - Includes accessibility features (ARIA live region, semantic HTML)

- **Input Bar Enhancement**
  - Converted `GameBubbleInputBar.tsx` from static placeholder to functional component
  - Added text input with Enter key submission support
  - Implemented send button with loading state and disabled state management
  - Proper form handling with IME composition awareness

- **Chat Logic & State Management**
  - Added bubble chat state in `GameModeShell.tsx` (sending status, segments, position)
  - Implemented `handleBubbleSend()` to call OpenRouter API with system prompt
  - Maintains conversation history (last 10 messages) for context
  - Parses AI responses using `parseBubbleReply()` utility to split multi-bubble messages (delimited by `|||`)

- **Position Tracking**
  - Added `SYZYGY_POSITION_UPDATE` event to EventBus
  - `HomeScene.ts` emits Syzygy's screen-space position on creation and window resize
  - Speech bubbles anchor to character position with proper coordinate transformation

- **Styling**
  - Added comprehensive CSS for send button (36px, gradient background, disabled state)
  - Styled speech bubble container with border, gradient fill, and animated appearance
  - Responsive design with mobile breakpoints (760px)
  - Bubble tail created with CSS borders and pseudo-element overlay

## Implementation Details

- System prompt configured for Syzygy character (Chinese, gentle tone, 1-2 sentences max, 60 char limit)
- Response parsing strips action tags and handles multi-segment responses
- Display duration scales with text length (minimum 2.5s, +80ms per character)
- Conversation history maintained in ref to survive re-renders
- Proper cleanup of event listeners and timers

https://claude.ai/code/session_015iFJLUYLBDeP9PgPcxEfPT