### PR TITLE
Refactor timeline context injection to use auto-inject utility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ import {
 } from './constants/aiOverlays'
 import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
 import { buildMemoInjectionBlock, buildMemoInjectionFromToggle } from './utils/memoRetrieval'
-import { resolveManualTimelineContext, resolveTimelineFromToggle } from './utils/timelineManualRetrieval'
+import { resolveTimelineFromToggle } from './utils/timelineManualRetrieval'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
@@ -1063,7 +1063,7 @@ const App = () => {
             : await buildMemoInjectionBlock(content)
           const manualTimelineResult = injectionOptions?.timelineEnabled
             ? await resolveTimelineFromToggle(content)
-            : await resolveManualTimelineContext(content)
+            : { detected: false, parsedRange: null, entries: [] as Array<{ eventDate: string; summary: string; recorder: string; createdAt: string }>, timelineText: null }
           const manualTimelineBlock = manualTimelineResult.timelineText?.trim() ?? ''
           const hasManualTimelineBlock = manualTimelineBlock.length > 0
           const requestSystemPrompt = memoInjectionBlock

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -23,7 +23,7 @@ import { persistBubbleMessage, resolveTodaySession, invalidateSessionCache } fro
 import { fetchBubbleMessages } from "../storage/supabaseSync";
 import BubbleChatHistoryModal from "./ui/BubbleChatHistoryModal";
 import { buildMemoInjectionBlock } from "../utils/memoRetrieval";
-import { resolveManualTimelineContext } from "../utils/timelineManualRetrieval";
+import { maybeInjectTimelineContext } from "../utils/timelineAutoInject";
 import "./gameHud.css";
 
 type SharedSnackAiConfig = {
@@ -67,8 +67,6 @@ const GAME_FEATURE_META: Record<
   checkin: { title: "打卡", subtitle: "游戏模式面板 · 每日陪伴打卡" },
   export: { title: "数据导出", subtitle: "游戏模式面板 · 导出数据包" },
 };
-
-const TIMELINE_MANUAL_DEBUG = import.meta.env.DEV;
 
 const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
@@ -216,35 +214,18 @@ const GameModeShell = ({
       }
 
       const memoInjectionBlock = await buildMemoInjectionBlock(text);
-      const manualTimelineResult = await resolveManualTimelineContext(text);
-      const manualTimelineBlock = manualTimelineResult.timelineText?.trim() ?? '';
-      const hasManualTimelineBlock = manualTimelineBlock.length > 0;
       const bubbleSystemPrompt = memoInjectionBlock
         ? [bubbleChatConfig.systemPrompt, memoInjectionBlock]
             .filter((item): item is string => Boolean(item?.trim()))
             .join("\n\n")
         : bubbleChatConfig.systemPrompt;
-      const bubbleSystemPromptWithTimeline = hasManualTimelineBlock
-        && !bubbleSystemPrompt.includes(manualTimelineBlock)
-        ? [bubbleSystemPrompt, manualTimelineBlock]
-            .filter((item): item is string => Boolean(item?.trim()))
-            .join('\n\n')
-        : bubbleSystemPrompt;
-      if (TIMELINE_MANUAL_DEBUG) {
-        const parsedRange = manualTimelineResult.parsedRange
-          ? `${manualTimelineResult.parsedRange.startDate} -> ${manualTimelineResult.parsedRange.endDate}`
-          : 'none';
-        console.info('[timeline-manual][send]', {
-          surface: 'bubble-chat/openrouter-chat',
-          detected: manualTimelineResult.detected,
-          parsedRange,
-          fetchedEntryCount: manualTimelineResult.entries.length,
-          timelineTextLength: manualTimelineBlock.length,
-          augmentationIncludesTimelineBlock:
-            hasManualTimelineBlock && bubbleSystemPromptWithTimeline.includes(manualTimelineBlock),
-          augmentationHasTimelineHeader: bubbleSystemPromptWithTimeline.includes('【时间轴】'),
-        });
-      }
+      const messagesPayload = await maybeInjectTimelineContext(
+        [
+          { role: 'system' as const, content: bubbleSystemPrompt },
+          ...bubbleChatHistoryRef.current,
+        ],
+        'bubble',
+      );
 
       const response = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,
@@ -259,10 +240,7 @@ const GameModeShell = ({
             model: bubbleChatConfig.model,
             modelId: bubbleChatConfig.model,
             module: 'bubble-chat',
-            messages: [
-              { role: 'system', content: bubbleSystemPromptWithTimeline },
-              ...bubbleChatHistoryRef.current,
-            ],
+            messages: messagesPayload,
             temperature: bubbleChatConfig.temperature,
             max_tokens: bubbleChatConfig.maxTokens,
             stream: false,


### PR DESCRIPTION
## Summary
Refactored the timeline context injection logic in the bubble chat feature to use a new `maybeInjectTimelineContext` utility function, replacing the previous manual timeline resolution approach with a more streamlined auto-injection pattern.

## Key Changes
- **GameModeShell.tsx**: 
  - Replaced import of `resolveManualTimelineContext` with `maybeInjectTimelineContext` from new `timelineAutoInject` utility
  - Removed `TIMELINE_MANUAL_DEBUG` constant and associated debug logging
  - Simplified timeline context handling by delegating to `maybeInjectTimelineContext()` which now handles message payload construction
  - Removed manual timeline block assembly and conditional augmentation logic
  - The new utility now directly processes and injects timeline context into the messages array

- **App.tsx**:
  - Removed import of `resolveManualTimelineContext` 
  - Replaced automatic timeline resolution with a default empty result object when timeline is not explicitly enabled via toggle
  - Maintains explicit timeline toggle behavior via `resolveTimelineFromToggle()`

## Implementation Details
The refactoring consolidates timeline injection logic into a dedicated utility function (`maybeInjectTimelineContext`) that:
- Takes the message array and a surface identifier as parameters
- Handles timeline context detection and injection internally
- Returns the augmented messages payload ready for API consumption
- Removes the need for manual timeline block assembly and debug logging at the call site

This change improves code maintainability by centralizing timeline injection logic and reducing complexity in the GameModeShell component.

https://claude.ai/code/session_019CxvvodYmGsfqhx2t8LaCL