### PR TITLE
Raise NPC action menu above sprite using sprite bounds

### DIFF
--- a/src/game/EventBus.ts
+++ b/src/game/EventBus.ts
@@ -9,6 +9,8 @@ export const GAME_EVENTS = {
 type SceneAnchorPayload = {
   x: number
   y: number
+  width?: number
+  height?: number
   sceneWidth: number
   sceneHeight: number
 }

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -71,7 +71,8 @@ const clamp = (value: number, min: number, max: number) =>
 const NPC_MENU_LAYOUT = {
   width: 176,
   estimatedHeight: 170,
-  anchorOffset: 18,
+  spriteClearance: 14,
+  fallbackAnchorOffset: 18,
   edgePadding: 12,
 } as const;
 
@@ -446,7 +447,7 @@ const GameModeShell = ({
       return null;
     }
 
-    const { edgePadding, anchorOffset } = NPC_MENU_LAYOUT;
+    const { edgePadding, spriteClearance, fallbackAnchorOffset } = NPC_MENU_LAYOUT;
     const viewportAnchor = toViewportAnchor(activeNpcMenu.anchor);
 
     if (!viewportAnchor) {
@@ -454,23 +455,22 @@ const GameModeShell = ({
     }
     const menuWidth = npcMenuSize.width;
     const menuHeight = npcMenuSize.height;
+    const spriteHeight = activeNpcMenu.anchor.height ?? 0;
+    const anchorOffset = activeNpcMenu.anchor.height
+      ? Math.max(spriteClearance, spriteHeight * 0.08)
+      : fallbackAnchorOffset;
+    const centeredLeft = viewportAnchor.x - menuWidth * 0.5;
+    const menuTopAboveSprite = viewportAnchor.y - menuHeight - anchorOffset;
+    const menuTopBelowSprite = viewportAnchor.y + spriteHeight + anchorOffset;
 
     const candidatePositions = [
       {
-        left: viewportAnchor.x + anchorOffset,
-        top: viewportAnchor.y - menuHeight - anchorOffset,
+        left: centeredLeft,
+        top: menuTopAboveSprite,
       },
       {
-        left: viewportAnchor.x + anchorOffset,
-        top: viewportAnchor.y + anchorOffset,
-      },
-      {
-        left: viewportAnchor.x - menuWidth - anchorOffset,
-        top: viewportAnchor.y - menuHeight - anchorOffset,
-      },
-      {
-        left: viewportAnchor.x - menuWidth - anchorOffset,
-        top: viewportAnchor.y + anchorOffset,
+        left: centeredLeft,
+        top: menuTopBelowSprite,
       },
     ];
 
@@ -492,12 +492,12 @@ const GameModeShell = ({
 
       return {
         left: clamp(
-          viewportAnchor.x + anchorOffset,
+          centeredLeft,
           edgePadding,
           viewportWidth - edgePadding - menuWidth,
         ),
         top: clamp(
-          viewportAnchor.y - menuHeight - anchorOffset,
+          menuTopAboveSprite,
           edgePadding,
           viewportHeight - edgePadding - menuHeight,
         ),

--- a/src/game/scenes/HomeScene.ts
+++ b/src/game/scenes/HomeScene.ts
@@ -13,8 +13,10 @@ export class HomeScene extends Phaser.Scene {
     const bounds = sprite.getBounds()
 
     return {
-      x: bounds.right,
-      y: bounds.top + bounds.height * 0.45,
+      x: bounds.x + bounds.width * 0.5,
+      y: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
       sceneWidth: this.scale.width,
       sceneHeight: this.scale.height,
     }


### PR DESCRIPTION
### Motivation
- After switching to 64×64 character containers the Syzygy NPC action menu opened too low and overlapped the sprite, so the menu anchor needs to use the NPC's actual display bounds instead of a hard-coded offset.  
- Speech bubble positioning and chat/interaction/event semantics must remain unchanged while ensuring the action menu appears clearly above the NPC when possible.

### Description
- Extend the anchor payload type to include optional `width` and `height` so callers can provide the clicked sprite's bounds via `SceneAnchorPayload`.  
- Change `HomeScene.getSpriteCanvasAnchor` to return the sprite top-center (`x`, `y`) plus `width` and `height` instead of the previous right/mid-body offset.  
- Update `GameModeShell` to prefer a horizontally centered menu placed above the sprite using a computed `anchorOffset` derived from the sprite height (with a `spriteClearance` minimum and `fallbackAnchorOffset`), falling back below only when needed to fit the viewport.  
- Keep speech bubble anchors, chat logic, interactions, and event names untouched.

### Testing
- Ran TypeScript check with `npm -s exec tsc -- --noEmit` which completed successfully.  
- Built the app with `npm run build` which completed successfully and produced the production bundles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be9988610883308d4658de2f93077f)