### PR TITLE
refactor: redesign bottom game control bar layout to give bubble input center priority

### DIFF
--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -282,9 +282,9 @@
 
 .game-bottom-bar {
   padding: 9px;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 14px;
   background: linear-gradient(180deg, #f7dace 0%, #efc7bd 100%);
   min-width: 0;
@@ -360,11 +360,11 @@
 }
 
 .game-bottom-controls {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: end;
   gap: 10px;
-  margin-left: auto;
   padding: 8px;
   border: 3px solid var(--game-shell-edge);
   border-radius: 12px;
@@ -373,21 +373,36 @@
 }
 
 .game-bubble-input-bar {
-  flex: 1;
   min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 10px;
   padding: 8px;
   border: 3px solid var(--game-shell-edge);
   border-radius: 12px;
   background: linear-gradient(180deg, #ffe5d9 0%, #f7c8bf 100%);
   box-shadow: inset 0 0 0 2px #fff2e9;
+  min-height: clamp(62px, 8vw, 76px);
+}
+
+.game-bubble-input-bar__main-input {
+  min-width: 0;
+  display: flex;
+}
+
+.game-bubble-input-bar__mini-stack {
+  display: grid;
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  width: clamp(40px, 4.6vw, 48px);
+  flex-shrink: 0;
 }
 
 .game-bubble-input-bar__history-button {
-  width: 36px;
-  height: 36px;
+  width: 100%;
+  height: 100%;
+  min-height: 28px;
   flex-shrink: 0;
   border: 2px solid #6f4a44;
   border-radius: 8px;
@@ -406,11 +421,15 @@
 .game-bubble-input-bar__input {
   flex: 1;
   min-width: 0;
-  height: 36px;
+  height: 100%;
+  min-height: 46px;
   border: 2px solid var(--game-shell-edge);
-  border-radius: 8px;
-  background: #fff2e9;
-  padding: 0 10px;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #fff6ef 0%, #ffe6db 100%);
+  box-shadow:
+    inset 0 2px 0 #fffdf8,
+    inset 0 -2px 0 rgba(126, 86, 78, 0.12);
+  padding: 0 14px;
   font-size: 13px;
   font-family: inherit;
   color: var(--game-text);
@@ -1011,18 +1030,23 @@
   }
 
   .game-bubble-input-bar {
-    gap: 6px;
+    gap: 8px;
     padding: 6px;
+    min-height: 58px;
+  }
+
+  .game-bubble-input-bar__mini-stack {
+    gap: 6px;
+    width: 38px;
   }
 
   .game-bubble-input-bar__history-button {
-    width: 32px;
-    height: 32px;
     font-size: 14px;
   }
 
   .game-bubble-input-bar__input {
-    height: 32px;
+    min-height: 42px;
+    padding: 0 12px;
     font-size: 12px;
   }
 
@@ -1176,7 +1200,7 @@
   .game-bottom-bar {
     gap: 6px;
     padding: 6px;
-    flex-wrap: wrap;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     border-radius: 10px;
   }
 
@@ -1189,10 +1213,19 @@
   }
 
   .game-bubble-input-bar {
-    gap: 4px;
+    gap: 5px;
     padding: 5px;
-    order: 3;
-    flex-basis: 100%;
+    min-height: 54px;
+  }
+
+  .game-bubble-input-bar__mini-stack {
+    gap: 5px;
+    width: 34px;
+  }
+
+  .game-bubble-input-bar__input {
+    min-height: 38px;
+    padding: 0 10px;
   }
 
   .game-bottom-controls {
@@ -1234,8 +1267,9 @@
 /* ── Send button in bubble input bar ── */
 
 .game-bubble-input-bar__send-button {
-  width: 36px;
-  height: 36px;
+  width: 100%;
+  height: 100%;
+  min-height: 28px;
   flex-shrink: 0;
   border: 2px solid #6f4a44;
   border-radius: 8px;

--- a/src/game/ui/GameBubbleInputBar.tsx
+++ b/src/game/ui/GameBubbleInputBar.tsx
@@ -39,34 +39,38 @@ const GameBubbleInputBar = ({ onSend, onOpenHistory, disabled }: GameBubbleInput
       aria-label="气泡聊天输入栏"
       onSubmit={handleSubmit}
     >
-      <button
-        type="button"
-        className="game-bubble-input-bar__history-button"
-        aria-label="聊天历史记录"
-        onClick={onOpenHistory}
-      >
-        🕐
-      </button>
+      <div className="game-bubble-input-bar__main-input">
+        <input
+          type="text"
+          className="game-bubble-input-bar__input"
+          placeholder="跟 Syzygy 说点什么..."
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          aria-label="气泡聊天输入框"
+        />
+      </div>
 
-      <input
-        type="text"
-        className="game-bubble-input-bar__input"
-        placeholder="跟 Syzygy 说点什么..."
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        aria-label="气泡聊天输入框"
-      />
+      <div className="game-bubble-input-bar__mini-stack" aria-label="聊天快捷操作">
+        <button
+          type="button"
+          className="game-bubble-input-bar__history-button"
+          aria-label="聊天历史记录"
+          onClick={onOpenHistory}
+        >
+          🕐
+        </button>
 
-      <button
-        type="submit"
-        className="game-bubble-input-bar__send-button"
-        disabled={disabled || !draft.trim()}
-        aria-label="发送消息"
-      >
-        {disabled ? '…' : '→'}
-      </button>
+        <button
+          type="submit"
+          className="game-bubble-input-bar__send-button"
+          disabled={disabled || !draft.trim()}
+          aria-label="发送消息"
+        >
+          {disabled ? '…' : '→'}
+        </button>
+      </div>
     </form>
   )
 }


### PR DESCRIPTION
### Motivation
- The bubble-chat input in Game Mode needs stronger visual priority and cleaner spatial organization so the core interaction is central and more tap-friendly.
- The previous bottom bar felt cramped with the input as a narrow strip between controls, reducing emphasis on conversation input.
- This change is a layout-only refactor to improve spacing, balance, and hierarchy while preserving the retro handheld / pixel-style UI language.

### Description
- Reworked the bottom bar container from a horizontal flex row to a three-column grid to establish left (D-pad), central (bubble input), and right (system controls) blocks by updating `src/game/gameHud.css`.
- Restructured the bubble input markup in `src/game/ui/GameBubbleInputBar.tsx` so the text field becomes a larger central block (`.game-bubble-input-bar__main-input`) and history/send move into a compact vertical mini-stack (`.game-bubble-input-bar__mini-stack`) immediately to the right of the input, keeping all handlers intact (`onSend`, `onOpenHistory`).
- Introduced new and adjusted CSS rules (`.game-bubble-input-bar`, `.game-bubble-input-bar__mini-stack`, `.game-bubble-input-bar__input`, `.game-bottom-controls`) to increase input prominence, preserve tappable mini-buttons, and keep the settings and paw buttons as larger separate system controls on the far right.
- Manual verification notes: on desktop the layout reads as `D-pad | larger input block + vertical history/send stack | settings | paw` with the input visually centered, and on mobile the structure is preserved with tightened sizing to avoid horizontal overflow and keep touch targets usable.

### Testing
- Ran `npm run build` (TypeScript build and `vite build`) and the build completed successfully with assets generated and no errors, only a size warning for large chunks.
- Ran `npm run lint` (`eslint .`) which completed; it surfaced one pre-existing warning in `src/pages/CheckinPage.tsx` but no new errors related to this refactor.
- Verified locally in development build (visual/manual checks) that the D-pad, input behavior, history modal, send action, settings, and paw button functions behave as before and that no console errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bca86a5e908330a0c056a395a7a83e)