### PR TITLE
Fix manual timeline injection on real send path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ import {
 } from './constants/aiOverlays'
 import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
 import { buildMemoInjectionBlock } from './utils/memoRetrieval'
-import { maybeInjectManualTimelineContext } from './utils/timelineManualRetrieval'
+import { resolveManualTimelineContext } from './utils/timelineManualRetrieval'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
@@ -138,6 +138,7 @@ const AUTO_EXTRACT_USER_TURN_INTERVAL = 12
 const AUTO_EXTRACT_COOLDOWN_MS = 10 * 60 * 1000
 const MEMORY_EXTRACT_RECENT_MESSAGES = 24
 const AUTO_EXTRACT_PENDING_LIMIT = 50
+const TIMELINE_MANUAL_DEBUG = import.meta.env.DEV
 
 const GameModeShell = lazy(() => import('./game/GameModeShell'))
 
@@ -171,6 +172,7 @@ const buildOpenAiMessages = (
   messages: ChatMessage[],
   systemPrompt?: string,
   linkedLetters: LetterEntry[] = [],
+  sendSurface: string = 'unknown',
 ) => {
   const trimmedPrompt = systemPrompt?.trim()
   const compactLetterEvents = buildCompactLetterEvents(linkedLetters)
@@ -188,6 +190,14 @@ const buildOpenAiMessages = (
   }
   if (compactLetterEvents) {
     systemLayers.push({ role: 'system', content: compactLetterEvents })
+  }
+  if (TIMELINE_MANUAL_DEBUG) {
+    console.info('[timeline-manual][request-builder]', {
+      surface: sendSurface,
+      systemPromptLength: trimmedPrompt?.length ?? 0,
+      systemPromptHasTimelineHeader: Boolean(trimmedPrompt?.includes('【时间轴】')),
+      systemLayerCount: systemLayers.length,
+    })
   }
   return [...systemLayers, ...history]
 }
@@ -1049,21 +1059,39 @@ const App = () => {
             console.warn('无法加载会话关联来信上下文', error)
           }
           const memoInjectionBlock = await buildMemoInjectionBlock(content)
-          const manualTimelineBlock = await maybeInjectManualTimelineContext(content)
+          const manualTimelineResult = await resolveManualTimelineContext(content)
+          const manualTimelineBlock = manualTimelineResult.timelineText?.trim() ?? ''
+          const hasManualTimelineBlock = manualTimelineBlock.length > 0
           const requestSystemPrompt = memoInjectionBlock
             ? [systemPrompt, memoInjectionBlock].filter((item): item is string => Boolean(item?.trim())).join('\n\n')
             : systemPrompt
-          const requestSystemPromptWithTimeline = manualTimelineBlock
-            && !requestSystemPrompt.includes('【时间轴】')
+          const requestSystemPromptWithTimeline = hasManualTimelineBlock
+            && !requestSystemPrompt.includes(manualTimelineBlock)
             ? [requestSystemPrompt, manualTimelineBlock]
                 .filter((item): item is string => Boolean(item?.trim()))
                 .join('\n\n')
             : requestSystemPrompt
+          if (TIMELINE_MANUAL_DEBUG) {
+            const parsedRange = manualTimelineResult.parsedRange
+              ? `${manualTimelineResult.parsedRange.startDate} -> ${manualTimelineResult.parsedRange.endDate}`
+              : 'none'
+            console.info('[timeline-manual][send]', {
+              surface: 'daily-chat/openrouter-chat',
+              detected: manualTimelineResult.detected,
+              parsedRange,
+              fetchedEntryCount: manualTimelineResult.entries.length,
+              timelineTextLength: manualTimelineBlock.length,
+              augmentationIncludesTimelineBlock:
+                hasManualTimelineBlock && requestSystemPromptWithTimeline.includes(manualTimelineBlock),
+              augmentationHasTimelineHeader: requestSystemPromptWithTimeline.includes('【时间轴】'),
+            })
+          }
           const messagesPayload = buildOpenAiMessages(
             sessionId,
             messagesRef.current,
             requestSystemPromptWithTimeline,
             linkedLetters,
+            'daily-chat/openrouter-chat',
           )
           const isClaudeModel = (model: string) => /claude|anthropic/i.test(model)
           const requestBody: Record<string, unknown> = {

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -23,7 +23,7 @@ import { persistBubbleMessage, resolveTodaySession, invalidateSessionCache } fro
 import { fetchBubbleMessages } from "../storage/supabaseSync";
 import BubbleChatHistoryModal from "./ui/BubbleChatHistoryModal";
 import { buildMemoInjectionBlock } from "../utils/memoRetrieval";
-import { maybeInjectManualTimelineContext } from "../utils/timelineManualRetrieval";
+import { resolveManualTimelineContext } from "../utils/timelineManualRetrieval";
 import "./gameHud.css";
 
 type SharedSnackAiConfig = {
@@ -67,6 +67,8 @@ const GAME_FEATURE_META: Record<
   checkin: { title: "打卡", subtitle: "游戏模式面板 · 每日陪伴打卡" },
   export: { title: "数据导出", subtitle: "游戏模式面板 · 导出数据包" },
 };
+
+const TIMELINE_MANUAL_DEBUG = import.meta.env.DEV;
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
@@ -214,18 +216,35 @@ const GameModeShell = ({
       }
 
       const memoInjectionBlock = await buildMemoInjectionBlock(text);
-      const manualTimelineBlock = await maybeInjectManualTimelineContext(text);
+      const manualTimelineResult = await resolveManualTimelineContext(text);
+      const manualTimelineBlock = manualTimelineResult.timelineText?.trim() ?? '';
+      const hasManualTimelineBlock = manualTimelineBlock.length > 0;
       const bubbleSystemPrompt = memoInjectionBlock
         ? [bubbleChatConfig.systemPrompt, memoInjectionBlock]
             .filter((item): item is string => Boolean(item?.trim()))
             .join("\n\n")
         : bubbleChatConfig.systemPrompt;
-      const bubbleSystemPromptWithTimeline = manualTimelineBlock
-        && !bubbleSystemPrompt.includes('【时间轴】')
+      const bubbleSystemPromptWithTimeline = hasManualTimelineBlock
+        && !bubbleSystemPrompt.includes(manualTimelineBlock)
         ? [bubbleSystemPrompt, manualTimelineBlock]
             .filter((item): item is string => Boolean(item?.trim()))
             .join('\n\n')
         : bubbleSystemPrompt;
+      if (TIMELINE_MANUAL_DEBUG) {
+        const parsedRange = manualTimelineResult.parsedRange
+          ? `${manualTimelineResult.parsedRange.startDate} -> ${manualTimelineResult.parsedRange.endDate}`
+          : 'none';
+        console.info('[timeline-manual][send]', {
+          surface: 'bubble-chat/openrouter-chat',
+          detected: manualTimelineResult.detected,
+          parsedRange,
+          fetchedEntryCount: manualTimelineResult.entries.length,
+          timelineTextLength: manualTimelineBlock.length,
+          augmentationIncludesTimelineBlock:
+            hasManualTimelineBlock && bubbleSystemPromptWithTimeline.includes(manualTimelineBlock),
+          augmentationHasTimelineHeader: bubbleSystemPromptWithTimeline.includes('【时间轴】'),
+        });
+      }
 
       const response = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,

--- a/src/utils/timelineManualRetrieval.ts
+++ b/src/utils/timelineManualRetrieval.ts
@@ -13,6 +13,13 @@ type TimelineDateRange = {
   endDate: string
 }
 
+export type ManualTimelineResolution = {
+  detected: boolean
+  parsedRange: TimelineDateRange | null
+  entries: TimelineEntryLite[]
+  timelineText: string | null
+}
+
 const TIMELINE_TRIGGER_TOKEN = '时间轴'
 const TIMELINE_HEADER = '【时间轴】'
 
@@ -212,19 +219,33 @@ export const buildTimelineManualInjectionText = (entries: TimelineEntryLite[]): 
 
 export const maybeInjectManualTimelineContext = async (message: string): Promise<string | null> => {
   try {
-    const parsedRange = detectTimelineManualRequest(message)
-    if (!parsedRange) {
-      return null
-    }
-
-    const entries = await fetchTimelineEntriesForRange(parsedRange)
-    if (entries.length === 0) {
-      return null
-    }
-
-    return buildTimelineManualInjectionText(entries)
+    const result = await resolveManualTimelineContext(message)
+    return result.timelineText
   } catch (error) {
     console.warn('[timeline-manual] Failed to inject timeline context:', error)
     return null
+  }
+}
+
+export const resolveManualTimelineContext = async (
+  message: string,
+): Promise<ManualTimelineResolution> => {
+  const parsedRange = detectTimelineManualRequest(message)
+  if (!parsedRange) {
+    return {
+      detected: false,
+      parsedRange: null,
+      entries: [],
+      timelineText: null,
+    }
+  }
+
+  const entries = await fetchTimelineEntriesForRange(parsedRange)
+  const timelineText = buildTimelineManualInjectionText(entries)
+  return {
+    detected: true,
+    parsedRange,
+    entries,
+    timelineText,
   }
 }


### PR DESCRIPTION
### Motivation

- The manual timeline retrieval parsed triggers but the built timeline block was not reliably included in the actual request payload on the real send paths for daily chat and bubble chat. 
- The root cause appeared to be a coarse dedupe guard and use of async/shared state which could cause the timeline block to be suppressed or race out before the request was assembled. 

### Description

- Added a structured resolver `resolveManualTimelineContext` and `ManualTimelineResolution` in `src/utils/timelineManualRetrieval.ts` that returns `{ detected, parsedRange, entries, timelineText }` so send handlers can handle timeline text as a per-send local value. 
- Updated `maybeInjectManualTimelineContext` to reuse the resolver and kept `buildTimelineManualInjectionText` unchanged, while keeping empty results as `null`. 
- Wired the resolver into the real send paths: `sendMessage` in `src/App.tsx` (daily chat / `chitchat` / `openrouter-chat`) and `handleBubbleSend` in `src/game/GameModeShell.tsx`, building the manual timeline block as a local trimmed string and appending it to the exact system augmentation before `fetch` is called. 
- Replaced the coarse header dedupe (`includes('【时间轴】')`) with an exact-block dedupe check using the built `manualTimelineBlock` to avoid suppressing valid injections when the prompt contains the header text for other reasons. 
- Added DEV-gated debug logs (`TIMELINE_MANUAL_DEBUG`) that emit diagnostics during send and inside the request builder, logging trigger detection, parsed range, fetched entry count, built timeline length, whether the augmentation contains the timeline block, and which surface handled the send. 
- Passed a `sendSurface` identifier into `buildOpenAiMessages` for richer debug output and left the injection one-turn-only by using only per-send local variables (no persisted state). 

### Testing

- Ran `npm run build` and the TypeScript build + Vite production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c4df42748330b01b0bdc75511c63)