### PR TITLE
Migrate bubble chat history from localStorage to Supabase

### DIFF
--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -19,7 +19,8 @@ import CheckinPage from "../pages/CheckinPage";
 import ExportPage from "../pages/ExportPage";
 import { supabase } from "../supabase/client";
 import { parseBubbleReply } from "./utils/parseBubbleReply";
-import { appendEntry } from "./utils/bubbleChatHistory";
+import { persistBubbleMessage, resolveTodaySession, invalidateSessionCache } from "./utils/bubbleChatHistory";
+import { fetchBubbleMessages } from "../storage/supabaseSync";
 import BubbleChatHistoryModal from "./ui/BubbleChatHistoryModal";
 import "./gameHud.css";
 
@@ -106,6 +107,7 @@ const GameModeShell = ({
   const [bubbleSegments, setBubbleSegments] = useState<string[]>([]);
   const [syzygyPos, setSyzygyPos] = useState<SyzygyPositionPayload | null>(null);
   const bubbleChatHistoryRef = useRef<Array<{ role: 'user' | 'assistant'; content: string }>>([]);
+  const bubbleSessionRestoredRef = useRef(false);
 
   const handleOpenNpcActions = useCallback((payload: OpenNpcActionsPayload) => {
     setActiveNpcMenu(payload);
@@ -132,6 +134,30 @@ const GameModeShell = ({
     setSyzygyPos(pos);
   }, []);
 
+  // Restore persisted bubble chat history on mount
+  useEffect(() => {
+    if (bubbleSessionRestoredRef.current || !user || !supabase) {
+      return;
+    }
+    bubbleSessionRestoredRef.current = true;
+    invalidateSessionCache();
+
+    const restore = async () => {
+      try {
+        const session = await resolveTodaySession();
+        const messages = await fetchBubbleMessages(session.id);
+        if (messages.length > 0) {
+          bubbleChatHistoryRef.current = messages
+            .slice(-12)
+            .map((m) => ({ role: m.role, content: m.content }));
+        }
+      } catch (error) {
+        console.warn('[bubble-chat] Failed to restore history:', error);
+      }
+    };
+    restore();
+  }, [user]);
+
   const handleBubbleSend = useCallback(async (text: string) => {
     if (bubbleSending || !user || !supabase) {
       return;
@@ -152,7 +178,12 @@ const GameModeShell = ({
         ...bubbleChatHistoryRef.current.slice(-10),
         { role: 'user' as const, content: text },
       ];
-      appendEntry('user', text);
+
+      try {
+        await persistBubbleMessage('user', text);
+      } catch (error) {
+        console.warn('[bubble-chat] Failed to persist user message:', error);
+      }
 
       const response = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,
@@ -193,7 +224,13 @@ const GameModeShell = ({
           ...bubbleChatHistoryRef.current,
           { role: 'assistant' as const, content },
         ];
-        appendEntry('assistant', content);
+
+        try {
+          await persistBubbleMessage('assistant', content);
+        } catch (error) {
+          console.warn('[bubble-chat] Failed to persist assistant message:', error);
+        }
+
         const segments = parseBubbleReply(content);
         if (segments.length > 0) {
           setBubbleSegments(segments);

--- a/src/game/ui/BubbleChatHistoryModal.tsx
+++ b/src/game/ui/BubbleChatHistoryModal.tsx
@@ -22,9 +22,28 @@ function formatDateHeading(): string {
 
 const BubbleChatHistoryModal = ({ onClose }: BubbleChatHistoryModalProps) => {
   const [entries, setEntries] = useState<BubbleChatEntry[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    setEntries(getTodayEntries())
+    let cancelled = false
+    const load = async () => {
+      try {
+        const result = await getTodayEntries()
+        if (!cancelled) {
+          setEntries(result)
+        }
+      } catch (error) {
+        console.warn('[bubble-chat] Failed to load history:', error)
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   return (
@@ -35,7 +54,11 @@ const BubbleChatHistoryModal = ({ onClose }: BubbleChatHistoryModalProps) => {
       onClose={onClose}
       contentClassName="game-system-modal__content--history"
     >
-      {entries.length === 0 ? (
+      {loading ? (
+        <div className="bubble-history-empty">
+          <p className="bubble-history-empty__text">加载中…</p>
+        </div>
+      ) : entries.length === 0 ? (
         <div className="bubble-history-empty">
           <p className="bubble-history-empty__icon">💬</p>
           <p className="bubble-history-empty__text">

--- a/src/game/utils/bubbleChatHistory.ts
+++ b/src/game/utils/bubbleChatHistory.ts
@@ -1,4 +1,9 @@
-const STORAGE_KEY = 'hamster-nest:bubble-chat-history'
+import type { BubbleMessage, BubbleSession } from '../../types'
+import {
+  resolveOrCreateBubbleSession,
+  createBubbleMessage,
+  fetchBubbleMessages,
+} from '../../storage/supabaseSync'
 
 export type BubbleChatEntry = {
   role: 'user' | 'assistant'
@@ -6,42 +11,62 @@ export type BubbleChatEntry = {
   timestamp: number
 }
 
-function loadAll(): BubbleChatEntry[] {
+let cachedSession: BubbleSession | null = null
+let cachedDateStr: string | null = null
+
+function todayDateStr(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function isCacheValid(): boolean {
+  return cachedSession !== null && cachedDateStr === todayDateStr()
+}
+
+export async function resolveTodaySession(): Promise<BubbleSession> {
+  const dateStr = todayDateStr()
+
+  if (isCacheValid() && cachedSession) {
+    return cachedSession
+  }
+
+  const session = await resolveOrCreateBubbleSession(dateStr)
+  cachedSession = session
+  cachedDateStr = dateStr
+  return session
+}
+
+export async function persistBubbleMessage(
+  role: 'user' | 'assistant',
+  content: string,
+): Promise<BubbleMessage> {
+  const session = await resolveTodaySession()
+  return createBubbleMessage(session.id, role, content)
+}
+
+function toBubbleChatEntry(msg: BubbleMessage): BubbleChatEntry {
+  return {
+    role: msg.role,
+    content: msg.content,
+    timestamp: new Date(msg.createdAt).getTime(),
+  }
+}
+
+export async function getTodayEntries(): Promise<BubbleChatEntry[]> {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) {
-      return []
-    }
-    const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
+    const session = await resolveTodaySession()
+    const messages = await fetchBubbleMessages(session.id)
+    return messages.map(toBubbleChatEntry)
+  } catch (error) {
+    console.error('[bubble-chat] Failed to fetch today entries:', error)
     return []
   }
 }
 
-function saveAll(entries: BubbleChatEntry[]): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
-  } catch {
-    // storage full – silently drop
-  }
-}
-
-function startOfToday(): number {
-  const now = new Date()
-  return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
-}
-
-export function getTodayEntries(): BubbleChatEntry[] {
-  const cutoff = startOfToday()
-  return loadAll().filter((entry) => entry.timestamp >= cutoff)
-}
-
-export function appendEntry(role: BubbleChatEntry['role'], content: string): void {
-  const all = loadAll()
-  all.push({ role, content, timestamp: Date.now() })
-
-  // keep at most 200 entries to avoid unbounded growth
-  const trimmed = all.length > 200 ? all.slice(all.length - 200) : all
-  saveAll(trimmed)
+export function invalidateSessionCache(): void {
+  cachedSession = null
+  cachedDateStr = null
 }

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1,4 +1,6 @@
 import type {
+  BubbleMessage,
+  BubbleSession,
   ChatMessage,
   ChatSession,
   CheckinEntry,
@@ -2204,4 +2206,149 @@ export const fetchCheckinTotalCount = async (): Promise<number> => {
     throw error
   }
   return count ?? 0
+}
+
+
+// --- Bubble Chat ---
+
+type BubbleSessionRow = {
+  id: string
+  user_id: string
+  session_date: string
+  created_at: string
+  updated_at: string
+}
+
+type BubbleMessageRow = {
+  id: string
+  session_id: string
+  user_id: string
+  role: 'user' | 'assistant'
+  content: string
+  created_at: string
+}
+
+const mapBubbleSessionRow = (row: BubbleSessionRow): BubbleSession => ({
+  id: row.id,
+  userId: row.user_id,
+  sessionDate: row.session_date,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const mapBubbleMessageRow = (row: BubbleMessageRow): BubbleMessage => ({
+  id: row.id,
+  sessionId: row.session_id,
+  userId: row.user_id,
+  role: row.role,
+  content: row.content,
+  createdAt: row.created_at,
+})
+
+export const resolveOrCreateBubbleSession = async (dateStr: string): Promise<BubbleSession> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('bubble_sessions')
+    .select('id,user_id,session_date,created_at,updated_at')
+    .eq('user_id', userId)
+    .eq('session_date', dateStr)
+    .maybeSingle()
+
+  if (fetchError) {
+    throw fetchError
+  }
+
+  if (existing) {
+    return mapBubbleSessionRow(existing as BubbleSessionRow)
+  }
+
+  const now = new Date().toISOString()
+  const { data: created, error: insertError } = await supabase
+    .from('bubble_sessions')
+    .insert({
+      user_id: userId,
+      session_date: dateStr,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id,user_id,session_date,created_at,updated_at')
+    .single()
+
+  if (insertError) {
+    if (insertError.code === '23505') {
+      const { data: retry, error: retryError } = await supabase
+        .from('bubble_sessions')
+        .select('id,user_id,session_date,created_at,updated_at')
+        .eq('user_id', userId)
+        .eq('session_date', dateStr)
+        .single()
+      if (retryError || !retry) {
+        throw retryError ?? new Error('获取气泡聊天会话失败')
+      }
+      return mapBubbleSessionRow(retry as BubbleSessionRow)
+    }
+    throw insertError
+  }
+
+  if (!created) {
+    throw new Error('创建气泡聊天会话失败')
+  }
+  return mapBubbleSessionRow(created as BubbleSessionRow)
+}
+
+export const createBubbleMessage = async (
+  sessionId: string,
+  role: 'user' | 'assistant',
+  content: string,
+): Promise<BubbleMessage> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('bubble_messages')
+    .insert({
+      session_id: sessionId,
+      user_id: userId,
+      role,
+      content,
+      created_at: now,
+    })
+    .select('id,session_id,user_id,role,content,created_at')
+    .single()
+
+  if (error || !data) {
+    throw error ?? new Error('保存气泡聊天消息失败')
+  }
+
+  await supabase
+    .from('bubble_sessions')
+    .update({ updated_at: now })
+    .eq('id', sessionId)
+    .eq('user_id', userId)
+
+  return mapBubbleMessageRow(data as BubbleMessageRow)
+}
+
+export const fetchBubbleMessages = async (sessionId: string): Promise<BubbleMessage[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('bubble_messages')
+    .select('id,session_id,user_id,role,content,created_at')
+    .eq('session_id', sessionId)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapBubbleMessageRow(row as BubbleMessageRow))
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,3 +254,20 @@ export type ChatTimelineLetterItem = {
 }
 
 export type ChatTimelineItem = ChatTimelineMessageItem | ChatTimelineLetterItem
+
+export type BubbleSession = {
+  id: string
+  userId: string
+  sessionDate: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type BubbleMessage = {
+  id: string
+  sessionId: string
+  userId: string
+  role: 'user' | 'assistant'
+  content: string
+  createdAt: string
+}

--- a/supabase/migrations/20260319130000_add_bubble_chat_tables.sql
+++ b/supabase/migrations/20260319130000_add_bubble_chat_tables.sql
@@ -1,0 +1,41 @@
+-- Create bubble_sessions table for daily bubble chat sessions
+CREATE TABLE IF NOT EXISTS bubble_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_date date NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, session_date)
+);
+
+ALTER TABLE bubble_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own bubble sessions"
+  ON bubble_sessions
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Create bubble_messages table for bubble chat messages
+CREATE TABLE IF NOT EXISTS bubble_messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES bubble_sessions(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role text NOT NULL CHECK (role IN ('user', 'assistant')),
+  content text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE bubble_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own bubble messages"
+  ON bubble_messages
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_bubble_sessions_user_date
+  ON bubble_sessions (user_id, session_date);
+
+CREATE INDEX IF NOT EXISTS idx_bubble_messages_session
+  ON bubble_messages (session_id, created_at);


### PR DESCRIPTION
## Summary
This PR migrates the bubble chat feature from client-side localStorage persistence to server-side Supabase storage, enabling chat history to persist across sessions and devices while maintaining daily session organization.

## Key Changes

- **Database Schema**: Added `bubble_sessions` and `bubble_messages` tables with RLS policies to store daily chat sessions and messages per user
- **Supabase Integration**: Implemented three new functions in `supabaseSync.ts`:
  - `resolveOrCreateBubbleSession()` - Gets or creates a daily session with race condition handling
  - `createBubbleMessage()` - Persists individual messages and updates session timestamp
  - `fetchBubbleMessages()` - Retrieves messages for a session in chronological order
- **Chat History Module**: Refactored `bubbleChatHistory.ts` to use Supabase backend instead of localStorage:
  - Replaced synchronous localStorage operations with async Supabase calls
  - Added session caching to minimize database queries
  - Implemented date-based session management
- **Game Integration**: Updated `GameModeShell.tsx` to:
  - Restore persisted chat history on component mount (last 12 messages)
  - Persist both user and assistant messages to Supabase
  - Handle errors gracefully with console warnings
- **UI Updates**: Modified `BubbleChatHistoryModal.tsx` to handle async data loading with loading state
- **Type Definitions**: Added `BubbleSession` and `BubbleMessage` types to `types.ts`

## Implementation Details

- Session resolution uses `maybeSingle()` for initial fetch and handles unique constraint violations (code 23505) with automatic retry
- Chat history is limited to the last 12 messages in memory to balance context window with performance
- All database operations include user ID validation via `requireAuthenticatedUserId()`
- RLS policies ensure users can only access their own sessions and messages
- Indexes on `(user_id, session_date)` and `(session_id, created_at)` optimize common queries

https://claude.ai/code/session_016HfhRXMQ5dk4o1Uh3J76WR