### PR TITLE
feat(frontend): on-demand memo retrieval and prompt injection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,7 @@ import {
   resolveBubbleChatPrompt,
 } from './constants/aiOverlays'
 import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
+import { buildMemoInjectionBlock } from './utils/memoRetrieval'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
@@ -1045,10 +1046,14 @@ const App = () => {
           } catch (error) {
             console.warn('无法加载会话关联来信上下文', error)
           }
+          const memoInjectionBlock = await buildMemoInjectionBlock(content)
+          const requestSystemPrompt = memoInjectionBlock
+            ? [systemPrompt, memoInjectionBlock].filter((item): item is string => Boolean(item?.trim())).join('\n\n')
+            : systemPrompt
           const messagesPayload = buildOpenAiMessages(
             sessionId,
             messagesRef.current,
-            systemPrompt,
+            requestSystemPrompt,
             linkedLetters,
           )
           const isClaudeModel = (model: string) => /claude|anthropic/i.test(model)

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -22,6 +22,7 @@ import { parseBubbleReply } from "./utils/parseBubbleReply";
 import { persistBubbleMessage, resolveTodaySession, invalidateSessionCache } from "./utils/bubbleChatHistory";
 import { fetchBubbleMessages } from "../storage/supabaseSync";
 import BubbleChatHistoryModal from "./ui/BubbleChatHistoryModal";
+import { buildMemoInjectionBlock } from "../utils/memoRetrieval";
 import "./gameHud.css";
 
 type SharedSnackAiConfig = {
@@ -211,6 +212,13 @@ const GameModeShell = ({
         console.warn('[bubble-chat] Failed to persist user message:', error);
       }
 
+      const memoInjectionBlock = await buildMemoInjectionBlock(text);
+      const bubbleSystemPrompt = memoInjectionBlock
+        ? [bubbleChatConfig.systemPrompt, memoInjectionBlock]
+            .filter((item): item is string => Boolean(item?.trim()))
+            .join("\n\n")
+        : bubbleChatConfig.systemPrompt;
+
       const response = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,
         {
@@ -225,7 +233,7 @@ const GameModeShell = ({
             modelId: bubbleChatConfig.model,
             module: 'bubble-chat',
             messages: [
-              { role: 'system', content: bubbleChatConfig.systemPrompt },
+              { role: 'system', content: bubbleSystemPrompt },
               ...bubbleChatHistoryRef.current,
             ],
             temperature: bubbleChatConfig.temperature,

--- a/src/utils/memoRetrieval.ts
+++ b/src/utils/memoRetrieval.ts
@@ -1,0 +1,198 @@
+import type { MemoSource } from '../types'
+import { supabase } from '../supabase/client'
+
+type MemoEntryRow = {
+  id: string
+  user_id: string
+  content: string
+  source: MemoSource
+  is_pinned: boolean | null
+  created_at: string
+  updated_at: string
+  is_deleted: boolean
+}
+
+type MatchedMemoEntry = {
+  id: string
+  content: string
+  isPinned: boolean
+  updatedAt: string
+}
+
+type MemoTagRow = {
+  id: string
+  name: string
+}
+
+type MemoEntryTagRow = {
+  memo_entry_id: string
+  memo_tag_id: string
+}
+
+const MEMO_TRIGGER_TOKEN = '备忘录'
+const CONNECTOR_SPLIT_REGEX = /[，。！？!?,、；;\s]+|(?:以及|还有|和|跟|或|或者)/g
+const STOPWORD_REGEX = /(看看|看下|看一下|查下|查一下|查询|检索|调一下|调下|提取|读取|关于|相关|内容|设定|有没有|有无|里|里面|中的|一下|帮我|帮忙|请|从|去|把|给我|的)/g
+
+const normalizeKeyword = (keyword: string) => keyword.trim().replace(/^['"“”‘’]+|['"“”‘’]+$/g, '')
+
+const extractQuotedKeywords = (input: string) => {
+  const keywords: string[] = []
+  const pattern = /["“]([^"”]+)["”]|[']([^']+)[']/g
+  let match: RegExpExecArray | null = pattern.exec(input)
+  while (match) {
+    const captured = normalizeKeyword(match[1] ?? match[2] ?? '')
+    if (captured.length > 0) {
+      keywords.push(captured)
+    }
+    match = pattern.exec(input)
+  }
+  return keywords
+}
+
+export const detectMemoRetrievalIntent = (message: string) => {
+  const trimmed = message.trim()
+  if (!trimmed.includes(MEMO_TRIGGER_TOKEN)) {
+    return { shouldRetrieve: false, keywords: [] as string[] }
+  }
+
+  const quotedKeywords = extractQuotedKeywords(trimmed)
+  const afterMemoToken = trimmed.split(MEMO_TRIGGER_TOKEN).slice(1).join(' ')
+  const sourceForParsing = (afterMemoToken || trimmed)
+    .replace(STOPWORD_REGEX, ' ')
+    .replace(/\b(?:memo|memoes)\b/gi, ' ')
+
+  const segmentedKeywords = sourceForParsing
+    .split(CONNECTOR_SPLIT_REGEX)
+    .map((segment) => normalizeKeyword(segment.replace(MEMO_TRIGGER_TOKEN, '')))
+    .filter((segment) => segment.length > 0 && segment !== MEMO_TRIGGER_TOKEN)
+
+  const uniqueKeywords = Array.from(
+    new Set(
+      [...quotedKeywords, ...segmentedKeywords].filter((keyword) => keyword.length > 0 && keyword !== MEMO_TRIGGER_TOKEN),
+    ),
+  )
+
+  if (uniqueKeywords.length === 0) {
+    return { shouldRetrieve: false, keywords: [] as string[] }
+  }
+
+  return { shouldRetrieve: true, keywords: uniqueKeywords }
+}
+
+const escapeForIlike = (value: string) => value.replace(/[%_]/g, '')
+
+export const fetchMemoEntriesByTagKeywords = async (keywords: string[]): Promise<MatchedMemoEntry[]> => {
+  if (!supabase || keywords.length === 0) {
+    return []
+  }
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
+    return []
+  }
+
+  const validKeywords = Array.from(new Set(keywords.map((keyword) => keyword.trim()).filter(Boolean)))
+  if (validKeywords.length === 0) {
+    return []
+  }
+
+  const orFilters = validKeywords
+    .map((keyword) => `name.ilike.%${escapeForIlike(keyword)}%`)
+    .join(',')
+
+  const { data: tags, error: tagError } = await supabase
+    .from('memo_tags')
+    .select('id,name')
+    .eq('user_id', user.id)
+    .or(orFilters)
+
+  if (tagError) {
+    throw tagError
+  }
+
+  const matchedTags = (tags ?? []) as MemoTagRow[]
+  if (matchedTags.length === 0) {
+    return []
+  }
+
+  const tagIds = Array.from(new Set(matchedTags.map((tag) => tag.id)))
+  const { data: relations, error: relationError } = await supabase
+    .from('memo_entry_tags')
+    .select('memo_entry_id,memo_tag_id')
+    .in('memo_tag_id', tagIds)
+
+  if (relationError) {
+    throw relationError
+  }
+
+  const entryIds = Array.from(new Set(((relations ?? []) as MemoEntryTagRow[]).map((item) => item.memo_entry_id)))
+  if (entryIds.length === 0) {
+    return []
+  }
+
+  const { data: entries, error: entryError } = await supabase
+    .from('memo_entries')
+    .select('id,user_id,content,source,is_pinned,created_at,updated_at,is_deleted')
+    .eq('user_id', user.id)
+    .eq('is_deleted', false)
+    .in('id', entryIds)
+
+  if (entryError) {
+    throw entryError
+  }
+
+  const deduped = new Map<string, MatchedMemoEntry>()
+  ;((entries ?? []) as MemoEntryRow[]).forEach((entry) => {
+    if (!deduped.has(entry.id)) {
+      deduped.set(entry.id, {
+        id: entry.id,
+        content: entry.content,
+        isPinned: entry.is_pinned ?? false,
+        updatedAt: entry.updated_at,
+      })
+    }
+  })
+
+  return Array.from(deduped.values()).sort((a, b) => {
+    if (a.isPinned !== b.isPinned) {
+      return a.isPinned ? -1 : 1
+    }
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  })
+}
+
+export const formatMemoInjectionBlock = (keywords: string[], entries: MatchedMemoEntry[]): string | null => {
+  if (keywords.length === 0 || entries.length === 0) {
+    return null
+  }
+
+  const header = `【Memo Retrieval | Keywords: ${keywords.join('，')}】`
+  const lines = entries.map((entry) => `- ${entry.isPinned ? '[Pinned] ' : ''}${entry.content.trim()}`)
+  return [header, ...lines].join('\n')
+}
+
+export const buildMemoInjectionBlock = async (message: string): Promise<string | null> => {
+  const detection = detectMemoRetrievalIntent(message)
+  if (!detection.shouldRetrieve) {
+    return null
+  }
+
+  try {
+    const entries = await fetchMemoEntriesByTagKeywords(detection.keywords)
+    if (entries.length === 0) {
+      return null
+    }
+    return formatMemoInjectionBlock(detection.keywords, entries)
+  } catch (error) {
+    console.warn('[memo-retrieval] Failed to retrieve memo entries:', error)
+    return null
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement Step 3 of the Memo system on the frontend so users can explicitly request tagged memos and have matching entries injected into the next outgoing prompt without changing backend chat code. 
- Keep retrieval one-shot and on-demand for non-RP flows to avoid always-on latency and preserve existing prompt/state immutability.

### Description
- Add `src/utils/memoRetrieval.ts` which provides rule-based trigger detection (`detectMemoRetrievalIntent`), keyword extraction (quoted + segmented), fuzzy tag lookup via `memo_tags.name ilike %keyword%`, relation resolution through `memo_entry_tags`, deduplication, and sorting (pinned first then `updated_at` desc). 
- Implement `fetchMemoEntriesByTagKeywords`, `formatMemoInjectionBlock`, and `buildMemoInjectionBlock` to return a compact plain-text injection block or `null` when no retrieval is needed. 
- Integrate one-shot injection into non-RP send paths by calling `buildMemoInjectionBlock` and appending the block to the system prompt only for that request in `src/App.tsx` (daily chat) and `src/game/GameModeShell.tsx` (bubble chat). 
- Maintain product constraints: frontend-only, no backend route changes, exclude soft-deleted entries, scope queries to the current authenticated user, and do not alter RP flows or persist prompt changes.

### Testing
- Ran `npm run build` which completed successfully (includes `tsc -b` type build and Vite production build). 
- Ran `npm run lint` which still reports pre-existing repository lint issues outside this change set (repo warnings and an unrelated unused-variable error). 
- Manual runtime validation: memo injection is only attempted when input contains the `备忘录` trigger and keywords, and when no matches are found the normal request proceeds with no injected block.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdce904de483309c7521c91871f379)