### PR TITLE
Fix push subscription upsert payload

### DIFF
--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -5,7 +5,7 @@ import {
 } from './serviceWorker'
 
 const PUSH_SUBSCRIPTIONS_TABLE = 'push_subscriptions'
-const PUSH_SUBSCRIPTION_COLUMNS = 'user_id,endpoint,p256dh,auth,subscription'
+const PUSH_SUBSCRIPTION_COLUMNS = 'user_id,endpoint,p256dh,auth'
 const WEB_PUSH_VAPID_PUBLIC_KEY =
   'BE4i06QAwLCwtbVEQEv1qfCW8a4_vclt6-swUq3Gs3D4CJiv3GgyjX4_g-CFI2zarw-ncgqLTJC0RGMExMaWvDc'
 
@@ -22,7 +22,6 @@ type PushSubscriptionRecord = {
   auth: string | null
   endpoint: string
   p256dh: string | null
-  subscription: ReturnType<PushSubscription['toJSON']>
   user_id: string
 }
 
@@ -103,7 +102,6 @@ const buildSubscriptionRecord = (
   endpoint: subscription.endpoint,
   p256dh: extractPushKey(subscription, 'p256dh'),
   auth: extractPushKey(subscription, 'auth'),
-  subscription: subscription.toJSON(),
 })
 
 const requireSupabase = () => {


### PR DESCRIPTION
### Motivation
- The frontend was including a non-existent `subscription` column when inserting/updating `push_subscriptions`, causing PostgREST schema errors (PGRST204) and blocking push enablement.
- The goal is to stop sending unknown columns and persist only the actual table fields without changing the service worker flow or backend schema.

### Description
- Remove the `subscription` column from `PUSH_SUBSCRIPTION_COLUMNS` so returned/selected columns are `user_id,endpoint,p256dh,auth` only.
- Remove the `subscription` property from the `PushSubscriptionRecord` type and stop including `subscription.toJSON()` in the persisted record, while still building a record with `user_id`, `endpoint`, `p256dh`, and `auth`.
- Preserve the existing endpoint-based lookup, update/insert and duplicate cleanup (dedupe) flow so upsert behavior remains unchanged.
- Skills used: none (no additional skill workflows were required for this change).

### Testing
- Ran `npm run build` which completed successfully (TypeScript build + `vite build`).
- Ran `npm run lint` which completed with two pre-existing `react-hooks/exhaustive-deps` warnings in `src/pages/CheckinPage.tsx` and `src/pages/LettersPage.tsx` and no new lint errors were introduced.
- Verified the changed code compiles and the push persistence code now only sends the supported `user_id`, `endpoint`, `p256dh`, and `auth` fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfdb2f9e1c83308dd75b50c2a13486)