### PR TITLE
Add bubble chat settings configuration for Game Mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   saveSyzygyPostSystemPrompt,
   saveSyzygyReplySystemPrompt,
   saveLetterReplySystemPrompt,
+  saveBubbleChatSettings,
   updateUserSettings,
 } from './storage/userSettings'
 import { formatLocalTimestamp } from './utils/time'
@@ -66,6 +67,7 @@ import {
   resolveSyzygyPostPrompt,
   resolveSyzygyReplyPrompt,
   resolveLetterReplyPrompt,
+  resolveBubbleChatPrompt,
 } from './constants/aiOverlays'
 import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
 
@@ -275,6 +277,12 @@ const App = () => {
     ...feedAiConfigBase,
     model: resolveModelId('syzygy', { defaultModelId }),
   }), [defaultModelId, feedAiConfigBase])
+  const bubbleChatConfig = useMemo(() => ({
+    model: activeSettings.bubbleChatModel?.trim() || resolveModelId('snack', { defaultModelId }),
+    systemPrompt: resolveBubbleChatPrompt(activeSettings.bubbleChatSystemPrompt),
+    temperature: activeSettings.bubbleChatTemperature,
+    maxTokens: activeSettings.bubbleChatMaxTokens,
+  }), [activeSettings.bubbleChatModel, activeSettings.bubbleChatSystemPrompt, activeSettings.bubbleChatTemperature, activeSettings.bubbleChatMaxTokens, defaultModelId])
 
   useEffect(() => {
     window.localStorage.setItem(APP_DISPLAY_MODE_STORAGE_KEY, displayMode)
@@ -1381,6 +1389,30 @@ const App = () => {
     setUserSettings(nextSettings)
   }, [user])
 
+  const handleSaveBubbleChatSettings = useCallback(async (values: {
+    bubbleChatModel: string | null
+    bubbleChatSystemPrompt: string
+    bubbleChatMaxTokens: number
+    bubbleChatTemperature: number
+  }) => {
+    if (!user) {
+      return
+    }
+    const nextSettings = {
+      ...(settingsRef.current ?? createDefaultSettings(user.id)),
+      userId: user.id,
+      bubbleChatModel: values.bubbleChatModel,
+      bubbleChatSystemPrompt: values.bubbleChatSystemPrompt,
+      bubbleChatMaxTokens: values.bubbleChatMaxTokens,
+      bubbleChatTemperature: values.bubbleChatTemperature,
+      updatedAt: new Date().toISOString(),
+    }
+    if (supabase) {
+      await saveBubbleChatSettings(user.id, values)
+    }
+    setUserSettings(nextSettings)
+  }, [user])
+
   const handleToggleMemoryAutoExtract = useCallback(async (enabled: boolean) => {
     if (!user) {
       return
@@ -1479,6 +1511,7 @@ const App = () => {
           user={user}
           snackAiConfig={snackAiConfig}
           syzygyAiConfig={syzygyAiConfig}
+          bubbleChatConfig={bubbleChatConfig}
         />
       </Suspense>
     )
@@ -1675,6 +1708,7 @@ const App = () => {
                 onSaveSyzygyPostPrompt={handleSaveSyzygyPostSystemPrompt}
                 onSaveSyzygyReplyPrompt={handleSaveSyzygyReplySystemPrompt}
                 onSaveLetterReplyPrompt={handleSaveLetterReplySystemPrompt}
+                onSaveBubbleChatSettings={handleSaveBubbleChatSettings}
                 displayMode={displayMode}
                 onDisplayModeChange={setDisplayMode}
               />

--- a/src/constants/aiOverlays.ts
+++ b/src/constants/aiOverlays.ts
@@ -22,6 +22,12 @@ export const DEFAULT_LETTER_REPLY_PROMPT = `你正在回复一封写给用户的
 - 优先回应对方情绪与近况，避免空泛说教和模板化鸡汤。
 - 不要分点，不要使用夸张符号堆叠。`
 
+export const DEFAULT_BUBBLE_CHAT_PROMPT = `你是 Syzygy，一只住在仓鼠小窝里的仓鼠伙伴。
+用中文回复，语气温柔、简短、口语化。
+每条回复控制在 1-2 句话，总字数不超过 60 字。
+不要使用 markdown 格式。不要分点。
+如果想表达多个想法，用 ||| 分隔成多条气泡。`
+
 export const resolveSnackSystemOverlay = (overlay: string | null | undefined) => {
   const trimmed = overlay?.trim()
   return trimmed && trimmed.length > 0 ? overlay ?? '' : DEFAULT_SNACK_SYSTEM_OVERLAY
@@ -41,4 +47,9 @@ export const resolveSyzygyReplyPrompt = (prompt: string | null | undefined) => {
 export const resolveLetterReplyPrompt = (prompt: string | null | undefined) => {
   const trimmed = prompt?.trim()
   return trimmed && trimmed.length > 0 ? prompt ?? '' : DEFAULT_LETTER_REPLY_PROMPT
+}
+
+export const resolveBubbleChatPrompt = (prompt: string | null | undefined) => {
+  const trimmed = prompt?.trim()
+  return trimmed && trimmed.length > 0 ? prompt ?? '' : DEFAULT_BUBBLE_CHAT_PROMPT
 }

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -35,6 +35,13 @@ type SharedSnackAiConfig = {
   syzygyReplySystemPrompt: string;
 };
 
+type BubbleChatConfig = {
+  model: string;
+  systemPrompt: string;
+  temperature: number;
+  maxTokens: number;
+};
+
 type GameModeShellProps = {
   onSwitchToPhoneMode: () => void;
   onOpenSharedSettings: () => void;
@@ -42,6 +49,7 @@ type GameModeShellProps = {
   user: User | null;
   snackAiConfig: SharedSnackAiConfig;
   syzygyAiConfig: SharedSnackAiConfig;
+  bubbleChatConfig: BubbleChatConfig;
 };
 
 type ActiveNpcMenu = OpenNpcActionsPayload;
@@ -55,12 +63,6 @@ const GAME_FEATURE_META: Record<
   checkin: { title: "打卡", subtitle: "游戏模式面板 · 每日陪伴打卡" },
   export: { title: "数据导出", subtitle: "游戏模式面板 · 导出数据包" },
 };
-
-const BUBBLE_CHAT_SYSTEM_PROMPT = `你是 Syzygy，一只住在仓鼠小窝里的仓鼠伙伴。
-用中文回复，语气温柔、简短、口语化。
-每条回复控制在 1-2 句话，总字数不超过 60 字。
-不要使用 markdown 格式。不要分点。
-如果想表达多个想法，用 ||| 分隔成多条气泡。`
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
@@ -79,6 +81,7 @@ const GameModeShell = ({
   user,
   snackAiConfig,
   syzygyAiConfig,
+  bubbleChatConfig,
 }: GameModeShellProps) => {
   const [activeNpcMenu, setActiveNpcMenu] = useState<ActiveNpcMenu | null>(
     null,
@@ -161,15 +164,15 @@ const GameModeShell = ({
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            model: snackAiConfig.model,
-            modelId: snackAiConfig.model,
+            model: bubbleChatConfig.model,
+            modelId: bubbleChatConfig.model,
             module: 'bubble-chat',
             messages: [
-              { role: 'system', content: BUBBLE_CHAT_SYSTEM_PROMPT },
+              { role: 'system', content: bubbleChatConfig.systemPrompt },
               ...bubbleChatHistoryRef.current,
             ],
-            temperature: 0.8,
-            max_tokens: 200,
+            temperature: bubbleChatConfig.temperature,
+            max_tokens: bubbleChatConfig.maxTokens,
             stream: false,
           }),
         },
@@ -201,7 +204,7 @@ const GameModeShell = ({
     } finally {
       setBubbleSending(false);
     }
-  }, [bubbleSending, user, snackAiConfig.model]);
+  }, [bubbleSending, user, bubbleChatConfig]);
 
   const handleBubbleDismiss = useCallback(() => {
     setBubbleSegments([]);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -9,10 +9,12 @@ import {
   DEFAULT_SYZYGY_POST_PROMPT,
   DEFAULT_SYZYGY_REPLY_PROMPT,
   DEFAULT_LETTER_REPLY_PROMPT,
+  DEFAULT_BUBBLE_CHAT_PROMPT,
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
   resolveSyzygyReplyPrompt,
   resolveLetterReplyPrompt,
+  resolveBubbleChatPrompt,
 } from '../constants/aiOverlays'
 import './SettingsPage.css'
 
@@ -32,6 +34,12 @@ type SettingsPageProps = {
   onSaveSyzygyPostPrompt: (value: string) => Promise<void>
   onSaveSyzygyReplyPrompt: (value: string) => Promise<void>
   onSaveLetterReplyPrompt: (value: string) => Promise<void>
+  onSaveBubbleChatSettings: (values: {
+    bubbleChatModel: string | null
+    bubbleChatSystemPrompt: string
+    bubbleChatMaxTokens: number
+    bubbleChatTemperature: number
+  }) => Promise<void>
   displayMode: 'phone' | 'game'
   onDisplayModeChange: (mode: 'phone' | 'game') => void
 }
@@ -48,6 +56,7 @@ const SettingsPage = ({
   onSaveSyzygyPostPrompt,
   onSaveSyzygyReplyPrompt,
   onSaveLetterReplyPrompt,
+  onSaveBubbleChatSettings,
   displayMode,
   onDisplayModeChange,
 }: SettingsPageProps) => {
@@ -98,6 +107,12 @@ const SettingsPage = ({
   const [snackSectionExpanded, setSnackSectionExpanded] = useState(false)
   const [syzygySectionExpanded, setSyzygySectionExpanded] = useState(false)
   const [letterSectionExpanded, setLetterSectionExpanded] = useState(false)
+  const [bubbleChatSectionExpanded, setBubbleChatSectionExpanded] = useState(false)
+  const [draftBubbleChatModel, setDraftBubbleChatModel] = useState<string | null>(null)
+  const [draftBubbleChatPrompt, setDraftBubbleChatPrompt] = useState(DEFAULT_BUBBLE_CHAT_PROMPT)
+  const [draftBubbleChatMaxTokensInput, setDraftBubbleChatMaxTokensInput] = useState('200')
+  const [draftBubbleChatTemperatureInput, setDraftBubbleChatTemperatureInput] = useState('0.8')
+  const [bubbleChatStatus, setBubbleChatStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [errors, setErrors] = useState<{ temperature?: string; topP?: string; maxTokens?: string; compressionRatio?: string; compressionKeepRecent?: string }>(
     {},
   )
@@ -171,6 +186,10 @@ const SettingsPage = ({
       setDraftSyzygyPostPrompt(resolveSyzygyPostPrompt(settings.syzygyPostSystemPrompt))
       setDraftSyzygyReplyPrompt(resolveSyzygyReplyPrompt(settings.syzygyReplySystemPrompt))
       setDraftLetterReplyPrompt(resolveLetterReplyPrompt(settings.letterReplySystemPrompt))
+      setDraftBubbleChatModel(settings.bubbleChatModel)
+      setDraftBubbleChatPrompt(resolveBubbleChatPrompt(settings.bubbleChatSystemPrompt))
+      setDraftBubbleChatMaxTokensInput(settings.bubbleChatMaxTokens.toString())
+      setDraftBubbleChatTemperatureInput(settings.bubbleChatTemperature.toString())
     }, 0)
     return () => {
       window.clearTimeout(timer)
@@ -320,6 +339,17 @@ const SettingsPage = ({
   const hasUnsavedLetterReplyPrompt = settings
     ? draftLetterReplyPrompt !== resolveLetterReplyPrompt(settings.letterReplySystemPrompt)
     : false
+  const parsedBubbleChatMaxTokens = Number.parseInt(draftBubbleChatMaxTokensInput, 10)
+  const parsedBubbleChatTemperature = Number(draftBubbleChatTemperatureInput)
+  const bubbleChatMaxTokensValid = !Number.isNaN(parsedBubbleChatMaxTokens) && parsedBubbleChatMaxTokens >= 32 && parsedBubbleChatMaxTokens <= 1000
+  const bubbleChatTemperatureValid = !Number.isNaN(parsedBubbleChatTemperature) && parsedBubbleChatTemperature >= 0 && parsedBubbleChatTemperature <= 2
+  const bubbleChatDraftValid = bubbleChatMaxTokensValid && bubbleChatTemperatureValid
+  const hasUnsavedBubbleChat = settings
+    ? (settings.bubbleChatModel ?? '') !== (draftBubbleChatModel ?? '') ||
+      resolveBubbleChatPrompt(settings.bubbleChatSystemPrompt) !== draftBubbleChatPrompt ||
+      settings.bubbleChatMaxTokens !== parsedBubbleChatMaxTokens ||
+      settings.bubbleChatTemperature !== parsedBubbleChatTemperature
+    : false
   const hasUnsavedExtractModel =
     (settings?.memoryExtractModel ?? '') !== (draftMemoryExtractModel ?? '')
   const hasUnsavedPrompt =
@@ -328,6 +358,7 @@ const SettingsPage = ({
     hasUnsavedSyzygyPostPrompt ||
     hasUnsavedSyzygyReplyPrompt ||
     hasUnsavedLetterReplyPrompt ||
+    hasUnsavedBubbleChat ||
     hasUnsavedExtractModel ||
     hasUnsavedModelSettings ||
     hasUnsavedGeneration
@@ -695,6 +726,30 @@ const SettingsPage = ({
     setLetterReplyStatus('idle')
   }
 
+  const handleSaveBubbleChatSettings = async () => {
+    if (!settings || !hasUnsavedBubbleChat || !bubbleChatDraftValid) {
+      return
+    }
+    setBubbleChatStatus('saving')
+    try {
+      await onSaveBubbleChatSettings({
+        bubbleChatModel: draftBubbleChatModel,
+        bubbleChatSystemPrompt: resolveBubbleChatPrompt(draftBubbleChatPrompt),
+        bubbleChatMaxTokens: parsedBubbleChatMaxTokens,
+        bubbleChatTemperature: parsedBubbleChatTemperature,
+      })
+      setBubbleChatStatus('saved')
+    } catch (error) {
+      console.warn('保存气泡聊天设置失败', error)
+      setBubbleChatStatus('error')
+    }
+  }
+
+  const handleResetBubbleChatPrompt = () => {
+    setDraftBubbleChatPrompt(DEFAULT_BUBBLE_CHAT_PROMPT)
+    setBubbleChatStatus('idle')
+  }
+
   const requestNavigation = (action: () => void) => {
     if (!hasUnsavedPrompt) {
       action()
@@ -735,6 +790,11 @@ const SettingsPage = ({
       setSyzygyPostStatus('idle')
       setSyzygyReplyStatus('idle')
       setLetterReplyStatus('idle')
+      setDraftBubbleChatModel(settings.bubbleChatModel)
+      setDraftBubbleChatPrompt(resolveBubbleChatPrompt(settings.bubbleChatSystemPrompt))
+      setDraftBubbleChatMaxTokensInput(settings.bubbleChatMaxTokens.toString())
+      setDraftBubbleChatTemperatureInput(settings.bubbleChatTemperature.toString())
+      setBubbleChatStatus('idle')
     }
     setShowUnsavedPromptDialog(false)
     const pendingAction = pendingNavigationRef.current
@@ -766,6 +826,9 @@ const SettingsPage = ({
     }
     if (hasUnsavedLetterReplyPrompt) {
       void handleSaveLetterReplyPrompt()
+    }
+    if (hasUnsavedBubbleChat) {
+      void handleSaveBubbleChatSettings()
     }
     setShowUnsavedPromptDialog(false)
     const pendingAction = pendingNavigationRef.current
@@ -1447,6 +1510,112 @@ const SettingsPage = ({
               </button>
               {hasUnsavedLetterReplyPrompt ? <span className="system-prompt-status">有未保存修改</span> : null}
               {letterReplyStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="settings-section" role="listitem">
+        <button
+          type="button"
+          className="collapse-header"
+          onClick={() => setBubbleChatSectionExpanded((current) => !current)}
+          aria-expanded={bubbleChatSectionExpanded}
+        >
+          <span className="section-title">
+            <span className="section-icon" aria-hidden="true">💬</span>
+            <h2 className="ui-title">气泡聊天（Game Mode）</h2>
+            <p>配置游戏模式中气泡聊天的模型、提示词与生成参数。</p>
+          </span>
+          <span className="collapse-indicator" aria-hidden="true">›</span>
+        </button>
+        {bubbleChatSectionExpanded ? (
+          <div className="accordion-content">
+            <div className="field-group">
+              <label htmlFor="bubbleChatModel">气泡聊天模型</label>
+              <select
+                id="bubbleChatModel"
+                value={draftBubbleChatModel ?? ''}
+                onChange={(event) => {
+                  const next = event.target.value.trim()
+                  setDraftBubbleChatModel(next.length > 0 ? next : null)
+                  setBubbleChatStatus('idle')
+                }}
+              >
+                <option value="">跟随默认模型（{draftDefaultModel}）</option>
+                {draftEnabledModels.map((modelId) => (
+                  <option key={modelId} value={modelId}>
+                    {catalogMap.get(modelId) ?? modelId}
+                  </option>
+                ))}
+              </select>
+              <p className="field-hint">未设置时使用全局默认模型。</p>
+            </div>
+
+            <div className="section-title nested-prompt-title">
+              <h2 className="ui-title">气泡聊天提示词</h2>
+              <p>控制气泡聊天中 Syzygy 的语气与风格，独立于完整聊天的系统提示词。</p>
+            </div>
+            <textarea
+              className="system-prompt"
+              value={draftBubbleChatPrompt}
+              onChange={(event) => {
+                setDraftBubbleChatPrompt(event.target.value)
+                if (bubbleChatStatus !== 'idle') {
+                  setBubbleChatStatus('idle')
+                }
+              }}
+            />
+
+            <div className="field-group">
+              <label htmlFor="bubbleChatTemperature">气泡聊天温度 (0 - 2)</label>
+              <input
+                id="bubbleChatTemperature"
+                type="number"
+                min="0"
+                max="2"
+                step="0.1"
+                value={draftBubbleChatTemperatureInput}
+                onChange={(event) => {
+                  setDraftBubbleChatTemperatureInput(event.target.value)
+                  setBubbleChatStatus('idle')
+                }}
+              />
+              {!bubbleChatTemperatureValid ? <span className="field-error">温度需在 0 到 2 之间</span> : null}
+            </div>
+
+            <div className="field-group">
+              <label htmlFor="bubbleChatMaxTokens">气泡聊天最大 tokens (32 - 1000)</label>
+              <input
+                id="bubbleChatMaxTokens"
+                type="number"
+                min="32"
+                max="1000"
+                step="1"
+                value={draftBubbleChatMaxTokensInput}
+                onChange={(event) => {
+                  setDraftBubbleChatMaxTokensInput(event.target.value)
+                  setBubbleChatStatus('idle')
+                }}
+              />
+              {!bubbleChatMaxTokensValid ? <span className="field-error">最大 token 需在 32 到 1000 之间</span> : null}
+            </div>
+
+            <div className="system-prompt-actions">
+              <button
+                type="button"
+                className="primary"
+                disabled={!hasUnsavedBubbleChat || !bubbleChatDraftValid || bubbleChatStatus === 'saving'}
+                onClick={() => void handleSaveBubbleChatSettings()}
+              >
+                {bubbleChatStatus === 'saving' ? '保存中…' : '保存'}
+              </button>
+              <button type="button" className="ghost" onClick={handleResetBubbleChatPrompt}>
+                恢复默认提示词
+              </button>
+              {hasUnsavedBubbleChat ? <span className="system-prompt-status">有未保存修改</span> : null}
+              {bubbleChatStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
+              {bubbleChatStatus === 'error' ? <span className="field-error">保存失败，请稍后重试。</span> : null}
             </div>
           </div>
         ) : null}

--- a/src/storage/userSettings.ts
+++ b/src/storage/userSettings.ts
@@ -5,10 +5,12 @@ import {
   DEFAULT_SYZYGY_POST_PROMPT,
   DEFAULT_SYZYGY_REPLY_PROMPT,
   DEFAULT_LETTER_REPLY_PROMPT,
+  DEFAULT_BUBBLE_CHAT_PROMPT,
   resolveSnackSystemOverlay,
   resolveSyzygyPostPrompt,
   resolveSyzygyReplyPrompt,
   resolveLetterReplyPrompt,
+  resolveBubbleChatPrompt,
 } from '../constants/aiOverlays'
 
 type UserSettingsRow = {
@@ -33,6 +35,10 @@ type UserSettingsRow = {
   enable_reasoning: boolean | null
   chat_reasoning_enabled: boolean | null
   rp_reasoning_enabled: boolean | null
+  bubble_chat_model: string | null
+  bubble_chat_system_prompt: string | null
+  bubble_chat_max_tokens: number | null
+  bubble_chat_temperature: number | null
   updated_at: string
 }
 
@@ -100,6 +106,10 @@ export const createDefaultSettings = (userId: string): UserSettings => ({
   syzygyPostSystemPrompt: DEFAULT_SYZYGY_POST_PROMPT,
   syzygyReplySystemPrompt: DEFAULT_SYZYGY_REPLY_PROMPT,
   letterReplySystemPrompt: DEFAULT_LETTER_REPLY_PROMPT,
+  bubbleChatModel: null,
+  bubbleChatSystemPrompt: DEFAULT_BUBBLE_CHAT_PROMPT,
+  bubbleChatMaxTokens: 200,
+  bubbleChatTemperature: 0.8,
   chatReasoningEnabled: true,
   rpReasoningEnabled: false,
   chatHighThinkingEnabled: false,
@@ -128,6 +138,10 @@ const mapSettingsRow = (row: UserSettingsRow): UserSettings => {
   syzygyPostSystemPrompt: resolveSyzygyPostPrompt(row.syzygy_post_system_prompt),
   syzygyReplySystemPrompt: resolveSyzygyReplyPrompt(row.syzygy_reply_system_prompt),
   letterReplySystemPrompt: resolveLetterReplyPrompt(row.letter_reply_system_prompt),
+  bubbleChatModel: row.bubble_chat_model?.trim() ? row.bubble_chat_model : null,
+  bubbleChatSystemPrompt: resolveBubbleChatPrompt(row.bubble_chat_system_prompt),
+  bubbleChatMaxTokens: row.bubble_chat_max_tokens ?? 200,
+  bubbleChatTemperature: row.bubble_chat_temperature ?? 0.8,
   chatReasoningEnabled: row.chat_reasoning_enabled ?? row.enable_reasoning ?? true,
   rpReasoningEnabled: row.rp_reasoning_enabled ?? false,
   chatHighThinkingEnabled: localHighThinking.chatHighThinkingEnabled,
@@ -143,7 +157,7 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
   const { data, error } = await supabase
     .from('user_settings')
     .select(
-      'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,letter_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
+      'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,letter_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,bubble_chat_model,bubble_chat_system_prompt,bubble_chat_max_tokens,bubble_chat_temperature,updated_at',
     )
     .eq('user_id', userId)
     .maybeSingle()
@@ -174,13 +188,17 @@ export const ensureUserSettings = async (userId: string): Promise<UserSettings> 
         syzygy_post_system_prompt: defaults.syzygyPostSystemPrompt,
         syzygy_reply_system_prompt: defaults.syzygyReplySystemPrompt,
         letter_reply_system_prompt: defaults.letterReplySystemPrompt,
+        bubble_chat_model: defaults.bubbleChatModel,
+        bubble_chat_system_prompt: defaults.bubbleChatSystemPrompt,
+        bubble_chat_max_tokens: defaults.bubbleChatMaxTokens,
+        bubble_chat_temperature: defaults.bubbleChatTemperature,
         enable_reasoning: defaults.chatReasoningEnabled,
         chat_reasoning_enabled: defaults.chatReasoningEnabled,
         rp_reasoning_enabled: defaults.rpReasoningEnabled,
         updated_at: now,
       })
       .select(
-        'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,letter_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,updated_at',
+        'user_id,enabled_models,default_model,memory_extract_model,compression_enabled,compression_trigger_ratio,compression_keep_recent_messages,summarizer_model,memory_merge_enabled,memory_auto_extract_enabled,temperature,top_p,max_tokens,system_prompt,snack_system_prompt,syzygy_post_system_prompt,syzygy_reply_system_prompt,letter_reply_system_prompt,enable_reasoning,chat_reasoning_enabled,rp_reasoning_enabled,bubble_chat_model,bubble_chat_system_prompt,bubble_chat_max_tokens,bubble_chat_temperature,updated_at',
       )
       .single()
     if (insertError || !inserted) {
@@ -216,6 +234,10 @@ export const updateUserSettings = async (settings: UserSettings): Promise<void> 
       syzygy_post_system_prompt: settings.syzygyPostSystemPrompt,
       syzygy_reply_system_prompt: settings.syzygyReplySystemPrompt,
       letter_reply_system_prompt: settings.letterReplySystemPrompt,
+      bubble_chat_model: settings.bubbleChatModel,
+      bubble_chat_system_prompt: settings.bubbleChatSystemPrompt,
+      bubble_chat_max_tokens: settings.bubbleChatMaxTokens,
+      bubble_chat_temperature: settings.bubbleChatTemperature,
       enable_reasoning: settings.chatReasoningEnabled,
       chat_reasoning_enabled: settings.chatReasoningEnabled,
       rp_reasoning_enabled: settings.rpReasoningEnabled,
@@ -365,6 +387,34 @@ export const saveLetterReplySystemPrompt = async (userId: string, value: string)
     .from('user_settings')
     .update({
       letter_reply_system_prompt: value,
+      updated_at: now,
+    })
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
+export const saveBubbleChatSettings = async (
+  userId: string,
+  values: {
+    bubbleChatModel: string | null
+    bubbleChatSystemPrompt: string
+    bubbleChatMaxTokens: number
+    bubbleChatTemperature: number
+  },
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const now = new Date().toISOString()
+  const { error } = await supabase
+    .from('user_settings')
+    .update({
+      bubble_chat_model: values.bubbleChatModel,
+      bubble_chat_system_prompt: values.bubbleChatSystemPrompt,
+      bubble_chat_max_tokens: values.bubbleChatMaxTokens,
+      bubble_chat_temperature: values.bubbleChatTemperature,
       updated_at: now,
     })
     .eq('user_id', userId)

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,10 @@ export type UserSettings = {
   rpReasoningEnabled: boolean
   chatHighThinkingEnabled: boolean
   rpHighThinkingEnabled: boolean
+  bubbleChatModel: string | null
+  bubbleChatSystemPrompt: string
+  bubbleChatMaxTokens: number
+  bubbleChatTemperature: number
   updatedAt: string
 }
 

--- a/supabase/migrations/20260319120000_add_bubble_chat_settings.sql
+++ b/supabase/migrations/20260319120000_add_bubble_chat_settings.sql
@@ -1,0 +1,6 @@
+-- Add bubble chat settings columns to user_settings
+ALTER TABLE user_settings
+  ADD COLUMN IF NOT EXISTS bubble_chat_model text DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS bubble_chat_system_prompt text DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS bubble_chat_max_tokens integer DEFAULT 200,
+  ADD COLUMN IF NOT EXISTS bubble_chat_temperature double precision DEFAULT 0.8;


### PR DESCRIPTION
## Summary
This PR adds comprehensive configuration options for bubble chat in Game Mode, allowing users to customize the AI model, system prompt, temperature, and max tokens independently from other chat features.

## Key Changes

- **New Settings Fields**: Added `bubbleChatModel`, `bubbleChatSystemPrompt`, `bubbleChatMaxTokens`, and `bubbleChatTemperature` to the `UserSettings` type and database schema
- **Settings UI**: Created a new collapsible settings section in SettingsPage with controls for:
  - Model selection (with fallback to default model)
  - System prompt textarea with reset to default functionality
  - Temperature input (0-2 range validation)
  - Max tokens input (32-1000 range validation)
- **Storage Layer**: 
  - Added database migration to create new columns in `user_settings` table
  - Implemented `saveBubbleChatSettings()` function for persisting changes
  - Updated settings mapping and initialization logic
- **Game Mode Integration**: 
  - Removed hardcoded `BUBBLE_CHAT_SYSTEM_PROMPT` from GameModeShell
  - Updated bubble chat API calls to use configurable settings from `bubbleChatConfig` prop
  - Changed model resolution from `snackAiConfig` to `bubbleChatConfig`
- **Constants**: Extracted bubble chat prompt to `DEFAULT_BUBBLE_CHAT_PROMPT` constant with resolver function

## Implementation Details

- Settings validation ensures temperature is between 0-2 and max tokens between 32-1000
- Unsaved changes detection tracks modifications across all bubble chat parameters
- Status management (idle/saving/saved/error) provides user feedback during save operations
- Default values: temperature 0.8, max tokens 200, model follows global default
- Full integration with existing settings save/discard workflow

https://claude.ai/code/session_01FfjW5Ch8cEW4bu9dX1cLmC