### PR TITLE
Add hourly auto-letter GitHub Actions trigger

### DIFF
--- a/.github/workflows/auto-letter-cron.yml
+++ b/.github/workflows/auto-letter-cron.yml
@@ -1,0 +1,19 @@
+name: Auto Letter Cron
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  trigger-letter-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger letter-check Edge Function
+        run: |
+          curl --fail --show-error --silent \
+            --request POST \
+            --url 'https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/letter-check' \
+            --header 'Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_KEY }}' \
+            --header 'Content-Type: application/json' \
+            --data '{}'


### PR DESCRIPTION
### Motivation
- Add a minimal scheduled GitHub Actions workflow to automatically trigger the Supabase Edge Function `letter-check` once per hour and allow manual testing via the Actions UI without changing any application code.

### Description
- Add `.github/workflows/auto-letter-cron.yml` which runs on `cron: '0 * * * *'` and `workflow_dispatch`, uses `ubuntu-latest`, and sends a `POST` with `curl --fail --show-error --silent` to `https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/letter-check` with headers `Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_KEY }}` and `Content-Type: application/json` and an empty JSON body (`{}`), causing the job to fail on non-2xx responses.

### Testing
- Validated the workflow file content with `nl -ba .github/workflows/auto-letter-cron.yml` (file present and contents as expected); attempted YAML parsing with Python/PyYAML but the `yaml` module was unavailable so parsing was skipped; inspected Ruby `YAML.load_file` output which showed `on` parsed specially so structural validation was completed via file inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa8801de88330b4a988147931dc8b)