### PR TITLE
Add realtime new-letter notifications (phone & game modes)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,4 +27,34 @@ button {
   color: #475569;
 }
 
+.app-toast-stack {
+  position: fixed;
+  top: max(16px, env(safe-area-inset-top, 0px) + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1200;
+  pointer-events: none;
+}
+
+.app-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  max-width: min(86vw, 320px);
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(255, 251, 245, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.82);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  color: #334155;
+  font-size: 13px;
+  font-weight: 600;
+  backdrop-filter: blur(14px);
+}
+
+.app-toast__icon {
+  font-size: 15px;
+  line-height: 1;
+}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import {
   createRemoteSession,
   deleteRemoteMessage,
   deleteRemoteSession,
+  fetchLetters,
   fetchLettersByConversation,
   fetchRemoteMessages,
   fetchRemoteSessions,
@@ -123,6 +124,10 @@ const createClientId = () =>
 const defaultOpenRouterModel = 'openrouter/auto'
 const APP_DISPLAY_MODE_STORAGE_KEY = 'hamster-app-display-mode'
 type AppDisplayMode = 'phone' | 'game'
+type LetterToast = {
+  id: string
+  message: string
+}
 const AUTO_EXTRACT_USER_TURN_INTERVAL = 12
 const AUTO_EXTRACT_COOLDOWN_MS = 10 * 60 * 1000
 const MEMORY_EXTRACT_RECENT_MESSAGES = 24
@@ -236,11 +241,15 @@ const App = () => {
   const [activeChatSessionId, setActiveChatSessionId] = useState<string | null>(null)
   const [displayMode, setDisplayMode] = useState<AppDisplayMode>(loadInitialDisplayMode)
   const [isChatOpenedFromGameMode, setIsChatOpenedFromGameMode] = useState(false)
+  const [hasUnreadLetters, setHasUnreadLetters] = useState(false)
+  const [letterToast, setLetterToast] = useState<LetterToast | null>(null)
   const sessionsRef = useRef(sessions)
   const messagesRef = useRef(messages)
   const streamingControllerRef = useRef<AbortController | null>(null)
   const settingsRef = useRef<UserSettings | null>(null)
   const autoExtractStateRef = useRef<Record<string, { lastUserCount: number; lastExtractedAt: number }>>({})
+  const knownLetterIdsRef = useRef<Set<string>>(new Set())
+  const letterToastTimeoutRef = useRef<number | null>(null)
   const fallbackSettings = useMemo(
     () => createDefaultSettings(user?.id ?? 'local'),
     [user?.id],
@@ -258,6 +267,99 @@ const App = () => {
   }, [activeSettings.enabledModels, defaultModelId])
 
   const latestSession = useMemo(() => selectMostRecentSession(sessions), [sessions])
+
+  const showLetterToast = useCallback((message: string) => {
+    const toastId = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`
+    setLetterToast({ id: toastId, message })
+  }, [])
+
+  useEffect(() => {
+    if (!letterToast) {
+      if (letterToastTimeoutRef.current !== null) {
+        window.clearTimeout(letterToastTimeoutRef.current)
+        letterToastTimeoutRef.current = null
+      }
+      return
+    }
+
+    if (letterToastTimeoutRef.current !== null) {
+      window.clearTimeout(letterToastTimeoutRef.current)
+    }
+
+    letterToastTimeoutRef.current = window.setTimeout(() => {
+      setLetterToast((current) => (current?.id === letterToast.id ? null : current))
+      letterToastTimeoutRef.current = null
+    }, 2600)
+
+    return () => {
+      if (letterToastTimeoutRef.current !== null) {
+        window.clearTimeout(letterToastTimeoutRef.current)
+        letterToastTimeoutRef.current = null
+      }
+    }
+  }, [letterToast])
+
+  useEffect(() => {
+    const client = supabase
+    if (!client || !user) {
+      knownLetterIdsRef.current = new Set()
+      setHasUnreadLetters(false)
+      return
+    }
+
+    let cancelled = false
+    const channel = client.channel(`letters-insert-${user.id}`)
+
+    const bootstrapRealtimeLetters = async () => {
+      try {
+        const existingLetters = await fetchLetters()
+        if (cancelled) {
+          return
+        }
+        knownLetterIdsRef.current = new Set(existingLetters.map((letter) => letter.id))
+        setHasUnreadLetters(existingLetters.some((letter) => !letter.isRead))
+      } catch (error) {
+        console.warn('初始化来信实时订阅失败', error)
+        if (!cancelled) {
+          knownLetterIdsRef.current = new Set()
+        }
+      }
+
+      if (cancelled) {
+        return
+      }
+
+      channel
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'letters',
+            filter: `user_id=eq.${user.id}`,
+          },
+          (payload) => {
+            const insertedLetter = payload.new as Partial<LetterEntry> & { id?: string; user_id?: string; is_read?: boolean | null }
+            const letterId = insertedLetter.id
+            const letterUserId = insertedLetter.userId ?? insertedLetter.user_id
+            if (!letterId || letterUserId !== user.id || knownLetterIdsRef.current.has(letterId)) {
+              return
+            }
+            knownLetterIdsRef.current.add(letterId)
+            setHasUnreadLetters(true)
+            showLetterToast('收到一封新来信')
+          },
+        )
+        .subscribe()
+    }
+
+    void bootstrapRealtimeLetters()
+
+    return () => {
+      cancelled = true
+      void client.removeChannel(channel)
+    }
+  }, [showLetterToast, user])
   const feedAiConfigBase = useMemo(() => ({
     reasoning: latestSession?.overrideReasoning ?? activeSettings.chatReasoningEnabled,
     temperature: activeSettings.temperature,
@@ -1483,30 +1585,41 @@ const App = () => {
 
   if (displayMode === 'game') {
     return (
-      <Suspense
-        fallback={
-          <div className="app-shell game-mode-shell">
-            <div className="game-mode-loading">游戏模式加载中...</div>
+      <>
+        <Suspense
+          fallback={
+            <div className="app-shell game-mode-shell">
+              <div className="game-mode-loading">游戏模式加载中...</div>
+            </div>
+          }
+        >
+          <GameModeShell
+            onSwitchToPhoneMode={() => {
+              setIsChatOpenedFromGameMode(false)
+              setDisplayMode('phone')
+            }}
+            onOpenSharedSettings={() => {
+              setIsChatOpenedFromGameMode(false)
+              setDisplayMode('phone')
+              navigate('/settings')
+            }}
+            onOpenChat={openChatFromGameMode}
+            user={user}
+            hasUnreadLetters={hasUnreadLetters}
+            snackAiConfig={snackAiConfig}
+            syzygyAiConfig={syzygyAiConfig}
+            bubbleChatConfig={bubbleChatConfig}
+          />
+        </Suspense>
+        {letterToast ? (
+          <div className="app-toast-stack" aria-live="polite" aria-atomic="true">
+            <div key={letterToast.id} className="app-toast app-toast--letter" role="status">
+              <span className="app-toast__icon" aria-hidden="true">💌</span>
+              <span>{letterToast.message}</span>
+            </div>
           </div>
-        }
-      >
-        <GameModeShell
-          onSwitchToPhoneMode={() => {
-            setIsChatOpenedFromGameMode(false)
-            setDisplayMode('phone')
-          }}
-          onOpenSharedSettings={() => {
-            setIsChatOpenedFromGameMode(false)
-            setDisplayMode('phone')
-            navigate('/settings')
-          }}
-          onOpenChat={openChatFromGameMode}
-          user={user}
-          snackAiConfig={snackAiConfig}
-          syzygyAiConfig={syzygyAiConfig}
-          bubbleChatConfig={bubbleChatConfig}
-        />
-      </Suspense>
+        ) : null}
+      </>
     )
   }
 
@@ -1523,6 +1636,7 @@ const App = () => {
             <RequireAuth ready={authReady} user={user}>
               <HomePage
                 user={user}
+                hasUnreadLetters={hasUnreadLetters}
                 onOpenChat={() => {
                   const latest = selectMostRecentSession(sessions)
                   if (latest) {
@@ -1609,7 +1723,11 @@ const App = () => {
           path="/letters"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <LettersPage sessions={sessions} onCreateSession={createSessionEntry} />
+              <LettersPage
+                sessions={sessions}
+                onCreateSession={createSessionEntry}
+                onUnreadStateChange={setHasUnreadLetters}
+              />
             </RequireAuth>
           }
         />
@@ -1743,6 +1861,14 @@ const App = () => {
         />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+      {letterToast ? (
+        <div className="app-toast-stack" aria-live="polite" aria-atomic="true">
+          <div key={letterToast.id} className="app-toast app-toast--letter" role="status">
+            <span className="app-toast__icon" aria-hidden="true">💌</span>
+            <span>{letterToast.message}</span>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -48,6 +48,7 @@ type GameModeShellProps = {
   onOpenSharedSettings: () => void;
   onOpenChat: (npcId: OpenNpcActionsPayload["npcId"]) => void;
   user: User | null;
+  hasUnreadLetters: boolean;
   snackAiConfig: SharedSnackAiConfig;
   syzygyAiConfig: SharedSnackAiConfig;
   bubbleChatConfig: BubbleChatConfig;
@@ -81,6 +82,7 @@ const GameModeShell = ({
   onOpenSharedSettings,
   onOpenChat,
   user,
+  hasUnreadLetters,
   snackAiConfig,
   syzygyAiConfig,
   bubbleChatConfig,
@@ -524,6 +526,7 @@ const GameModeShell = ({
           onBubbleSend={handleBubbleSend}
           onOpenBubbleHistory={() => setIsBubbleHistoryOpen(true)}
           bubbleSending={bubbleSending}
+          hasUnreadLetters={hasUnreadLetters}
           viewportOverlay={
             <>
               {playerBubbleText && playerBubbleAnchor ? (
@@ -595,6 +598,7 @@ const GameModeShell = ({
           <GameMenuOverlay
             onClose={() => setIsPawMenuOpen(false)}
             onOpenFeature={handleOpenFeature}
+            hasUnreadLetters={hasUnreadLetters}
           />
         ) : null}
 

--- a/src/game/gameHud.css
+++ b/src/game/gameHud.css
@@ -612,6 +612,17 @@
   background: var(--game-control-accent-bg);
 }
 
+.game-notification-dot {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ef4444;
+  box-shadow: 0 0 0 2px rgba(255, 251, 245, 0.95);
+}
+
 .npc-actions-layer {
   position: absolute;
   inset: 0;
@@ -997,6 +1008,18 @@
   font-size: 12px;
   line-height: 1.45;
   color: #86827d;
+}
+
+.game-menu-section__badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  font-size: 11px;
+  font-weight: 800;
 }
 
 .game-feature-shell-backdrop {

--- a/src/game/ui/GameBottomBar.tsx
+++ b/src/game/ui/GameBottomBar.tsx
@@ -38,9 +38,10 @@ type GameBottomBarProps = {
   onBubbleSend: (text: string) => void
   onOpenBubbleHistory: () => void
   bubbleSending: boolean
+  hasUnreadLetters: boolean
 }
 
-const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending }: GameBottomBarProps) => {
+const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending, hasUnreadLetters }: GameBottomBarProps) => {
   return (
     <footer className="game-bottom-bar" aria-label="游戏操作栏">
       <div className="game-direction-pad" aria-label="方向控制（占位）">
@@ -66,7 +67,8 @@ const GameBottomBar = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubb
           <SettingsIcon />
         </button>
 
-        <button type="button" className="game-control-button game-control-button--paw" onClick={onOpenPawMenu} aria-label="打开互动菜单">
+        <button type="button" className="game-control-button game-control-button--paw" onClick={onOpenPawMenu} aria-label={hasUnreadLetters ? '打开互动菜单（有新来信）' : '打开互动菜单'}>
+          {hasUnreadLetters ? <span className="game-notification-dot" aria-hidden="true" /> : null}
           <PawIcon />
         </button>
       </div>

--- a/src/game/ui/GameHud.tsx
+++ b/src/game/ui/GameHud.tsx
@@ -9,11 +9,12 @@ type GameHudProps = {
   onBubbleSend: (text: string) => void
   onOpenBubbleHistory: () => void
   bubbleSending: boolean
+  hasUnreadLetters: boolean
   viewportRef: RefObject<HTMLElement | null>
   viewportOverlay?: ReactNode
 }
 
-const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending, viewportRef, viewportOverlay }: GameHudProps) => {
+const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHistory, bubbleSending, hasUnreadLetters, viewportRef, viewportOverlay }: GameHudProps) => {
   return (
     <div className="game-hud-layout" aria-label="游戏模式主布局">
       <GameTopBar stamina={30} maxStamina={100} level={1} exp={45} maxExp={100} />
@@ -29,6 +30,7 @@ const GameHud = ({ onOpenPawMenu, onOpenSettings, onBubbleSend, onOpenBubbleHist
         onBubbleSend={onBubbleSend}
         onOpenBubbleHistory={onOpenBubbleHistory}
         bubbleSending={bubbleSending}
+        hasUnreadLetters={hasUnreadLetters}
       />
     </div>
   )

--- a/src/game/ui/GameMenuOverlay.tsx
+++ b/src/game/ui/GameMenuOverlay.tsx
@@ -11,6 +11,7 @@ type MenuEntry = {
 type GameMenuOverlayProps = {
   onClose: () => void
   onOpenFeature: (featureId: GameFeatureId) => void
+  hasUnreadLetters: boolean
 }
 
 const GAME_MENU_ENTRIES: MenuEntry[] = [
@@ -20,7 +21,7 @@ const GAME_MENU_ENTRIES: MenuEntry[] = [
   { id: 'export', title: '数据导出', description: '以游戏模式外壳进入数据导出功能。' },
 ]
 
-const GameMenuOverlay = ({ onClose, onOpenFeature }: GameMenuOverlayProps) => {
+const GameMenuOverlay = ({ onClose, onOpenFeature, hasUnreadLetters }: GameMenuOverlayProps) => {
   return (
     <GameSystemModal
       title="游戏菜单"
@@ -32,7 +33,10 @@ const GameMenuOverlay = ({ onClose, onOpenFeature }: GameMenuOverlayProps) => {
       <div className="game-system-modal__content-shell">
         <section className="game-settings-section" aria-label="游戏菜单入口">
           <p className="game-menu-section__title">系统功能入口</p>
-          <p className="game-menu-section__hint">与游戏设置共享同一系统弹窗外壳，保留稳定尺寸，并在内容较多时于内部滚动。</p>
+          <p className="game-menu-section__hint">
+            与游戏设置共享同一系统弹窗外壳，保留稳定尺寸，并在内容较多时于内部滚动。
+            {hasUnreadLetters ? <span className="game-menu-section__badge">新来信</span> : null}
+          </p>
         </section>
 
         <div className="game-overlay-list game-overlay-list--scrollable">

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -498,6 +498,7 @@
 }
 
 .icon-emoji {
+  position: relative;
   display: inline-grid;
   place-items: center;
   width: clamp(50px, 14.2vw, 64px);
@@ -508,6 +509,17 @@
   box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
   font-size: clamp(1.35rem, 4.8vw, 1.8rem);
   overflow: hidden;
+}
+
+.app-icon-notification-dot {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ef4444;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.92);
 }
 
 .icon-image {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -31,6 +31,7 @@ import "./HomePage.css";
 type HomePageProps = {
   user: User | null;
   onOpenChat: () => void;
+  hasUnreadLetters?: boolean;
   mode?: "default" | "settings";
 };
 
@@ -190,7 +191,7 @@ const computeStreak = (dates: string[], todayKey: string) => {
   return streak;
 };
 
-const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
+const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default" }: HomePageProps) => {
   const isSettingsPage = mode === "settings";
   const navigate = useNavigate();
   const [now, setNow] = useState(() => new Date());
@@ -1558,6 +1559,9 @@ const HomePage = ({ user, onOpenChat, mode = "default" }: HomePageProps) => {
                           }}
                         >
                           <span className="icon-emoji">
+                            {icon.id === "letters" && hasUnreadLetters ? (
+                              <span className="app-icon-notification-dot" aria-hidden="true" />
+                            ) : null}
                             {iconImageUrl ? (
                               <img
                                 src={iconImageUrl}

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -61,9 +61,11 @@ const buildMemoryContext = async () => {
 const LettersPage = ({
   sessions,
   onCreateSession,
+  onUnreadStateChange,
 }: {
   sessions: ChatSession[]
   onCreateSession: (title?: string) => Promise<ChatSession>
+  onUnreadStateChange?: (hasUnread: boolean) => void
 }) => {
   const location = useLocation()
   const navigate = useNavigate()
@@ -104,13 +106,14 @@ const LettersPage = ({
     try {
       const list = await fetchLetters()
       setLetters(list)
+      onUnreadStateChange?.(list.some((letter) => !letter.isRead))
     } catch (loadError) {
       console.warn('加载来信失败', loadError)
       setError('加载失败，请稍后重试。')
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [onUnreadStateChange])
 
   useEffect(() => {
     void loadLetters()
@@ -164,9 +167,11 @@ const LettersPage = ({
     if (letter.isRead) {
       return
     }
-    setLetters((current) =>
-      current.map((item) => (item.id === letter.id ? { ...item, isRead: true } : item)),
-    )
+    setLetters((current) => {
+      const nextLetters = current.map((item) => (item.id === letter.id ? { ...item, isRead: true } : item))
+      onUnreadStateChange?.(nextLetters.some((item) => !item.isRead))
+      return nextLetters
+    })
     try {
       await markLetterAsRead(letter.id)
     } catch (markError) {
@@ -262,7 +267,11 @@ const LettersPage = ({
         triggerReason: null,
         module: 'letter',
       })
-      setLetters((current) => [created, ...current])
+      setLetters((current) => {
+        const nextLetters = [created, ...current]
+        onUnreadStateChange?.(nextLetters.some((letter) => !letter.isRead))
+        return nextLetters
+      })
       setActiveLetterId(created.id)
     } catch (generateError) {
       console.warn('手动生成来信失败', generateError)
@@ -285,7 +294,11 @@ const LettersPage = ({
     setDeletingLetterId(activeLetter.id)
     try {
       await deleteLetter(activeLetter.id)
-      setLetters((current) => current.filter((letter) => letter.id !== activeLetter.id))
+      setLetters((current) => {
+        const nextLetters = current.filter((letter) => letter.id !== activeLetter.id)
+        onUnreadStateChange?.(nextLetters.some((letter) => !letter.isRead))
+        return nextLetters
+      })
       setActiveLetterId(null)
     } catch (deleteActionError) {
       console.warn('删除来信失败', deleteActionError)


### PR DESCRIPTION
### Motivation
- Provide lightweight, shared frontend notification when a new row is inserted into the `letters` table so users see non-blocking feedback while actively using the app.
- Support both phone and game display modes using the existing shared UI flows (home app icons and paw-menu) without adding new dedicated letter panels or auto-opening behavior.
- Reuse the existing Supabase client and the Letters page load/read lifecycle so the unread indicator stays consistent across the app.

### Description
- Added an app-level Supabase Realtime bootstrap + subscription in `src/App.tsx` that listens for `INSERT` events on `letters` filtered by the current user and deduplicates events using a `knownLetterIdsRef` set to avoid duplicate notifications.
- Introduced shared state `hasUnreadLetters` and a subtle toast mechanism (`letterToast`) in `src/App.tsx` to surface a short non-blocking message ("收到一封新来信") and a persistent unread flag.
- Wired the shared unread flag into phone and game UI: the Home page letters app icon now shows a small red dot (`src/pages/HomePage.tsx`, `src/pages/HomePage.css`) and game mode shows a dot on the paw button plus a small "新来信" badge in the existing game menu overlay (`src/game/ui/GameBottomBar.tsx`, `src/game/gameHud.css`, `src/game/ui/GameMenuOverlay.tsx`, `src/game/GameModeShell.tsx`).
- Extended the existing Letters page (`src/pages/LettersPage.tsx`) to report unread state changes via an `onUnreadStateChange` callback so loading, reading, creating, and deleting letters update the shared flag consistently.
- Ensured cleanup by removing the Supabase channel on user change/unmount and avoided noisy UI changes: no automatic page openings, no blocking modals, and no new game-only letters regions.

### Testing
- Built the production bundle with `npm run build`, which completed successfully (Vite production build and TypeScript compilation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfafb6621c8330974f62799f61e33a)