### PR TITLE
Complete frontend Web Push integration for Auto Letter

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -4,6 +4,7 @@ const LETTERS_PATH = '/#/letters'
 const DEFAULT_NOTIFICATION_TITLE = 'Hamster Nest'
 const DEFAULT_NOTIFICATION_BODY = '你收到了一条新的提醒。'
 const DEFAULT_NOTIFICATION_ICON = './icons/pwa-192.png'
+const DEFAULT_NOTIFICATION_TAG = 'auto-letter'
 
 const APP_SHELL_URLS = ['./', './index.html', './manifest.webmanifest']
 
@@ -32,8 +33,10 @@ const buildNotificationOptions = (payload = {}) => {
     body: payload.body || DEFAULT_NOTIFICATION_BODY,
     icon: payload.icon || DEFAULT_NOTIFICATION_ICON,
     badge: payload.badge || DEFAULT_NOTIFICATION_ICON,
-    tag: payload.tag || 'auto-letter',
+    image: typeof payload.image === 'string' ? payload.image : undefined,
+    tag: payload.tag || DEFAULT_NOTIFICATION_TAG,
     renotify: Boolean(payload.renotify),
+    requireInteraction: Boolean(payload.requireInteraction),
     data: {
       url: targetUrl,
     },
@@ -125,7 +128,18 @@ self.addEventListener('notificationclick', (event) => {
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
-      const matchingClient = clients.find((client) => 'focus' in client)
+      const targetPathname = new URL(targetUrl, self.location.origin).pathname
+      const matchingClient = clients.find((client) => {
+        if (!('focus' in client)) {
+          return false
+        }
+
+        try {
+          return new URL(client.url).pathname === targetPathname
+        } catch (error) {
+          return false
+        }
+      }) ?? clients.find((client) => 'focus' in client)
 
       if (matchingClient) {
         return matchingClient.focus().then(() => {

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -113,6 +113,61 @@ const requireSupabase = () => {
   return supabase
 }
 
+const upsertSubscriptionRecord = async (record: PushSubscriptionRecord): Promise<void> => {
+  const client = requireSupabase()
+  const { data: existingRows, error: lookupError } = await client
+    .from(PUSH_SUBSCRIPTIONS_TABLE)
+    .select('endpoint')
+    .eq('user_id', record.user_id)
+    .eq('endpoint', record.endpoint)
+
+  if (lookupError) {
+    throw lookupError
+  }
+
+  const hasExistingRow = (existingRows?.length ?? 0) > 0
+  const duplicateRows = existingRows?.slice(1) ?? []
+
+  const writeQuery = hasExistingRow
+    ? client
+        .from(PUSH_SUBSCRIPTIONS_TABLE)
+        .update(record)
+        .eq('user_id', record.user_id)
+        .eq('endpoint', record.endpoint)
+    : client.from(PUSH_SUBSCRIPTIONS_TABLE).insert(record)
+
+  const { error: writeError } = await writeQuery
+    .select(PUSH_SUBSCRIPTION_COLUMNS)
+    .limit(1)
+    .single()
+
+  if (writeError) {
+    throw writeError
+  }
+
+  if (duplicateRows.length > 0) {
+    const { error: cleanupError } = await client
+      .from(PUSH_SUBSCRIPTIONS_TABLE)
+      .delete()
+      .eq('user_id', record.user_id)
+      .eq('endpoint', record.endpoint)
+
+    if (cleanupError) {
+      throw cleanupError
+    }
+
+    const { error: restoreError } = await client
+      .from(PUSH_SUBSCRIPTIONS_TABLE)
+      .insert(record)
+      .select(PUSH_SUBSCRIPTION_COLUMNS)
+      .single()
+
+    if (restoreError) {
+      throw restoreError
+    }
+  }
+}
+
 export const getPushSupportStatus = (): PushSupportStatus => {
   const reason = getMissingSupportReason()
   return {
@@ -154,19 +209,8 @@ export const persistPushSubscription = async (
   userId: string,
   subscription: PushSubscription,
 ): Promise<void> => {
-  const client = requireSupabase()
   const record = buildSubscriptionRecord(userId, subscription)
-  const { error } = await client
-    .from(PUSH_SUBSCRIPTIONS_TABLE)
-    .upsert(record, {
-      onConflict: 'endpoint',
-    })
-    .select(PUSH_SUBSCRIPTION_COLUMNS)
-    .single()
-
-  if (error) {
-    throw error
-  }
+  await upsertSubscriptionRecord(record)
 }
 
 export const removePushSubscription = async (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1110,7 +1110,20 @@ const SettingsPage = ({
     if (!autoLetterSectionExpanded) {
       return
     }
+
     void refreshPushState()
+
+    const handleVisibilityOrFocus = () => {
+      void refreshPushState()
+    }
+
+    window.addEventListener('focus', handleVisibilityOrFocus)
+    document.addEventListener('visibilitychange', handleVisibilityOrFocus)
+
+    return () => {
+      window.removeEventListener('focus', handleVisibilityOrFocus)
+      document.removeEventListener('visibilitychange', handleVisibilityOrFocus)
+    }
   }, [autoLetterSectionExpanded, refreshPushState])
 
   const handleEnablePush = async () => {


### PR DESCRIPTION
### Motivation
- Enable frontend Web Push so Auto Letter can surface system notifications and the settings UI becomes actionable by wiring a VAPID public key and completing the subscription flow. 
- Persist device subscriptions in the existing `push_subscriptions` table scoped to the signed-in user and avoid duplicate active rows for the same endpoint. 
- Ensure Service Worker shows notifications on `push` and opens/focuses the app routing to the letters page on notification clicks.

### Description
- Wired the provided VAPID public key exactly as `WEB_PUSH_VAPID_PUBLIC_KEY` and decode it for `PushManager.subscribe()` with `userVisibleOnly: true` in `src/lib/pushNotifications.ts`. 
- Implemented idempotent persistence for subscriptions by upserting and cleaning duplicate endpoint rows, storing `endpoint`, `p256dh`, `auth`, and the serialized `subscription` payload in `push_subscriptions`. 
- Kept Service Worker registration modular and reused the existing `registerAppServiceWorker` helper; added calls that request permission only after explicit user action via the settings UI flow (`enablePushOnCurrentDevice`). 
- Improved `public/sw.js` push handling to use sensible defaults, accept optional payload fields (`image`, `requireInteraction`, etc.), and implement `notificationclick` behavior that prefers focusing an existing window and navigating it to the letters route (`/#/letters`), otherwise opening a new window. 
- Updated the Settings UI (`src/pages/SettingsPage.tsx`) to refresh push state when the Auto Letter section is open and the app regains focus or visibility, and to reflect subscribe/unsubscribe results in the UI state.

### Testing
- Ran TypeScript checks with `npm exec tsc -- --noEmit`, which passed. 
- Built a production bundle with `npm run build`, which succeeded. 
- Ran lints with `npm run lint`, which completed; lint produced two pre-existing React Hook warnings unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd5482c348330ba5d7d7e5f4e1a27)