### PR TITLE
fix: correct mobile speech bubble anchoring so player/NPC bubbles stay attached to sprites

### DIFF
--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -6,22 +6,20 @@ export const GAME_EVENTS = {
   PLAYER_POSITION_UPDATE: 'player-position-update',
 } as const
 
+type SceneAnchorPayload = {
+  x: number
+  y: number
+  sceneWidth: number
+  sceneHeight: number
+}
+
 export type OpenNpcActionsPayload = {
   npcId: 'syzygy'
-  anchor: {
-    x: number
-    y: number
-  }
+  anchor: SceneAnchorPayload
 }
 
-export type SyzygyPositionPayload = {
-  x: number
-  y: number
-}
+export type SyzygyPositionPayload = SceneAnchorPayload
 
-export type PlayerPositionPayload = {
-  x: number
-  y: number
-}
+export type PlayerPositionPayload = SceneAnchorPayload
 
 export const EventBus = new Phaser.Events.EventEmitter()

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -93,6 +93,7 @@ const GameModeShell = ({
     null,
   );
   const npcMenuRef = useRef<HTMLDivElement | null>(null);
+  const viewportRef = useRef<HTMLElement | null>(null);
   const [npcMenuSize, setNpcMenuSize] = useState<{
     width: number;
     height: number;
@@ -105,6 +106,14 @@ const GameModeShell = ({
   const [isBubbleHistoryOpen, setIsBubbleHistoryOpen] = useState(false);
   const [bubbleSending, setBubbleSending] = useState(false);
   const [bubbleSegments, setBubbleSegments] = useState<string[]>([]);
+  const [viewportMetrics, setViewportMetrics] = useState<{
+    viewportWidth: number;
+    viewportHeight: number;
+    canvasOffsetLeft: number;
+    canvasOffsetTop: number;
+    canvasWidth: number;
+    canvasHeight: number;
+  } | null>(null);
   const [playerBubbleText, setPlayerBubbleText] = useState<string | null>(null);
   const [syzygyPos, setSyzygyPos] = useState<SyzygyPositionPayload | null>(null);
   const [playerPos, setPlayerPos] = useState<PlayerPositionPayload | null>(null);
@@ -349,36 +358,118 @@ const GameModeShell = ({
     );
   }, [activeNpcMenu]);
 
+  const toViewportAnchor = useCallback((anchor: { x: number; y: number; sceneWidth: number; sceneHeight: number }) => {
+    if (!viewportMetrics || !anchor.sceneWidth || !anchor.sceneHeight) {
+      return null;
+    }
+
+    const relativeX = anchor.x / anchor.sceneWidth;
+    const relativeY = anchor.y / anchor.sceneHeight;
+
+    return {
+      x: viewportMetrics.canvasOffsetLeft + relativeX * viewportMetrics.canvasWidth,
+      y: viewportMetrics.canvasOffsetTop + relativeY * viewportMetrics.canvasHeight,
+    };
+  }, [viewportMetrics]);
+
+  useLayoutEffect(() => {
+    const viewportElement = viewportRef.current;
+    if (!viewportElement) {
+      return;
+    }
+
+    const refreshLayout = () => {
+      const canvasElement = viewportElement.querySelector('canvas');
+      if (!(canvasElement instanceof HTMLCanvasElement)) {
+        setViewportMetrics(null);
+        return;
+      }
+
+      const viewportRect = viewportElement.getBoundingClientRect();
+      const canvasRect = canvasElement.getBoundingClientRect();
+
+      setViewportMetrics({
+        viewportWidth: viewportRect.width,
+        viewportHeight: viewportRect.height,
+        canvasOffsetLeft: canvasRect.left - viewportRect.left,
+        canvasOffsetTop: canvasRect.top - viewportRect.top,
+        canvasWidth: canvasRect.width,
+        canvasHeight: canvasRect.height,
+      });
+    };
+
+    refreshLayout();
+
+    const resizeObserver = new ResizeObserver(() => {
+      refreshLayout();
+    });
+
+    resizeObserver.observe(viewportElement);
+
+    const canvasElement = viewportElement.querySelector('canvas');
+    if (canvasElement instanceof HTMLCanvasElement) {
+      resizeObserver.observe(canvasElement);
+    }
+
+    window.addEventListener('resize', refreshLayout);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', refreshLayout);
+    };
+  }, []);
+
+  const playerBubbleAnchor = useMemo(() => {
+    if (!playerPos) {
+      return null;
+    }
+
+    return toViewportAnchor(playerPos);
+  }, [playerPos, toViewportAnchor]);
+
+  const syzygyBubbleAnchor = useMemo(() => {
+    if (!syzygyPos) {
+      return null;
+    }
+
+    return toViewportAnchor(syzygyPos);
+  }, [syzygyPos, toViewportAnchor]);
+
   const npcMenuPosition = useMemo(() => {
     if (!activeNpcMenu) {
       return null;
     }
 
     const { edgePadding, anchorOffset } = NPC_MENU_LAYOUT;
+    const viewportAnchor = toViewportAnchor(activeNpcMenu.anchor);
+
+    if (!viewportAnchor) {
+      return null;
+    }
     const menuWidth = npcMenuSize.width;
     const menuHeight = npcMenuSize.height;
 
     const candidatePositions = [
       {
-        left: activeNpcMenu.anchor.x + anchorOffset,
-        top: activeNpcMenu.anchor.y - menuHeight - anchorOffset,
+        left: viewportAnchor.x + anchorOffset,
+        top: viewportAnchor.y - menuHeight - anchorOffset,
       },
       {
-        left: activeNpcMenu.anchor.x + anchorOffset,
-        top: activeNpcMenu.anchor.y + anchorOffset,
+        left: viewportAnchor.x + anchorOffset,
+        top: viewportAnchor.y + anchorOffset,
       },
       {
-        left: activeNpcMenu.anchor.x - menuWidth - anchorOffset,
-        top: activeNpcMenu.anchor.y - menuHeight - anchorOffset,
+        left: viewportAnchor.x - menuWidth - anchorOffset,
+        top: viewportAnchor.y - menuHeight - anchorOffset,
       },
       {
-        left: activeNpcMenu.anchor.x - menuWidth - anchorOffset,
-        top: activeNpcMenu.anchor.y + anchorOffset,
+        left: viewportAnchor.x - menuWidth - anchorOffset,
+        top: viewportAnchor.y + anchorOffset,
       },
     ];
 
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
+    const viewportWidth = viewportMetrics?.viewportWidth ?? window.innerWidth;
+    const viewportHeight = viewportMetrics?.viewportHeight ?? window.innerHeight;
 
     const findBestPosition = () => {
       for (const position of candidatePositions) {
@@ -395,12 +486,12 @@ const GameModeShell = ({
 
       return {
         left: clamp(
-          activeNpcMenu.anchor.x + anchorOffset,
+          viewportAnchor.x + anchorOffset,
           edgePadding,
           viewportWidth - edgePadding - menuWidth,
         ),
         top: clamp(
-          activeNpcMenu.anchor.y - menuHeight - anchorOffset,
+          viewportAnchor.y - menuHeight - anchorOffset,
           edgePadding,
           viewportHeight - edgePadding - menuHeight,
         ),
@@ -413,7 +504,7 @@ const GameModeShell = ({
       left: `${position.left}px`,
       top: `${position.top}px`,
     };
-  }, [activeNpcMenu, npcMenuSize.height, npcMenuSize.width]);
+  }, [activeNpcMenu, npcMenuSize.height, npcMenuSize.width, toViewportAnchor, viewportMetrics]);
 
   const featureMeta = activeFeature ? GAME_FEATURE_META[activeFeature] : null;
 
@@ -421,64 +512,68 @@ const GameModeShell = ({
     <div className="app-shell game-mode-shell">
       <div className="game-mode-container">
         <GameHud
+          viewportRef={viewportRef}
           onOpenPawMenu={() => setIsPawMenuOpen((open) => !open)}
           onOpenSettings={() => setIsSettingsOpen(true)}
           onBubbleSend={handleBubbleSend}
           onOpenBubbleHistory={() => setIsBubbleHistoryOpen(true)}
           bubbleSending={bubbleSending}
+          viewportOverlay={
+            <>
+              {playerBubbleText && playerBubbleAnchor ? (
+                <SpeechBubbleOverlay
+                  segments={[playerBubbleText]}
+                  anchorX={playerBubbleAnchor.x}
+                  anchorY={playerBubbleAnchor.y}
+                  variant="player"
+                />
+              ) : null}
+
+              {bubbleSegments.length > 0 && syzygyBubbleAnchor ? (
+                <SpeechBubbleOverlay
+                  segments={bubbleSegments}
+                  anchorX={syzygyBubbleAnchor.x}
+                  anchorY={syzygyBubbleAnchor.y}
+                  variant="npc"
+                />
+              ) : null}
+
+              {activeNpcMenu && npcMenuPosition ? (
+                <div className="npc-actions-layer" role="presentation">
+                  <div
+                    ref={npcMenuRef}
+                    className="npc-actions-menu"
+                    role="dialog"
+                    aria-label="仓鼠互动菜单"
+                    style={npcMenuPosition}
+                  >
+                    <button
+                      type="button"
+                      className="npc-actions-menu__button npc-actions-menu__button--chat"
+                      onClick={handleOpenChat}
+                    >
+                      聊天
+                    </button>
+                    <button
+                      type="button"
+                      className="npc-actions-menu__button npc-actions-menu__button--close"
+                      onClick={handleCloseNpcActions}
+                    >
+                      关闭
+                    </button>
+                    <button
+                      type="button"
+                      className="npc-actions-menu__button npc-actions-menu__button--disabled"
+                      disabled
+                    >
+                      互动（即将开放）
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </>
+          }
         />
-
-        {playerBubbleText && playerPos ? (
-          <SpeechBubbleOverlay
-            segments={[playerBubbleText]}
-            anchorX={playerPos.x}
-            anchorY={playerPos.y}
-            variant="player"
-          />
-        ) : null}
-
-        {bubbleSegments.length > 0 && syzygyPos ? (
-          <SpeechBubbleOverlay
-            segments={bubbleSegments}
-            anchorX={syzygyPos.x}
-            anchorY={syzygyPos.y}
-            variant="npc"
-          />
-        ) : null}
-
-        {activeNpcMenu && npcMenuPosition ? (
-          <div className="npc-actions-layer" role="presentation">
-            <div
-              ref={npcMenuRef}
-              className="npc-actions-menu"
-              role="dialog"
-              aria-label="仓鼠互动菜单"
-              style={npcMenuPosition}
-            >
-              <button
-                type="button"
-                className="npc-actions-menu__button npc-actions-menu__button--chat"
-                onClick={handleOpenChat}
-              >
-                聊天
-              </button>
-              <button
-                type="button"
-                className="npc-actions-menu__button npc-actions-menu__button--close"
-                onClick={handleCloseNpcActions}
-              >
-                关闭
-              </button>
-              <button
-                type="button"
-                className="npc-actions-menu__button npc-actions-menu__button--disabled"
-                disabled
-              >
-                互动（即将开放）
-              </button>
-            </div>
-          </div>
-        ) : null}
 
         {isPawMenuOpen ? (
           <GameMenuOverlay

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -243,6 +243,7 @@
 }
 
 .game-viewport-shell {
+  position: relative;
   min-height: 0;
   padding: clamp(8px, 1.8vw, 14px);
   border-radius: 18px;
@@ -269,6 +270,14 @@
   width: 100%;
   height: 100%;
   min-height: 220px;
+}
+
+.game-viewport-overlay-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+  overflow: visible;
 }
 
 .game-bottom-bar {
@@ -432,7 +441,7 @@
 }
 
 .npc-actions-layer {
-  position: fixed;
+  position: absolute;
   inset: 0;
   z-index: 28;
   pointer-events: none;
@@ -1251,7 +1260,7 @@
 /* ── Speech bubble overlay ── */
 
 .speech-bubble-overlay {
-  position: fixed;
+  position: absolute;
   z-index: 35;
   transform: translate(-50%, -100%);
   pointer-events: none;

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -9,16 +9,14 @@ export class HomeScene extends Phaser.Scene {
   private playerSprite?: Phaser.GameObjects.Image
   private syzygySprite?: Phaser.GameObjects.Image
 
-  private getSpriteScreenAnchor(sprite: Phaser.GameObjects.Image) {
+  private getSpriteCanvasAnchor(sprite: Phaser.GameObjects.Image) {
     const bounds = sprite.getBounds()
-    const canvas = this.game.canvas
-    const canvasRect = canvas.getBoundingClientRect()
-    const scaleX = canvasRect.width / this.scale.width
-    const scaleY = canvasRect.height / this.scale.height
 
     return {
-      x: canvasRect.left + bounds.right * scaleX,
-      y: canvasRect.top + (bounds.top + bounds.height * 0.45) * scaleY,
+      x: bounds.right,
+      y: bounds.top + bounds.height * 0.45,
+      sceneWidth: this.scale.width,
+      sceneHeight: this.scale.height,
     }
   }
 
@@ -41,14 +39,12 @@ export class HomeScene extends Phaser.Scene {
       return
     }
     const bounds = this.playerSprite.getBounds()
-    const canvas = this.game.canvas
-    const canvasRect = canvas.getBoundingClientRect()
-    const scaleX = canvasRect.width / this.scale.width
-    const scaleY = canvasRect.height / this.scale.height
 
     EventBus.emit(GAME_EVENTS.PLAYER_POSITION_UPDATE, {
-      x: canvasRect.left + (bounds.x + bounds.width * 0.5) * scaleX,
-      y: canvasRect.top + bounds.top * scaleY,
+      x: bounds.x + bounds.width * 0.5,
+      y: bounds.top,
+      sceneWidth: this.scale.width,
+      sceneHeight: this.scale.height,
     })
   }
 
@@ -57,14 +53,12 @@ export class HomeScene extends Phaser.Scene {
       return
     }
     const bounds = this.syzygySprite.getBounds()
-    const canvas = this.game.canvas
-    const canvasRect = canvas.getBoundingClientRect()
-    const scaleX = canvasRect.width / this.scale.width
-    const scaleY = canvasRect.height / this.scale.height
 
     EventBus.emit(GAME_EVENTS.SYZYGY_POSITION_UPDATE, {
-      x: canvasRect.left + (bounds.x + bounds.width * 0.5) * scaleX,
-      y: canvasRect.top + bounds.top * scaleY,
+      x: bounds.x + bounds.width * 0.5,
+      y: bounds.top,
+      sceneWidth: this.scale.width,
+      sceneHeight: this.scale.height,
     })
   }
 
@@ -101,7 +95,7 @@ export class HomeScene extends Phaser.Scene {
 
       EventBus.emit(GAME_EVENTS.OPEN_NPC_ACTIONS, {
         npcId: 'syzygy',
-        anchor: this.getSpriteScreenAnchor(this.syzygySprite),
+        anchor: this.getSpriteCanvasAnchor(this.syzygySprite),
       })
     })
 

--- a/src/game/ui/GameHud.tsx
+++ b/src/game/ui/GameHud.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode, RefObject } from 'react'
 import GameContainer from '../GameContainer'
 import GameBottomBar from './GameBottomBar'
 import GameTopBar from './GameTopBar'
@@ -8,16 +9,19 @@ type GameHudProps = {
   onBubbleSend: (text: string) => void
   onOpenBubbleHistory: () => void
   bubbleSending: boolean
+  viewportRef: RefObject<HTMLElement | null>
+  viewportOverlay?: ReactNode
 }
 
-const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending }: GameHudProps) => {
+const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending, viewportRef, viewportOverlay }: GameHudProps) => {
   return (
     <div className="game-hud-layout" aria-label="游戏模式主布局">
       <GameTopBar stamina={30} maxStamina={100} level={1} exp={45} maxExp={100} />
-      <section className="game-viewport-shell" aria-label="游戏主视口">
+      <section ref={viewportRef} className="game-viewport-shell" aria-label="游戏主视口">
         <div className="game-viewport-inner-frame">
           <GameContainer />
         </div>
+        {viewportOverlay ? <div className="game-viewport-overlay-layer">{viewportOverlay}</div> : null}
       </section>
       <GameBottomBar
         onOpenPawMenu={onOpenPawMenu}


### PR DESCRIPTION
### Motivation
- On narrow/mobile viewports speech bubbles drift toward the top of the page because overlay positioning used page-level coordinates instead of the rendered game viewport and canvas metrics. 
- The intent is to compute bubble anchors relative to the actual game viewport/canvas so both player and Syzygy bubbles remain visually attached across responsive layouts while keeping desktop behavior unchanged.

### Description
- Emit sprite anchors in scene/canvas space including `sceneWidth` and `sceneHeight` by changing the EventBus payload types and having `HomeScene` provide canvas-relative sprite coordinates instead of page coordinates (`src/game/EventBus.ts`, `src/game/scenes/HomeScene.ts`).
- Add a viewport-aware anchor converter and measurement layer in `GameModeShell` that reads the viewport and canvas bounding rects, computes relative coordinates, and returns overlay positions that include canvas offset and scaling for mobile (`src/game/GameModeShell.tsx`).
- Move bubble and NPC-menu overlays into a dedicated viewport overlay inside the HUD and wire a `viewportRef` so overlays are positioned relative to the game viewport, not the page, preserving bubble visuals/stacking (`src/game/ui/GameHud.tsx`, `src/game/gameHud.css`).
- Update CSS so the overlay layer is positioned inside the viewport and speech bubbles use absolute positioning within that local coordinate space, leaving bubble styling and chat/history logic unchanged (`src/game/gameHud.css`).

### Testing
- Ran lint on the touched files with `./node_modules/.bin/eslint src/game/GameModeShell.tsx src/game/ui/GameHud.tsx src/game/scenes/HomeScene.ts src/game/EventBus.ts` and it completed successfully for the modified files (no new errors; pre-existing unrelated warnings remain). 
- Built a production bundle with `npm run build` which ran `tsc -b && vite build` and completed successfully (exit 0). 
- Manual verification: on desktop bubble positioning remains unchanged and correctly anchored; on narrow/mobile viewports player bubbles appear near 串串 and Syzygy reply bubbles appear near Syzygy instead of drifting to the top; no console errors observed during these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bca1bab3608330aca9153f9fe9c1c4)