### PR TITLE
Add service-role authentication support to rag-embed function

### DIFF
--- a/supabase/functions/rag-backfill/index.ts
+++ b/supabase/functions/rag-backfill/index.ts
@@ -72,7 +72,7 @@ const callRagEmbed = async (
       apikey: serviceRoleKey,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ items }),
+    body: JSON.stringify({ items, user_id: FIXED_USER_ID }),
   })
 
   if (!resp.ok) {

--- a/supabase/functions/rag-embed/index.ts
+++ b/supabase/functions/rag-embed/index.ts
@@ -14,6 +14,7 @@ type RagEmbedItemInput = {
 
 type RagEmbedPayload = {
   items?: unknown
+  user_id?: unknown
 } & RagEmbedItemInput
 
 type NormalizedRagEmbedItem = {
@@ -304,24 +305,12 @@ serve(async (req) => {
       return jsonResponse({ error: 'Missing auth headers' }, 401, origin)
     }
 
-    const supabase = createClient(supabaseUrl, anonKey, {
-      global: {
-        headers: {
-          Authorization: authHeader,
-          apikey,
-        },
-      },
-    })
+    // Detect service-role calls (server-to-server, e.g. from rag-backfill)
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+    const isServiceRole = serviceRoleKey && apikey === serviceRoleKey
 
-    // Auth handling: block anonymous writes and bind user_id from Supabase auth.
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser()
-
-    if (userError || !user) {
-      return jsonResponse({ error: 'Unauthorized' }, 401, origin)
-    }
+    let userId: string
+    let supabase: ReturnType<typeof createClient>
 
     let payload: RagEmbedPayload
     try {
@@ -330,16 +319,46 @@ serve(async (req) => {
       return jsonResponse({ error: 'Invalid JSON body' }, 400, origin)
     }
 
+    if (isServiceRole) {
+      // Service-role: create client with service role key (bypasses RLS)
+      supabase = createClient(supabaseUrl, serviceRoleKey)
+
+      if (typeof payload.user_id !== 'string' || !payload.user_id) {
+        return jsonResponse({ error: 'Service-role calls must provide user_id' }, 400, origin)
+      }
+      userId = payload.user_id
+    } else {
+      supabase = createClient(supabaseUrl, anonKey, {
+        global: {
+          headers: {
+            Authorization: authHeader,
+            apikey,
+          },
+        },
+      })
+
+      // Auth handling: block anonymous writes and bind user_id from Supabase auth.
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser()
+
+      if (userError || !user) {
+        return jsonResponse({ error: 'Unauthorized' }, 401, origin)
+      }
+      userId = user.id
+    }
+
     const normalized = normalizePayload(payload)
     if (normalized.earlyError) {
       return jsonResponse({ error: normalized.earlyError }, 400, origin)
     }
 
-    const runtimeConfig = await loadEmbeddingRuntimeConfig(supabase, user.id)
+    const runtimeConfig = await loadEmbeddingRuntimeConfig(supabase, userId)
 
     if (runtimeConfig.embeddingProvider !== 'openrouter') {
       console.warn(
-        `[rag-embed] user ${user.id} embedding_provider=${runtimeConfig.embeddingProvider}, falling back to OpenRouter for this endpoint`,
+        `[rag-embed] user ${userId} embedding_provider=${runtimeConfig.embeddingProvider}, falling back to OpenRouter for this endpoint`,
       )
     }
 
@@ -353,7 +372,7 @@ serve(async (req) => {
         // Hash generation + dedupe key: stable content hash includes model/version and source identity.
         const contentHash = await sha256Hex(
           [
-            user.id,
+            userId,
             item.source,
             item.zone,
             item.source_table,
@@ -380,7 +399,7 @@ serve(async (req) => {
             error: embeddingResult.error,
           })
           console.error('[rag-embed] embedding failed', {
-            user_id: user.id,
+            user_id: userId,
             source_id: item.source_id,
             error: embeddingResult.error,
           })
@@ -401,7 +420,7 @@ serve(async (req) => {
           embedding_version: EMBEDDING_VERSION,
           chunk_index: item.chunk_index,
           token_count: item.token_count,
-          user_id: user.id,
+          user_id: userId,
         })
 
         if (insertError) {
@@ -418,7 +437,7 @@ serve(async (req) => {
             error: insertError.message,
           })
           console.error('[rag-embed] insert failed', {
-            user_id: user.id,
+            user_id: userId,
             source_id: item.source_id,
             error: insertError,
           })
@@ -437,7 +456,7 @@ serve(async (req) => {
         })
         // Error handling: keep item-scoped failures isolated in batch mode.
         console.error('[rag-embed] unexpected item failure', {
-          user_id: user.id,
+          user_id: userId,
           source_id: item.source_id,
           error,
         })


### PR DESCRIPTION
## Summary
This PR adds support for service-role (server-to-server) authentication to the `rag-embed` function, enabling backend services like `rag-backfill` to call the embedding endpoint without user authentication. The function now detects service-role API keys and handles them separately from user-authenticated requests.

## Key Changes
- **Added `user_id` to payload type**: Extended `RagEmbedPayload` to accept an optional `user_id` field for service-role calls
- **Service-role detection**: Added logic to detect when requests use the `SUPABASE_SERVICE_ROLE_KEY` and route them through a different authentication path
- **Dual authentication paths**: 
  - Service-role calls: Create Supabase client with service role key (bypasses RLS) and require explicit `user_id` in payload
  - User-authenticated calls: Maintain existing behavior with auth headers and user extraction from Supabase auth
- **Unified user ID handling**: Refactored to use a single `userId` variable that's set based on the authentication method, replacing direct references to `user.id`
- **Updated rag-backfill**: Modified to pass `user_id` in the request body when calling `rag-embed`

## Implementation Details
- Service-role calls must explicitly provide a `user_id` in the request payload; missing `user_id` returns a 400 error
- User-authenticated calls continue to extract `user_id` from Supabase auth tokens
- All downstream operations (embedding, database inserts, logging) use the unified `userId` variable regardless of authentication method
- The service role key is read from the `SUPABASE_SERVICE_ROLE_KEY` environment variable

https://claude.ai/code/session_01MZJb2d2vaaf5m33cQc7TgM