### PR TITLE
Add RAG context injection to OpenRouter chat function

### DIFF
--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -54,6 +54,25 @@ type AuthUserResponse = {
   id: string
 }
 
+type RagConfigRow = {
+  config_key: string | null
+  config_value: unknown
+}
+
+type RagRuntimeConfig = {
+  searchTopK: number
+  searchThreshold: number
+  defaultSearchZones: string[]
+  rpSearchMode: 'story_group' | 'session' | 'all_rp'
+  embeddingModel: string
+  embeddingDimensions: number
+}
+
+type RagChunkRow = {
+  chunk_text?: unknown
+  similarity?: unknown
+}
+
 type RuntimeCompressionResult = {
   messages: OpenAiMessage[]
   cacheWriteFailed: boolean
@@ -116,6 +135,17 @@ const injectMemoryBlock = (messages: OpenAiMessage[], memoryMessage: OpenAiMessa
   }
   return [...messages.slice(0, firstUserIndex), memoryMessage, ...messages.slice(firstUserIndex)]
 }
+
+const RAG_DEFAULTS = {
+  searchTopK: 5,
+  searchThreshold: 0.7,
+  defaultSearchZones: ['daily_chat', 'bubble', 'letter'],
+  rpSearchMode: 'story_group' as const,
+  embeddingModel: 'text-embedding-3-small',
+  embeddingDimensions: 1536,
+}
+
+const RAG_EMBEDDING_VERSION = 'v1'
 
 const shouldInjectSnackFeedMemory = (payload: OpenRouterPayload) => payload.module === 'snack-feed'
 
@@ -829,6 +859,228 @@ const fetchMemoriesByStatus = async (
     .filter((content) => content.length > 0)
 }
 
+const loadRagConfig = async (
+  serviceClient: ReturnType<typeof createClient>,
+  userId: string,
+): Promise<RagRuntimeConfig> => {
+  const keys = [
+    'search_top_k',
+    'search_threshold',
+    'default_search_zones',
+    'rp_search_mode',
+    'embedding_model',
+    'embedding_dimensions',
+  ]
+
+  const { data, error } = await serviceClient
+    .from('rag_config')
+    .select('config_key, config_value')
+    .eq('user_id', userId)
+    .in('config_key', keys)
+
+  if (error || !data) {
+    console.warn('[rag] failed to load rag_config; using defaults', { userId, error })
+    return { ...RAG_DEFAULTS }
+  }
+
+  const map = new Map<string, unknown>()
+  for (const row of data as RagConfigRow[]) {
+    if (!row.config_key || row.config_value === null || row.config_value === undefined) continue
+    map.set(row.config_key, row.config_value)
+  }
+
+  const parseInteger = (v: unknown): number | null => {
+    if (typeof v === 'number' && Number.isInteger(v)) return v
+    if (typeof v === 'string') { const n = Number.parseInt(v, 10); return Number.isNaN(n) ? null : n }
+    return null
+  }
+  const parseFloat_ = (v: unknown): number | null => {
+    if (typeof v === 'number' && Number.isFinite(v)) return v
+    if (typeof v === 'string') { const n = Number.parseFloat(v); return Number.isNaN(n) ? null : n }
+    return null
+  }
+
+  const rawZones = map.get('default_search_zones')
+  let parsedZones: string[] | null = null
+  if (Array.isArray(rawZones)) {
+    parsedZones = rawZones.map((e) => String(e).trim()).filter(Boolean)
+  } else if (typeof rawZones === 'string') {
+    parsedZones = rawZones.split(',').map((e) => e.trim()).filter(Boolean)
+  }
+
+  const rpRaw = map.get('rp_search_mode')
+  const rpCandidate = typeof rpRaw === 'string' ? rpRaw.trim().toLowerCase() : ''
+  const rpSearchMode: RagRuntimeConfig['rpSearchMode'] =
+    rpCandidate === 'session' || rpCandidate === 'all_rp' ? rpCandidate : RAG_DEFAULTS.rpSearchMode
+
+  return {
+    searchTopK: parseInteger(map.get('search_top_k')) ?? RAG_DEFAULTS.searchTopK,
+    searchThreshold: parseFloat_(map.get('search_threshold')) ?? RAG_DEFAULTS.searchThreshold,
+    defaultSearchZones: parsedZones && parsedZones.length > 0 ? parsedZones : RAG_DEFAULTS.defaultSearchZones,
+    rpSearchMode,
+    embeddingModel:
+      typeof map.get('embedding_model') === 'string' && (map.get('embedding_model') as string).trim()
+        ? (map.get('embedding_model') as string).trim()
+        : RAG_DEFAULTS.embeddingModel,
+    embeddingDimensions: parseInteger(map.get('embedding_dimensions')) ?? RAG_DEFAULTS.embeddingDimensions,
+  }
+}
+
+const fetchRagEmbedding = async (
+  apiKey: string,
+  model: string,
+  dimensions: number,
+  query: string,
+): Promise<number[] | null> => {
+  try {
+    const resp = await fetch('https://openrouter.ai/api/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model, input: query, dimensions }),
+    })
+    if (!resp.ok) return null
+    const body = (await resp.json()) as { data?: Array<{ embedding?: number[] }> }
+    const embedding = body.data?.[0]?.embedding
+    return Array.isArray(embedding) && embedding.length > 0 ? embedding : null
+  } catch {
+    return null
+  }
+}
+
+const resolveRpStoryGroupId = async (
+  serviceClient: ReturnType<typeof createClient>,
+  sessionId: string,
+): Promise<string | null> => {
+  const { data, error } = await serviceClient
+    .from('rp_session_groups')
+    .select('story_group_id')
+    .eq('session_id', sessionId)
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data) return null
+  const groupId = (data as Record<string, unknown>).story_group_id
+  return typeof groupId === 'string' && groupId.trim() ? groupId.trim() : null
+}
+
+const maybeInjectRagContext = async (
+  payload: OpenRouterPayload,
+  messages: OpenAiMessage[],
+  userId: string,
+  openRouterApiKey: string,
+): Promise<OpenAiMessage[]> => {
+  const isChitchat = !payload.module || payload.module === 'chitchat'
+  const isRp = payload.module === 'rp-room'
+  if (!isChitchat && !isRp) return messages
+
+  try {
+    const serviceClient = buildSupabaseServiceRoleClient()
+    const ragConfig = await loadRagConfig(serviceClient, userId)
+
+    // Determine zones and metadata filter
+    let zones: string[]
+    let metadataFilter: Record<string, unknown> | null = null
+
+    if (isRp) {
+      zones = ['rp']
+      const sessionId = payload.conversationId?.trim()
+      if (sessionId) {
+        const storyGroupId = await resolveRpStoryGroupId(serviceClient, sessionId)
+        if (storyGroupId) {
+          metadataFilter = { story_group_id: storyGroupId }
+        } else {
+          metadataFilter = { session_id: sessionId }
+        }
+      }
+    } else {
+      zones = ragConfig.defaultSearchZones
+    }
+
+    // Extract latest user message as query
+    const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user')
+    const query = lastUserMessage?.content?.trim()
+    if (!query) return messages
+
+    // Get embedding
+    const embedding = await fetchRagEmbedding(
+      openRouterApiKey,
+      ragConfig.embeddingModel,
+      ragConfig.embeddingDimensions,
+      query,
+    )
+    if (!embedding) return messages
+
+    // Call match_rag_chunks RPC with multiple signature attempts
+    const rpcArgs = [
+      {
+        p_user_id: userId,
+        p_query_embedding: embedding,
+        p_zones: zones,
+        p_threshold: ragConfig.searchThreshold,
+        p_top_k: ragConfig.searchTopK,
+        p_metadata_filter: metadataFilter,
+        p_embedding_model: ragConfig.embeddingModel,
+        p_embedding_version: RAG_EMBEDDING_VERSION,
+      },
+      {
+        query_embedding: embedding,
+        filter_user_id: userId,
+        zones,
+        match_threshold: ragConfig.searchThreshold,
+        match_count: ragConfig.searchTopK,
+        metadata_filter: metadataFilter,
+        embedding_model: ragConfig.embeddingModel,
+        embedding_version: RAG_EMBEDDING_VERSION,
+      },
+      {
+        embedding,
+        user_id: userId,
+        zones,
+        threshold: ragConfig.searchThreshold,
+        top_k: ragConfig.searchTopK,
+        metadata_filter: metadataFilter,
+        embedding_model: ragConfig.embeddingModel,
+        embedding_version: RAG_EMBEDDING_VERSION,
+      },
+    ]
+
+    let chunks: RagChunkRow[] | null = null
+    for (const args of rpcArgs) {
+      const { data, error } = await serviceClient.rpc('match_rag_chunks', args)
+      if (!error) {
+        chunks = (data ?? []) as RagChunkRow[]
+        break
+      }
+      const msg = String((error as { message?: string }).message ?? '')
+      if (!msg.includes('Could not find the function') && !msg.includes('function match_rag_chunks')) {
+        console.warn('[rag] match_rag_chunks RPC failed', { userId, error })
+        return messages
+      }
+    }
+
+    if (!chunks || chunks.length === 0) return messages
+
+    const chunkTexts = chunks
+      .map((c) => (typeof c.chunk_text === 'string' ? c.chunk_text.trim() : ''))
+      .filter(Boolean)
+
+    if (chunkTexts.length === 0) return messages
+
+    const ragSystemMessage: OpenAiMessage = {
+      role: 'system',
+      content: ['[相关记忆]', ...chunkTexts.map((t) => `- ${t}`)].join('\n'),
+    }
+
+    return injectMemoryBlock(messages, ragSystemMessage)
+  } catch (error) {
+    console.warn('[rag] RAG retrieval failed, skipping injection', error)
+    return messages
+  }
+}
+
 const maybeInjectMemory = async (
   payload: OpenRouterPayload,
   messages: OpenAiMessage[],
@@ -989,6 +1241,8 @@ serve(async (req) => {
     compressionCacheWriteFailed = compressionResult.cacheWriteFailed
     compressionCacheWriteSucceeded = compressionResult.cacheWriteSucceeded
     compressionCacheWriteErrorMessage = compressionResult.cacheWriteErrorMessage
+
+    messages = await maybeInjectRagContext(resolvedPayload, messages, userId, apiKey)
   }
 
   const buildRpCompressionDebugHeaders = () => {


### PR DESCRIPTION
## Summary
This PR adds Retrieval-Augmented Generation (RAG) capabilities to the OpenRouter chat function, enabling the system to inject relevant contextual memories into chat messages based on semantic similarity search.

## Key Changes

- **New Type Definitions**: Added `RagConfigRow`, `RagRuntimeConfig`, and `RagChunkRow` types to support RAG configuration and chunk data structures

- **RAG Configuration Management**:
  - Added `RAG_DEFAULTS` constant with sensible defaults (top-k=5, threshold=0.7, embedding model=text-embedding-3-small)
  - Implemented `loadRagConfig()` function to fetch and parse user-specific RAG settings from the database with fallback to defaults
  - Supports flexible parsing of configuration values (integers, floats, arrays, strings)

- **Embedding Generation**: Implemented `fetchRagEmbedding()` to call OpenRouter's embedding API with configurable model and dimensions

- **RP Context Resolution**: Added `resolveRpStoryGroupId()` to fetch story group IDs for roleplay sessions, enabling scoped context retrieval

- **RAG Context Injection**: Implemented `maybeInjectRagContext()` function that:
  - Activates for chitchat and roleplay modules
  - Extracts the latest user message as a search query
  - Generates embeddings and calls the `match_rag_chunks` RPC with multiple signature attempts for compatibility
  - Injects retrieved chunks as a system message with Chinese label "[相关记忆]" (relevant memories)
  - Gracefully handles failures and returns original messages if RAG retrieval fails

- **Integration**: Integrated RAG context injection into the main message processing pipeline, executing after message compression

## Notable Implementation Details

- The `maybeInjectRagContext()` function attempts multiple RPC signatures to handle different database schema versions
- Configuration values are robustly parsed with type checking and validation
- Roleplay sessions can be filtered by story group or session ID
- RAG injection is non-blocking—failures are logged but don't interrupt the chat flow
- Uses `injectMemoryBlock()` utility to properly position the RAG context in the message sequence

https://claude.ai/code/session_01L7xddBRLpeTsAWFmQBswjg