### PR TITLE
Add frontend Web Push subscription flow and Settings UI

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -72,3 +72,40 @@ self.addEventListener('fetch', (event) => {
     }),
   )
 })
+
+
+self.addEventListener('push', (event) => {
+  const payload = event.data ? event.data.json() : {}
+  const title = payload.title || 'Hamster Nest'
+  const options = {
+    body: payload.body || '你收到了一条新的提醒。',
+    icon: payload.icon || './icons/pwa-192.png',
+    badge: payload.badge || './icons/pwa-192.png',
+    data: {
+      url: payload.url || './#/letters',
+    },
+  }
+
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const targetUrl = event.notification.data?.url || './#/letters'
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      const matchingClient = clients.find((client) => 'focus' in client)
+      if (matchingClient) {
+        matchingClient.focus()
+        if ('navigate' in matchingClient) {
+          return matchingClient.navigate(targetUrl)
+        }
+        return undefined
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl)
+      }
+      return undefined
+    }),
+  )
+})

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -1,0 +1,183 @@
+import { supabase } from '../supabase/client'
+
+const PUSH_SUBSCRIPTIONS_TABLE = 'push_subscriptions'
+const PUSH_SUBSCRIPTION_COLUMNS = 'user_id,endpoint,subscription'
+const swUrl = `${import.meta.env.BASE_URL}sw.js`
+
+export type NotificationPermissionState = NotificationPermission | 'unsupported'
+
+export type PushSupportStatus = {
+  supported: boolean
+  reason: string | null
+  permission: NotificationPermissionState
+  vapidKeyConfigured: boolean
+}
+
+const getNotificationPermission = (): NotificationPermissionState => {
+  if (typeof window === 'undefined' || !('Notification' in window)) {
+    return 'unsupported'
+  }
+  return Notification.permission
+}
+
+const getMissingSupportReason = (): string | null => {
+  if (typeof window === 'undefined') {
+    return '当前环境不支持推送通知。'
+  }
+  if (!window.isSecureContext) {
+    return '推送通知需要 HTTPS 或本地开发环境。'
+  }
+  if (!('serviceWorker' in navigator)) {
+    return '当前浏览器不支持 Service Worker。'
+  }
+  if (!('PushManager' in window)) {
+    return '当前浏览器不支持 Web Push。'
+  }
+  if (!('Notification' in window)) {
+    return '当前浏览器不支持系统通知权限。'
+  }
+  return null
+}
+
+export const getPushSupportStatus = (): PushSupportStatus => {
+  const reason = getMissingSupportReason()
+  return {
+    supported: reason === null,
+    reason,
+    permission: getNotificationPermission(),
+    vapidKeyConfigured: Boolean(import.meta.env.VITE_WEB_PUSH_VAPID_PUBLIC_KEY),
+  }
+}
+
+export const registerPushServiceWorker = async (): Promise<ServiceWorkerRegistration> => {
+  if (!('serviceWorker' in navigator)) {
+    throw new Error('当前浏览器不支持 Service Worker。')
+  }
+  return navigator.serviceWorker.register(swUrl)
+}
+
+export const getExistingPushSubscription = async (): Promise<PushSubscription | null> => {
+  const support = getPushSupportStatus()
+  if (!support.supported) {
+    return null
+  }
+  const registration = await registerPushServiceWorker()
+  return registration.pushManager.getSubscription()
+}
+
+const decodeVapidPublicKey = (publicKey: string): ArrayBuffer => {
+  const normalized = publicKey.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+  const binary = window.atob(padded)
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0)).buffer
+}
+
+const requireSupabase = () => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置。')
+  }
+  return supabase
+}
+
+export const createPushSubscription = async (): Promise<PushSubscription> => {
+  const support = getPushSupportStatus()
+  if (!support.supported) {
+    throw new Error(support.reason ?? '当前环境不支持推送通知。')
+  }
+  const vapidPublicKey = import.meta.env.VITE_WEB_PUSH_VAPID_PUBLIC_KEY as string | undefined
+  if (!vapidPublicKey) {
+    throw new Error('缺少 Web Push VAPID 公钥配置。')
+  }
+
+  const registration = await registerPushServiceWorker()
+  const existingSubscription = await registration.pushManager.getSubscription()
+  if (existingSubscription) {
+    return existingSubscription
+  }
+
+  return registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: decodeVapidPublicKey(vapidPublicKey),
+  })
+}
+
+export const persistPushSubscription = async (
+  userId: string,
+  subscription: PushSubscription,
+): Promise<void> => {
+  const client = requireSupabase()
+  const payload = subscription.toJSON()
+  const { error } = await client
+    .from(PUSH_SUBSCRIPTIONS_TABLE)
+    .upsert(
+      {
+        user_id: userId,
+        endpoint: subscription.endpoint,
+        subscription: payload,
+      },
+      {
+        onConflict: 'endpoint',
+      },
+    )
+    .select(PUSH_SUBSCRIPTION_COLUMNS)
+    .single()
+
+  if (error) {
+    throw error
+  }
+}
+
+export const removePushSubscription = async (
+  userId: string,
+  endpoint: string,
+): Promise<void> => {
+  const client = requireSupabase()
+  const { error } = await client
+    .from(PUSH_SUBSCRIPTIONS_TABLE)
+    .delete()
+    .eq('user_id', userId)
+    .eq('endpoint', endpoint)
+
+  if (error) {
+    throw error
+  }
+}
+
+export const enablePushOnCurrentDevice = async (userId: string): Promise<PushSubscription> => {
+  const permission = getNotificationPermission()
+  if (permission === 'unsupported') {
+    throw new Error('当前环境不支持通知权限。')
+  }
+  if (permission === 'denied') {
+    throw new Error('通知权限已被拒绝，请在浏览器或系统设置中重新开启。')
+  }
+
+  let resolvedPermission: NotificationPermission = permission
+  if (permission === 'default') {
+    resolvedPermission = await Notification.requestPermission()
+  }
+  if (resolvedPermission !== 'granted') {
+    throw new Error('没有获得通知权限，因此无法启用推送通知。')
+  }
+
+  const subscription = await createPushSubscription()
+  try {
+    await persistPushSubscription(userId, subscription)
+    return subscription
+  } catch (error) {
+    await subscription.unsubscribe().catch(() => undefined)
+    throw error
+  }
+}
+
+export const disablePushOnCurrentDevice = async (userId: string): Promise<void> => {
+  const existingSubscription = await getExistingPushSubscription()
+  if (!existingSubscription) {
+    return
+  }
+  await removePushSubscription(userId, existingSubscription.endpoint)
+  const unsubscribed = await existingSubscription.unsubscribe()
+  if (!unsubscribed) {
+    throw new Error('当前设备取消订阅失败，请稍后重试。')
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { HashRouter } from 'react-router-dom'
 import './index.css'
 import './styles/ui.css'
 import App from './App.tsx'
+import { registerPushServiceWorker } from './lib/pushNotifications'
 
 const noFxEnabled =
   new URLSearchParams(window.location.search).get('noFx') === '1' ||
@@ -23,7 +24,7 @@ createRoot(document.getElementById('root')!).render(
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch((error) => {
+    registerPushServiceWorker().catch((error) => {
       console.error('Service worker registration failed:', error)
     })
   })

--- a/src/pages/SettingsPage.css
+++ b/src/pages/SettingsPage.css
@@ -553,3 +553,40 @@
     grid-column: auto;
   }
 }
+
+.push-notification-card {
+  border-radius: 12px;
+  border: 1px solid #ffe3ee;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.push-notification-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.push-notification-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(255, 240, 246, 0.7);
+  color: #5c5c5c;
+}
+
+.push-notification-label,
+.settings-helper-text {
+  color: #8c8c8c;
+  font-size: 13px;
+}
+
+.settings-helper-text {
+  margin: 0;
+  line-height: 1.4;
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -17,6 +17,13 @@ import {
   resolveBubbleChatPrompt,
 } from '../constants/aiOverlays'
 import './SettingsPage.css'
+import {
+  disablePushOnCurrentDevice,
+  enablePushOnCurrentDevice,
+  getExistingPushSubscription,
+  getPushSupportStatus,
+  type NotificationPermissionState,
+} from '../lib/pushNotifications'
 
 type OpenRouterModel = {
   id: string
@@ -50,6 +57,15 @@ type SpecialDateDraft = {
   label: string
   enabled: boolean
   isNew?: boolean
+}
+
+type PushSubscriptionState = {
+  supportStatus: ReturnType<typeof getPushSupportStatus>
+  subscribed: boolean
+  endpoint: string | null
+  loading: boolean
+  actionStatus: 'idle' | 'saving' | 'saved' | 'error'
+  error: string | null
 }
 
 type SettingsPageProps = {
@@ -150,6 +166,14 @@ const SettingsPage = ({
   const [specialDateDrafts, setSpecialDateDrafts] = useState<SpecialDateDraft[]>([])
   const [specialDatesStatus, setSpecialDatesStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [specialDatesError, setSpecialDatesError] = useState<string | null>(null)
+  const [pushState, setPushState] = useState<PushSubscriptionState>({
+    supportStatus: getPushSupportStatus(),
+    subscribed: false,
+    endpoint: null,
+    loading: false,
+    actionStatus: 'idle',
+    error: null,
+  })
   const [errors, setErrors] = useState<{ temperature?: string; topP?: string; maxTokens?: string; compressionRatio?: string; compressionKeepRecent?: string }>(
     {},
   )
@@ -1003,6 +1027,28 @@ const SettingsPage = ({
       ? defaultModelId
       : draftEnabledModels[0] ?? draftDefaultModel ?? defaultModelId
 
+  const permissionLabel = (permission: NotificationPermissionState) => {
+    switch (permission) {
+      case 'granted':
+        return '已允许'
+      case 'denied':
+        return '已拒绝'
+      case 'default':
+        return '未请求'
+      default:
+        return '不支持'
+    }
+  }
+
+  const supportLabel = pushState.supportStatus.supported ? '支持' : '不支持'
+  const pushSummary = pushState.loading
+    ? '检查中…'
+    : pushState.subscribed
+      ? '当前设备已启用'
+      : pushState.supportStatus.permission === 'denied'
+        ? '权限已拒绝'
+        : '当前设备未启用'
+
   const displayModeLabel = displayMode === 'phone' ? 'Phone Mode' : 'Game Mode'
   const autoLetterMode = autoLetterConfig?.t2_mode ?? 'off'
   const autoLetterSummary = autoLetterLoading
@@ -1020,6 +1066,95 @@ const SettingsPage = ({
   const autoLetterIntervalValid = Number.isInteger(parsedAutoLetterIntervalHours) && parsedAutoLetterIntervalHours > 0
   const autoLetterDailyLimitValid = Number.isInteger(parsedAutoLetterDailyLimit) && parsedAutoLetterDailyLimit >= 0
   const autoLetterProbabilityValid = !Number.isNaN(parsedAutoLetterProbability) && parsedAutoLetterProbability >= 0 && parsedAutoLetterProbability <= 1
+
+  const refreshPushState = useCallback(async () => {
+    const supportStatus = getPushSupportStatus()
+    if (!user || !supportStatus.supported) {
+      setPushState((current) => ({
+        ...current,
+        supportStatus,
+        subscribed: false,
+        endpoint: null,
+        loading: false,
+        actionStatus: current.actionStatus === 'saving' ? 'idle' : current.actionStatus,
+      }))
+      return
+    }
+
+    setPushState((current) => ({ ...current, supportStatus, loading: true, error: null }))
+    try {
+      const subscription = await getExistingPushSubscription()
+      setPushState((current) => ({
+        ...current,
+        supportStatus: getPushSupportStatus(),
+        subscribed: Boolean(subscription),
+        endpoint: subscription?.endpoint ?? null,
+        loading: false,
+      }))
+    } catch (error) {
+      console.warn('读取推送订阅状态失败', error)
+      setPushState((current) => ({
+        ...current,
+        supportStatus: getPushSupportStatus(),
+        subscribed: false,
+        endpoint: null,
+        loading: false,
+        actionStatus: 'error',
+        error: '无法读取当前设备的推送状态，请稍后重试。',
+      }))
+    }
+  }, [user])
+
+  useEffect(() => {
+    if (!autoLetterSectionExpanded) {
+      return
+    }
+    void refreshPushState()
+  }, [autoLetterSectionExpanded, refreshPushState])
+
+  const handleEnablePush = async () => {
+    if (!user) {
+      return
+    }
+    setPushState((current) => ({ ...current, actionStatus: 'saving', error: null }))
+    try {
+      await enablePushOnCurrentDevice(user.id)
+      setPushState((current) => ({ ...current, actionStatus: 'saved' }))
+      await refreshPushState()
+    } catch (error) {
+      console.warn('启用推送通知失败', error)
+      const message = error instanceof Error ? error.message : '启用推送通知失败，请稍后重试。'
+      setPushState((current) => ({
+        ...current,
+        supportStatus: getPushSupportStatus(),
+        actionStatus: 'error',
+        error: message,
+        loading: false,
+      }))
+    }
+  }
+
+  const handleDisablePush = async () => {
+    if (!user) {
+      return
+    }
+    setPushState((current) => ({ ...current, actionStatus: 'saving', error: null }))
+    try {
+      await disablePushOnCurrentDevice(user.id)
+      setPushState((current) => ({ ...current, actionStatus: 'saved' }))
+      await refreshPushState()
+    } catch (error) {
+      console.warn('关闭推送通知失败', error)
+      const message = error instanceof Error ? error.message : '关闭推送通知失败，请稍后重试。'
+      setPushState((current) => ({
+        ...current,
+        supportStatus: getPushSupportStatus(),
+        actionStatus: 'error',
+        error: message,
+        loading: false,
+      }))
+    }
+  }
 
   const updateAutoLetterDraft = (updates: Partial<AutoLetterConfigRow>) => {
     setAutoLetterConfig((current) => {
@@ -1371,6 +1506,62 @@ const SettingsPage = ({
                     </button>
                     {autoLetterStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
                     {autoLetterStatus === 'error' ? <span className="field-error">{autoLetterError}</span> : null}
+                  </div>
+                </div>
+
+                <div className="push-notification-card">
+                  <div className="section-title nested-prompt-title">
+                    <h2 className="ui-title">Push Notifications</h2>
+                    <p>作为 Auto Letter 的系统通知增强层；权限不可用时不会影响原有来信流程。</p>
+                  </div>
+                  <div className="push-notification-grid">
+                    <div className="push-notification-stat">
+                      <span className="push-notification-label">支持状态</span>
+                      <strong>{supportLabel}</strong>
+                    </div>
+                    <div className="push-notification-stat">
+                      <span className="push-notification-label">权限状态</span>
+                      <strong>{permissionLabel(pushState.supportStatus.permission)}</strong>
+                    </div>
+                    <div className="push-notification-stat">
+                      <span className="push-notification-label">当前设备</span>
+                      <strong>{pushSummary}</strong>
+                    </div>
+                  </div>
+                  <p className="settings-helper-text">仅在你点击启用后才会请求通知权限。iPhone / iPad 通常需要先将 PWA 添加到主屏幕后，才能使用 Web Push。</p>
+                  {!pushState.supportStatus.supported && pushState.supportStatus.reason ? (
+                    <p className="settings-helper-text">{pushState.supportStatus.reason}</p>
+                  ) : null}
+                  {pushState.supportStatus.supported && !pushState.supportStatus.vapidKeyConfigured ? (
+                    <p className="settings-helper-text">当前前端尚未配置 Web Push 公钥，暂时无法为此设备创建订阅。</p>
+                  ) : null}
+                  <div className="system-prompt-actions">
+                    {!pushState.subscribed ? (
+                      <button
+                        type="button"
+                        className="primary"
+                        onClick={() => void handleEnablePush()}
+                        disabled={
+                          pushState.actionStatus === 'saving' ||
+                          !pushState.supportStatus.supported ||
+                          !pushState.supportStatus.vapidKeyConfigured ||
+                          pushState.supportStatus.permission === 'denied'
+                        }
+                      >
+                        {pushState.actionStatus === 'saving' ? '启用中…' : '启用当前设备推送'}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="ghost"
+                        onClick={() => void handleDisablePush()}
+                        disabled={pushState.actionStatus === 'saving'}
+                      >
+                        {pushState.actionStatus === 'saving' ? '关闭中…' : '关闭当前设备推送'}
+                      </button>
+                    )}
+                    {pushState.actionStatus === 'saved' ? <span className="system-prompt-status">已更新</span> : null}
+                    {pushState.actionStatus === 'error' && pushState.error ? <span className="field-error">{pushState.error}</span> : null}
                   </div>
                 </div>
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL?: string
+  readonly VITE_SUPABASE_ANON_KEY?: string
+  readonly VITE_NO_FX?: string
+  readonly VITE_WEB_PUSH_VAPID_PUBLIC_KEY?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
### Motivation
- Prepare the frontend for Web Push so devices can register service workers and store subscriptions in Supabase once the backend table/edge functions exist.
- Keep Web Push as an unobtrusive enhancement to the existing Auto Letter flow by making permission requests explicit and non-blocking.
- Provide a modular, easy-to-adjust frontend adapter for subscribing/unsubscribing and persisting subscription data without changing backend generation logic.

### Description
- Added a modular push utility at `src/lib/pushNotifications.ts` implementing support detection (`getPushSupportStatus`), SW registration (`registerPushServiceWorker`), subscription creation/removal (`createPushSubscription`, `getExistingPushSubscription`, `disablePushOnCurrentDevice`), and Supabase persistence (`persistPushSubscription`, `removePushSubscription`) using an idempotent `upsert` on `endpoint`.
- Updated app bootstrap to reuse the push-aware registration path by calling `registerPushServiceWorker` from `src/main.tsx` instead of directly calling `navigator.serviceWorker.register`.
- Extended the existing service worker `public/sw.js` with `push` and `notificationclick` handlers so notifications can be shown and clicks route users back into the app.
- Added a subtle Push Notifications subsection inside the Auto Letter settings in `src/pages/SettingsPage.tsx` (with styles in `src/pages/SettingsPage.css`) that shows support/permission/device subscription state and exposes explicit `Enable`/`Disable` actions which only request permission after the user clicks `Enable`.
- Added safe Vite env typing `VITE_WEB_PUSH_VAPID_PUBLIC_KEY` in `src/vite-env.d.ts` and read the public VAPID key from `import.meta.env` (no secrets hardcoded).
- UI and behavior follow product rules: no auto-prompt on load, no blocking modals, graceful messages for unsupported environments, single subscription per device via upsert and checks, and no changes to the auto-letter generation flow or backend schema.

### Testing
- Ran `npm run build` which completed successfully and produced the production bundles.
- Ran `npm run lint` which completed; lint reported two pre-existing React Hook dependency warnings in `src/pages/CheckinPage.tsx` and `src/pages/LettersPage.tsx` that were not introduced by this change.
- Verified the project compiles and the new files (`src/lib/pushNotifications.ts`, `src/vite-env.d.ts`) and edits to `src/pages/SettingsPage.tsx`, `src/pages/SettingsPage.css`, `src/main.tsx`, and `public/sw.js` are included in the diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb41f79cc8330b240c789e379967d)