### PR TITLE
Refactor speech bubbles to display multiple segments simultaneously

### DIFF
--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -1089,7 +1089,20 @@
   flex-direction: column;
   align-items: center;
   max-width: min(280px, calc(100vw - 32px));
-  animation: bubble-appear 0.25s ease-out;
+}
+
+.speech-bubble-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.speech-bubble-stack__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  animation: bubble-appear 0.25s ease-out both;
 }
 
 .speech-bubble {
@@ -1111,15 +1124,6 @@
 
 .speech-bubble__text {
   display: block;
-}
-
-.speech-bubble__counter {
-  display: block;
-  margin-top: 4px;
-  font-size: 10px;
-  font-weight: 700;
-  color: #9a7067;
-  letter-spacing: 0.06em;
 }
 
 .speech-bubble__tail {
@@ -1146,11 +1150,11 @@
 @keyframes bubble-appear {
   from {
     opacity: 0;
-    transform: translate(-50%, -90%);
+    transform: translateY(8px);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, -100%);
+    transform: translateY(0);
   }
 }
 
@@ -1256,6 +1260,10 @@
 
   .speech-bubble-overlay {
     max-width: min(220px, calc(100vw - 24px));
+  }
+
+  .speech-bubble-stack {
+    gap: 4px;
   }
 
   .speech-bubble {

--- a/src/game/ui/SpeechBubbleOverlay.tsx
+++ b/src/game/ui/SpeechBubbleOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 type SpeechBubbleOverlayProps = {
   segments: string[]
@@ -10,52 +10,93 @@ type SpeechBubbleOverlayProps = {
 const BUBBLE_DISPLAY_MS = 4000
 const BUBBLE_PER_CHAR_MS = 80
 const MIN_DISPLAY_MS = 2500
+const MAX_VISIBLE_BUBBLES = 3
+const STAGGER_DELAY_MS = 400
 
 const computeDisplayTime = (text: string) =>
   Math.max(MIN_DISPLAY_MS, BUBBLE_DISPLAY_MS + text.length * BUBBLE_PER_CHAR_MS)
 
-const SpeechBubbleSequence = ({
+type BubbleItemProps = {
+  text: string
+  showTail: boolean
+  staggerIndex: number
+}
+
+const BubbleItem = ({ text, showTail, staggerIndex }: BubbleItemProps) => {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setVisible(true)
+    }, staggerIndex * STAGGER_DELAY_MS)
+    return () => window.clearTimeout(timer)
+  }, [staggerIndex])
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <div className="speech-bubble-stack__item" style={{ animationDelay: '0ms' }}>
+      <div className="speech-bubble">
+        <span className="speech-bubble__text">{text}</span>
+      </div>
+      {showTail ? <div className="speech-bubble__tail" aria-hidden="true" /> : null}
+    </div>
+  )
+}
+
+const SpeechBubbleStack = ({
   segments,
   onDismiss,
 }: {
   segments: string[]
   onDismiss: () => void
 }) => {
-  const [visibleIndex, setVisibleIndex] = useState(0)
+  const dismissTimerRef = useRef<number | null>(null)
+
+  // Cap visible bubbles
+  const visibleSegments = segments.length > MAX_VISIBLE_BUBBLES
+    ? segments.slice(segments.length - MAX_VISIBLE_BUBBLES)
+    : segments
 
   useEffect(() => {
     if (segments.length === 0) {
       return
     }
-    if (visibleIndex >= segments.length) {
-      onDismiss()
-      return
-    }
-    const duration = computeDisplayTime(segments[visibleIndex])
-    const timer = window.setTimeout(() => {
-      setVisibleIndex((i) => i + 1)
-    }, duration)
-    return () => window.clearTimeout(timer)
-  }, [segments, visibleIndex, onDismiss])
 
-  if (segments.length === 0 || visibleIndex >= segments.length) {
+    // Calculate total time: stagger delays + last bubble display time
+    const lastIndex = visibleSegments.length - 1
+    const staggerTotal = lastIndex * STAGGER_DELAY_MS
+    const lastBubbleTime = computeDisplayTime(visibleSegments[lastIndex])
+    const totalTime = staggerTotal + lastBubbleTime
+
+    dismissTimerRef.current = window.setTimeout(() => {
+      onDismiss()
+    }, totalTime)
+
+    return () => {
+      if (dismissTimerRef.current !== null) {
+        window.clearTimeout(dismissTimerRef.current)
+      }
+    }
+  }, [segments, visibleSegments, onDismiss])
+
+  if (segments.length === 0) {
     return null
   }
 
-  const currentText = segments[visibleIndex]
-
   return (
-    <>
-      <div className="speech-bubble">
-        <span className="speech-bubble__text">{currentText}</span>
-        {segments.length > 1 ? (
-          <span className="speech-bubble__counter">
-            {visibleIndex + 1}/{segments.length}
-          </span>
-        ) : null}
-      </div>
-      <div className="speech-bubble__tail" aria-hidden="true" />
-    </>
+    <div className="speech-bubble-stack">
+      {visibleSegments.map((text, index) => (
+        <BubbleItem
+          key={`${index}-${text}`}
+          text={text}
+          showTail={index === visibleSegments.length - 1}
+          staggerIndex={index}
+        />
+      ))}
+    </div>
   )
 }
 
@@ -82,7 +123,7 @@ const SpeechBubbleOverlay = ({
       aria-live="polite"
       aria-label="Syzygy 的回复"
     >
-      <SpeechBubbleSequence
+      <SpeechBubbleStack
         key={sequenceKey}
         segments={segments}
         onDismiss={onDismiss}


### PR DESCRIPTION
## Summary
Changed the speech bubble overlay from displaying segments sequentially (one at a time) to displaying multiple segments simultaneously in a stacked layout. This provides a better visual experience by showing the conversation flow more naturally.

## Key Changes
- **Renamed component**: `SpeechBubbleSequence` → `SpeechBubbleStack` to reflect the new stacked display behavior
- **New `BubbleItem` component**: Extracted individual bubble rendering logic with staggered entrance animations
- **Staggered display**: Bubbles now appear with a 400ms delay between each one using `STAGGER_DELAY_MS` constant
- **Capped visible bubbles**: Limited to 3 visible bubbles at once with `MAX_VISIBLE_BUBBLES` constant to prevent UI overflow
- **Simplified timing logic**: Changed from sequential timing (waiting for each bubble to complete) to calculating total time based on stagger delays plus the last bubble's display duration
- **Removed counter**: Eliminated the "X/Y" counter display since all relevant bubbles are now visible
- **Updated animations**: Modified `bubble-appear` keyframes to use `translateY` instead of `translate(-50%, ...)` for cleaner vertical slide-in effect
- **Added spacing**: New `.speech-bubble-stack` and `.speech-bubble-stack__item` CSS classes with gap spacing between bubbles
- **Responsive adjustments**: Updated mobile breakpoint to reduce gap from 6px to 4px

## Implementation Details
- Uses `useRef` to track dismiss timer for proper cleanup
- Each `BubbleItem` manages its own visibility state with individual stagger delays
- Only the last bubble in the stack displays the tail element
- Total display time is calculated as: `(lastIndex × STAGGER_DELAY_MS) + computeDisplayTime(lastBubble)`
- Maintains proper cleanup of timers to prevent memory leaks

https://claude.ai/code/session_012hmbQ7dcvKNtTAvTNx4d1Y