### PR TITLE
refactor: strengthen pixel-style borders, panels, and control language across Game Mode

### DIFF
--- a/src/components/SessionsDrawer.css
+++ b/src/components/SessionsDrawer.css
@@ -259,8 +259,9 @@
   border-top-right-radius: 18px;
   border-bottom-right-radius: 18px;
   box-shadow:
-    inset 0 0 0 2px #fffdf9,
-    inset 0 0 0 6px rgba(246, 215, 212, 0.42),
+    inset 0 0 0 2px #726e69,
+    inset 0 0 0 6px #fffdf9,
+    inset 0 0 0 10px rgba(246, 215, 212, 0.42),
     inset -7px 0 0 rgba(134, 130, 125, 0.24),
     0 12px 0 rgba(134, 130, 125, 0.26),
     0 18px 34px rgba(90, 85, 81, 0.18);
@@ -287,7 +288,9 @@
   border-radius: 12px;
   padding: 10px 12px;
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.18);
 }
 
 .sessions-drawer--pixel .drawer-header h2 {
@@ -316,8 +319,24 @@
   border-radius: 9px;
   box-shadow:
     inset 0 1px 0 #fffdf9,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.45);
+    inset 0 -3px 0 rgba(134, 130, 125, 0.45),
+    0 2px 0 rgba(134, 130, 125, 0.14);
   font-weight: 800;
+  position: relative;
+  overflow: hidden;
+}
+
+.sessions-drawer--pixel .drawer-tabs button::before,
+.sessions-drawer--pixel button.primary::before,
+.sessions-drawer--pixel button.ghost::before,
+.sessions-drawer--pixel button.danger::before,
+.sessions-drawer--pixel .inline-actions button::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  border-radius: inherit;
+  pointer-events: none;
 }
 
 .sessions-drawer--pixel .drawer-tabs button {
@@ -345,7 +364,10 @@
   border-radius: 10px;
   padding: 10px 12px;
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.12),
+    inset 0 -3px 0 rgba(134, 130, 125, 0.12);
   color: #5a5551;
 }
 
@@ -366,6 +388,7 @@
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   box-shadow:
     inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.12),
     inset 0 -4px 0 rgba(134, 130, 125, 0.2);
 }
 

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -11,6 +11,24 @@
   --game-screen-bezel: #86827d;
   --game-screen-glow: #fffbf5;
   --game-text: #5a5551;
+  --game-frame-border: 4px;
+  --game-panel-border: 3px;
+  --game-control-border: 3px;
+  --game-pixel-radius-lg: 18px;
+  --game-pixel-radius-md: 12px;
+  --game-pixel-radius-sm: 8px;
+  --game-frame-outline: rgba(255, 251, 245, 0.94);
+  --game-frame-inner: rgba(246, 215, 212, 0.42);
+  --game-shadow-drop: rgba(134, 130, 125, 0.28);
+  --game-shadow-deep: rgba(90, 85, 81, 0.18);
+  --game-press-shadow: rgba(134, 130, 125, 0.45);
+  --game-screen-line: rgba(134, 130, 125, 0.12);
+  --game-control-bg: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
+  --game-control-accent-bg: linear-gradient(180deg, #f6d7d4 0%, #efc2bc 100%);
+}
+
+.game-mode-shell button {
+  font-family: inherit;
 }
 
 .game-mode-shell {
@@ -43,13 +61,15 @@
   max-width: 960px;
   margin: 0 auto;
   padding: clamp(10px, 2vw, 18px);
-  border: 4px solid var(--game-shell-edge);
+  border: var(--game-frame-border) solid var(--game-shell-edge);
   border-radius: 24px;
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
   box-shadow:
-    inset 0 0 0 3px var(--game-shell-light),
-    inset 0 -6px 0 var(--game-shell-shadow),
-    0 10px 0 rgba(134, 130, 125, 0.28);
+    inset 0 0 0 2px #726e69,
+    inset 0 0 0 6px var(--game-shell-light),
+    inset 0 0 0 10px rgba(246, 215, 212, 0.56),
+    inset 0 -8px 0 var(--game-shell-shadow),
+    0 12px 0 var(--game-shadow-drop);
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   gap: clamp(10px, 1.8vw, 16px);
@@ -62,19 +82,34 @@
 .game-viewport-shell,
 .game-overlay-panel,
 .game-feature-shell {
-  border: 3px solid var(--game-shell-edge);
+  border: var(--game-panel-border) solid var(--game-shell-edge);
   border-radius: 14px;
   background: var(--game-panel-light);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px var(--game-frame-outline),
+    inset 0 0 0 5px var(--game-frame-inner);
   color: var(--game-text);
 }
 
 .game-top-bar {
-  padding: 10px;
+  padding: 12px;
   display: grid;
   gap: 10px;
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
   min-width: 0;
+  position: relative;
+}
+
+.game-top-bar::after,
+.game-bottom-bar::after,
+.game-overlay-panel::after,
+.game-feature-shell::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border: 1px dashed rgba(134, 130, 125, 0.22);
+  border-radius: calc(var(--game-pixel-radius-md) - 2px);
+  pointer-events: none;
 }
 
 .game-top-bar__main-grid {
@@ -86,10 +121,13 @@
 
 .game-avatar-chip {
   width: clamp(58px, 8vw, 76px);
-  border: 3px solid var(--game-shell-edge);
-  border-radius: 10px;
+  border: var(--game-panel-border) solid var(--game-shell-edge);
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.35),
+    inset 0 -4px 0 rgba(134, 130, 125, 0.2);
   display: grid;
   place-items: center;
 }
@@ -99,13 +137,16 @@
 }
 
 .game-player-panel {
-  border: 3px solid var(--game-shell-edge);
-  border-radius: 10px;
+  border: var(--game-panel-border) solid var(--game-shell-edge);
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
-  padding: 6px 8px;
+  padding: 7px 9px;
   display: grid;
   gap: 6px;
   min-width: 0;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 -4px 0 rgba(134, 130, 125, 0.18);
 }
 
 .game-player-panel__label-row {
@@ -145,6 +186,9 @@
   border-radius: 4px;
   background: #efe4d8;
   overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -2px 0 rgba(134, 130, 125, 0.16);
 }
 
 .game-mini-status__fill {
@@ -177,6 +221,9 @@
   display: grid;
   place-items: center;
   padding: 0 6px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    inset 0 -2px 0 rgba(134, 130, 125, 0.14);
 }
 
 .game-chip--coin {
@@ -199,9 +246,12 @@
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
-  border: 3px solid var(--game-shell-edge);
+  border: var(--game-panel-border) solid var(--game-shell-edge);
   border-radius: 9px;
   background: #fdf4e8;
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 251, 245, 0.92),
+    inset 0 -4px 0 rgba(134, 130, 125, 0.14);
 }
 
 .game-status-label {
@@ -220,6 +270,9 @@
   border-radius: 5px;
   background: #efe4d8;
   overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -2px 0 rgba(134, 130, 125, 0.16);
 }
 
 .game-progress-track__fill {
@@ -246,24 +299,44 @@
   position: relative;
   min-height: 0;
   padding: clamp(8px, 1.8vw, 14px);
-  border-radius: 18px;
+  border-radius: var(--game-pixel-radius-lg);
   background: linear-gradient(180deg, #fdf4e8 0%, #eadbcf 100%);
   box-shadow:
-    inset 0 0 0 3px var(--game-screen-outer),
-    inset 0 0 0 6px #d7ccc1;
+    inset 0 0 0 2px rgba(115, 109, 103, 0.82),
+    inset 0 0 0 5px var(--game-screen-outer),
+    inset 0 0 0 9px #d7ccc1,
+    inset 0 0 0 12px rgba(255, 251, 245, 0.55),
+    0 8px 0 rgba(134, 130, 125, 0.18);
 }
 
 .game-viewport-inner-frame {
   height: 100%;
-  border: 3px solid var(--game-screen-bezel);
-  border-radius: 10px;
+  border: 4px solid var(--game-screen-bezel);
+  border-radius: var(--game-pixel-radius-md);
   overflow: hidden;
   background:
     linear-gradient(180deg, rgba(255, 251, 245, 0.72), rgba(255, 251, 245, 0)),
     var(--game-screen-glow);
   box-shadow:
-    inset 0 0 0 2px #d0c7bf,
+    inset 0 0 0 2px #6f6a65,
+    inset 0 0 0 6px #d0c7bf,
+    inset 0 0 0 9px rgba(255, 251, 245, 0.38),
     inset 0 -6px 12px rgba(134, 130, 125, 0.18);
+  position: relative;
+}
+
+.game-viewport-inner-frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0)),
+    repeating-linear-gradient(
+      180deg,
+      transparent 0 12px,
+      var(--game-screen-line) 12px 13px
+    );
+  pointer-events: none;
 }
 
 .game-canvas-container {
@@ -281,6 +354,7 @@
 }
 
 .game-bottom-bar {
+  position: relative;
   padding: 9px;
   display: grid;
   grid-template-columns: clamp(108px, 13vw, 126px) minmax(0, 1fr) clamp(68px, 7vw, 82px);
@@ -299,19 +373,23 @@
   gap: 5px;
   padding: 8px;
   border: 3px solid var(--game-shell-edge);
-  border-radius: 12px;
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #f6d7d4 0%, #e8c5c1 100%);
-  box-shadow: inset 0 0 0 2px #fff6f3;
+  box-shadow:
+    inset 0 0 0 2px #fff6f3,
+    inset 0 0 0 5px rgba(255, 251, 245, 0.2),
+    inset 0 -4px 0 rgba(134, 130, 125, 0.18);
   flex-shrink: 0;
 }
 
 .game-dpad-button {
-  border: 2px solid var(--game-shell-edge);
-  border-radius: 6px;
+  border: var(--game-control-border) solid var(--game-shell-edge);
+  border-radius: var(--game-pixel-radius-sm);
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
   box-shadow:
     inset 0 2px 0 #fffdf9,
-    inset 0 -2px 0 #c8b8aa;
+    inset 0 -3px 0 #c8b8aa,
+    0 2px 0 rgba(134, 130, 125, 0.16);
   display: grid;
   place-items: center;
   padding: 0;
@@ -367,8 +445,11 @@
   gap: 8px;
   padding: 8px;
   border: 3px solid var(--game-shell-edge);
-  border-radius: 12px;
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 251, 245, 0.92),
+    inset 0 -4px 0 rgba(134, 130, 125, 0.14);
   flex-shrink: 0;
   min-height: 100%;
 }
@@ -381,9 +462,12 @@
   gap: 10px;
   padding: 8px;
   border: 3px solid var(--game-shell-edge);
-  border-radius: 12px;
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.18),
+    inset 0 -4px 0 rgba(134, 130, 125, 0.14);
   min-height: clamp(62px, 8vw, 76px);
 }
 
@@ -400,17 +484,49 @@
   flex-shrink: 0;
 }
 
+.game-bubble-input-bar__history-button,
+.game-bubble-input-bar__send-button,
+.game-control-button,
+.game-overlay-close,
+.game-settings-action,
+.game-overlay-card__button,
+.game-feature-shell__utility-button,
+.game-feature-shell__close-button,
+.npc-actions-menu__button,
+.game-paw-menu-item {
+  position: relative;
+  overflow: hidden;
+}
+
+.game-bubble-input-bar__history-button::before,
+.game-bubble-input-bar__send-button::before,
+.game-control-button::before,
+.game-overlay-close::before,
+.game-settings-action::before,
+.game-overlay-card__button::before,
+.game-feature-shell__utility-button::before,
+.game-feature-shell__close-button::before,
+.npc-actions-menu__button::before,
+.game-paw-menu-item::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: inherit;
+  pointer-events: none;
+}
+
 .game-bubble-input-bar__history-button {
   width: 100%;
   height: 100%;
   min-height: 28px;
   flex-shrink: 0;
   border: 2px solid var(--game-shell-edge);
-  border-radius: 8px;
-  background: linear-gradient(180deg, #fdf4e8 0%, #f6d7d4 100%);
+  border-radius: var(--game-pixel-radius-sm);
+  background: var(--game-control-bg);
   box-shadow:
     inset 0 1px 0 #fffdf9,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.42);
+    inset 0 -3px 0 rgba(134, 130, 125, 0.42);
   color: var(--game-text);
   font-size: 16px;
   padding: 0;
@@ -425,11 +541,12 @@
   height: 100%;
   min-height: 46px;
   border: 2px solid var(--game-shell-edge);
-  border-radius: 10px;
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   box-shadow:
     inset 0 2px 0 #ffffff,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.12);
+    inset 0 -3px 0 rgba(134, 130, 125, 0.14),
+    inset 0 0 0 4px rgba(246, 215, 212, 0.1);
   padding: 0 14px;
   font-size: 13px;
   font-family: inherit;
@@ -447,19 +564,25 @@
   min-width: 0;
   height: 100%;
   min-height: 0;
-  border: 3px solid var(--game-shell-edge);
+  border: var(--game-control-border) solid var(--game-shell-edge);
   border-radius: 14px;
-  background: linear-gradient(180deg, #f6d7d4 0%, #edc2bc 100%);
+  background: var(--game-control-bg);
   box-shadow:
     inset 0 2px 0 #fffdf9,
-    inset 0 -2px 0 #c8b8aa;
+    inset 0 -4px 0 #c8b8aa,
+    0 3px 0 rgba(134, 130, 125, 0.16);
   color: var(--game-text);
   font-size: clamp(22px, 3vw, 26px);
   padding: 0;
 }
 
+.game-control-button--icon {
+  background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
+}
+
 .game-control-button--paw {
   font-size: clamp(24px, 3vw, 28px);
+  background: var(--game-control-accent-bg);
 }
 
 .npc-actions-layer {
@@ -476,10 +599,11 @@
   display: grid;
   gap: 6px;
   border: 3px solid var(--game-shell-edge);
-  border-radius: 12px;
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   box-shadow:
     inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.18),
     inset 0 -4px 0 rgba(134, 130, 125, 0.28),
     0 6px 0 rgba(134, 130, 125, 0.22);
   pointer-events: auto;
@@ -488,10 +612,10 @@
 .npc-actions-menu__button {
   min-height: 40px;
   border: 2px solid var(--game-shell-edge);
-  border-radius: 10px;
+  border-radius: var(--game-pixel-radius-md);
   box-shadow:
     inset 0 1px 0 #fffdf9,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.42);
+    inset 0 -3px 0 rgba(134, 130, 125, 0.42);
   color: var(--game-text);
   font-size: 13px;
   font-weight: 700;
@@ -550,6 +674,7 @@
 }
 
 .game-overlay-panel {
+  position: relative;
   width: min(448px, calc(100vw - 24px));
   min-height: min(560px, calc(100vh - 32px));
   max-height: min(78vh, 700px);
@@ -559,7 +684,7 @@
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   box-shadow:
     inset 0 0 0 2px #fffdf9,
-    inset 0 0 0 6px rgba(246, 215, 212, 0.42),
+    inset 0 0 0 7px rgba(246, 215, 212, 0.42),
     inset 0 -7px 0 rgba(134, 130, 125, 0.32),
     0 12px 0 rgba(134, 130, 125, 0.28),
     0 16px 32px rgba(90, 85, 81, 0.16);
@@ -586,8 +711,8 @@
 .game-overlay-close {
   min-height: 36px;
   border: 2px solid var(--game-shell-edge);
-  border-radius: 8px;
-  background: linear-gradient(180deg, #f6d7d4 0%, #efc0b8 100%);
+  border-radius: var(--game-pixel-radius-sm);
+  background: var(--game-control-accent-bg);
   box-shadow:
     inset 0 1px 0 #fffdf9,
     inset 0 -2px 0 #c8b8aa;
@@ -619,10 +744,13 @@
   margin: 10px 0 0;
   padding: 8px 10px;
   border: 2px solid #86827d;
-  border-radius: 8px;
+  border-radius: var(--game-pixel-radius-sm);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   font-size: 12px;
   line-height: 1.4;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.78),
+    inset 0 -3px 0 rgba(134, 130, 125, 0.12);
 }
 
 .game-system-modal__subtitle {
@@ -667,10 +795,12 @@
 
 .game-system-modal__footer {
   border: 3px solid var(--game-shell-edge);
-  border-radius: 10px;
+  border-radius: var(--game-pixel-radius-md);
   padding: 9px;
   background: linear-gradient(180deg, #fdf4e8 0%, #f6d7d4 100%);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 -4px 0 rgba(134, 130, 125, 0.14);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
@@ -688,11 +818,12 @@
 .game-overlay-card,
 .game-shared-settings-entry {
   border: 3px solid var(--game-shell-edge);
-  border-radius: 10px;
+  border-radius: var(--game-pixel-radius-md);
   padding: 10px;
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   box-shadow:
     inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.14),
     inset 0 -4px 0 rgba(134, 130, 125, 0.2);
 }
 
@@ -744,10 +875,12 @@
 
 .game-settings-section {
   border: 3px solid var(--game-shell-edge);
-  border-radius: 10px;
+  border-radius: var(--game-pixel-radius-md);
   padding: 10px;
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.14);
 }
 
 .game-settings-section__title {
@@ -766,9 +899,11 @@
 .game-settings-placeholder-item {
   min-height: 42px;
   border: 2px solid #86827d;
-  border-radius: 8px;
+  border-radius: var(--game-pixel-radius-sm);
   background: linear-gradient(180deg, #fdf4e8 0%, #f6d7d4 100%);
-  box-shadow: inset 0 1px 0 #ffeae4;
+  box-shadow:
+    inset 0 1px 0 #ffeae4,
+    inset 0 -3px 0 rgba(134, 130, 125, 0.16);
   padding: 8px 10px;
   display: flex;
   align-items: center;
@@ -785,6 +920,7 @@
   padding: 2px 6px;
   font-size: 10px;
   white-space: nowrap;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.82);
 }
 
 .game-settings-section--shared {
@@ -804,7 +940,8 @@
   border-radius: 9px;
   box-shadow:
     inset 0 1px 0 #fffdf9,
-    inset 0 -2px 0 rgba(97, 64, 57, 0.6);
+    inset 0 -3px 0 rgba(97, 64, 57, 0.6),
+    0 2px 0 rgba(134, 130, 125, 0.16);
   color: var(--game-text);
   font-size: 12px;
   font-weight: 800;
@@ -812,12 +949,12 @@
 }
 
 .game-settings-action--secondary {
-  background: linear-gradient(180deg, #fdf4e8 0%, #f6d7d4 100%);
+  background: var(--game-control-bg);
 }
 
 .game-settings-action--primary,
 .game-overlay-card__button {
-  background: linear-gradient(180deg, #f6d7d4 0%, #efc2bc 100%);
+  background: var(--game-control-accent-bg);
   color: var(--game-text);
 }
 
@@ -841,6 +978,7 @@
 }
 
 .game-feature-shell {
+  position: relative;
   width: min(980px, 100%);
   max-width: min(980px, calc(100vw - 24px));
   height: min(760px, calc(100vh - 24px));
@@ -872,10 +1010,11 @@
   min-height: 38px;
   border: 2px solid var(--game-shell-edge);
   border-radius: 9px;
-  background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
+  background: var(--game-control-bg);
   box-shadow:
     inset 0 1px 0 #fff1eb,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.4);
+    inset 0 -3px 0 rgba(134, 130, 125, 0.4),
+    0 2px 0 rgba(134, 130, 125, 0.14);
   color: var(--game-text);
   font-size: 12px;
   font-weight: 800;
@@ -883,7 +1022,7 @@
 }
 
 .game-feature-shell__close-button {
-  background: linear-gradient(180deg, #f6d7d4 0%, #efc2bc 100%);
+  background: var(--game-control-accent-bg);
   color: var(--game-text);
 }
 
@@ -896,16 +1035,20 @@
   font-weight: 800;
   letter-spacing: 0.12em;
   color: #86827d;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    inset 0 -2px 0 rgba(134, 130, 125, 0.12);
 }
 
 .game-feature-shell__header,
 .game-feature-shell__body {
   min-height: 0;
   border: 3px solid var(--game-shell-edge);
-  border-radius: 12px;
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   box-shadow:
     inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.14),
     inset 0 -4px 0 rgba(134, 130, 125, 0.18);
 }
 
@@ -943,11 +1086,14 @@
   margin: 0;
   padding: 10px 12px;
   border: 2px solid #86827d;
-  border-radius: 10px;
+  border-radius: var(--game-pixel-radius-md);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   font-size: 12px;
   line-height: 1.45;
   color: #6f6964;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    inset 0 -3px 0 rgba(134, 130, 125, 0.14);
 }
 
 .game-feature-shell__body {
@@ -1272,11 +1418,12 @@
   min-height: 28px;
   flex-shrink: 0;
   border: 2px solid var(--game-shell-edge);
-  border-radius: 8px;
-  background: linear-gradient(180deg, #f6d7d4 0%, #efc8c3 100%);
+  border-radius: var(--game-pixel-radius-sm);
+  background: var(--game-control-accent-bg);
   box-shadow:
     inset 0 1px 0 #fffdf9,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.42);
+    inset 0 -3px 0 rgba(134, 130, 125, 0.42),
+    0 2px 0 rgba(134, 130, 125, 0.14);
   color: var(--game-text);
   font-size: 16px;
   font-weight: 700;
@@ -1289,6 +1436,22 @@
 .game-bubble-input-bar__send-button:disabled {
   opacity: 0.55;
   cursor: default;
+}
+
+.game-bubble-input-bar__history-button:active,
+.game-bubble-input-bar__send-button:active,
+.game-control-button:active,
+.game-overlay-close:active,
+.game-settings-action:active,
+.game-overlay-card__button:active,
+.game-feature-shell__utility-button:active,
+.game-feature-shell__close-button:active,
+.npc-actions-menu__button:active,
+.game-paw-menu-item:active {
+  transform: translateY(2px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    inset 0 -1px 0 rgba(134, 130, 125, 0.3);
 }
 
 /* ── Speech bubble overlay ── */

--- a/src/game/ui/GameBottomBar.tsx
+++ b/src/game/ui/GameBottomBar.tsx
@@ -31,11 +31,11 @@ const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubb
 
       <div className="game-bottom-controls" aria-label="功能控制区">
         <button type="button" className="game-control-button game-control-button--icon" onClick={onOpenSettings} aria-label="打开游戏设置">
-          ⚙
+          设
         </button>
 
         <button type="button" className="game-control-button game-control-button--paw" onClick={onOpenPawMenu} aria-label="打开互动菜单">
-          🐾
+          爪
         </button>
       </div>
     </footer>

--- a/src/game/ui/GameBubbleInputBar.tsx
+++ b/src/game/ui/GameBubbleInputBar.tsx
@@ -59,7 +59,7 @@ const GameBubbleInputBar = ({ onSend, onOpenHistory, disabled }: GameBubbleInput
           aria-label="聊天历史记录"
           onClick={onOpenHistory}
         >
-          🕐
+          录
         </button>
 
         <button
@@ -68,7 +68,7 @@ const GameBubbleInputBar = ({ onSend, onOpenHistory, disabled }: GameBubbleInput
           disabled={disabled || !draft.trim()}
           aria-label="发送消息"
         >
-          {disabled ? '…' : '→'}
+          {disabled ? '…' : '发'}
         </button>
       </div>
     </form>

--- a/src/game/ui/GameFeatureShell.tsx
+++ b/src/game/ui/GameFeatureShell.tsx
@@ -12,9 +12,9 @@ const GameFeatureShell = ({ title, subtitle, onBackToGame, children }: GameFeatu
     <div className="game-feature-shell" role="dialog" aria-modal="true" aria-label={`${title} 游戏面板`}>
       <div className="game-feature-shell__utility-row">
         <button type="button" className="game-feature-shell__utility-button" onClick={onBackToGame}>
-          返回游戏
+          返回主机
         </button>
-        <span className="game-feature-shell__utility-tag">PAW MENU FEATURE AREA</span>
+        <span className="game-feature-shell__utility-tag">PAW MENU / SYSTEM CART</span>
       </div>
 
       <header className="game-feature-shell__header">
@@ -23,7 +23,7 @@ const GameFeatureShell = ({ title, subtitle, onBackToGame, children }: GameFeatu
           <div className="game-feature-shell__title-row">
             <h2 className="ui-title">{title}</h2>
             <button type="button" className="game-feature-shell__close-button" onClick={onBackToGame}>
-              关闭
+              收起面板
             </button>
           </div>
           <p className="game-feature-shell__subtitle">{subtitle}</p>

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -781,7 +781,10 @@
 .chat-page--pixel .app-shell__header {
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%) !important;
   border-bottom: 3px solid var(--pixel-border);
-  box-shadow: inset 0 0 0 2px #fffdf9;
+  box-shadow:
+    inset 0 0 0 2px #726e69,
+    inset 0 0 0 6px #fffdf9,
+    inset 0 -6px 0 rgba(134, 130, 125, 0.18);
 }
 
 .chat-page--pixel .chat-header .ghost,
@@ -792,9 +795,22 @@
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   box-shadow:
     inset 0 1px 0 #fffdf9,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.4);
+    inset 0 -3px 0 rgba(134, 130, 125, 0.4),
+    0 2px 0 rgba(134, 130, 125, 0.14);
   color: var(--pixel-text);
   font-weight: 800;
+  position: relative;
+  overflow: hidden;
+}
+
+.chat-page--pixel .chat-header .ghost::before,
+.chat-page--pixel .return-to-game-button::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  border-radius: inherit;
+  pointer-events: none;
 }
 
 .chat-page--pixel .chat-header .ghost:hover,
@@ -820,6 +836,7 @@
   border-radius: 12px;
   box-shadow:
     inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 6px rgba(246, 215, 212, 0.18),
     inset 0 -6px 0 rgba(134, 130, 125, 0.22),
     0 12px 22px rgba(90, 85, 81, 0.14);
 }
@@ -841,9 +858,10 @@
   border: 3px solid var(--pixel-border);
   border-radius: 18px;
   box-shadow:
-    inset 0 0 0 3px #b8b1aa,
-    inset 0 0 0 6px #d7ccc1,
-    inset 0 0 0 9px rgba(255, 251, 245, 0.65),
+    inset 0 0 0 2px #726e69,
+    inset 0 0 0 5px #b8b1aa,
+    inset 0 0 0 9px #d7ccc1,
+    inset 0 0 0 12px rgba(255, 251, 245, 0.65),
     0 10px 18px rgba(90, 85, 81, 0.14);
   padding: 12px 12px calc(18px + env(safe-area-inset-bottom));
 }
@@ -855,6 +873,7 @@
   border-radius: 12px;
   box-shadow:
     inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 5px rgba(246, 215, 212, 0.12),
     inset 0 -4px 0 rgba(134, 130, 125, 0.2);
   color: var(--pixel-text);
 }

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -316,7 +316,7 @@ const ChatPage = ({
         <div className="header-actions" ref={headerMenuRef}>
           {onReturnToGame ? (
             <button type="button" className="ghost return-to-game-button" onClick={onReturnToGame}>
-              Return to Game
+              返回主机
             </button>
           ) : null}
           <button


### PR DESCRIPTION
### Motivation
- Strengthen the pixel-style border/panel/control language so Game Mode reads more like a cozy retro handheld console while preserving the already-updated color palette from the previous change. 
- Focus the change on border weights, layered framing, subtle inset/outset effects, tactile button surfaces, and control label language without altering feature behavior or the color system. 
- Performed a brief manual verification of HUD framing, viewport shell, bottom controls, settings/paw menus, feature modals, NPC action menus, and the Game-mode chat drawer to confirm visual cohesion and no runtime errors. 

### Description
- Added CSS tokens and pixel-oriented frame variables (border weights, radii, inset layers, press states) and applied them across the Game Mode shell, HUD, viewport frame, bottom controls, overlays, and feature panels (`src/game/gameHud.css`).
- Introduced layered frame outlines, dashed interior guide lines for panels, repeating-line subtle scanlines on the viewport, and stronger inset/outset shadowing for device-like shells (`src/game/gameHud.css`).
- Made buttons and control surfaces chunkier and more tactile with inner highlight lines and active press transforms, and unified control backgrounds via new CSS variables (`src/game/gameHud.css`).
- Updated compact control labels and feature-shell language to feel more console-native by changing `⚙`/`🐾`/`🕐`/`→` to `设`/`爪`/`录`/`发`, and renaming feature-shell actions to `返回主机` / `收起面板` (`src/game/ui/GameBottomBar.tsx`, `src/game/ui/GameBubbleInputBar.tsx`, `src/game/ui/GameFeatureShell.tsx`, `src/pages/ChatPage.tsx`).
- Extended the same pixel-framing refinements to the Game-family chat shell and sessions drawer theme so adjacent surfaces remain visually cohesive (`src/pages/ChatPage.css`, `src/components/SessionsDrawer.css`).

### Testing
- Ran a production build with `npm run build`, which completed successfully and produced the application bundles. 
- No automated unit tests were added or modified for this styling-only change and the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce494f0fc8330a36f670e9f673ccd)