### PR TITLE
Add player speech bubbles with click-away dismissal

### DIFF
--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -3,6 +3,7 @@ import Phaser from 'phaser'
 export const GAME_EVENTS = {
   OPEN_NPC_ACTIONS: 'open-npc-actions',
   SYZYGY_POSITION_UPDATE: 'syzygy-position-update',
+  PLAYER_POSITION_UPDATE: 'player-position-update',
 } as const
 
 export type OpenNpcActionsPayload = {
@@ -14,6 +15,11 @@ export type OpenNpcActionsPayload = {
 }
 
 export type SyzygyPositionPayload = {
+  x: number
+  y: number
+}
+
+export type PlayerPositionPayload = {
   x: number
   y: number
 }

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 import type { User } from "@supabase/supabase-js";
-import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload, type SyzygyPositionPayload } from "./EventBus";
+import { EventBus, GAME_EVENTS, type OpenNpcActionsPayload, type SyzygyPositionPayload, type PlayerPositionPayload } from "./EventBus";
 import GameHud from "./ui/GameHud";
 import GameMenuOverlay, { type GameFeatureId } from "./ui/GameMenuOverlay";
 import GameSettingsOverlay from "./ui/GameSettingsOverlay";
@@ -105,9 +105,12 @@ const GameModeShell = ({
   const [isBubbleHistoryOpen, setIsBubbleHistoryOpen] = useState(false);
   const [bubbleSending, setBubbleSending] = useState(false);
   const [bubbleSegments, setBubbleSegments] = useState<string[]>([]);
+  const [playerBubbleText, setPlayerBubbleText] = useState<string | null>(null);
   const [syzygyPos, setSyzygyPos] = useState<SyzygyPositionPayload | null>(null);
+  const [playerPos, setPlayerPos] = useState<PlayerPositionPayload | null>(null);
   const bubbleChatHistoryRef = useRef<Array<{ role: 'user' | 'assistant'; content: string }>>([]);
   const bubbleSessionRestoredRef = useRef(false);
+  const sceneBubblesVisibleRef = useRef(false);
 
   const handleOpenNpcActions = useCallback((payload: OpenNpcActionsPayload) => {
     setActiveNpcMenu(payload);
@@ -132,6 +135,10 @@ const GameModeShell = ({
 
   const handleSyzygyPositionUpdate = useCallback((pos: SyzygyPositionPayload) => {
     setSyzygyPos(pos);
+  }, []);
+
+  const handlePlayerPositionUpdate = useCallback((pos: PlayerPositionPayload) => {
+    setPlayerPos(pos);
   }, []);
 
   // Restore persisted bubble chat history on mount
@@ -178,6 +185,10 @@ const GameModeShell = ({
         ...bubbleChatHistoryRef.current.slice(-10),
         { role: 'user' as const, content: text },
       ];
+
+      // Show player bubble immediately
+      setPlayerBubbleText(text);
+      sceneBubblesVisibleRef.current = true;
 
       try {
         await persistBubbleMessage('user', text);
@@ -234,6 +245,7 @@ const GameModeShell = ({
         const segments = parseBubbleReply(content);
         if (segments.length > 0) {
           setBubbleSegments(segments);
+          sceneBubblesVisibleRef.current = true;
         }
       }
     } catch (error) {
@@ -245,17 +257,21 @@ const GameModeShell = ({
 
   const handleBubbleDismiss = useCallback(() => {
     setBubbleSegments([]);
+    setPlayerBubbleText(null);
+    sceneBubblesVisibleRef.current = false;
   }, []);
 
   useEffect(() => {
     EventBus.on(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions);
     EventBus.on(GAME_EVENTS.SYZYGY_POSITION_UPDATE, handleSyzygyPositionUpdate);
+    EventBus.on(GAME_EVENTS.PLAYER_POSITION_UPDATE, handlePlayerPositionUpdate);
 
     return () => {
       EventBus.off(GAME_EVENTS.OPEN_NPC_ACTIONS, handleOpenNpcActions);
       EventBus.off(GAME_EVENTS.SYZYGY_POSITION_UPDATE, handleSyzygyPositionUpdate);
+      EventBus.off(GAME_EVENTS.PLAYER_POSITION_UPDATE, handlePlayerPositionUpdate);
     };
-  }, [handleOpenNpcActions, handleSyzygyPositionUpdate]);
+  }, [handleOpenNpcActions, handleSyzygyPositionUpdate, handlePlayerPositionUpdate]);
 
   useEffect(() => {
     if (!activeNpcMenu) {
@@ -278,6 +294,38 @@ const GameModeShell = ({
       window.removeEventListener("pointerdown", handlePointerDown);
     };
   }, [activeNpcMenu]);
+
+  // Click-away dismissal for scene bubbles
+  useEffect(() => {
+    if (!sceneBubblesVisibleRef.current) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        handleBubbleDismiss();
+        return;
+      }
+
+      // Don't dismiss when interacting with the bubble input bar
+      if (target.closest('.game-bubble-input-bar')) {
+        return;
+      }
+
+      // Don't dismiss when interacting with the speech bubbles themselves
+      if (target.closest('.speech-bubble-overlay')) {
+        return;
+      }
+
+      handleBubbleDismiss();
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [handleBubbleDismiss, playerBubbleText, bubbleSegments]);
 
   useLayoutEffect(() => {
     if (!activeNpcMenu) {
@@ -380,12 +428,23 @@ const GameModeShell = ({
           bubbleSending={bubbleSending}
         />
 
+        {playerBubbleText && playerPos ? (
+          <SpeechBubbleOverlay
+            segments={[playerBubbleText]}
+            anchorX={playerPos.x}
+            anchorY={playerPos.y}
+            onDismiss={handleBubbleDismiss}
+            variant="player"
+          />
+        ) : null}
+
         {bubbleSegments.length > 0 && syzygyPos ? (
           <SpeechBubbleOverlay
             segments={bubbleSegments}
             anchorX={syzygyPos.x}
             anchorY={syzygyPos.y}
             onDismiss={handleBubbleDismiss}
+            variant="npc"
           />
         ) : null}
 

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -1147,6 +1147,22 @@
   border-color: #f8ddd4 transparent transparent transparent;
 }
 
+.speech-bubble--player {
+  background: linear-gradient(180deg, #e8f4fd 0%, #d0e8f8 100%);
+  border-color: #5a7a8a;
+  box-shadow:
+    inset 0 0 0 2px #f0f8ff,
+    0 4px 8px rgba(30, 50, 60, 0.18);
+}
+
+.speech-bubble--player + .speech-bubble__tail {
+  border-color: #5a7a8a transparent transparent transparent;
+}
+
+.speech-bubble--player + .speech-bubble__tail::after {
+  border-color: #d0e8f8 transparent transparent transparent;
+}
+
 @keyframes bubble-appear {
   from {
     opacity: 0;

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -6,6 +6,7 @@ const CHUAN_KEY = 'chuan1'
 const SYZYGY_KEY = 'syzygy1'
 
 export class HomeScene extends Phaser.Scene {
+  private playerSprite?: Phaser.GameObjects.Image
   private syzygySprite?: Phaser.GameObjects.Image
 
   private getSpriteScreenAnchor(sprite: Phaser.GameObjects.Image) {
@@ -35,6 +36,22 @@ export class HomeScene extends Phaser.Scene {
     this.load.image(SYZYGY_KEY, `${assetBase}syzygy1.png`)
   }
 
+  private emitPlayerPosition() {
+    if (!this.playerSprite) {
+      return
+    }
+    const bounds = this.playerSprite.getBounds()
+    const canvas = this.game.canvas
+    const canvasRect = canvas.getBoundingClientRect()
+    const scaleX = canvasRect.width / this.scale.width
+    const scaleY = canvasRect.height / this.scale.height
+
+    EventBus.emit(GAME_EVENTS.PLAYER_POSITION_UPDATE, {
+      x: canvasRect.left + (bounds.x + bounds.width * 0.5) * scaleX,
+      y: canvasRect.top + bounds.top * scaleY,
+    })
+  }
+
   private emitSyzygyPosition() {
     if (!this.syzygySprite) {
       return
@@ -60,7 +77,7 @@ export class HomeScene extends Phaser.Scene {
     const spacing = Math.round(Math.min(220, width * 0.18))
     const centerX = Math.round(width * 0.5)
 
-    this.add
+    this.playerSprite = this.add
       .image(centerX - spacing, baseY, CHUAN_KEY)
       .setOrigin(0.5, 1)
       .setScale(2)
@@ -89,6 +106,10 @@ export class HomeScene extends Phaser.Scene {
     })
 
     this.emitSyzygyPosition()
-    this.scale.on('resize', () => this.emitSyzygyPosition())
+    this.emitPlayerPosition()
+    this.scale.on('resize', () => {
+      this.emitSyzygyPosition()
+      this.emitPlayerPosition()
+    })
   }
 }

--- a/src/game/ui/SpeechBubbleOverlay.tsx
+++ b/src/game/ui/SpeechBubbleOverlay.tsx
@@ -1,28 +1,24 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 type SpeechBubbleOverlayProps = {
   segments: string[]
   anchorX: number
   anchorY: number
   onDismiss: () => void
+  variant?: 'npc' | 'player'
 }
 
-const BUBBLE_DISPLAY_MS = 4000
-const BUBBLE_PER_CHAR_MS = 80
-const MIN_DISPLAY_MS = 2500
 const MAX_VISIBLE_BUBBLES = 3
 const STAGGER_DELAY_MS = 400
-
-const computeDisplayTime = (text: string) =>
-  Math.max(MIN_DISPLAY_MS, BUBBLE_DISPLAY_MS + text.length * BUBBLE_PER_CHAR_MS)
 
 type BubbleItemProps = {
   text: string
   showTail: boolean
   staggerIndex: number
+  variant: 'npc' | 'player'
 }
 
-const BubbleItem = ({ text, showTail, staggerIndex }: BubbleItemProps) => {
+const BubbleItem = ({ text, showTail, staggerIndex, variant }: BubbleItemProps) => {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -36,9 +32,13 @@ const BubbleItem = ({ text, showTail, staggerIndex }: BubbleItemProps) => {
     return null
   }
 
+  const bubbleClass = variant === 'player'
+    ? 'speech-bubble speech-bubble--player'
+    : 'speech-bubble'
+
   return (
     <div className="speech-bubble-stack__item" style={{ animationDelay: '0ms' }}>
-      <div className="speech-bubble">
+      <div className={bubbleClass}>
         <span className="speech-bubble__text">{text}</span>
       </div>
       {showTail ? <div className="speech-bubble__tail" aria-hidden="true" /> : null}
@@ -48,39 +48,15 @@ const BubbleItem = ({ text, showTail, staggerIndex }: BubbleItemProps) => {
 
 const SpeechBubbleStack = ({
   segments,
-  onDismiss,
+  variant,
 }: {
   segments: string[]
-  onDismiss: () => void
+  variant: 'npc' | 'player'
 }) => {
-  const dismissTimerRef = useRef<number | null>(null)
-
   // Cap visible bubbles
   const visibleSegments = segments.length > MAX_VISIBLE_BUBBLES
     ? segments.slice(segments.length - MAX_VISIBLE_BUBBLES)
     : segments
-
-  useEffect(() => {
-    if (segments.length === 0) {
-      return
-    }
-
-    // Calculate total time: stagger delays + last bubble display time
-    const lastIndex = visibleSegments.length - 1
-    const staggerTotal = lastIndex * STAGGER_DELAY_MS
-    const lastBubbleTime = computeDisplayTime(visibleSegments[lastIndex])
-    const totalTime = staggerTotal + lastBubbleTime
-
-    dismissTimerRef.current = window.setTimeout(() => {
-      onDismiss()
-    }, totalTime)
-
-    return () => {
-      if (dismissTimerRef.current !== null) {
-        window.clearTimeout(dismissTimerRef.current)
-      }
-    }
-  }, [segments, visibleSegments, onDismiss])
 
   if (segments.length === 0) {
     return null
@@ -94,6 +70,7 @@ const SpeechBubbleStack = ({
           text={text}
           showTail={index === visibleSegments.length - 1}
           staggerIndex={index}
+          variant={variant}
         />
       ))}
     </div>
@@ -105,12 +82,15 @@ const SpeechBubbleOverlay = ({
   anchorX,
   anchorY,
   onDismiss,
+  variant = 'npc',
 }: SpeechBubbleOverlayProps) => {
   const sequenceKey = useMemo(() => segments.join('\n'), [segments])
 
   if (segments.length === 0) {
     return null
   }
+
+  const ariaLabel = variant === 'player' ? '串串的消息' : 'Syzygy 的回复'
 
   return (
     <div
@@ -121,12 +101,12 @@ const SpeechBubbleOverlay = ({
       }}
       role="status"
       aria-live="polite"
-      aria-label="Syzygy 的回复"
+      aria-label={ariaLabel}
     >
       <SpeechBubbleStack
         key={sequenceKey}
         segments={segments}
-        onDismiss={onDismiss}
+        variant={variant}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
This PR adds support for displaying speech bubbles from the player character and implements click-away dismissal for all speech bubbles in the game scene.

## Key Changes

- **Player Speech Bubbles**: Added `PlayerPositionPayload` event type and `PLAYER_POSITION_UPDATE` event to track player position, enabling speech bubbles to be displayed at the player's location when they send messages
- **Position Tracking**: Modified `HomeScene` to emit player position updates alongside existing Syzygy position updates, with proper canvas scaling calculations
- **Click-Away Dismissal**: Implemented a new `useEffect` hook in `GameModeShell` that listens for pointer events and dismisses bubbles when clicking outside of the bubble UI or input bar
- **Bubble Variant Styling**: Added `variant` prop to `SpeechBubbleOverlay` to support different visual styles for player vs NPC bubbles, with new CSS styling for player bubbles (blue gradient background)
- **Simplified Bubble Lifecycle**: Removed automatic dismissal timer logic from `SpeechBubbleStack` component, delegating all dismissal control to the parent component
- **State Management**: Added `playerBubbleText`, `playerPos`, and `sceneBubblesVisibleRef` to track player bubble state and visibility

## Implementation Details

- Player bubbles display immediately when the user sends a message, while NPC bubbles continue to appear after the API response
- Click-away detection uses `pointerdown` events and checks for specific CSS classes (`.game-bubble-input-bar`, `.speech-bubble-overlay`) to prevent accidental dismissal during interaction
- Player bubble styling uses a blue color scheme to visually distinguish it from NPC responses
- Position updates are emitted on scene resize to maintain accurate bubble positioning

https://claude.ai/code/session_01DgJPoa8iBpadmdEtvdNpi7