### PR TITLE
Add GitHub Actions workflow for Edge Functions deployment

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,0 +1,29 @@
+name: Deploy Edge Functions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/functions/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Deploy all Edge Functions
+        run: supabase functions deploy --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow to automatically deploy Supabase Edge Functions when changes are pushed to the main branch.

## Key Changes
- Added `.github/workflows/deploy-edge-functions.yml` workflow file that:
  - Triggers on pushes to `main` branch when files in `supabase/functions/` directory change
  - Supports manual triggering via `workflow_dispatch`
  - Sets up the Supabase CLI
  - Links the Supabase project using project reference and access token from secrets
  - Deploys all Edge Functions to the configured Supabase project

## Implementation Details
- Uses `supabase/setup-cli@v1` action to install the latest Supabase CLI
- Requires two secrets to be configured: `SUPABASE_PROJECT_REF` and `SUPABASE_ACCESS_TOKEN`
- Workflow runs on `ubuntu-latest` for consistency and reliability
- Path filtering ensures the workflow only runs when Edge Functions are actually modified, reducing unnecessary CI runs

https://claude.ai/code/session_01WNTzVEgDCfDUnGcVq2cAfc