### PR TITLE
Add Memo CRUD UI on Page 2 with Supabase integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import ForumSettingsPage from './pages/ForumSettingsPage'
 import LettersPage from './pages/LettersPage'
 import RagSettingsPage from './pages/RagSettingsPage'
 import StoryGroupPage from './pages/StoryGroupPage'
+import MemoPage from './pages/MemoPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1874,6 +1875,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <SyzygyFeedPage user={user} snackAiConfig={syzygyAiConfig} />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/memo"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <MemoPage />
             </RequireAuth>
           }
         />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "rag"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "rag", "memo"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -265,6 +265,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "forum", defaultEmoji: "💭", label: "Forum", route: "/forum" },
       { id: "letters", defaultEmoji: "💌", label: "Letters", route: "/letters" },
       { id: "rag", defaultEmoji: "🔮", label: "记忆引擎", route: "/rag-settings" },
+      { id: "memo", defaultEmoji: "📝", label: "备忘录", route: "/memo" },
     ],
     [onOpenChat],
   );

--- a/src/pages/MemoPage.css
+++ b/src/pages/MemoPage.css
@@ -1,0 +1,156 @@
+.memo-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.memo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.memo-filter-card {
+  padding: 12px;
+  border-radius: 16px;
+}
+
+.memo-filter-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.memo-mode-toggle {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.memo-mode-toggle button,
+.tag-chip {
+  border: 1px solid rgba(110, 98, 174, 0.22);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+  color: #4f437e;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.memo-mode-toggle button.active,
+.tag-chip.selected {
+  background: #8f80ff;
+  color: #fff;
+  border-color: #8f80ff;
+}
+
+.memo-tag-chip-list {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.memo-list {
+  display: grid;
+  gap: 10px;
+}
+
+.memo-card {
+  border: 1px solid rgba(139, 126, 219, 0.2);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.memo-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #6b5aa8;
+}
+
+.memo-content-preview {
+  margin: 0;
+  color: #2d2a41;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.memo-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-chip.static {
+  pointer-events: none;
+}
+
+.memo-time,
+.memo-notice,
+.memo-error {
+  font-size: 12px;
+}
+
+.memo-notice {
+  color: #2d7d50;
+}
+
+.memo-error {
+  color: #b13f4d;
+}
+
+.memo-editor-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(30, 27, 46, 0.36);
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  z-index: 20;
+}
+
+.memo-editor {
+  width: min(620px, 100%);
+  background: #fff;
+  border-radius: 18px;
+  padding: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.memo-editor textarea,
+.memo-editor input[type='text'] {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(139, 126, 219, 0.25);
+  padding: 10px;
+}
+
+.memo-editor__pin {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.memo-editor__new-tag {
+  display: flex;
+  gap: 8px;
+}
+
+.memo-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.memo-editor__actions .danger {
+  background: #ffe1e4;
+  color: #992f3d;
+}

--- a/src/pages/MemoPage.tsx
+++ b/src/pages/MemoPage.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { MemoEntry, MemoTag } from '../types'
+import {
+  createMemoEntry,
+  createMemoTag,
+  listMemoEntries,
+  listMemoTags,
+  softDeleteMemoEntry,
+  updateMemoEntry,
+} from '../storage/supabaseSync'
+import { formatLocalTimestamp } from '../utils/time'
+import './MemoPage.css'
+
+type FilterMode = 'or' | 'and'
+
+type EditorState = {
+  mode: 'create' | 'edit'
+  entryId?: string
+  content: string
+  isPinned: boolean
+  selectedTagIds: string[]
+  newTagInput: string
+}
+
+const buildEditorState = (entry?: MemoEntry): EditorState => ({
+  mode: entry ? 'edit' : 'create',
+  entryId: entry?.id,
+  content: entry?.content ?? '',
+  isPinned: entry?.isPinned ?? false,
+  selectedTagIds: entry?.tagIds ?? [],
+  newTagInput: '',
+})
+
+const MemoPage = () => {
+  const navigate = useNavigate()
+  const [entries, setEntries] = useState<MemoEntry[]>([])
+  const [tags, setTags] = useState<MemoTag[]>([])
+  const [selectedFilterTagIds, setSelectedFilterTagIds] = useState<string[]>([])
+  const [filterMode, setFilterMode] = useState<FilterMode>('or')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [editor, setEditor] = useState<EditorState | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [nextEntries, nextTags] = await Promise.all([listMemoEntries(), listMemoTags()])
+      setEntries(nextEntries)
+      setTags(nextTags)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载备忘录失败', loadError)
+      setError('加载备忘录失败，请稍后重试')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const tagMap = useMemo(() => new Map(tags.map((tag) => [tag.id, tag])), [tags])
+
+  const sortedAndFilteredEntries = useMemo(() => {
+    const scoped = entries.filter((entry) => {
+      if (selectedFilterTagIds.length === 0) {
+        return true
+      }
+      if (filterMode === 'and') {
+        return selectedFilterTagIds.every((tagId) => entry.tagIds.includes(tagId))
+      }
+      return selectedFilterTagIds.some((tagId) => entry.tagIds.includes(tagId))
+    })
+    return [...scoped].sort((a, b) => {
+      if (a.isPinned !== b.isPinned) {
+        return a.isPinned ? -1 : 1
+      }
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    })
+  }, [entries, filterMode, selectedFilterTagIds])
+
+  const toggleFilterTag = (tagId: string) => {
+    setSelectedFilterTagIds((current) =>
+      current.includes(tagId) ? current.filter((item) => item !== tagId) : [...current, tagId],
+    )
+  }
+
+  const toggleEditorTag = (tagId: string) => {
+    if (!editor) {
+      return
+    }
+    setEditor({
+      ...editor,
+      selectedTagIds: editor.selectedTagIds.includes(tagId)
+        ? editor.selectedTagIds.filter((id) => id !== tagId)
+        : [...editor.selectedTagIds, tagId],
+    })
+  }
+
+  const ensureTag = async (rawName: string): Promise<MemoTag | null> => {
+    const trimmed = rawName.trim()
+    if (!trimmed) {
+      return null
+    }
+    const existing = tags.find((tag) => tag.name === trimmed)
+    if (existing) {
+      return existing
+    }
+    const created = await createMemoTag(trimmed)
+    setTags((current) => [...current, created].sort((a, b) => a.name.localeCompare(b.name)))
+    return created
+  }
+
+  const handleCreateInlineTag = async () => {
+    if (!editor) {
+      return
+    }
+    try {
+      const created = await ensureTag(editor.newTagInput)
+      if (!created) {
+        return
+      }
+      setEditor((current) => {
+        if (!current) {
+          return current
+        }
+        const nextTagIds = current.selectedTagIds.includes(created.id)
+          ? current.selectedTagIds
+          : [...current.selectedTagIds, created.id]
+        return {
+          ...current,
+          selectedTagIds: nextTagIds,
+          newTagInput: '',
+        }
+      })
+      setNotice('标签已添加')
+      setError(null)
+    } catch (tagError) {
+      console.warn('创建标签失败', tagError)
+      setError('创建标签失败，请稍后重试')
+    }
+  }
+
+  const handleSave = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!editor) {
+      return
+    }
+    const trimmedContent = editor.content.trim()
+    if (!trimmedContent) {
+      setError('内容不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      let nextTagIds = editor.selectedTagIds
+      if (editor.newTagInput.trim()) {
+        const created = await ensureTag(editor.newTagInput)
+        if (created && !nextTagIds.includes(created.id)) {
+          nextTagIds = [...nextTagIds, created.id]
+        }
+      }
+      if (editor.mode === 'create') {
+        await createMemoEntry({
+          content: trimmedContent,
+          isPinned: editor.isPinned,
+          source: 'user',
+          tagIds: nextTagIds,
+        })
+        setNotice('备忘录已创建')
+      } else if (editor.entryId) {
+        await updateMemoEntry(editor.entryId, {
+          content: trimmedContent,
+          isPinned: editor.isPinned,
+          tagIds: nextTagIds,
+        })
+        setNotice('备忘录已更新')
+      }
+      setEditor(null)
+      setError(null)
+      await refresh()
+    } catch (saveError) {
+      console.warn('保存备忘录失败', saveError)
+      setError('保存失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!editor?.entryId || saving) {
+      return
+    }
+    const confirmed = window.confirm('确认删除这条备忘录吗？删除后将在列表中隐藏。')
+    if (!confirmed) {
+      return
+    }
+    setSaving(true)
+    try {
+      await softDeleteMemoEntry(editor.entryId)
+      setEditor(null)
+      setNotice('备忘录已删除')
+      setError(null)
+      await refresh()
+    } catch (deleteError) {
+      console.warn('删除备忘录失败', deleteError)
+      setError('删除失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="memo-page">
+      <header className="memo-header">
+        <button type="button" className="ghost" onClick={() => navigate(-1)}>
+          返回
+        </button>
+        <h1 className="ui-title">备忘录</h1>
+        <button type="button" className="ghost" onClick={() => setEditor(buildEditorState())}>
+          新建
+        </button>
+      </header>
+
+      <section className="memo-filter-card glass-card">
+        <div className="memo-filter-top">
+          <strong>标签筛选</strong>
+          <div className="memo-mode-toggle" role="group" aria-label="筛选模式">
+            <button
+              type="button"
+              className={filterMode === 'or' ? 'active' : ''}
+              onClick={() => setFilterMode('or')}
+            >
+              OR
+            </button>
+            <button
+              type="button"
+              className={filterMode === 'and' ? 'active' : ''}
+              onClick={() => setFilterMode('and')}
+            >
+              AND
+            </button>
+          </div>
+        </div>
+        <div className="memo-tag-chip-list">
+          {tags.length === 0 ? <span className="tips">暂无标签</span> : null}
+          {tags.map((tag) => (
+            <button
+              key={tag.id}
+              type="button"
+              className={selectedFilterTagIds.includes(tag.id) ? 'tag-chip selected' : 'tag-chip'}
+              onClick={() => toggleFilterTag(tag.id)}
+            >
+              #{tag.name}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {notice ? <p className="memo-notice">{notice}</p> : null}
+      {error ? <p className="memo-error">{error}</p> : null}
+
+      <section className="memo-list">
+        {loading ? <p className="tips">加载中…</p> : null}
+        {!loading && sortedAndFilteredEntries.length === 0 ? (
+          <p className="tips">还没有备忘录，点击右上角新建吧。</p>
+        ) : null}
+        {sortedAndFilteredEntries.map((entry) => (
+          <article key={entry.id} className="memo-card" onClick={() => setEditor(buildEditorState(entry))}>
+            <div className="memo-card__top">
+              <span className="memo-source">来源：{entry.source === 'ai' ? 'AI' : '用户'}</span>
+              {entry.isPinned ? <span className="memo-pin">📌 置顶</span> : null}
+            </div>
+            <p className="memo-content-preview">{entry.content}</p>
+            <div className="memo-card__tags">
+              {entry.tagIds.length === 0 ? <span className="tips">无标签</span> : null}
+              {entry.tagIds.map((tagId) => (
+                <span key={tagId} className="tag-chip static">
+                  #{tagMap.get(tagId)?.name ?? '未命名'}
+                </span>
+              ))}
+            </div>
+            <time className="memo-time">更新于 {formatLocalTimestamp(entry.updatedAt)}</time>
+          </article>
+        ))}
+      </section>
+
+      {editor ? (
+        <div className="memo-editor-backdrop" role="dialog" aria-modal="true" aria-label="备忘录编辑">
+          <form className="memo-editor" onSubmit={handleSave}>
+            <h2>{editor.mode === 'create' ? '新建备忘录' : '编辑备忘录'}</h2>
+            <textarea
+              rows={6}
+              value={editor.content}
+              onChange={(event) => setEditor({ ...editor, content: event.target.value })}
+              placeholder="写下你想保存的信息..."
+            />
+
+            <label className="memo-editor__pin">
+              <input
+                type="checkbox"
+                checked={editor.isPinned}
+                onChange={(event) => setEditor({ ...editor, isPinned: event.target.checked })}
+              />
+              置顶
+            </label>
+
+            <div className="memo-editor__tag-pool">
+              <strong>标签</strong>
+              <div className="memo-tag-chip-list">
+                {tags.map((tag) => (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    className={editor.selectedTagIds.includes(tag.id) ? 'tag-chip selected' : 'tag-chip'}
+                    onClick={() => toggleEditorTag(tag.id)}
+                  >
+                    #{tag.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="memo-editor__new-tag">
+              <input
+                type="text"
+                value={editor.newTagInput}
+                onChange={(event) => setEditor({ ...editor, newTagInput: event.target.value })}
+                placeholder="输入新标签"
+              />
+              <button type="button" className="ghost" onClick={() => void handleCreateInlineTag()}>
+                添加标签
+              </button>
+            </div>
+
+            <div className="memo-editor__actions">
+              <button type="button" className="ghost" onClick={() => setEditor(null)}>
+                取消
+              </button>
+              {editor.mode === 'edit' ? (
+                <button type="button" className="danger" onClick={() => void handleDelete()} disabled={saving}>
+                  删除
+                </button>
+              ) : null}
+              <button type="submit" disabled={saving || !editor.content.trim()}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default MemoPage

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -76,7 +76,7 @@ const DEFAULT_PAGE_LAYOUTS: Record<HomeLayoutPageId, HomePageLayoutState> = {
     appIconConfigs: {},
   },
   page2: {
-    iconOrder: ['forum', 'letters'],
+    iconOrder: ['forum', 'letters', 'rag', 'memo'],
     widgetOrder: ['widget-checkin'],
     widgets: [],
     checkinSize: '1x1',

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -10,6 +10,9 @@ import type {
   ForumAuthorType,
   LetterEntry,
   LetterTriggerType,
+  MemoEntry,
+  MemoSource,
+  MemoTag,
   MemoryEntry,
   MemoryStatus,
   RpNpcCard,
@@ -102,6 +105,29 @@ type MemoryEntryRow = {
   created_at: string
   updated_at: string
   is_deleted: boolean
+}
+
+type MemoEntryRow = {
+  id: string
+  user_id: string
+  content: string
+  source: MemoSource
+  is_pinned: boolean | null
+  created_at: string
+  updated_at: string
+  is_deleted: boolean
+}
+
+type MemoTagRow = {
+  id: string
+  user_id: string
+  name: string
+  created_at: string
+}
+
+type MemoEntryTagRow = {
+  memo_entry_id: string
+  memo_tag_id: string
 }
 
 type CheckinRow = {
@@ -274,6 +300,25 @@ const mapCheckinRow = (row: CheckinRow): CheckinEntry => ({
   id: row.id,
   userId: row.user_id,
   checkinDate: row.checkin_date,
+  createdAt: row.created_at,
+})
+
+const mapMemoEntryRow = (row: MemoEntryRow, tagIds: string[]): MemoEntry => ({
+  id: row.id,
+  userId: row.user_id,
+  content: row.content,
+  source: row.source,
+  isPinned: row.is_pinned ?? false,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+  isDeleted: row.is_deleted,
+  tagIds,
+})
+
+const mapMemoTagRow = (row: MemoTagRow): MemoTag => ({
+  id: row.id,
+  userId: row.user_id,
+  name: row.name,
   createdAt: row.created_at,
 })
 
@@ -2162,6 +2207,189 @@ export const discardMemory = async (id: string): Promise<void> => {
     .from('memory_entries')
     .update({ is_deleted: true, updated_at: new Date().toISOString() })
     .eq('id', id)
+  if (error) {
+    throw error
+  }
+}
+
+export const listMemoTags = async (): Promise<MemoTag[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('memo_tags')
+    .select('id,user_id,name,created_at')
+    .eq('user_id', userId)
+    .order('name', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapMemoTagRow(row as MemoTagRow))
+}
+
+export const createMemoTag = async (name: string): Promise<MemoTag> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const trimmed = name.trim()
+  if (!trimmed) {
+    throw new Error('标签名不能为空')
+  }
+  const { data: existing, error: findError } = await supabase
+    .from('memo_tags')
+    .select('id,user_id,name,created_at')
+    .eq('user_id', userId)
+    .eq('name', trimmed)
+    .maybeSingle()
+  if (findError) {
+    throw findError
+  }
+  if (existing) {
+    return mapMemoTagRow(existing as MemoTagRow)
+  }
+  const { data, error } = await supabase
+    .from('memo_tags')
+    .insert({ user_id: userId, name: trimmed })
+    .select('id,user_id,name,created_at')
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('创建标签失败')
+  }
+  return mapMemoTagRow(data as MemoTagRow)
+}
+
+export const listMemoEntries = async (): Promise<MemoEntry[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data: entryRows, error: entryError } = await supabase
+    .from('memo_entries')
+    .select('id,user_id,content,source,is_pinned,created_at,updated_at,is_deleted')
+    .eq('user_id', userId)
+    .eq('is_deleted', false)
+    .order('updated_at', { ascending: false })
+  if (entryError) {
+    throw entryError
+  }
+  const entries = (entryRows ?? []) as MemoEntryRow[]
+  if (entries.length === 0) {
+    return []
+  }
+  const entryIds = entries.map((entry) => entry.id)
+  const { data: relationRows, error: relationError } = await supabase
+    .from('memo_entry_tags')
+    .select('memo_entry_id,memo_tag_id')
+    .in('memo_entry_id', entryIds)
+  if (relationError) {
+    throw relationError
+  }
+
+  const tagIdsByEntryId = new Map<string, string[]>()
+  ;((relationRows ?? []) as MemoEntryTagRow[]).forEach((relation) => {
+    const current = tagIdsByEntryId.get(relation.memo_entry_id) ?? []
+    current.push(relation.memo_tag_id)
+    tagIdsByEntryId.set(relation.memo_entry_id, current)
+  })
+  return entries.map((entry) => mapMemoEntryRow(entry, tagIdsByEntryId.get(entry.id) ?? []))
+}
+
+export const createMemoEntry = async (payload: {
+  content: string
+  isPinned: boolean
+  source?: MemoSource
+  tagIds: string[]
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const now = new Date().toISOString()
+  const { data: entry, error: entryError } = await supabase
+    .from('memo_entries')
+    .insert({
+      user_id: userId,
+      content: payload.content,
+      source: payload.source ?? 'user',
+      is_pinned: payload.isPinned,
+      is_deleted: false,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id')
+    .single()
+  if (entryError || !entry) {
+    throw entryError ?? new Error('创建备忘录失败')
+  }
+  const uniqueTagIds = Array.from(new Set(payload.tagIds))
+  if (uniqueTagIds.length === 0) {
+    return
+  }
+  const { error: linkError } = await supabase.from('memo_entry_tags').insert(
+    uniqueTagIds.map((tagId) => ({
+      memo_entry_id: entry.id,
+      memo_tag_id: tagId,
+    })),
+  )
+  if (linkError) {
+    throw linkError
+  }
+}
+
+export const updateMemoEntry = async (
+  entryId: string,
+  payload: { content: string; isPinned: boolean; tagIds: string[] },
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const now = new Date().toISOString()
+  const { error: updateError } = await supabase
+    .from('memo_entries')
+    .update({
+      content: payload.content,
+      is_pinned: payload.isPinned,
+      updated_at: now,
+    })
+    .eq('id', entryId)
+    .eq('is_deleted', false)
+  if (updateError) {
+    throw updateError
+  }
+
+  const { error: deleteLinksError } = await supabase
+    .from('memo_entry_tags')
+    .delete()
+    .eq('memo_entry_id', entryId)
+  if (deleteLinksError) {
+    throw deleteLinksError
+  }
+
+  const uniqueTagIds = Array.from(new Set(payload.tagIds))
+  if (uniqueTagIds.length === 0) {
+    return
+  }
+  const { error: linkError } = await supabase.from('memo_entry_tags').insert(
+    uniqueTagIds.map((tagId) => ({
+      memo_entry_id: entryId,
+      memo_tag_id: tagId,
+    })),
+  )
+  if (linkError) {
+    throw linkError
+  }
+}
+
+export const softDeleteMemoEntry = async (entryId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('memo_entries')
+    .update({ is_deleted: true, updated_at: new Date().toISOString() })
+    .eq('id', entryId)
   if (error) {
     throw error
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,27 @@ export type BubbleSession = {
   updatedAt: string
 }
 
+export type MemoSource = 'user' | 'ai'
+
+export type MemoTag = {
+  id: string
+  userId: string
+  name: string
+  createdAt: string
+}
+
+export type MemoEntry = {
+  id: string
+  userId: string
+  content: string
+  source: MemoSource
+  isPinned: boolean
+  createdAt: string
+  updatedAt: string
+  isDeleted: boolean
+  tagIds: string[]
+}
+
 export type BubbleMessage = {
   id: string
   sessionId: string


### PR DESCRIPTION
### Motivation
- Provide a lightweight, user-controlled memo system accessible from Home Page 2 that supports tag-based CRUD operations and filtering using the existing Supabase schema.
- Keep the UI consistent with the mobile-style Home Page 2 visual language and Chinese copy requirements (`备忘录`).

### Description
- Added a new authenticated route `/memo` and a `MemoPage` component that implements list, create, edit, soft-delete, tag selection, inline tag creation, and OR/AND multi-tag filtering. (`src/pages/MemoPage.tsx`, `src/pages/MemoPage.css`, `src/App.tsx`).
- Introduced Supabase data-access functions to load/create tags, load entries with their tag links, create/update memo entries (with tag link writes), and soft-delete entries (`is_deleted = true`) in `src/storage/supabaseSync.ts` using `memo_entries`, `memo_tags`, and `memo_entry_tags`.
- Extended shared types with `MemoEntry`, `MemoTag`, and `MemoSource` to model memo domain entities (`src/types.ts`).
- Added a Page 2 dock icon labeled `备忘录` (📝) and updated default Page 2 layout to include `memo` while preserving existing items (`src/pages/HomePage.tsx`, `src/storage/homeLayout.ts`).
- The memo list sorts pinned items first then by `updated_at` descending, hides soft-deleted rows, and shows source / tags / pinned / updated time; editor enforces non-empty content and trims new tag names before creation. (`src/pages/MemoPage.tsx`).

### Testing
- Production build was executed with `npm run build` and completed successfully (TypeScript compile + Vite build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdc71ac4c48330bedcc3531d2dea0f)