### PR TITLE
Add typing indicator animation for NPC responses

### DIFF
--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -105,6 +105,7 @@ const GameModeShell = ({
   // Bubble chat state
   const [isBubbleHistoryOpen, setIsBubbleHistoryOpen] = useState(false);
   const [bubbleSending, setBubbleSending] = useState(false);
+  const [isWaitingForReply, setIsWaitingForReply] = useState(false);
   const [bubbleSegments, setBubbleSegments] = useState<string[]>([]);
   const [viewportMetrics, setViewportMetrics] = useState<{
     viewportWidth: number;
@@ -195,8 +196,10 @@ const GameModeShell = ({
         { role: 'user' as const, content: text },
       ];
 
-      // Show player bubble immediately
+      // Show player bubble immediately and typing indicator
       setPlayerBubbleText(text);
+      setBubbleSegments([]);
+      setIsWaitingForReply(true);
       sceneBubblesVisibleRef.current = true;
 
       try {
@@ -252,6 +255,7 @@ const GameModeShell = ({
         }
 
         const segments = parseBubbleReply(content);
+        setIsWaitingForReply(false);
         if (segments.length > 0) {
           setBubbleSegments(segments);
           sceneBubblesVisibleRef.current = true;
@@ -261,12 +265,14 @@ const GameModeShell = ({
       console.warn('Bubble chat error', error);
     } finally {
       setBubbleSending(false);
+      setIsWaitingForReply(false);
     }
   }, [bubbleSending, user, bubbleChatConfig]);
 
   const handleBubbleDismiss = useCallback(() => {
     setBubbleSegments([]);
     setPlayerBubbleText(null);
+    setIsWaitingForReply(false);
     sceneBubblesVisibleRef.current = false;
   }, []);
 
@@ -526,6 +532,16 @@ const GameModeShell = ({
                   anchorX={playerBubbleAnchor.x}
                   anchorY={playerBubbleAnchor.y}
                   variant="player"
+                />
+              ) : null}
+
+              {isWaitingForReply && bubbleSegments.length === 0 && syzygyBubbleAnchor ? (
+                <SpeechBubbleOverlay
+                  segments={[]}
+                  anchorX={syzygyBubbleAnchor.x}
+                  anchorY={syzygyBubbleAnchor.y}
+                  variant="npc"
+                  isTyping
                 />
               ) : null}
 

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -1579,6 +1579,46 @@
   }
 }
 
+/* ── Typing indicator dots ── */
+
+.speech-bubble--typing {
+  padding: 10px 18px;
+  min-width: 64px;
+}
+
+.typing-dots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 20px;
+}
+
+.typing-dots__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--game-shell-edge);
+  animation: typing-bounce 0.7s ease-in-out infinite;
+}
+
+.typing-dots__dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.typing-dots__dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes typing-bounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-4px);
+  }
+}
+
 /* ── Bubble chat history modal ── */
 
 .game-system-modal__content--history {

--- a/src/game/ui/SpeechBubbleOverlay.tsx
+++ b/src/game/ui/SpeechBubbleOverlay.tsx
@@ -5,6 +5,7 @@ type SpeechBubbleOverlayProps = {
   anchorX: number
   anchorY: number
   variant?: 'npc' | 'player'
+  isTyping?: boolean
 }
 
 const MAX_VISIBLE_BUBBLES = 3
@@ -76,19 +77,35 @@ const SpeechBubbleStack = ({
   )
 }
 
+const TypingIndicator = () => (
+  <div className="speech-bubble-stack">
+    <div className="speech-bubble-stack__item" style={{ animationDelay: '0ms' }}>
+      <div className="speech-bubble speech-bubble--typing">
+        <span className="typing-dots" aria-hidden="true">
+          <span className="typing-dots__dot" />
+          <span className="typing-dots__dot" />
+          <span className="typing-dots__dot" />
+        </span>
+      </div>
+      <div className="speech-bubble__tail" aria-hidden="true" />
+    </div>
+  </div>
+)
+
 const SpeechBubbleOverlay = ({
   segments,
   anchorX,
   anchorY,
   variant = 'npc',
+  isTyping = false,
 }: SpeechBubbleOverlayProps) => {
   const sequenceKey = useMemo(() => segments.join('\n'), [segments])
 
-  if (segments.length === 0) {
+  if (segments.length === 0 && !isTyping) {
     return null
   }
 
-  const ariaLabel = variant === 'player' ? '串串的消息' : 'Syzygy 的回复'
+  const ariaLabel = isTyping ? 'Syzygy 正在输入' : variant === 'player' ? '串串的消息' : 'Syzygy 的回复'
 
   return (
     <div
@@ -101,11 +118,15 @@ const SpeechBubbleOverlay = ({
       aria-live="polite"
       aria-label={ariaLabel}
     >
-      <SpeechBubbleStack
-        key={sequenceKey}
-        segments={segments}
-        variant={variant}
-      />
+      {isTyping ? (
+        <TypingIndicator />
+      ) : (
+        <SpeechBubbleStack
+          key={sequenceKey}
+          segments={segments}
+          variant={variant}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
This PR adds a typing indicator animation that displays while waiting for NPC responses in bubble chat conversations. The indicator shows three animated dots that bounce in sequence, providing visual feedback to the player that the NPC is "typing" a response.

## Key Changes
- **New CSS animations**: Added `.typing-dots` styles with a `typing-bounce` keyframe animation that creates a bouncing effect for three dots with staggered delays
- **TypingIndicator component**: Created a new React component that renders the animated typing dots within a speech bubble
- **State management**: Added `isWaitingForReply` state to `GameModeShell` to track when the NPC is composing a response
- **Conditional rendering**: Modified `SpeechBubbleOverlay` to accept an `isTyping` prop and display the typing indicator instead of message segments when active
- **Flow integration**: Updated the bubble chat message flow to:
  - Set `isWaitingForReply` to `true` immediately after the player sends a message
  - Display the typing indicator while waiting for the API response
  - Clear the typing indicator once the NPC response is received or on error
  - Reset state when the bubble is dismissed

## Implementation Details
- The typing indicator uses three 7px circular dots with a 0.7s bounce animation
- Each dot has a 0.15s staggered animation delay for a cascading effect
- The indicator is only shown when `isWaitingForReply` is true and no message segments are present
- Proper accessibility attributes (`aria-hidden`, `aria-label`, `aria-live`) are maintained for screen readers
- The typing indicator is cleared in all exit paths (success, error, dismiss)

https://claude.ai/code/session_01X7vMnZYaCg2NK5y7xVUEJU