### PR TITLE
Add Web Push support for Auto Letters (service worker, VAPID, persistence)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,44 @@
-const APP_SHELL_CACHE = 'hamster-nest-app-shell-v1'
-const RUNTIME_CACHE = 'hamster-nest-runtime-v1'
+const APP_SHELL_CACHE = 'hamster-nest-app-shell-v2'
+const RUNTIME_CACHE = 'hamster-nest-runtime-v2'
+const LETTERS_PATH = '/#/letters'
+const DEFAULT_NOTIFICATION_TITLE = 'Hamster Nest'
+const DEFAULT_NOTIFICATION_BODY = '你收到了一条新的提醒。'
+const DEFAULT_NOTIFICATION_ICON = './icons/pwa-192.png'
 
 const APP_SHELL_URLS = ['./', './index.html', './manifest.webmanifest']
+
+const resolveLettersUrl = () => new URL(LETTERS_PATH, self.location.origin).href
+
+const parsePushPayload = (event) => {
+  if (!event.data) {
+    return {}
+  }
+
+  try {
+    return event.data.json()
+  } catch (error) {
+    return {
+      body: event.data.text(),
+    }
+  }
+}
+
+const buildNotificationOptions = (payload = {}) => {
+  const targetUrl = typeof payload.url === 'string' && payload.url.trim().length > 0
+    ? payload.url
+    : resolveLettersUrl()
+
+  return {
+    body: payload.body || DEFAULT_NOTIFICATION_BODY,
+    icon: payload.icon || DEFAULT_NOTIFICATION_ICON,
+    badge: payload.badge || DEFAULT_NOTIFICATION_ICON,
+    tag: payload.tag || 'auto-letter',
+    renotify: Boolean(payload.renotify),
+    data: {
+      url: targetUrl,
+    },
+  }
+}
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -73,38 +110,36 @@ self.addEventListener('fetch', (event) => {
   )
 })
 
-
 self.addEventListener('push', (event) => {
-  const payload = event.data ? event.data.json() : {}
-  const title = payload.title || 'Hamster Nest'
-  const options = {
-    body: payload.body || '你收到了一条新的提醒。',
-    icon: payload.icon || './icons/pwa-192.png',
-    badge: payload.badge || './icons/pwa-192.png',
-    data: {
-      url: payload.url || './#/letters',
-    },
-  }
+  const payload = parsePushPayload(event)
+  const title = payload.title || DEFAULT_NOTIFICATION_TITLE
+  const options = buildNotificationOptions(payload)
 
   event.waitUntil(self.registration.showNotification(title, options))
 })
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close()
-  const targetUrl = event.notification.data?.url || './#/letters'
+
+  const targetUrl = event.notification.data?.url || resolveLettersUrl()
+
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
       const matchingClient = clients.find((client) => 'focus' in client)
+
       if (matchingClient) {
-        matchingClient.focus()
-        if ('navigate' in matchingClient) {
-          return matchingClient.navigate(targetUrl)
-        }
-        return undefined
+        return matchingClient.focus().then(() => {
+          if ('navigate' in matchingClient) {
+            return matchingClient.navigate(targetUrl)
+          }
+          return undefined
+        })
       }
+
       if (self.clients.openWindow) {
         return self.clients.openWindow(targetUrl)
       }
+
       return undefined
     }),
   )

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -1,8 +1,13 @@
 import { supabase } from '../supabase/client'
+import {
+  registerAppServiceWorker,
+  type AppServiceWorkerRegistration,
+} from './serviceWorker'
 
 const PUSH_SUBSCRIPTIONS_TABLE = 'push_subscriptions'
-const PUSH_SUBSCRIPTION_COLUMNS = 'user_id,endpoint,subscription'
-const swUrl = `${import.meta.env.BASE_URL}sw.js`
+const PUSH_SUBSCRIPTION_COLUMNS = 'user_id,endpoint,p256dh,auth,subscription'
+const WEB_PUSH_VAPID_PUBLIC_KEY =
+  'BE4i06QAwLCwtbVEQEv1qfCW8a4_vclt6-swUq3Gs3D4CJiv3GgyjX4_g-CFI2zarw-ncgqLTJC0RGMExMaWvDc'
 
 export type NotificationPermissionState = NotificationPermission | 'unsupported'
 
@@ -11,6 +16,14 @@ export type PushSupportStatus = {
   reason: string | null
   permission: NotificationPermissionState
   vapidKeyConfigured: boolean
+}
+
+type PushSubscriptionRecord = {
+  auth: string | null
+  endpoint: string
+  p256dh: string | null
+  subscription: ReturnType<PushSubscription['toJSON']>
+  user_id: string
 }
 
 const getNotificationPermission = (): NotificationPermissionState => {
@@ -39,38 +52,59 @@ const getMissingSupportReason = (): string | null => {
   return null
 }
 
-export const getPushSupportStatus = (): PushSupportStatus => {
-  const reason = getMissingSupportReason()
-  return {
-    supported: reason === null,
-    reason,
-    permission: getNotificationPermission(),
-    vapidKeyConfigured: Boolean(import.meta.env.VITE_WEB_PUSH_VAPID_PUBLIC_KEY),
-  }
-}
-
-export const registerPushServiceWorker = async (): Promise<ServiceWorkerRegistration> => {
-  if (!('serviceWorker' in navigator)) {
-    throw new Error('当前浏览器不支持 Service Worker。')
-  }
-  return navigator.serviceWorker.register(swUrl)
-}
-
-export const getExistingPushSubscription = async (): Promise<PushSubscription | null> => {
+const requirePushSupport = (): PushSupportStatus => {
   const support = getPushSupportStatus()
   if (!support.supported) {
-    return null
+    throw new Error(support.reason ?? '当前环境不支持推送通知。')
   }
-  const registration = await registerPushServiceWorker()
-  return registration.pushManager.getSubscription()
+  return support
+}
+
+const requirePushRegistration = async (): Promise<AppServiceWorkerRegistration> => {
+  requirePushSupport()
+  return registerAppServiceWorker()
 }
 
 const decodeVapidPublicKey = (publicKey: string): ArrayBuffer => {
   const normalized = publicKey.replace(/-/g, '+').replace(/_/g, '/')
   const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
   const binary = window.atob(padded)
-  return Uint8Array.from(binary, (char) => char.charCodeAt(0)).buffer
+  const bytes = new Uint8Array(binary.length)
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
 }
+
+const extractPushKey = (
+  subscription: PushSubscription,
+  keyName: PushEncryptionKeyName,
+): string | null => {
+  const key = subscription.getKey(keyName)
+  if (!key) {
+    return null
+  }
+
+  const bytes = new Uint8Array(key)
+  let binary = ''
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+  return window.btoa(binary)
+}
+
+const buildSubscriptionRecord = (
+  userId: string,
+  subscription: PushSubscription,
+): PushSubscriptionRecord => ({
+  user_id: userId,
+  endpoint: subscription.endpoint,
+  p256dh: extractPushKey(subscription, 'p256dh'),
+  auth: extractPushKey(subscription, 'auth'),
+  subscription: subscription.toJSON(),
+})
 
 const requireSupabase = () => {
   if (!supabase) {
@@ -79,17 +113,32 @@ const requireSupabase = () => {
   return supabase
 }
 
-export const createPushSubscription = async (): Promise<PushSubscription> => {
+export const getPushSupportStatus = (): PushSupportStatus => {
+  const reason = getMissingSupportReason()
+  return {
+    supported: reason === null,
+    reason,
+    permission: getNotificationPermission(),
+    vapidKeyConfigured: WEB_PUSH_VAPID_PUBLIC_KEY.length > 0,
+  }
+}
+
+export const registerPushServiceWorker = async (): Promise<ServiceWorkerRegistration> =>
+  requirePushRegistration()
+
+export const getExistingPushSubscription = async (): Promise<PushSubscription | null> => {
   const support = getPushSupportStatus()
   if (!support.supported) {
-    throw new Error(support.reason ?? '当前环境不支持推送通知。')
+    return null
   }
-  const vapidPublicKey = import.meta.env.VITE_WEB_PUSH_VAPID_PUBLIC_KEY as string | undefined
-  if (!vapidPublicKey) {
-    throw new Error('缺少 Web Push VAPID 公钥配置。')
-  }
+  const registration = await requirePushRegistration()
+  return registration.pushManager.getSubscription()
+}
 
-  const registration = await registerPushServiceWorker()
+export const createPushSubscription = async (): Promise<PushSubscription> => {
+  requirePushSupport()
+
+  const registration = await requirePushRegistration()
   const existingSubscription = await registration.pushManager.getSubscription()
   if (existingSubscription) {
     return existingSubscription
@@ -97,7 +146,7 @@ export const createPushSubscription = async (): Promise<PushSubscription> => {
 
   return registration.pushManager.subscribe({
     userVisibleOnly: true,
-    applicationServerKey: decodeVapidPublicKey(vapidPublicKey),
+    applicationServerKey: decodeVapidPublicKey(WEB_PUSH_VAPID_PUBLIC_KEY),
   })
 }
 
@@ -106,19 +155,12 @@ export const persistPushSubscription = async (
   subscription: PushSubscription,
 ): Promise<void> => {
   const client = requireSupabase()
-  const payload = subscription.toJSON()
+  const record = buildSubscriptionRecord(userId, subscription)
   const { error } = await client
     .from(PUSH_SUBSCRIPTIONS_TABLE)
-    .upsert(
-      {
-        user_id: userId,
-        endpoint: subscription.endpoint,
-        subscription: payload,
-      },
-      {
-        onConflict: 'endpoint',
-      },
-    )
+    .upsert(record, {
+      onConflict: 'endpoint',
+    })
     .select(PUSH_SUBSCRIPTION_COLUMNS)
     .single()
 
@@ -155,6 +197,9 @@ export const enablePushOnCurrentDevice = async (userId: string): Promise<PushSub
   let resolvedPermission: NotificationPermission = permission
   if (permission === 'default') {
     resolvedPermission = await Notification.requestPermission()
+  }
+  if (resolvedPermission === 'denied') {
+    throw new Error('通知权限已被拒绝，请在浏览器或系统设置中重新开启。')
   }
   if (resolvedPermission !== 'granted') {
     throw new Error('没有获得通知权限，因此无法启用推送通知。')

--- a/src/lib/serviceWorker.ts
+++ b/src/lib/serviceWorker.ts
@@ -1,0 +1,27 @@
+const APP_SERVICE_WORKER_URL = `${import.meta.env.BASE_URL}sw.js`
+
+export type AppServiceWorkerRegistration = ServiceWorkerRegistration
+
+let serviceWorkerRegistrationPromise: Promise<AppServiceWorkerRegistration> | null = null
+
+export const registerAppServiceWorker = async (): Promise<AppServiceWorkerRegistration> => {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    throw new Error('当前浏览器不支持 Service Worker。')
+  }
+
+  serviceWorkerRegistrationPromise ??= navigator.serviceWorker.register(APP_SERVICE_WORKER_URL)
+  return serviceWorkerRegistrationPromise
+}
+
+export const initializeAppServiceWorker = (): void => {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return
+  }
+
+  window.addEventListener('load', () => {
+    void registerAppServiceWorker().catch((error) => {
+      console.error('Service worker registration failed:', error)
+      serviceWorkerRegistrationPromise = null
+    })
+  })
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { HashRouter } from 'react-router-dom'
 import './index.css'
 import './styles/ui.css'
 import App from './App.tsx'
-import { registerPushServiceWorker } from './lib/pushNotifications'
+import { initializeAppServiceWorker } from './lib/serviceWorker'
 
 const noFxEnabled =
   new URLSearchParams(window.location.search).get('noFx') === '1' ||
@@ -22,10 +22,4 @@ createRoot(document.getElementById('root')!).render(
   </StrictMode>,
 )
 
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    registerPushServiceWorker().catch((error) => {
-      console.error('Service worker registration failed:', error)
-    })
-  })
-}
+initializeAppServiceWorker()

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1041,11 +1041,12 @@ const SettingsPage = ({
   }
 
   const supportLabel = pushState.supportStatus.supported ? '支持' : '不支持'
+  const permissionDenied = pushState.supportStatus.permission === 'denied'
   const pushSummary = pushState.loading
     ? '检查中…'
     : pushState.subscribed
       ? '当前设备已启用'
-      : pushState.supportStatus.permission === 'denied'
+      : permissionDenied
         ? '权限已拒绝'
         : '当前设备未启用'
 
@@ -1532,6 +1533,9 @@ const SettingsPage = ({
                   {!pushState.supportStatus.supported && pushState.supportStatus.reason ? (
                     <p className="settings-helper-text">{pushState.supportStatus.reason}</p>
                   ) : null}
+                  {permissionDenied ? (
+                    <p className="settings-helper-text">通知权限已被拒绝。你仍可继续使用 Auto Letter；如需启用推送，请前往浏览器或系统设置重新允许通知。</p>
+                  ) : null}
                   {pushState.supportStatus.supported && !pushState.supportStatus.vapidKeyConfigured ? (
                     <p className="settings-helper-text">当前前端尚未配置 Web Push 公钥，暂时无法为此设备创建订阅。</p>
                   ) : null}
@@ -1545,7 +1549,7 @@ const SettingsPage = ({
                           pushState.actionStatus === 'saving' ||
                           !pushState.supportStatus.supported ||
                           !pushState.supportStatus.vapidKeyConfigured ||
-                          pushState.supportStatus.permission === 'denied'
+                          permissionDenied
                         }
                       >
                         {pushState.actionStatus === 'saving' ? '启用中…' : '启用当前设备推送'}


### PR DESCRIPTION
### Motivation

- Enable Web Push for the Auto Letter feature on the frontend by wiring a public VAPID key and completing the subscription + persistence flow. 
- Keep Service Worker registration modular and reuse the existing PWA `sw.js` without changing PWA behavior. 
- Ensure push notifications show usable notifications and clicking them opens/focuses the app and navigates to the letters page.

### Description

- Added a small service-worker helper `src/lib/serviceWorker.ts` with `registerAppServiceWorker` and `initializeAppServiceWorker` to centralize registration and reuse the existing `public/sw.js` file. 
- Rewired push logic in `src/lib/pushNotifications.ts` to use the provided VAPID public key exactly: `BE4i06QAwLCwtbVEQEv1qfCW8a4_vclt6-swUq3Gs3D4CJiv3GgyjX4_g-CFI2zarw-ncgqqLTJC0RGMExMaWvDc` as the `applicationServerKey` when calling `PushManager.subscribe()`, converting it to the correct `ArrayBuffer` form for the browser. 
- Extracted subscription encryption keys (`p256dh` and `auth`) and persist an idempotent record scoped to the current user into the `push_subscriptions` table with an upsert on `endpoint`, saving `endpoint`, `p256dh`, `auth`, and the full `subscription` payload. 
- Improved `public/sw.js` push handling to parse payloads safely, show notifications with sensible defaults, and handle `notificationclick` by closing the notification and focusing or opening the app and navigating to the letters route (`/#/letters`). 
- Kept settings UI behavior intact while updating `src/pages/SettingsPage.tsx` to show permission/subscribe state, show a non-blocking message when permission is denied, and to only request permission after an explicit user action that calls `enablePushOnCurrentDevice`.

### Testing

- Ran `npm run build`, which completed successfully and produced the production build. 
- Ran `npm run lint`, which completed successfully; lint reported two pre-existing warnings in `src/pages/CheckinPage.tsx` and `src/pages/LettersPage.tsx` that are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfccff17708330bdb4e3323a949ef0)