### PR TITLE
Remove overflow hidden from timeline calendar item

### DIFF
--- a/src/pages/TimelinePage.css
+++ b/src/pages/TimelinePage.css
@@ -82,7 +82,6 @@
   padding: 14px;
   box-shadow: 0 10px 20px rgba(255, 214, 231, 0.2);
   position: relative;
-  overflow: hidden;
 }
 
 .timeline-calendar__dot {


### PR DESCRIPTION
## Summary
Removed the `overflow: hidden` CSS property from the `.timeline-calendar__item` class to allow content to display beyond the element's boundaries.

## Changes
- Removed `overflow: hidden;` from `.timeline-calendar__item` styling in TimelinePage.css

## Details
This change allows child elements of timeline calendar items to overflow their container, which may be necessary for displaying tooltips, popovers, or other content that extends beyond the item's box model without being clipped.

https://claude.ai/code/session_013L7GrCHfatS2cgyFQHchVZ