### PR TITLE
Polish Memo page with Observation Log–inspired pink notebook UI

### DIFF
--- a/src/pages/MemoPage.css
+++ b/src/pages/MemoPage.css
@@ -1,53 +1,137 @@
 .memo-page {
   max-width: 720px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 14px 14px 20px;
   display: grid;
   gap: 12px;
+  position: relative;
+  isolation: isolate;
+}
+
+.memo-page::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(255, 214, 231, 0.34), transparent 42%),
+    radial-gradient(circle at 90% 0%, rgba(255, 239, 246, 0.82), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.96) 0%, rgba(253, 245, 249, 0.96) 100%);
 }
 
 .memo-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8px 18px rgba(255, 214, 231, 0.24);
+}
+
+.memo-title-wrap {
+  text-align: center;
+  min-width: 0;
+}
+
+.memo-kicker {
+  margin: 0 0 2px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #b27f98;
+}
+
+.memo-header .ui-title {
+  margin: 0;
+  color: #5c5c5c;
+}
+
+.memo-header-btn,
+.memo-create-btn {
+  border-radius: 999px;
+  border: 1px solid #ffd6e7;
+  background: #fff;
+  color: #7d5d70;
+  padding: 7px 12px;
+  font-size: 13px;
+}
+
+.memo-create-btn {
+  background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%);
+  font-weight: 600;
 }
 
 .memo-filter-card {
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 18px;
+  background: #fff;
   padding: 12px;
-  border-radius: 16px;
+  box-shadow: 0 10px 20px rgba(255, 214, 231, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+.memo-filter-dot {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.62) 1.2px, transparent 1.2px);
+  background-size: 16px 16px;
+  opacity: 0.38;
+}
+
+.memo-filter-top,
+.memo-tag-chip-list {
+  position: relative;
+  z-index: 1;
 }
 
 .memo-filter-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 10px;
+}
+
+.memo-filter-top strong {
+  color: #76556c;
+  font-size: 14px;
 }
 
 .memo-mode-toggle {
   display: inline-flex;
-  gap: 6px;
+  padding: 3px;
+  gap: 3px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 231, 0.8);
+  background: rgba(255, 248, 252, 0.95);
 }
 
 .memo-mode-toggle button,
 .tag-chip {
-  border: 1px solid rgba(110, 98, 174, 0.22);
+  border: 1px solid rgba(255, 214, 231, 0.85);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.8);
-  color: #4f437e;
-  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #7c5a70;
+  padding: 6px 11px;
   font-size: 12px;
+  line-height: 1.2;
 }
 
 .memo-mode-toggle button.active,
 .tag-chip.selected {
-  background: #8f80ff;
-  color: #fff;
-  border-color: #8f80ff;
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  color: #59354b;
+  border-color: #f8bed9;
+  box-shadow: 0 3px 7px rgba(255, 185, 216, 0.38);
 }
 
 .memo-tag-chip-list {
-  margin-top: 10px;
+  margin-top: 11px;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -59,12 +143,13 @@
 }
 
 .memo-card {
-  border: 1px solid rgba(139, 126, 219, 0.2);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(255, 214, 231, 0.8);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.94);
   padding: 12px;
   display: grid;
-  gap: 8px;
+  gap: 9px;
+  box-shadow: 0 8px 14px rgba(255, 214, 231, 0.18);
 }
 
 .memo-card__top {
@@ -72,12 +157,22 @@
   align-items: center;
   justify-content: space-between;
   font-size: 12px;
-  color: #6b5aa8;
+  color: #8f7285;
+}
+
+.memo-pin {
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid #ffd6e7;
+  background: #fff3f9;
+  color: #9a4b72;
+  font-weight: 600;
 }
 
 .memo-content-preview {
   margin: 0;
-  color: #2d2a41;
+  color: #4f3f4a;
+  line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -90,6 +185,7 @@
 
 .tag-chip.static {
   pointer-events: none;
+  background: #fffafc;
 }
 
 .memo-time,
@@ -98,18 +194,40 @@
   font-size: 12px;
 }
 
+.memo-time {
+  color: #9a8793;
+}
+
+.memo-notice,
+.memo-error {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid;
+  background: #fff;
+}
+
 .memo-notice {
-  color: #2d7d50;
+  color: #2f7a56;
+  border-color: rgba(126, 211, 167, 0.5);
 }
 
 .memo-error {
   color: #b13f4d;
+  border-color: rgba(255, 181, 192, 0.7);
+}
+
+.memo-empty {
+  border: 1px dashed rgba(255, 214, 231, 0.85);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.75);
+  padding: 16px;
 }
 
 .memo-editor-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(30, 27, 46, 0.36);
+  background: rgba(78, 56, 73, 0.34);
   display: grid;
   place-items: center;
   padding: 18px;
@@ -118,25 +236,55 @@
 
 .memo-editor {
   width: min(620px, 100%);
-  background: #fff;
-  border-radius: 18px;
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 233, 244, 0.6), transparent 30%),
+    #fff;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 20px;
   padding: 14px;
   display: grid;
   gap: 10px;
+  box-shadow: 0 14px 28px rgba(255, 214, 231, 0.24);
+}
+
+.memo-editor h2 {
+  margin: 0;
+  color: #68485e;
+  font-size: 18px;
 }
 
 .memo-editor textarea,
 .memo-editor input[type='text'] {
   width: 100%;
   border-radius: 12px;
-  border: 1px solid rgba(139, 126, 219, 0.25);
+  border: 1px solid rgba(255, 214, 231, 0.88);
   padding: 10px;
+  color: #4f3f4a;
+  background: #fffafd;
+}
+
+.memo-editor textarea {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 28px,
+    rgba(255, 214, 231, 0.35) 28px,
+    rgba(255, 214, 231, 0.35) 30px
+  );
+}
+
+.memo-editor textarea:focus,
+.memo-editor input[type='text']:focus {
+  outline: none;
+  border-color: #f5b3d2;
+  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.35);
 }
 
 .memo-editor__pin {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  color: #77566b;
 }
 
 .memo-editor__new-tag {
@@ -150,7 +298,55 @@
   gap: 8px;
 }
 
+.memo-editor__actions .danger,
+.memo-save-btn,
+.memo-editor__actions .ghost {
+  border-radius: 10px;
+  border: 1px solid #ffd6e7;
+  padding: 7px 12px;
+}
+
 .memo-editor__actions .danger {
-  background: #ffe1e4;
-  color: #992f3d;
+  background: #ffe8ee;
+  color: #9d3e53;
+}
+
+.memo-save-btn {
+  background: linear-gradient(180deg, #ffdcec 0%, #ffcfe5 100%);
+  color: #5a3448;
+  font-weight: 600;
+}
+
+@media (max-width: 560px) {
+  .memo-page {
+    padding: 12px;
+  }
+
+  .memo-header {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+  }
+
+  .memo-title-wrap {
+    order: -1;
+    text-align: left;
+  }
+
+  .memo-header-btn,
+  .memo-create-btn {
+    width: 100%;
+  }
+
+  .memo-filter-top {
+    flex-wrap: wrap;
+  }
+
+  .memo-mode-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .memo-editor__new-tag {
+    flex-direction: column;
+  }
 }

--- a/src/pages/MemoPage.tsx
+++ b/src/pages/MemoPage.tsx
@@ -217,16 +217,20 @@ const MemoPage = () => {
   return (
     <div className="memo-page">
       <header className="memo-header">
-        <button type="button" className="ghost" onClick={() => navigate(-1)}>
-          返回
+        <button type="button" className="ghost memo-header-btn" onClick={() => navigate(-1)}>
+          ← 返回
         </button>
-        <h1 className="ui-title">备忘录</h1>
-        <button type="button" className="ghost" onClick={() => setEditor(buildEditorState())}>
-          新建
+        <div className="memo-title-wrap">
+          <p className="memo-kicker">Cozy Notes</p>
+          <h1 className="ui-title">备忘录</h1>
+        </div>
+        <button type="button" className="memo-create-btn" onClick={() => setEditor(buildEditorState())}>
+          + 新建
         </button>
       </header>
 
-      <section className="memo-filter-card glass-card">
+      <section className="memo-filter-card" aria-label="标签筛选面板">
+        <div className="memo-filter-dot" aria-hidden="true" />
         <div className="memo-filter-top">
           <strong>标签筛选</strong>
           <div className="memo-mode-toggle" role="group" aria-label="筛选模式">
@@ -264,10 +268,10 @@ const MemoPage = () => {
       {notice ? <p className="memo-notice">{notice}</p> : null}
       {error ? <p className="memo-error">{error}</p> : null}
 
-      <section className="memo-list">
+      <section className="memo-list" aria-label="备忘录列表">
         {loading ? <p className="tips">加载中…</p> : null}
         {!loading && sortedAndFilteredEntries.length === 0 ? (
-          <p className="tips">还没有备忘录，点击右上角新建吧。</p>
+          <p className="tips memo-empty">还没有备忘录，点击右上角新建吧。</p>
         ) : null}
         {sortedAndFilteredEntries.map((entry) => (
           <article key={entry.id} className="memo-card" onClick={() => setEditor(buildEditorState(entry))}>
@@ -346,7 +350,7 @@ const MemoPage = () => {
                   删除
                 </button>
               ) : null}
-              <button type="submit" disabled={saving || !editor.content.trim()}>
+              <button type="submit" className="memo-save-btn" disabled={saving || !editor.content.trim()}>
                 {saving ? '保存中…' : '保存'}
               </button>
             </div>


### PR DESCRIPTION
### Motivation
- Bring the Memo page visual language closer to the product’s Observation Log (soft pink + white, dotted decoration, rounded panels) while keeping all memo behavior unchanged.  
- Improve layout hierarchy and scanability for the header, filter area, memo list, and editor without touching business logic or retrieval behavior.  
- Maintain mobile-first usability and preserve all existing CRUD/filter/sort flows and Supabase-backed data handling.

### Description
- Restyled the page shell and header by adding a lightweight kicker, clearer title rhythm, a prominent `+ 新建` action and subtle pink/white background treatment (`src/pages/MemoPage.tsx`, `src/pages/MemoPage.css`).  
- Redesigned the tag filter panel into a soft control card with a dotted decorative overlay, integrated OR/AND segmented control, and clearer selected/unselected tag chip visuals (`memo-filter-card`, `memo-filter-dot`, `memo-mode-toggle`, `tag-chip` in CSS).  
- Polished memo cards and metadata grouping with softer borders/shadows, improved tag pill visuals and a distinct pinned badge so source/content/tags/updated-time remain visible and unchanged (`memo-card`, `memo-pin`, `.tag-chip` updates).  
- Updated the editor modal and inputs to a cozy notebook style with lined textarea, softer focus states, pink-accent action buttons, and responsive layout tweaks for small screens (`memo-editor`, `.memo-editor textarea`, `.memo-save-btn`, media rules).

### Testing
- Built the frontend to validate style changes by running `npm run build`, which completed successfully.  
- No automated unit tests were added or modified; visual changes are CSS/JSX-only and do not affect memo data logic or API calls.  
- Manual sanity checks during the build confirmed that create/edit/delete, tag selection, and filtering code paths were not altered (behavior preserved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd87d0e648330a4b9c9377730f184)