### PR TITLE
Refine Timeline calendar-to-list interaction and stabilize empty-month layout

### DIFF
--- a/src/pages/TimelinePage.css
+++ b/src/pages/TimelinePage.css
@@ -76,6 +76,8 @@
 /* ── Calendar ─────────────────────────────────── */
 
 .timeline-calendar {
+  width: 100%;
+  box-sizing: border-box;
   border: 1px solid rgba(255, 214, 231, 0.88);
   border-radius: 18px;
   background: #fff;
@@ -136,6 +138,8 @@
 }
 
 .timeline-calendar__cell {
+  appearance: none;
+  cursor: pointer;
   min-height: 2.4rem;
   border-radius: 12px;
   border: 1px solid rgba(255, 214, 231, 0.5);
@@ -159,15 +163,22 @@
   color: #68485e;
 }
 
-.timeline-calendar__cell.active {
+.timeline-calendar__cell.has-entry {
   border-color: #f8bed9;
-  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
-  color: #59354b;
-  box-shadow: 0 3px 7px rgba(255, 185, 216, 0.38);
+  background: #fff3f8;
+  color: #6a4459;
 }
 
-.timeline-calendar__cell.active.today {
-  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.35), 0 3px 7px rgba(255, 185, 216, 0.38);
+.timeline-calendar__cell.selected {
+  border-color: #f29cc3;
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  color: #59354b;
+  box-shadow: 0 4px 10px rgba(255, 185, 216, 0.45);
+  font-weight: 700;
+}
+
+.timeline-calendar__cell.selected.today {
+  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.35), 0 4px 10px rgba(255, 185, 216, 0.45);
 }
 
 .timeline-calendar__cell em {
@@ -184,6 +195,7 @@
 .timeline-calendar__cell--blank {
   border: none;
   background: transparent;
+  pointer-events: none;
 }
 
 .timeline-calendar__cell--blank:hover {
@@ -225,6 +237,9 @@
 /* ── Timeline list ────────────────────────────── */
 
 .timeline-list {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 124px;
   border: 1px solid rgba(255, 214, 231, 0.88);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.6);

--- a/src/pages/TimelinePage.tsx
+++ b/src/pages/TimelinePage.tsx
@@ -64,6 +64,7 @@ const TimelinePage = () => {
     return new Date(now.getFullYear(), now.getMonth(), 1)
   })
   const [entries, setEntries] = useState<TimelineEntry[]>([])
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
@@ -74,6 +75,7 @@ const TimelinePage = () => {
 
   const refresh = useCallback(async () => {
     setLoading(true)
+    setEntries([])
     try {
       const data = await listTimelineEntriesByMonth(monthRange.start, monthRange.end)
       setEntries(data)
@@ -123,6 +125,22 @@ const TimelinePage = () => {
   const groupedList = useMemo(() => {
     return Array.from(entriesByDate.entries()).sort((a, b) => b[0].localeCompare(a[0]))
   }, [entriesByDate])
+
+  const selectedEntries = useMemo(() => {
+    if (!selectedDate) {
+      return []
+    }
+    return entriesByDate.get(selectedDate) ?? []
+  }, [entriesByDate, selectedDate])
+
+  useEffect(() => {
+    if (entries.length === 0) {
+      setSelectedDate(null)
+      return
+    }
+    const latestDate = entries.reduce((latest, entry) => (entry.eventDate > latest ? entry.eventDate : latest), entries[0].eventDate)
+    setSelectedDate(latestDate)
+  }, [entries, monthRange.start])
 
   const shiftMonth = (delta: number) => {
     setMonthCursor((current) => new Date(current.getFullYear(), current.getMonth() + delta, 1))
@@ -233,18 +251,22 @@ const TimelinePage = () => {
         <div className="timeline-calendar__grid">
           {calendarCells.map((cell, index) =>
             cell ? (
-              <div
+              <button
                 key={cell.dateKey}
+                type="button"
                 className={[
                   'timeline-calendar__cell',
-                  cell.count > 0 && 'active',
+                  cell.count > 0 && 'has-entry',
                   cell.dateKey === today && 'today',
+                  cell.dateKey === selectedDate && 'selected',
                 ].filter(Boolean).join(' ')}
                 title={cell.count > 0 ? `${cell.dateKey} 有 ${cell.count} 条记录` : cell.dateKey}
+                onClick={() => setSelectedDate(cell.dateKey)}
+                aria-pressed={cell.dateKey === selectedDate}
               >
                 <span>{cell.day}</span>
                 {cell.count > 1 ? <em>{cell.count}</em> : null}
-              </div>
+              </button>
             ) : (
               <div key={`blank-${index}`} className="timeline-calendar__cell timeline-calendar__cell--blank" />
             ),
@@ -257,32 +279,37 @@ const TimelinePage = () => {
 
       <section className="timeline-list" aria-label="时间轴列表">
         {loading ? <p className="tips">加载中…</p> : null}
-        {!loading && groupedList.length === 0 ? <p className="timeline-empty">当前月份暂无记录。</p> : null}
-        {groupedList.map(([dateKey, dayEntries]) => (
-          <article key={dateKey} className="timeline-date-group">
-            <h2>{dateKey}</h2>
-            <div className="timeline-date-group__entries">
-              {dayEntries.map((entry) => {
-                const recorderMeta = RECORDER_META[entry.recorder]
-                return (
-                  <button
-                    key={entry.id}
-                    type="button"
-                    className="timeline-card"
-                    onClick={() => setEditor(buildEditorState(entry))}
-                  >
-                    <span className="timeline-card__recorder" title={recorderMeta.label}>
-                      {recorderMeta.emoji}
-                    </span>
-                    <div className="timeline-card__content">
-                      <p>{entry.summary}</p>
-                    </div>
-                  </button>
-                )
-              })}
-            </div>
+        {!loading && groupedList.length === 0 ? <p className="timeline-empty">当前月份暂无记录</p> : null}
+        {!loading && groupedList.length > 0 && !selectedDate ? <p className="timeline-empty">请选择日期查看记录</p> : null}
+        {!loading && selectedDate ? (
+          <article className="timeline-date-group">
+            <h2>{selectedDate}</h2>
+            {selectedEntries.length === 0 ? (
+              <p className="timeline-empty">当天暂无记录</p>
+            ) : (
+              <div className="timeline-date-group__entries">
+                {selectedEntries.map((entry) => {
+                  const recorderMeta = RECORDER_META[entry.recorder]
+                  return (
+                    <button
+                      key={entry.id}
+                      type="button"
+                      className="timeline-card"
+                      onClick={() => setEditor(buildEditorState(entry))}
+                    >
+                      <span className="timeline-card__recorder" title={recorderMeta.label}>
+                        {recorderMeta.emoji}
+                      </span>
+                      <div className="timeline-card__content">
+                        <p>{entry.summary}</p>
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
           </article>
-        ))}
+        ) : null}
       </section>
 
       {editor ? (


### PR DESCRIPTION
### Motivation

- Improve Timeline UX so the lower record panel shows only a selected day's entries instead of the whole month to make browsing large months easier.
- Ensure months without entries keep the same card width and page rhythm so empty months don't visually collapse.

### Description

- Added `selectedDate` state and wired calendar day cells to be interactive buttons that call `setSelectedDate(dateKey)` and expose `aria-pressed` for accessibility.
- Changed lower-list rendering from month-grouped output to selected-day output with `selectedEntries`, showing `当天暂无记录` when the selected day has no entries and `当前月份暂无记录` when the month is empty.
- Implemented default selection logic that auto-selects the most recent `eventDate` in the visible month when entries exist and clears selection when the month has no entries.
- Stabilized layout by enforcing full-width/box-sizing on the calendar and list containers and adding a `min-height` so empty months keep consistent width/height; updated CSS classes to distinguish `has-entry`, `today`, and `selected` states.

### Testing

- Ran `npm run build` and the build completed successfully (production bundle produced) indicating no runtime type errors in the modified files. ✅
- Ran `npm run lint` which failed due to pre-existing issues unrelated to these changes (existing unused variable and hook-deps warnings elsewhere in the repo). ❌
- Manual smoke-checks in code: calendar cells now render as buttons with correct class names and the list panel conditionally renders month-empty, choose-date prompt, or selected-day entries based on `entries` and `selectedDate` state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6131160fc8330b0b27b1ce71eacf1)