### PR TITLE
Add Timeline CRUD page (Pages2) with monthly calendar and Supabase CRUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ import LettersPage from './pages/LettersPage'
 import RagSettingsPage from './pages/RagSettingsPage'
 import StoryGroupPage from './pages/StoryGroupPage'
 import MemoPage from './pages/MemoPage'
+import TimelinePage from './pages/TimelinePage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1888,6 +1889,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <MemoPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/timeline"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <TimelinePage />
             </RequireAuth>
           }
         />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "rag", "memo"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "rag", "memo", "timeline"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -266,6 +266,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "letters", defaultEmoji: "💌", label: "Letters", route: "/letters" },
       { id: "rag", defaultEmoji: "🔮", label: "记忆引擎", route: "/rag-settings" },
       { id: "memo", defaultEmoji: "📝", label: "备忘录", route: "/memo" },
+      { id: "timeline", defaultEmoji: "🗓️", label: "时间轴", route: "/timeline" },
     ],
     [onOpenChat],
   );

--- a/src/pages/TimelinePage.css
+++ b/src/pages/TimelinePage.css
@@ -1,0 +1,193 @@
+.timeline-page {
+  min-height: 100dvh;
+  padding: 1rem;
+  color: #1f2937;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.timeline-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.timeline-title-wrap {
+  display: grid;
+  gap: 0.2rem;
+  justify-items: center;
+}
+
+.timeline-kicker {
+  margin: 0;
+  font-size: 0.8rem;
+  opacity: 0.7;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.timeline-back-btn,
+.timeline-create-btn {
+  white-space: nowrap;
+}
+
+.timeline-calendar,
+.timeline-list {
+  border-radius: 16px;
+  padding: 0.9rem;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.08);
+}
+
+.timeline-calendar__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.timeline-calendar__weekdays,
+.timeline-calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.timeline-calendar__weekdays {
+  margin-bottom: 0.4rem;
+  font-size: 0.82rem;
+  opacity: 0.7;
+  text-align: center;
+}
+
+.timeline-calendar__cell {
+  min-height: 2.2rem;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  display: grid;
+  place-items: center;
+  position: relative;
+  background: #fff;
+}
+
+.timeline-calendar__cell.active {
+  border-color: #f59e0b;
+  background: #fef3c7;
+  color: #7c2d12;
+}
+
+.timeline-calendar__cell em {
+  position: absolute;
+  right: 0.35rem;
+  top: 0.2rem;
+  font-size: 0.7rem;
+  font-style: normal;
+  opacity: 0.8;
+}
+
+.timeline-calendar__cell--blank {
+  border: none;
+  background: transparent;
+}
+
+.timeline-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.timeline-date-group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.timeline-date-group h2 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.timeline-date-group__entries {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.timeline-card {
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.6rem;
+  text-align: left;
+}
+
+.timeline-card__content p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.timeline-notice {
+  margin: 0;
+  color: #166534;
+}
+
+.timeline-error {
+  margin: 0;
+  color: #b91c1c;
+}
+
+.timeline-empty {
+  margin: 0;
+}
+
+.timeline-editor-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.42);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  z-index: 60;
+}
+
+.timeline-editor {
+  width: min(520px, 100%);
+  background: white;
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.timeline-editor h2 {
+  margin: 0;
+}
+
+.timeline-editor label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.88rem;
+}
+
+.timeline-editor input,
+.timeline-editor textarea,
+.timeline-editor select {
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  border-radius: 10px;
+  padding: 0.55rem 0.65rem;
+  font: inherit;
+}
+
+.timeline-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.timeline-editor__actions .danger {
+  background: #fee2e2;
+  color: #b91c1c;
+}

--- a/src/pages/TimelinePage.tsx
+++ b/src/pages/TimelinePage.tsx
@@ -1,0 +1,335 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { TimelineEntry, TimelineRecorder } from '../types'
+import {
+  createTimelineEntry,
+  deleteTimelineEntry,
+  listTimelineEntriesByMonth,
+  updateTimelineEntry,
+} from '../storage/supabaseSync'
+import './TimelinePage.css'
+
+type TimelineEditorState = {
+  mode: 'create' | 'edit'
+  entryId?: string
+  eventDate: string
+  summary: string
+  recorder: TimelineRecorder
+}
+
+const RECORDER_META: Record<TimelineRecorder, { emoji: string; label: string }> = {
+  chuanchuan: { emoji: '🐹', label: '串串' },
+  syzygy: { emoji: '🌙', label: 'Syzygy' },
+}
+
+const getTodayDate = () => {
+  const date = new Date()
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const getMonthRange = (anchorDate: Date) => {
+  const year = anchorDate.getFullYear()
+  const month = anchorDate.getMonth()
+  const start = new Date(year, month, 1)
+  const end = new Date(year, month + 1, 0)
+  const toDateKey = (value: Date) => {
+    const y = value.getFullYear()
+    const m = `${value.getMonth() + 1}`.padStart(2, '0')
+    const d = `${value.getDate()}`.padStart(2, '0')
+    return `${y}-${m}-${d}`
+  }
+  return {
+    monthLabel: `${year}年${month + 1}月`,
+    start: toDateKey(start),
+    end: toDateKey(end),
+  }
+}
+
+const buildEditorState = (entry?: TimelineEntry): TimelineEditorState => ({
+  mode: entry ? 'edit' : 'create',
+  entryId: entry?.id,
+  eventDate: entry?.eventDate ?? getTodayDate(),
+  summary: entry?.summary ?? '',
+  recorder: entry?.recorder ?? 'chuanchuan',
+})
+
+const TimelinePage = () => {
+  const navigate = useNavigate()
+  const [monthCursor, setMonthCursor] = useState(() => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), 1)
+  })
+  const [entries, setEntries] = useState<TimelineEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [editor, setEditor] = useState<TimelineEditorState | null>(null)
+
+  const monthRange = useMemo(() => getMonthRange(monthCursor), [monthCursor])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await listTimelineEntriesByMonth(monthRange.start, monthRange.end)
+      setEntries(data)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载时间轴失败', loadError)
+      setError('加载时间轴失败，请稍后重试')
+    } finally {
+      setLoading(false)
+    }
+  }, [monthRange.end, monthRange.start])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const entriesByDate = useMemo(() => {
+    const groups = new Map<string, TimelineEntry[]>()
+    entries.forEach((entry) => {
+      const current = groups.get(entry.eventDate) ?? []
+      current.push(entry)
+      groups.set(entry.eventDate, current)
+    })
+    return groups
+  }, [entries])
+
+  const calendarCells = useMemo(() => {
+    const first = new Date(monthCursor.getFullYear(), monthCursor.getMonth(), 1)
+    const firstWeekday = first.getDay()
+    const daysInMonth = new Date(monthCursor.getFullYear(), monthCursor.getMonth() + 1, 0).getDate()
+    const cells: Array<{ dateKey: string; day: number; count: number } | null> = []
+
+    for (let i = 0; i < firstWeekday; i += 1) {
+      cells.push(null)
+    }
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const dateKey = `${monthCursor.getFullYear()}-${`${monthCursor.getMonth() + 1}`.padStart(2, '0')}-${`${day}`.padStart(2, '0')}`
+      const count = entriesByDate.get(dateKey)?.length ?? 0
+      cells.push({ dateKey, day, count })
+    }
+    while (cells.length % 7 !== 0) {
+      cells.push(null)
+    }
+    return cells
+  }, [entriesByDate, monthCursor])
+
+  const groupedList = useMemo(() => {
+    return Array.from(entriesByDate.entries()).sort((a, b) => b[0].localeCompare(a[0]))
+  }, [entriesByDate])
+
+  const shiftMonth = (delta: number) => {
+    setMonthCursor((current) => new Date(current.getFullYear(), current.getMonth() + delta, 1))
+  }
+
+  const handleSave = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!editor) {
+      return
+    }
+
+    const summary = editor.summary.trim()
+    if (!editor.eventDate) {
+      setError('请选择日期')
+      return
+    }
+    if (!summary) {
+      setError('摘要不能为空')
+      return
+    }
+    if (editor.recorder !== 'chuanchuan' && editor.recorder !== 'syzygy') {
+      setError('记录人无效')
+      return
+    }
+
+    setSaving(true)
+    try {
+      if (editor.mode === 'create') {
+        await createTimelineEntry({
+          eventDate: editor.eventDate,
+          summary,
+          recorder: editor.recorder,
+        })
+        setNotice('时间轴已创建')
+      } else if (editor.entryId) {
+        await updateTimelineEntry(editor.entryId, {
+          eventDate: editor.eventDate,
+          summary,
+          recorder: editor.recorder,
+        })
+        setNotice('时间轴已更新')
+      }
+      setEditor(null)
+      setError(null)
+      await refresh()
+    } catch (saveError) {
+      console.warn('保存时间轴失败', saveError)
+      setError('保存失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!editor?.entryId || saving) {
+      return
+    }
+    const confirmed = window.confirm('确认删除这条时间轴记录吗？删除后不可恢复。')
+    if (!confirmed) {
+      return
+    }
+    setSaving(true)
+    try {
+      await deleteTimelineEntry(editor.entryId)
+      setEditor(null)
+      setNotice('时间轴已删除')
+      setError(null)
+      await refresh()
+    } catch (deleteError) {
+      console.warn('删除时间轴失败', deleteError)
+      setError('删除失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="timeline-page">
+      <header className="timeline-header">
+        <button type="button" className="ghost timeline-back-btn" onClick={() => navigate(-1)}>
+          ← 返回
+        </button>
+        <div className="timeline-title-wrap">
+          <p className="timeline-kicker">Timeline</p>
+          <h1 className="ui-title">时间轴</h1>
+        </div>
+        <button type="button" className="timeline-create-btn" onClick={() => setEditor(buildEditorState())}>
+          + 新建
+        </button>
+      </header>
+
+      <section className="timeline-calendar" aria-label="月份日历">
+        <div className="timeline-calendar__top">
+          <button type="button" className="ghost" onClick={() => shiftMonth(-1)}>
+            ← 上月
+          </button>
+          <strong>{monthRange.monthLabel}</strong>
+          <button type="button" className="ghost" onClick={() => shiftMonth(1)}>
+            下月 →
+          </button>
+        </div>
+        <div className="timeline-calendar__weekdays">
+          {['日', '一', '二', '三', '四', '五', '六'].map((label) => (
+            <span key={label}>{label}</span>
+          ))}
+        </div>
+        <div className="timeline-calendar__grid">
+          {calendarCells.map((cell, index) =>
+            cell ? (
+              <div
+                key={cell.dateKey}
+                className={cell.count > 0 ? 'timeline-calendar__cell active' : 'timeline-calendar__cell'}
+                title={cell.count > 0 ? `${cell.dateKey} 有 ${cell.count} 条记录` : cell.dateKey}
+              >
+                <span>{cell.day}</span>
+                {cell.count > 1 ? <em>{cell.count}</em> : null}
+              </div>
+            ) : (
+              <div key={`blank-${index}`} className="timeline-calendar__cell timeline-calendar__cell--blank" />
+            ),
+          )}
+        </div>
+      </section>
+
+      {notice ? <p className="timeline-notice">{notice}</p> : null}
+      {error ? <p className="timeline-error">{error}</p> : null}
+
+      <section className="timeline-list" aria-label="时间轴列表">
+        {loading ? <p className="tips">加载中…</p> : null}
+        {!loading && groupedList.length === 0 ? <p className="tips timeline-empty">当前月份暂无记录。</p> : null}
+        {groupedList.map(([dateKey, dayEntries]) => (
+          <article key={dateKey} className="timeline-date-group">
+            <h2>{dateKey}</h2>
+            <div className="timeline-date-group__entries">
+              {dayEntries.map((entry) => {
+                const recorderMeta = RECORDER_META[entry.recorder]
+                return (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    className="timeline-card"
+                    onClick={() => setEditor(buildEditorState(entry))}
+                  >
+                    <span className="timeline-card__recorder" title={recorderMeta.label}>
+                      {recorderMeta.emoji}
+                    </span>
+                    <div className="timeline-card__content">
+                      <p>{entry.summary}</p>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      {editor ? (
+        <div className="timeline-editor-backdrop" role="dialog" aria-modal="true">
+          <form className="timeline-editor" onSubmit={handleSave}>
+            <h2>{editor.mode === 'create' ? '新建时间轴' : '编辑时间轴'}</h2>
+            <label>
+              日期
+              <input
+                type="date"
+                value={editor.eventDate}
+                onChange={(event) => setEditor({ ...editor, eventDate: event.target.value })}
+                required
+              />
+            </label>
+            <label>
+              摘要
+              <textarea
+                value={editor.summary}
+                onChange={(event) => setEditor({ ...editor, summary: event.target.value })}
+                rows={5}
+                required
+              />
+            </label>
+            <label>
+              记录人
+              <select
+                value={editor.recorder}
+                onChange={(event) => setEditor({ ...editor, recorder: event.target.value as TimelineRecorder })}
+              >
+                <option value="chuanchuan">chuanchuan</option>
+                <option value="syzygy">syzygy</option>
+              </select>
+            </label>
+
+            <div className="timeline-editor__actions">
+              <button type="button" className="secondary" onClick={() => setEditor(null)} disabled={saving}>
+                取消
+              </button>
+              {editor.mode === 'edit' ? (
+                <button type="button" className="danger" onClick={handleDelete} disabled={saving}>
+                  删除
+                </button>
+              ) : null}
+              <button type="submit" className="primary" disabled={saving}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default TimelinePage

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -76,7 +76,7 @@ const DEFAULT_PAGE_LAYOUTS: Record<HomeLayoutPageId, HomePageLayoutState> = {
     appIconConfigs: {},
   },
   page2: {
-    iconOrder: ['forum', 'letters', 'rag', 'memo'],
+    iconOrder: ['forum', 'letters', 'rag', 'memo', 'timeline'],
     widgetOrder: ['widget-checkin'],
     widgets: [],
     checkinSize: '1x1',

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -24,6 +24,8 @@ import type {
   SnackReply,
   SyzygyPost,
   SyzygyReply,
+  TimelineEntry,
+  TimelineRecorder,
 } from '../types'
 import { supabase } from '../supabase/client'
 
@@ -128,6 +130,17 @@ type MemoTagRow = {
 type MemoEntryTagRow = {
   memo_entry_id: string
   memo_tag_id: string
+}
+
+type TimelineEntryRow = {
+  id: string
+  user_id: string
+  event_date: string
+  summary: string
+  recorder: TimelineRecorder
+  source: string
+  created_at: string
+  updated_at: string
 }
 
 type CheckinRow = {
@@ -320,6 +333,17 @@ const mapMemoTagRow = (row: MemoTagRow): MemoTag => ({
   userId: row.user_id,
   name: row.name,
   createdAt: row.created_at,
+})
+
+const mapTimelineEntryRow = (row: TimelineEntryRow): TimelineEntry => ({
+  id: row.id,
+  userId: row.user_id,
+  eventDate: row.event_date,
+  summary: row.summary,
+  recorder: row.recorder,
+  source: row.source,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
 })
 
 const mapRpSessionRow = (row: RpSessionRow): RpSession => ({
@@ -2390,6 +2414,83 @@ export const softDeleteMemoEntry = async (entryId: string): Promise<void> => {
     .from('memo_entries')
     .update({ is_deleted: true, updated_at: new Date().toISOString() })
     .eq('id', entryId)
+  if (error) {
+    throw error
+  }
+}
+
+export const listTimelineEntriesByMonth = async (
+  monthStart: string,
+  monthEnd: string,
+): Promise<TimelineEntry[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('timeline_entries')
+    .select('id,user_id,event_date,summary,recorder,source,created_at,updated_at')
+    .eq('user_id', userId)
+    .gte('event_date', monthStart)
+    .lte('event_date', monthEnd)
+    .order('event_date', { ascending: false })
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapTimelineEntryRow(row as TimelineEntryRow))
+}
+
+export const createTimelineEntry = async (payload: {
+  eventDate: string
+  summary: string
+  recorder: TimelineRecorder
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase.from('timeline_entries').insert({
+    user_id: userId,
+    event_date: payload.eventDate,
+    summary: payload.summary,
+    recorder: payload.recorder,
+    source: 'user',
+  })
+  if (error) {
+    throw error
+  }
+}
+
+export const updateTimelineEntry = async (
+  entryId: string,
+  payload: {
+    eventDate: string
+    summary: string
+    recorder: TimelineRecorder
+  },
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('timeline_entries')
+    .update({
+      event_date: payload.eventDate,
+      summary: payload.summary,
+      recorder: payload.recorder,
+    })
+    .eq('id', entryId)
+  if (error) {
+    throw error
+  }
+}
+
+export const deleteTimelineEntry = async (entryId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase.from('timeline_entries').delete().eq('id', entryId)
   if (error) {
     throw error
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -299,6 +299,20 @@ export type MemoEntry = {
   tagIds: string[]
 }
 
+export type TimelineRecorder = 'chuanchuan' | 'syzygy'
+export type TimelineSource = string
+
+export type TimelineEntry = {
+  id: string
+  userId: string
+  eventDate: string
+  summary: string
+  recorder: TimelineRecorder
+  source: TimelineSource
+  createdAt: string
+  updatedAt: string
+}
+
 export type BubbleMessage = {
   id: string
   sessionId: string


### PR DESCRIPTION
### Motivation

- Provide a standalone Pages2 UI for manual Timeline management that matches the finalized rules (hard delete, display ordering, stable `created_at`).
- Surface month-scoped entries with a simple calendar and grouped list so users can create, edit, and remove timeline rows from the frontend.

### Description

- Added a new page component and styles: `src/pages/TimelinePage.tsx` and `src/pages/TimelinePage.css`, implementing a month calendar (prev/next), highlighted date markers, month-scoped grouped list, and a create/edit modal with date/summary/recorder fields and validation.
- Added timeline domain types in `src/types.ts`: `TimelineEntry` and `TimelineRecorder`, and used them across the page and storage layer.
- Implemented Supabase helpers in `src/storage/supabaseSync.ts`: `listTimelineEntriesByMonth`, `createTimelineEntry`, `updateTimelineEntry`, and `deleteTimelineEntry`; `listTimelineEntriesByMonth` applies the ordering `event_date DESC` then `created_at ASC`, `createTimelineEntry` writes `source: 'user'`, updates only editable fields (does not touch `created_at`), and `deleteTimelineEntry` performs hard delete.
- Registered the route `/timeline` in `src/App.tsx`, added a Page2 app icon and default Page2 icon order entries in `src/pages/HomePage.tsx` and `src/storage/homeLayout.ts` so the page is reachable from Pages2 navigation.
- Implementation intentionally avoids `is_deleted` paths and does not introduce new dependencies or implement auto-injection, chat-command retrieval, or function-calling write paths.

### Testing

- Built the app with `npm run build` and the build completed successfully (production build passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b20f3f0c8330bac7174c7de56ffa)