### PR TITLE
Replace isFirstMessage flag with module-based memory injection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -665,12 +665,6 @@ const App = () => {
         max_tokens: activeSettings.maxTokens,
       }
       const systemPrompt = activeSettings.systemPrompt
-      const isFirstMessageInSession = !messagesRef.current.some(
-        (message) =>
-          message.sessionId === sessionId &&
-          message.role === 'user' &&
-          message.content.trim().length > 0,
-      )
       const clientId = createClientId()
       const clientCreatedAt = new Date().toISOString()
       const optimisticMessage: ChatMessage = {
@@ -963,7 +957,6 @@ const App = () => {
             top_p: paramsSnapshot.top_p,
             max_tokens: paramsSnapshot.max_tokens,
             stream: true,
-            isFirstMessage: isFirstMessageInSession,
           }
           if (reasoningEnabled) {
             requestBody.reasoning = highThinkingEnabled && isGpt5Auto(effectiveModel)

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -16,8 +16,7 @@ type OpenRouterPayload = {
   max_tokens?: number
   reasoning?: boolean | Record<string, unknown>
   stream?: boolean
-  isFirstMessage?: boolean
-  module?: 'snack-feed' | 'syzygy-feed' | 'rp-room' | string
+  module?: 'snack-feed' | 'syzygy-feed' | 'bubble-chat' | 'rp-room' | string
   rpKeepRecentMessages?: number
   debug?: boolean
   extra?: Record<string, unknown>
@@ -171,7 +170,10 @@ const extractOpenRouterContent = (payload: Record<string, unknown>): string => {
 
 const shouldInjectSyzygyFeedMemory = (payload: OpenRouterPayload) => payload.module === 'syzygy-feed'
 
-const shouldInjectChitchatMemory = (payload: OpenRouterPayload) => Boolean(payload.isFirstMessage)
+const shouldInjectChitchatMemory = (payload: OpenRouterPayload) =>
+  !payload.module || payload.module === 'chitchat'
+
+const shouldInjectBubbleChatMemory = (payload: OpenRouterPayload) => payload.module === 'bubble-chat'
 const resolveCompressionModule = (payload: OpenRouterPayload): 'chat' | 'rp' | null => {
   if (!payload.module || payload.module === 'chitchat') {
     return 'chat'
@@ -839,6 +841,7 @@ const maybeInjectMemory = async (
     !shouldInjectSnackFeedMemory(payload)
     && !shouldInjectSyzygyFeedMemory(payload)
     && !shouldInjectChitchatMemory(payload)
+    && !shouldInjectBubbleChatMemory(payload)
   ) {
     return messages
   }


### PR DESCRIPTION
## Summary
Refactored the memory injection logic to use module-based detection instead of tracking whether a message is the first in a session. This simplifies the codebase by removing session-level state tracking and makes the memory injection strategy more explicit and maintainable.

## Key Changes
- Removed `isFirstMessage` parameter from OpenRouter payload type and client request logic
- Replaced `isFirstMessage` flag-based chitchat memory detection with module-based detection (`!payload.module || payload.module === 'chitchat'`)
- Added support for `'bubble-chat'` module with dedicated memory injection logic (`shouldInjectBubbleChatMemory`)
- Removed session-level first message detection logic from App.tsx that tracked user messages across sessions
- Updated memory injection guard to check for bubble-chat module alongside existing module checks

## Implementation Details
- The `shouldInjectChitchatMemory` function now checks if no module is specified or if the module is explicitly 'chitchat', making the default behavior more transparent
- New `shouldInjectBubbleChatMemory` function handles memory injection for the bubble-chat module specifically
- The memory injection guard in `maybeInjectMemory` now includes the bubble-chat check to prevent unnecessary memory operations
- This change moves from implicit state-based detection (first message flag) to explicit module-based detection, improving code clarity

https://claude.ai/code/session_017tifP2CRQoGVHMFfT6dpot