### PR TITLE
fix: remove unused onDismiss prop from SpeechBubbleOverlay

### DIFF
--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -433,7 +433,6 @@ const GameModeShell = ({
             segments={[playerBubbleText]}
             anchorX={playerPos.x}
             anchorY={playerPos.y}
-            onDismiss={handleBubbleDismiss}
             variant="player"
           />
         ) : null}
@@ -443,7 +442,6 @@ const GameModeShell = ({
             segments={bubbleSegments}
             anchorX={syzygyPos.x}
             anchorY={syzygyPos.y}
-            onDismiss={handleBubbleDismiss}
             variant="npc"
           />
         ) : null}

--- a/src/game/ui/SpeechBubbleOverlay.tsx
+++ b/src/game/ui/SpeechBubbleOverlay.tsx
@@ -4,7 +4,6 @@ type SpeechBubbleOverlayProps = {
   segments: string[]
   anchorX: number
   anchorY: number
-  onDismiss: () => void
   variant?: 'npc' | 'player'
 }
 
@@ -81,7 +80,6 @@ const SpeechBubbleOverlay = ({
   segments,
   anchorX,
   anchorY,
-  onDismiss,
   variant = 'npc',
 }: SpeechBubbleOverlayProps) => {
   const sequenceKey = useMemo(() => segments.join('\n'), [segments])


### PR DESCRIPTION
Dismissal is now handled entirely by the click-away listener in GameModeShell, so the component no longer needs the prop.

https://claude.ai/code/session_01DgJPoa8iBpadmdEtvdNpi7