### PR TITLE
Add bubble chat history modal with localStorage persistence

### DIFF
--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -19,6 +19,8 @@ import CheckinPage from "../pages/CheckinPage";
 import ExportPage from "../pages/ExportPage";
 import { supabase } from "../supabase/client";
 import { parseBubbleReply } from "./utils/parseBubbleReply";
+import { appendEntry } from "./utils/bubbleChatHistory";
+import BubbleChatHistoryModal from "./ui/BubbleChatHistoryModal";
 import "./gameHud.css";
 
 type SharedSnackAiConfig = {
@@ -96,6 +98,7 @@ const GameModeShell = ({
   });
 
   // Bubble chat state
+  const [isBubbleHistoryOpen, setIsBubbleHistoryOpen] = useState(false);
   const [bubbleSending, setBubbleSending] = useState(false);
   const [bubbleSegments, setBubbleSegments] = useState<string[]>([]);
   const [syzygyPos, setSyzygyPos] = useState<SyzygyPositionPayload | null>(null);
@@ -146,6 +149,7 @@ const GameModeShell = ({
         ...bubbleChatHistoryRef.current.slice(-10),
         { role: 'user' as const, content: text },
       ];
+      appendEntry('user', text);
 
       const response = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,
@@ -186,6 +190,7 @@ const GameModeShell = ({
           ...bubbleChatHistoryRef.current,
           { role: 'assistant' as const, content },
         ];
+        appendEntry('assistant', content);
         const segments = parseBubbleReply(content);
         if (segments.length > 0) {
           setBubbleSegments(segments);
@@ -331,6 +336,7 @@ const GameModeShell = ({
           onOpenPawMenu={() => setIsPawMenuOpen((open) => !open)}
           onOpenSettings={() => setIsSettingsOpen(true)}
           onBubbleSend={handleBubbleSend}
+          onOpenBubbleHistory={() => setIsBubbleHistoryOpen(true)}
           bubbleSending={bubbleSending}
         />
 
@@ -389,6 +395,12 @@ const GameModeShell = ({
             onClose={() => setIsSettingsOpen(false)}
             onSwitchToPhoneMode={onSwitchToPhoneMode}
             onOpenSharedSettings={onOpenSharedSettings}
+          />
+        ) : null}
+
+        {isBubbleHistoryOpen ? (
+          <BubbleChatHistoryModal
+            onClose={() => setIsBubbleHistoryOpen(false)}
           />
         ) : null}
 

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -1154,6 +1154,99 @@
   }
 }
 
+/* ── Bubble chat history modal ── */
+
+.game-system-modal__content--history {
+  display: block;
+}
+
+.bubble-history-empty {
+  display: grid;
+  place-items: center;
+  gap: 6px;
+  padding: 40px 16px;
+  text-align: center;
+}
+
+.bubble-history-empty__icon {
+  margin: 0;
+  font-size: 32px;
+}
+
+.bubble-history-empty__text {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--game-text);
+}
+
+.bubble-history-empty__hint {
+  margin: 0;
+  font-size: 12px;
+  color: #8a6860;
+  line-height: 1.4;
+}
+
+.bubble-history-list {
+  display: grid;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.bubble-history-entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 8px;
+  padding: 10px 12px;
+  border: 2px solid #9a7067;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #fff0e8 0%, #f8d8ce 100%);
+  box-shadow: inset 0 0 0 1px #fff6ef;
+}
+
+.bubble-history-entry--assistant {
+  background: linear-gradient(180deg, #fde4e6 0%, #f5c8cc 100%);
+  border-color: #b07a7e;
+}
+
+.bubble-history-entry__role {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: #7c5650;
+}
+
+.bubble-history-entry--assistant .bubble-history-entry__role {
+  color: #8a4e5a;
+}
+
+.bubble-history-entry__time {
+  font-size: 10px;
+  font-weight: 600;
+  color: #a08078;
+  text-align: right;
+}
+
+.bubble-history-entry__content {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+  color: var(--game-text);
+  word-break: break-word;
+}
+
+@media (max-width: 760px) {
+  .bubble-history-entry {
+    padding: 8px 10px;
+  }
+
+  .bubble-history-entry__content {
+    font-size: 12px;
+  }
+}
+
 @media (max-width: 760px) {
   .game-bubble-input-bar__send-button {
     width: 32px;

--- a/src/game/ui/BubbleChatHistoryModal.tsx
+++ b/src/game/ui/BubbleChatHistoryModal.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+import GameSystemModal from './GameSystemModal'
+import { getTodayEntries, type BubbleChatEntry } from '../utils/bubbleChatHistory'
+
+type BubbleChatHistoryModalProps = {
+  onClose: () => void
+}
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp)
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${hours}:${minutes}`
+}
+
+function formatDateHeading(): string {
+  const now = new Date()
+  const month = now.getMonth() + 1
+  const day = now.getDate()
+  return `${month}月${day}日`
+}
+
+const BubbleChatHistoryModal = ({ onClose }: BubbleChatHistoryModalProps) => {
+  const [entries, setEntries] = useState<BubbleChatEntry[]>([])
+
+  useEffect(() => {
+    setEntries(getTodayEntries())
+  }, [])
+
+  return (
+    <GameSystemModal
+      title="今日闲聊记录"
+      subtitle={`${formatDateHeading()} · 气泡聊天记录`}
+      ariaLabel="气泡聊天历史记录"
+      onClose={onClose}
+      contentClassName="game-system-modal__content--history"
+    >
+      {entries.length === 0 ? (
+        <div className="bubble-history-empty">
+          <p className="bubble-history-empty__icon">💬</p>
+          <p className="bubble-history-empty__text">
+            今天还没有聊天记录哦
+          </p>
+          <p className="bubble-history-empty__hint">
+            在下方输入栏跟 Syzygy 说点什么吧
+          </p>
+        </div>
+      ) : (
+        <div className="bubble-history-list">
+          {entries.map((entry, index) => (
+            <div
+              key={index}
+              className={`bubble-history-entry bubble-history-entry--${entry.role}`}
+            >
+              <span className="bubble-history-entry__role">
+                {entry.role === 'user' ? '你' : 'Syzygy'}
+              </span>
+              <span className="bubble-history-entry__time">
+                {formatTime(entry.timestamp)}
+              </span>
+              <p className="bubble-history-entry__content">{entry.content}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </GameSystemModal>
+  )
+}
+
+export default BubbleChatHistoryModal

--- a/src/game/ui/GameBottomBar.tsx
+++ b/src/game/ui/GameBottomBar.tsx
@@ -4,10 +4,11 @@ type GameBottomBarProps = {
   onOpenPawMenu: () => void
   onOpenSettings: () => void
   onBubbleSend: (text: string) => void
+  onOpenBubbleHistory: () => void
   bubbleSending: boolean
 }
 
-const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, bubbleSending }: GameBottomBarProps) => {
+const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending }: GameBottomBarProps) => {
   return (
     <footer className="game-bottom-bar" aria-label="游戏操作栏">
       <div className="game-direction-pad" aria-label="方向控制（占位）">
@@ -26,7 +27,7 @@ const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, bubbleSend
         </button>
       </div>
 
-      <GameBubbleInputBar onSend={onBubbleSend} disabled={bubbleSending} />
+      <GameBubbleInputBar onSend={onBubbleSend} onOpenHistory={onOpenBubbleHistory} disabled={bubbleSending} />
 
       <div className="game-bottom-controls" aria-label="功能控制区">
         <button type="button" className="game-control-button game-control-button--icon" onClick={onOpenSettings} aria-label="打开游戏设置">

--- a/src/game/ui/GameBubbleInputBar.tsx
+++ b/src/game/ui/GameBubbleInputBar.tsx
@@ -2,10 +2,11 @@ import { useState, type FormEvent, type KeyboardEvent } from 'react'
 
 type GameBubbleInputBarProps = {
   onSend: (text: string) => void
+  onOpenHistory: () => void
   disabled?: boolean
 }
 
-const GameBubbleInputBar = ({ onSend, disabled }: GameBubbleInputBarProps) => {
+const GameBubbleInputBar = ({ onSend, onOpenHistory, disabled }: GameBubbleInputBarProps) => {
   const [draft, setDraft] = useState('')
 
   const submit = () => {
@@ -42,7 +43,7 @@ const GameBubbleInputBar = ({ onSend, disabled }: GameBubbleInputBarProps) => {
         type="button"
         className="game-bubble-input-bar__history-button"
         aria-label="聊天历史记录"
-        disabled
+        onClick={onOpenHistory}
       >
         🕐
       </button>

--- a/src/game/ui/GameHud.tsx
+++ b/src/game/ui/GameHud.tsx
@@ -6,10 +6,11 @@ type GameHudProps = {
   onOpenPawMenu: () => void
   onOpenSettings: () => void
   onBubbleSend: (text: string) => void
+  onOpenBubbleHistory: () => void
   bubbleSending: boolean
 }
 
-const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, bubbleSending }: GameHudProps) => {
+const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending }: GameHudProps) => {
   return (
     <div className="game-hud-layout" aria-label="游戏模式主布局">
       <GameTopBar stamina={30} maxStamina={100} level={1} exp={45} maxExp={100} />
@@ -22,6 +23,7 @@ const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, bubbleSending }:
         onOpenPawMenu={onOpenPawMenu}
         onOpenSettings={onOpenSettings}
         onBubbleSend={onBubbleSend}
+        onOpenBubbleHistory={onOpenBubbleHistory}
         bubbleSending={bubbleSending}
       />
     </div>

--- a/src/game/utils/bubbleChatHistory.ts
+++ b/src/game/utils/bubbleChatHistory.ts
@@ -1,0 +1,47 @@
+const STORAGE_KEY = 'hamster-nest:bubble-chat-history'
+
+export type BubbleChatEntry = {
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: number
+}
+
+function loadAll(): BubbleChatEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) {
+      return []
+    }
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function saveAll(entries: BubbleChatEntry[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+  } catch {
+    // storage full – silently drop
+  }
+}
+
+function startOfToday(): number {
+  const now = new Date()
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+}
+
+export function getTodayEntries(): BubbleChatEntry[] {
+  const cutoff = startOfToday()
+  return loadAll().filter((entry) => entry.timestamp >= cutoff)
+}
+
+export function appendEntry(role: BubbleChatEntry['role'], content: string): void {
+  const all = loadAll()
+  all.push({ role, content, timestamp: Date.now() })
+
+  // keep at most 200 entries to avoid unbounded growth
+  const trimmed = all.length > 200 ? all.slice(all.length - 200) : all
+  saveAll(trimmed)
+}


### PR DESCRIPTION
## Summary
This PR adds a chat history feature for bubble chat conversations, allowing users to view today's chat history in a dedicated modal. Chat entries are persisted to localStorage and can be accessed via a history button in the chat input bar.

## Key Changes
- **New utility module** (`bubbleChatHistory.ts`): Manages localStorage persistence of chat entries with automatic trimming to 200 entries to prevent unbounded growth
- **New modal component** (`BubbleChatHistoryModal.tsx`): Displays today's chat history with formatted timestamps and role indicators, includes empty state with helpful hint
- **Styling** (`gameHud.css`): Added comprehensive styles for the history modal including entry cards with different styling for user vs assistant messages, responsive design for mobile
- **Integration**: 
  - Modified `GameModeShell.tsx` to capture chat entries via `appendEntry()` calls when messages are sent/received
  - Updated `GameBottomBar.tsx`, `GameBubbleInputBar.tsx`, and `GameHud.tsx` to wire up the history modal open handler
  - Enabled the previously disabled history button (🕐) in the input bar

## Implementation Details
- Chat entries are stored with role ('user' or 'assistant'), content, and timestamp
- `getTodayEntries()` filters entries from the start of the current day
- Time display uses 24-hour format (HH:MM)
- Empty state shows a chat bubble emoji with encouraging message
- History entries are styled with gradient backgrounds (warm tone for user, pink tone for assistant)
- Mobile responsive with adjusted padding and font sizes for screens ≤760px

https://claude.ai/code/session_01B4u62VWdp57mEh3VCWZAHx