### PR TITLE
Frontend: Timeline auto-injection for selected modules

### DIFF
--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -13,6 +13,7 @@ import {
 import { ensureUserSettings } from '../storage/userSettings'
 import { formatLocalTimestamp } from '../utils/time'
 import './LettersPage.css'
+import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
 
 const PREVIEW_LIMIT = 30
 const LETTER_MEMORY_LIMIT = 20
@@ -211,6 +212,30 @@ const LettersPage = ({
       const modelId = settings.defaultModel.trim() || 'openrouter/auto'
       setDefaultModelId(modelId)
 
+      const messages = await maybeInjectTimelineContext(
+        [
+          ...(appSystemPrompt
+            ? [{ role: 'system' as const, content: appSystemPrompt }]
+            : []),
+          {
+            role: 'system' as const,
+            content: `Memory context (latest user memory entries):\n${memoryContext}`,
+          },
+          ...(letterReplyPrompt
+            ? [{ role: 'system' as const, content: letterReplyPrompt }]
+            : []),
+          {
+            role: 'system' as const,
+            content: LETTER_HELPER_INSTRUCTION,
+          },
+          {
+            role: 'user' as const,
+            content: manualPrompt.trim() || 'Write a check-in style letter for today.',
+          },
+        ],
+        'letter',
+      )
+
       const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`, {
         method: 'POST',
         headers: {
@@ -223,26 +248,7 @@ const LettersPage = ({
           modelId: modelId,
           module: 'letter',
           stream: false,
-          messages: [
-            ...(appSystemPrompt
-              ? [{ role: 'system' as const, content: appSystemPrompt }]
-              : []),
-            {
-              role: 'system',
-              content: `Memory context (latest user memory entries):\n${memoryContext}`,
-            },
-            ...(letterReplyPrompt
-              ? [{ role: 'system' as const, content: letterReplyPrompt }]
-              : []),
-            {
-              role: 'system',
-              content: LETTER_HELPER_INSTRUCTION,
-            },
-            {
-              role: 'user',
-              content: manualPrompt.trim() || 'Write a check-in style letter for today.',
-            },
-          ],
+          messages,
         }),
       })
 

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -25,6 +25,7 @@ import {
   resolveSyzygyReplyPrompt,
 } from '../constants/aiOverlays'
 import './SnacksPage.css'
+import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
 
 type SnacksPageProps = {
   user: User | null
@@ -425,6 +426,7 @@ const SnacksPage = ({ user, snackAiConfig, entryMode = 'phone' }: SnacksPageProp
   }
 
   const requestOpenRouter = async (messagesPayload: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>) => {
+    const injectedMessages = await maybeInjectTimelineContext(messagesPayload, 'snack')
     if (!supabase) {
       throw new Error('Supabase 客户端未配置')
     }
@@ -442,7 +444,7 @@ const SnacksPage = ({ user, snackAiConfig, entryMode = 'phone' }: SnacksPageProp
         apikey: anonKey,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(buildRequestBody(messagesPayload)),
+      body: JSON.stringify(buildRequestBody(injectedMessages)),
     })
 
     if (!response.ok) {

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -27,6 +27,7 @@ import {
   resolveSyzygyReplyPrompt,
 } from '../constants/aiOverlays'
 import './SnacksPage.css'
+import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
 
 type SyzygyFeedPageProps = {
   user: User | null
@@ -430,6 +431,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
   }
 
   const requestOpenRouter = async (messagesPayload: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>) => {
+    const injectedMessages = await maybeInjectTimelineContext(messagesPayload, 'observation')
     if (!supabase) {
       throw new Error('Supabase 客户端未配置')
     }
@@ -447,7 +449,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
         apikey: anonKey,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(buildRequestBody(messagesPayload)),
+      body: JSON.stringify(buildRequestBody(injectedMessages)),
     })
 
     if (!response.ok) {

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -2,6 +2,7 @@ import type { ForumAiProfile, ForumReply, ForumThread } from '../types'
 import { supabase } from '../supabase/client'
 import type { MemoryEntry } from '../types'
 import { ensureUserSettings } from '../storage/userSettings'
+import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
 
 export const FORUM_AI_SLOTS = [1, 2, 3] as const
 export const FORUM_USER_DISPLAY_NAME = '串串'
@@ -650,6 +651,8 @@ export async function requestForumAiContent({
     })
   }
 
+  const finalMessagesPayload = await maybeInjectTimelineContext(messagesPayload, 'forum')
+
   const selectedModel = profile.model.trim()
   const resolvedModel =
     selectedModel && globalModelConfig.enabledModelIds.includes(selectedModel)
@@ -669,7 +672,7 @@ export async function requestForumAiContent({
     model: resolvedModel,
     modelId: resolvedModel,
     module: 'forum',
-    messages: messagesPayload,
+    messages: finalMessagesPayload,
     temperature: profile.temperature,
     top_p: profile.topP,
     max_tokens: maxOutputTokens,

--- a/src/utils/timelineAutoInject.ts
+++ b/src/utils/timelineAutoInject.ts
@@ -1,0 +1,228 @@
+import { supabase } from '../supabase/client'
+import type { TimelineRecorder } from '../types'
+
+type TimelineConfigRow = Record<string, unknown>
+
+type TimelineEntryLite = {
+  eventDate: string
+  summary: string
+  recorder: TimelineRecorder
+}
+
+type TimelineAutoInjectConfig = {
+  autoInjectDays: number
+  autoInjectModules: Set<string>
+  injectFormat: 'date_summary'
+}
+
+const DEFAULT_DAYS = 5
+const DEFAULT_FORMAT: TimelineAutoInjectConfig['injectFormat'] = 'date_summary'
+const TIMELINE_BLOCK_PREFIX = '【时间轴·最近'
+
+const toDateKey = (value: Date) => {
+  const year = value.getFullYear()
+  const month = `${value.getMonth() + 1}`.padStart(2, '0')
+  const day = `${value.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const toDisplayDate = (dateKey: string) => dateKey.replace(/-/g, '.')
+
+const normalizeModuleKey = (value: string) => value.trim().toLowerCase()
+
+const extractConfigValue = (row: TimelineConfigRow) => {
+  const value = row.value ?? row.config_value ?? row.setting_value
+  if (typeof value === 'number') {
+    return `${value}`
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  return ''
+}
+
+const extractConfigKey = (row: TimelineConfigRow) => {
+  const key = row.key ?? row.config_key ?? row.setting_key ?? row.name
+  return typeof key === 'string' ? key : ''
+}
+
+const parseAutoInjectDays = (rawValue: string) => {
+  const parsed = Number.parseInt(rawValue, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DAYS
+}
+
+const parseInjectFormat = (rawValue: string): TimelineAutoInjectConfig['injectFormat'] => {
+  const normalized = rawValue.trim().toLowerCase()
+  return normalized === 'date_summary' ? 'date_summary' : DEFAULT_FORMAT
+}
+
+const parseAutoInjectModules = (rawValue: string) =>
+  new Set(
+    rawValue
+      .split(',')
+      .map((item) => normalizeModuleKey(item))
+      .filter(Boolean),
+  )
+
+const loadTimelineConfigRows = async () => {
+  if (!supabase) {
+    return [] as TimelineConfigRow[]
+  }
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
+    return [] as TimelineConfigRow[]
+  }
+
+  const scoped = await supabase.from('timeline_config').select('*').eq('user_id', user.id)
+  if (!scoped.error) {
+    return (scoped.data ?? []) as TimelineConfigRow[]
+  }
+
+  const fallback = await supabase.from('timeline_config').select('*')
+  if (fallback.error) {
+    throw scoped.error
+  }
+
+  return ((fallback.data ?? []) as TimelineConfigRow[]).filter((row) => {
+    const rowUserId = row.user_id
+    return typeof rowUserId !== 'string' || rowUserId === user.id
+  })
+}
+
+export const loadTimelineAutoInjectConfig = async (): Promise<TimelineAutoInjectConfig | null> => {
+  try {
+    const rows = await loadTimelineConfigRows()
+    if (rows.length === 0) {
+      return null
+    }
+
+    const byKey = new Map<string, string>()
+    rows.forEach((row) => {
+      const key = extractConfigKey(row).trim()
+      if (!key) {
+        return
+      }
+      byKey.set(key, extractConfigValue(row))
+    })
+
+    return {
+      autoInjectDays: parseAutoInjectDays(byKey.get('auto_inject_days') ?? ''),
+      autoInjectModules: parseAutoInjectModules(byKey.get('auto_inject_modules') ?? ''),
+      injectFormat: parseInjectFormat(byKey.get('inject_format') ?? ''),
+    }
+  } catch (error) {
+    console.warn('[timeline-auto-inject] Failed to load timeline_config:', error)
+    return null
+  }
+}
+
+export const fetchRecentTimelineEntries = async (autoInjectDays: number): Promise<TimelineEntryLite[]> => {
+  if (!supabase) {
+    return []
+  }
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
+    return []
+  }
+
+  const startDate = new Date()
+  startDate.setHours(0, 0, 0, 0)
+  startDate.setDate(startDate.getDate() - autoInjectDays)
+  const startDateKey = toDateKey(startDate)
+
+  const { data, error } = await supabase
+    .from('timeline_entries')
+    .select('event_date,summary,recorder,created_at')
+    .eq('user_id', user.id)
+    .gte('event_date', startDateKey)
+    .order('event_date', { ascending: false })
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    throw error
+  }
+
+  return ((data ?? []) as Array<Record<string, unknown>>)
+    .map((row) => ({
+      eventDate: typeof row.event_date === 'string' ? row.event_date : '',
+      summary: typeof row.summary === 'string' ? row.summary : '',
+      recorder: (row.recorder === 'syzygy' ? 'syzygy' : 'chuanchuan') as TimelineRecorder,
+    }))
+    .filter((entry) => entry.eventDate && entry.summary.trim().length > 0)
+}
+
+export const buildTimelineInjectionText = (entries: TimelineEntryLite[], autoInjectDays: number): string | null => {
+  if (entries.length === 0) {
+    return null
+  }
+
+  const grouped = new Map<string, TimelineEntryLite[]>()
+  entries.forEach((entry) => {
+    const current = grouped.get(entry.eventDate) ?? []
+    current.push(entry)
+    grouped.set(entry.eventDate, current)
+  })
+
+  const dateSections = Array.from(grouped.entries()).map(([eventDate, dayEntries]) => {
+    const lines = dayEntries.map((entry) => {
+      const recorderLabel = entry.recorder === 'syzygy' ? '[Syzygy]' : '[串串]'
+      return `* ${recorderLabel} ${entry.summary.trim()}`
+    })
+    return [toDisplayDate(eventDate), ...lines].join('\n')
+  })
+
+  return [`【时间轴·最近${autoInjectDays}天】`, ...dateSections].join('\n\n')
+}
+
+export const maybeInjectTimelineContext = async (
+  baseMessages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>,
+  moduleKey: string,
+) => {
+  try {
+    if (baseMessages.some((message) => message.role === 'system' && message.content.includes(TIMELINE_BLOCK_PREFIX))) {
+      return baseMessages
+    }
+
+    const config = await loadTimelineAutoInjectConfig()
+    if (!config) {
+      return baseMessages
+    }
+
+    if (config.injectFormat !== 'date_summary') {
+      return baseMessages
+    }
+
+    if (!config.autoInjectModules.has(normalizeModuleKey(moduleKey))) {
+      return baseMessages
+    }
+
+    const entries = await fetchRecentTimelineEntries(config.autoInjectDays)
+    const timelineBlock = buildTimelineInjectionText(entries, config.autoInjectDays)
+    if (!timelineBlock) {
+      return baseMessages
+    }
+
+    return [...baseMessages, { role: 'system' as const, content: timelineBlock }]
+  } catch (error) {
+    console.warn('[timeline-auto-inject] Failed to inject timeline context:', error)
+    return baseMessages
+  }
+}


### PR DESCRIPTION
### Motivation

- Add frontend-side automatic timeline injection (Step 3) to enrich system prompt augmentation for low-context modules without changing the openrouter-chat contract. 
- Support user-configurable modules and time window while failing open if config or fetch fails. 

### Description

- Introduced a new helper `src/utils/timelineAutoInject.ts` that loads `timeline_config`, parses `auto_inject_days` (default 5), `auto_inject_modules` (comma-separated), and `inject_format` (defaults to `date_summary`), fetches recent `timeline_entries` for the current user, and builds a formatted timeline block. 
- Enforced the required query and presentation ordering: `event_date DESC` and `created_at ASC` for same-day ordering, grouped by date and rendered in `YYYY.MM.DD` with recorder labels (`syzygy -> [Syzygy]`, `chuanchuan -> [串串]`). 
- Wired injection into module prompt assembly points only for selected modules: `letter` (`LettersPage.tsx`), `snack` (`SnacksPage.tsx`), `observation`/syzygy feed (`SyzygyFeedPage.tsx`), and `forum` AI flow (`forumShared.ts`), while preserving existing memo/memory injection behavior and keeping the OpenRouter request flow unchanged. 
- Made the logic fail-open with light console warnings on errors and avoided any `is_deleted` references or backend schema changes. 

### Testing

- Ran the production build (`npm run build`) which runs TypeScript compilation and Vite build, and it completed successfully. 
- The build emitted Vite bundle-size warnings but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b86f716c8330a2e3be8a27882c85)