### PR TITLE
Add fire-and-forget embedding calls for content indexing

### DIFF
--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -446,6 +446,42 @@ const requireAuthenticatedUserId = async (): Promise<string> => {
   return user.id
 }
 
+/**
+ * Fire-and-forget embedding: calls rag-embed edge function after a write.
+ * Never throws — failures are logged only, so the main write flow is unaffected.
+ */
+const fireEmbedding = (params: {
+  userId: string
+  text: string
+  zone: string
+  sourceTable: string
+  sourceId: string
+  metadata?: Record<string, unknown>
+}) => {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
+  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
+  if (!supabaseUrl || !anonKey) return
+
+  fetch(`${supabaseUrl}/functions/v1/rag-embed`, {
+    method: 'POST',
+    headers: {
+      apikey: anonKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      user_id: params.userId,
+      text: params.text,
+      source: 'hamster-nest',
+      zone: params.zone,
+      source_table: params.sourceTable,
+      source_id: params.sourceId,
+      metadata: params.metadata ?? {},
+    }),
+  }).catch((err) => {
+    console.warn('[fireEmbedding] failed (non-blocking)', err)
+  })
+}
+
 export const fetchLetters = async (): Promise<LetterEntry[]> => {
   if (!supabase) {
     return []
@@ -540,7 +576,15 @@ export const createLetter = async (
   if (error || !data) {
     throw error ?? new Error('创建信件失败')
   }
-  return mapLetterRow(data as LetterRow)
+  const letter = mapLetterRow(data as LetterRow)
+  fireEmbedding({
+    userId,
+    text: letter.content,
+    zone: 'letter',
+    sourceTable: 'letters',
+    sourceId: letter.id,
+  })
+  return letter
 }
 
 export const markLetterAsRead = async (letterId: string): Promise<void> => {
@@ -1252,7 +1296,15 @@ export const addRemoteMessage = async (
   if (sessionError) {
     throw sessionError
   }
-  return { message: mapMessageRow(data as MessageRow), updatedAt: now }
+  const message = mapMessageRow(data as MessageRow)
+  fireEmbedding({
+    userId,
+    text: message.content,
+    zone: 'daily_chat',
+    sourceTable: 'messages',
+    sourceId: message.id,
+  })
+  return { message, updatedAt: now }
 }
 
 export const deleteRemoteMessage = async (messageId: string) => {
@@ -1311,7 +1363,15 @@ export const createSnackPost = async (content: string): Promise<SnackPost> => {
   if (error || !data) {
     throw error ?? new Error('发布零食记录失败')
   }
-  return mapSnackPostRow(data as SnackPostRow)
+  const post = mapSnackPostRow(data as SnackPostRow)
+  fireEmbedding({
+    userId: post.userId,
+    text: post.content,
+    zone: 'snack',
+    sourceTable: 'snack_posts',
+    sourceId: post.id,
+  })
+  return post
 }
 
 
@@ -1388,7 +1448,15 @@ export const createSnackReply = async (
   if (error || !data) {
     throw error ?? new Error('保存零食回复失败')
   }
-  return mapSnackReplyRow(data as SnackReplyRow)
+  const reply = mapSnackReplyRow(data as SnackReplyRow)
+  fireEmbedding({
+    userId: reply.userId,
+    text: reply.content,
+    zone: 'snack',
+    sourceTable: 'snack_replies',
+    sourceId: reply.id,
+  })
+  return reply
 }
 
 export const softDeleteSnackReply = async (replyId: string): Promise<void> => {
@@ -1516,7 +1584,15 @@ export const createSyzygyPost = async (
   if (error || !data) {
     throw error ?? new Error('发布观察日志失败')
   }
-  return mapSyzygyPostRow(data as SyzygyPostRow)
+  const post = mapSyzygyPostRow(data as SyzygyPostRow)
+  fireEmbedding({
+    userId: post.userId,
+    text: post.content,
+    zone: 'syzygy_post',
+    sourceTable: 'syzygy_posts',
+    sourceId: post.id,
+  })
+  return post
 }
 
 export const restoreSyzygyPost = async (postId: string): Promise<void> => {
@@ -1605,7 +1681,15 @@ export const createSyzygyReply = async (
   if (error || !data) {
     throw error ?? new Error('保存观察日志回复失败')
   }
-  return mapSyzygyReplyRow(data as SyzygyReplyRow)
+  const reply = mapSyzygyReplyRow(data as SyzygyReplyRow)
+  fireEmbedding({
+    userId: reply.userId,
+    text: reply.content,
+    zone: 'syzygy_post',
+    sourceTable: 'syzygy_replies',
+    sourceId: reply.id,
+  })
+  return reply
 }
 
 export const softDeleteSyzygyReply = async (replyId: string): Promise<void> => {
@@ -1855,7 +1939,15 @@ export const createForumThread = async (params: {
   if (error || !data) {
     throw error ?? new Error('创建论坛主题失败')
   }
-  return mapForumThreadRow(data as ForumThreadRow)
+  const thread = mapForumThreadRow(data as ForumThreadRow)
+  fireEmbedding({
+    userId,
+    text: `${thread.title}\n${thread.content}`,
+    zone: 'forum',
+    sourceTable: 'forum_threads',
+    sourceId: thread.id,
+  })
+  return thread
 }
 
 export const fetchForumRepliesByThread = async (threadId: string): Promise<ForumReply[]> => {
@@ -1928,7 +2020,15 @@ export const createForumReply = async (params: {
   if (error || !data) {
     throw error ?? new Error('创建论坛回复失败')
   }
-  return mapForumReplyRow(data as ForumReplyRow)
+  const reply = mapForumReplyRow(data as ForumReplyRow)
+  fireEmbedding({
+    userId,
+    text: reply.content,
+    zone: 'forum',
+    sourceTable: 'forum_replies',
+    sourceId: reply.id,
+  })
+  return reply
 }
 
 export const deleteForumThread = async (threadId: string): Promise<void> => {
@@ -2332,7 +2432,15 @@ export const createBubbleMessage = async (
     .eq('id', sessionId)
     .eq('user_id', userId)
 
-  return mapBubbleMessageRow(data as BubbleMessageRow)
+  const message = mapBubbleMessageRow(data as BubbleMessageRow)
+  fireEmbedding({
+    userId,
+    text: message.content,
+    zone: 'bubble',
+    sourceTable: 'bubble_messages',
+    sourceId: message.id,
+  })
+  return message
 }
 
 export const fetchAllBubbleSessions = async (): Promise<BubbleSession[]> => {


### PR DESCRIPTION
## Summary
This PR adds automatic embedding generation for user-created content across multiple features. A new `fireEmbedding` helper function is introduced that asynchronously calls the `rag-embed` edge function after content creation, enabling RAG (Retrieval-Augmented Generation) indexing without blocking the main write flow.

## Key Changes
- **New `fireEmbedding` helper function**: Fire-and-forget async function that calls the `rag-embed` edge function with content metadata. Failures are logged but never thrown, ensuring the main write flow is unaffected.
- **Integrated embedding calls** in 8 content creation functions:
  - `createLetter` - indexes letter content
  - `addRemoteMessage` - indexes daily chat messages
  - `createSnackPost` - indexes snack posts
  - `createSnackReply` - indexes snack replies
  - `createSyzygyPost` - indexes observation log posts
  - `createSyzygyReply` - indexes observation log replies
  - `createForumThread` - indexes forum threads (title + content)
  - `createForumReply` - indexes forum replies
  - `createBubbleMessage` - indexes bubble session messages

## Implementation Details
- Each embedding call includes: user ID, content text, zone identifier, source table name, and source ID for traceability
- The function gracefully handles missing Supabase configuration by returning early
- All fetch errors are caught and logged as warnings without affecting the calling function
- Forum threads include both title and content in the embedding text for better indexing
- Consistent metadata structure across all content types for unified RAG processing

https://claude.ai/code/session_012FJvTvUdPHgwTQWVWsU1fa