### PR TITLE
Add RAG settings page for memory engine configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ import ForumNewThreadPage from './pages/ForumNewThreadPage'
 import ForumThreadPage from './pages/ForumThreadPage'
 import ForumSettingsPage from './pages/ForumSettingsPage'
 import LettersPage from './pages/LettersPage'
+import RagSettingsPage from './pages/RagSettingsPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1728,6 +1729,14 @@ const App = () => {
                 onCreateSession={createSessionEntry}
                 onUnreadStateChange={setHasUnreadLetters}
               />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/rag-settings"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <RagSettingsPage />
             </RequireAuth>
           }
         />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "rag"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -264,6 +264,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "export", defaultEmoji: "📦", label: "导出", route: "/export" },
       { id: "forum", defaultEmoji: "💭", label: "Forum", route: "/forum" },
       { id: "letters", defaultEmoji: "💌", label: "Letters", route: "/letters" },
+      { id: "rag", defaultEmoji: "🔮", label: "记忆引擎", route: "/rag-settings" },
     ],
     [onOpenChat],
   );
@@ -516,6 +517,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
         {
           forum: defaultAppIconConfigs.forum,
           letters: defaultAppIconConfigs.letters,
+          rag: defaultAppIconConfigs.rag,
         },
         false,
       ),

--- a/src/pages/RagSettingsPage.css
+++ b/src/pages/RagSettingsPage.css
@@ -1,0 +1,299 @@
+@import url('https://fonts.googleapis.com/css2?family=DotGothic16&family=VT323&display=swap');
+
+.rag-settings-page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.rag-settings-shell {
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.rag-settings-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.rag-settings-header .ui-title {
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 2rem;
+  letter-spacing: 0.04em;
+}
+
+.rag-settings-content {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.rag-settings-loading,
+.rag-settings-saving {
+  margin: 0;
+  color: #7a7078;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.15rem;
+}
+
+.rag-settings-card {
+  padding: 0.55rem 0.65rem;
+}
+
+.rag-settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.rag-settings-row--vertical {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.rag-settings-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #4f4750;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+
+.rag-settings-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.2rem;
+  padding: 0.08rem 0.4rem;
+  border: 2px solid #c3b2bb;
+  background: #fff5e7;
+  color: #7a7078;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.1rem;
+  line-height: 1.2;
+  margin-left: auto;
+}
+
+.rag-settings-select {
+  width: 100%;
+  max-width: 260px;
+  min-height: 2.2rem;
+  border-radius: 0 !important;
+  border: 2px solid #a1919a !important;
+  background: #fffdf8 !important;
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  color: #4f4750;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+/* Toggle switch */
+.rag-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.rag-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.rag-toggle__track {
+  position: relative;
+  width: 42px;
+  height: 22px;
+  border: 2px solid #a1919a;
+  background: #ffe7f1;
+  transition: background-color 0.2s ease;
+}
+
+.rag-toggle input:checked + .rag-toggle__track {
+  background: #f39dc4;
+  border-color: #c8799e;
+}
+
+.rag-toggle__thumb {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 16px;
+  height: 16px;
+  background: #fff;
+  border: 2px solid #a1919a;
+  transition: transform 0.2s ease;
+}
+
+.rag-toggle input:checked ~ .rag-toggle__track .rag-toggle__thumb,
+.rag-toggle input:checked + .rag-toggle__track .rag-toggle__thumb {
+  transform: translateX(20px);
+  border-color: #c8799e;
+}
+
+.rag-toggle__label {
+  color: #7a7078;
+  font-family: 'VT323', 'DotGothic16', monospace;
+  font-size: 1.1rem;
+}
+
+/* Slider */
+.rag-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border: 2px solid #c3b2bb;
+  background: #ffe7f1;
+  outline: none;
+  margin: 0.35rem 0;
+}
+
+.rag-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border: 2px solid #a1919a;
+  cursor: pointer;
+  box-shadow: 2px 2px 0 0 #efd4de;
+}
+
+.rag-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border: 2px solid #a1919a;
+  cursor: pointer;
+  box-shadow: 2px 2px 0 0 #efd4de;
+  border-radius: 0;
+}
+
+/* Checkbox group */
+.rag-checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1rem;
+  margin-top: 0.25rem;
+}
+
+.rag-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  color: #4f4750;
+  font-size: 0.9rem;
+}
+
+.rag-checkbox input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.rag-checkbox__box {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #a1919a;
+  background: #fffdf8;
+  position: relative;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease;
+}
+
+.rag-checkbox input:checked + .rag-checkbox__box {
+  background: #f39dc4;
+  border-color: #c8799e;
+}
+
+.rag-checkbox input:checked + .rag-checkbox__box::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 4px;
+  width: 5px;
+  height: 9px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+/* Radio group */
+.rag-radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1rem;
+  margin-top: 0.25rem;
+}
+
+.rag-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  color: #4f4750;
+  font-size: 0.9rem;
+}
+
+.rag-radio input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.rag-radio__dot {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #a1919a;
+  border-radius: 50%;
+  background: #fffdf8;
+  position: relative;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease;
+}
+
+.rag-radio input:checked + .rag-radio__dot {
+  border-color: #c8799e;
+}
+
+.rag-radio input:checked + .rag-radio__dot::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #f39dc4;
+}
+
+@media (max-width: 640px) {
+  .rag-settings-page {
+    padding-inline: 0;
+  }
+
+  .rag-settings-shell {
+    max-width: 100%;
+  }
+
+  .rag-settings-select {
+    max-width: 100%;
+  }
+
+  .rag-settings-row {
+    gap: 0.45rem;
+  }
+}

--- a/src/pages/RagSettingsPage.tsx
+++ b/src/pages/RagSettingsPage.tsx
@@ -1,0 +1,329 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { supabase } from '../supabase/client'
+import './RagSettingsPage.css'
+
+type RagConfigRow = {
+  id: string
+  user_id: string
+  config_key: string
+  config_value: string
+}
+
+type RagConfigState = {
+  rag_enabled: boolean
+  embedding_model: string
+  api_provider: string
+  top_k: number
+  similarity_threshold: number
+  retrieval_areas: string[]
+  rp_retrieval_mode: string
+}
+
+const DEFAULT_CONFIG: RagConfigState = {
+  rag_enabled: false,
+  embedding_model: 'text-embedding-3-small',
+  api_provider: 'openrouter',
+  top_k: 5,
+  similarity_threshold: 0.7,
+  retrieval_areas: ['daily_chat'],
+  rp_retrieval_mode: 'story_group',
+}
+
+const RETRIEVAL_AREA_OPTIONS = [
+  { value: 'daily_chat', label: '日常聊天' },
+  { value: 'bubble', label: 'Bubble' },
+  { value: 'letter', label: '信件' },
+  { value: 'diary', label: '日记' },
+]
+
+const RP_MODE_OPTIONS = [
+  { value: 'story_group', label: '按故事组' },
+  { value: 'session', label: '按窗口' },
+  { value: 'all_rp', label: '全部RP' },
+]
+
+const getUserId = async () => {
+  if (!supabase) return null
+  const { data } = await supabase.auth.getSession()
+  return data.session?.user.id ?? null
+}
+
+const fetchRagConfig = async (): Promise<RagConfigRow[]> => {
+  if (!supabase) return []
+  const userId = await getUserId()
+  if (!userId) return []
+  const { data, error } = await supabase
+    .from('rag_config')
+    .select()
+    .eq('user_id', userId)
+  if (error) throw error
+  return data ?? []
+}
+
+const upsertRagConfig = async (key: string, value: string) => {
+  if (!supabase) return
+  const userId = await getUserId()
+  if (!userId) return
+  const { error } = await supabase
+    .from('rag_config')
+    .upsert(
+      { user_id: userId, config_key: key, config_value: value },
+      { onConflict: 'user_id,config_key' },
+    )
+  if (error) throw error
+}
+
+const parseRows = (rows: RagConfigRow[]): RagConfigState => {
+  const map = new Map(rows.map((r) => [r.config_key, r.config_value]))
+  return {
+    rag_enabled: map.get('rag_enabled') === 'true',
+    embedding_model: map.get('embedding_model') ?? DEFAULT_CONFIG.embedding_model,
+    api_provider: map.get('api_provider') ?? DEFAULT_CONFIG.api_provider,
+    top_k: Number(map.get('top_k')) || DEFAULT_CONFIG.top_k,
+    similarity_threshold: Number(map.get('similarity_threshold')) || DEFAULT_CONFIG.similarity_threshold,
+    retrieval_areas: map.has('retrieval_areas')
+      ? JSON.parse(map.get('retrieval_areas')!) as string[]
+      : DEFAULT_CONFIG.retrieval_areas,
+    rp_retrieval_mode: map.get('rp_retrieval_mode') ?? DEFAULT_CONFIG.rp_retrieval_mode,
+  }
+}
+
+const RagSettingsPage = () => {
+  const [config, setConfig] = useState<RagConfigState>(DEFAULT_CONFIG)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const rows = await fetchRagConfig()
+      setConfig(parseRows(rows))
+    } catch {
+      setError('加载RAG配置失败，请稍后重试。')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const save = async (key: string, value: string) => {
+    setSaving(key)
+    setError(null)
+    try {
+      await upsertRagConfig(key, value)
+    } catch {
+      setError(`保存 ${key} 失败，请重试。`)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const handleToggle = (checked: boolean) => {
+    setConfig((c) => ({ ...c, rag_enabled: checked }))
+    void save('rag_enabled', String(checked))
+  }
+
+  const handleSelect = (key: 'embedding_model' | 'api_provider', value: string) => {
+    setConfig((c) => ({ ...c, [key]: value }))
+    void save(key, value)
+  }
+
+  const handleTopK = (value: number) => {
+    const clamped = Math.min(20, Math.max(1, value))
+    setConfig((c) => ({ ...c, top_k: clamped }))
+    void save('top_k', String(clamped))
+  }
+
+  const handleThreshold = (value: number) => {
+    const rounded = Math.round(value * 100) / 100
+    setConfig((c) => ({ ...c, similarity_threshold: rounded }))
+    void save('similarity_threshold', String(rounded))
+  }
+
+  const handleAreaToggle = (area: string) => {
+    setConfig((prev) => {
+      const current = prev.retrieval_areas
+      const next = current.includes(area)
+        ? current.filter((a) => a !== area)
+        : [...current, area]
+      void save('retrieval_areas', JSON.stringify(next))
+      return { ...prev, retrieval_areas: next }
+    })
+  }
+
+  const handleRpMode = (mode: string) => {
+    setConfig((c) => ({ ...c, rp_retrieval_mode: mode }))
+    void save('rp_retrieval_mode', mode)
+  }
+
+  return (
+    <div className="rag-settings-page forum-page">
+      <div className="rag-settings-shell forum-page__wrapper">
+        <header className="rag-settings-header forum-header--index">
+          <Link to="/" className="forum-pixel-btn">
+            ← 返回
+          </Link>
+          <h1 className="ui-title">记忆引擎</h1>
+          <div />
+        </header>
+
+        <div className="rag-settings-content forum-thread-list">
+          {loading ? (
+            <p className="rag-settings-loading">加载中…</p>
+          ) : (
+            <>
+              {error ? <p className="forum-error">{error}</p> : null}
+
+              {/* RAG 总开关 */}
+              <div className="rag-settings-card forum-thread-item">
+                <div className="rag-settings-row">
+                  <span className="rag-settings-label">RAG 总开关</span>
+                  <label className="rag-toggle">
+                    <input
+                      type="checkbox"
+                      checked={config.rag_enabled}
+                      onChange={(e) => handleToggle(e.target.checked)}
+                      disabled={saving === 'rag_enabled'}
+                    />
+                    <span className="rag-toggle__track">
+                      <span className="rag-toggle__thumb" />
+                    </span>
+                    <span className="rag-toggle__label">
+                      {config.rag_enabled ? '已开启' : '已关闭'}
+                    </span>
+                  </label>
+                </div>
+              </div>
+
+              {/* Embedding 模型 */}
+              <div className="rag-settings-card forum-thread-item">
+                <div className="rag-settings-row">
+                  <span className="rag-settings-label">Embedding 模型</span>
+                  <select
+                    className="rag-settings-select input-glass"
+                    value={config.embedding_model}
+                    onChange={(e) => handleSelect('embedding_model', e.target.value)}
+                    disabled={saving === 'embedding_model'}
+                  >
+                    <option value="text-embedding-3-small">text-embedding-3-small</option>
+                    <option value="text-embedding-3-large">text-embedding-3-large</option>
+                  </select>
+                </div>
+              </div>
+
+              {/* API 提供商 */}
+              <div className="rag-settings-card forum-thread-item">
+                <div className="rag-settings-row">
+                  <span className="rag-settings-label">API 提供商</span>
+                  <select
+                    className="rag-settings-select input-glass"
+                    value={config.api_provider}
+                    onChange={(e) => handleSelect('api_provider', e.target.value)}
+                    disabled={saving === 'api_provider'}
+                  >
+                    <option value="openrouter">OpenRouter</option>
+                    <option value="openai">OpenAI</option>
+                  </select>
+                </div>
+              </div>
+
+              {/* Top-K */}
+              <div className="rag-settings-card forum-thread-item">
+                <div className="rag-settings-row rag-settings-row--vertical">
+                  <span className="rag-settings-label">
+                    检索数量 Top-K
+                    <span className="rag-settings-value">{config.top_k}</span>
+                  </span>
+                  <input
+                    type="range"
+                    className="rag-slider"
+                    min={1}
+                    max={20}
+                    step={1}
+                    value={config.top_k}
+                    onChange={(e) => handleTopK(Number(e.target.value))}
+                    disabled={saving === 'top_k'}
+                  />
+                </div>
+              </div>
+
+              {/* 相似度阈值 */}
+              <div className="rag-settings-card forum-thread-item">
+                <div className="rag-settings-row rag-settings-row--vertical">
+                  <span className="rag-settings-label">
+                    相似度阈值
+                    <span className="rag-settings-value">{config.similarity_threshold.toFixed(2)}</span>
+                  </span>
+                  <input
+                    type="range"
+                    className="rag-slider"
+                    min={0.1}
+                    max={1.0}
+                    step={0.05}
+                    value={config.similarity_threshold}
+                    onChange={(e) => handleThreshold(Number(e.target.value))}
+                    disabled={saving === 'similarity_threshold'}
+                  />
+                </div>
+              </div>
+
+              {/* 日常聊天检索区域 */}
+              <div className="rag-settings-card forum-thread-item">
+                <div className="rag-settings-row rag-settings-row--vertical">
+                  <span className="rag-settings-label">日常聊天检索区域</span>
+                  <div className="rag-checkbox-group">
+                    {RETRIEVAL_AREA_OPTIONS.map((opt) => (
+                      <label key={opt.value} className="rag-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={config.retrieval_areas.includes(opt.value)}
+                          onChange={() => handleAreaToggle(opt.value)}
+                        />
+                        <span className="rag-checkbox__box" />
+                        <span>{opt.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* RP 检索模式 */}
+              <div className="rag-settings-card forum-thread-item">
+                <div className="rag-settings-row rag-settings-row--vertical">
+                  <span className="rag-settings-label">RP 检索模式</span>
+                  <div className="rag-radio-group">
+                    {RP_MODE_OPTIONS.map((opt) => (
+                      <label key={opt.value} className="rag-radio">
+                        <input
+                          type="radio"
+                          name="rp_retrieval_mode"
+                          value={opt.value}
+                          checked={config.rp_retrieval_mode === opt.value}
+                          onChange={() => handleRpMode(opt.value)}
+                        />
+                        <span className="rag-radio__dot" />
+                        <span>{opt.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {saving ? (
+                <p className="rag-settings-saving">保存中…</p>
+              ) : null}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RagSettingsPage


### PR DESCRIPTION
## Summary
This PR adds a new RAG (Retrieval-Augmented Generation) settings page that allows users to configure memory engine parameters for the application.

## Key Changes
- **New RagSettingsPage component** (`src/pages/RagSettingsPage.tsx`): A comprehensive settings interface for RAG configuration with the following features:
  - Toggle RAG functionality on/off
  - Select embedding model (text-embedding-3-small or text-embedding-3-large)
  - Choose API provider (OpenRouter or OpenAI)
  - Configure retrieval parameters (Top-K and similarity threshold) with sliders
  - Select retrieval areas for daily chat (daily_chat, bubble, letter, diary)
  - Choose RP retrieval mode (story_group, session, or all_rp)
  - Real-time persistence to Supabase `rag_config` table

- **Styling** (`src/pages/RagSettingsPage.css`): Custom CSS with retro pixel-art aesthetic matching the application's design system, including:
  - Toggle switches, sliders, checkboxes, and radio buttons
  - Responsive layout for mobile and desktop
  - Consistent color scheme and typography

- **Routing integration** (`src/App.tsx`): Added `/rag-settings` route with authentication protection

- **Home page navigation** (`src/pages/HomePage.tsx`): Added "rag" icon to the second page icon order for easy access

## Implementation Details
- Configuration is stored per-user in Supabase with automatic upsert on changes
- Default configuration values are provided with fallback parsing logic
- UI state updates optimistically while saving asynchronously
- Error handling with user-friendly messages in Chinese
- Loading and saving states to provide user feedback

https://claude.ai/code/session_014Lnx5z8Fb5Xwa4EJszaSpd