### PR TITLE
fix: center icon alignment inside Game Mode control buttons

### DIFF
--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -532,8 +532,10 @@
   color: var(--game-text);
   font-size: 16px;
   padding: 0;
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
   cursor: pointer;
 }
 
@@ -541,7 +543,9 @@
   width: 18px;
   height: 18px;
   display: block;
+  flex-shrink: 0;
   color: currentColor;
+  pointer-events: none;
 }
 
 .game-button-icon--settings {
@@ -593,6 +597,10 @@
   color: var(--game-text);
   font-size: clamp(22px, 3vw, 26px);
   padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
 }
 
 .game-control-button--icon {
@@ -1447,8 +1455,10 @@
   font-size: 16px;
   font-weight: 700;
   padding: 0;
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
   cursor: pointer;
 }
 


### PR DESCRIPTION
### Motivation
- Icons in the Game Mode bottom control buttons (history, send, settings, paw) were visually offset because they were treated like text content instead of true icon buttons. 
- The goal is to center each SVG horizontally and vertically while preserving existing button sizes, layout, and retro styling.

### Description
- Convert the control button centering from CSS grid to shared flex centering by updating `.game-bubble-input-bar__history-button`, `.game-bubble-input-bar__send-button`, and `.game-control-button` to use `display: flex`, `align-items: center`, `justify-content: center`, and `line-height: 0` so SVGs sit precisely in the middle. 
- Normalize icon behavior by adding `flex-shrink: 0` and `pointer-events: none` to `.game-button-icon` so icons keep their intended size and do not capture pointer events. 
- Kept all button footprint, sizes, visual treatments and retro handheld styling unchanged; no JS or functionality was modified. 
- Manual verification summary: open Game Mode and inspect the history, send, settings, and paw buttons to confirm each icon is visually centered horizontally and vertically and buttons remain functional.

### Testing
- Ran `npm run build` which completed successfully and produced the production bundles. 
- Ran `npm run lint` which completed successfully with one unrelated pre-existing React Hooks warning in `src/pages/CheckinPage.tsx`. 
- No runtime/build errors were produced during the automated build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcec211f288330b2c4ca1a11b3e70e)