### PR TITLE
Add comprehensive logging to RAG context injection flow

### DIFF
--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -990,6 +990,9 @@ const maybeInjectRagContext = async (
     const serviceClient = buildSupabaseServiceRoleClient()
     const ragConfig = await loadRagConfig(serviceClient, userId)
 
+    console.log('[RAG] starting, ragEnabled:', ragConfig.ragEnabled)
+    console.log('[RAG] config:', JSON.stringify(ragConfig))
+
     if (!ragConfig.ragEnabled) return messages
 
     // Determine zones and metadata filter
@@ -1034,6 +1037,7 @@ const maybeInjectRagContext = async (
       query,
     )
     if (!embedding) return messages
+    console.log('[RAG] query embedding generated, dimensions:', embedding.length)
 
     // Call match_rag_chunks RPC with multiple signature attempts
     const rpcArgs = [
@@ -1074,6 +1078,8 @@ const maybeInjectRagContext = async (
       const { data, error } = await serviceClient.rpc('match_rag_chunks', args)
       if (!error) {
         chunks = (data ?? []) as RagChunkRow[]
+        console.log('[RAG] RPC result:', JSON.stringify(data?.length), 'chunks found')
+        console.log('[RAG] first chunk preview:', data?.[0]?.chunk_text?.substring(0, 100))
         break
       }
       const msg = String((error as { message?: string }).message ?? '')
@@ -1091,13 +1097,16 @@ const maybeInjectRagContext = async (
 
     if (chunkTexts.length === 0) return messages
 
+    const ragContext = ['[相关记忆 - 以下内容来自历史对话，供参考]', ...chunkTexts.map((t) => `- ${t}`)].join('\n')
     const ragSystemMessage: OpenAiMessage = {
       role: 'system',
-      content: ['[相关记忆 - 以下内容来自历史对话，供参考]', ...chunkTexts.map((t) => `- ${t}`)].join('\n'),
+      content: ragContext,
     }
 
+    console.log('[RAG] injected into system prompt, total context length:', ragContext.length)
     return injectMemoryBlock(messages, ragSystemMessage)
   } catch (error) {
+    console.error('[RAG] error:', (error as Error).message)
     console.warn('[rag] RAG retrieval failed, skipping injection', error)
     return messages
   }


### PR DESCRIPTION
## Summary
Added detailed console logging throughout the RAG (Retrieval-Augmented Generation) context injection pipeline to improve observability and debugging of the retrieval process.

## Key Changes
- Added logging at RAG initialization to track enabled status and configuration details
- Added logging after embedding generation to confirm query embedding dimensions
- Added logging after RPC call to report number of chunks retrieved and preview first chunk
- Added logging when RAG context is injected into system prompt with total context length
- Added error logging in catch block to capture failure reasons
- Refactored RAG context construction to a variable for better readability and logging

## Implementation Details
- All logs use `[RAG]` prefix for easy filtering in logs
- Logs include relevant metrics (embedding dimensions, chunk count, context length) for performance monitoring
- Added chunk text preview (first 100 characters) to help verify retrieval quality
- Error logging captures the error message for troubleshooting failed RAG operations
- The refactoring of `ragContext` to a separate variable improves code clarity while enabling the context length logging

https://claude.ai/code/session_01H83WDpEvGtVjCqYkb5X7Qz