### PR TITLE
Simplify Timeline UI container structure and border layering

### DIFF
--- a/src/pages/TimelinePage.css
+++ b/src/pages/TimelinePage.css
@@ -225,10 +225,12 @@
 }
 
 .timeline-empty {
-  border: 1px dashed rgba(255, 214, 231, 0.85);
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 214, 231, 0.65);
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.75);
-  padding: 16px;
+  background: rgba(255, 246, 251, 0.9);
+  padding: 18px 16px;
   margin: 0;
   color: #8f7285;
   text-align: center;
@@ -239,13 +241,18 @@
 .timeline-list {
   width: 100%;
   box-sizing: border-box;
-  min-height: 124px;
+  min-height: 180px;
   border: 1px solid rgba(255, 214, 231, 0.88);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.6);
+  background: #fff;
   padding: 14px;
-  box-shadow: 0 10px 20px rgba(255, 214, 231, 0.2);
+  box-shadow: 0 10px 20px rgba(255, 214, 231, 0.16);
+}
+
+.timeline-list__body {
+  min-height: 100%;
   display: grid;
+  align-content: start;
   gap: 14px;
 }
 
@@ -272,7 +279,7 @@
 
 .timeline-card {
   border: 1px solid rgba(255, 214, 231, 0.8);
-  background: rgba(255, 255, 255, 0.94);
+  background: #fff;
   border-radius: 16px;
   padding: 10px 12px;
   display: grid;
@@ -280,13 +287,13 @@
   gap: 10px;
   align-items: start;
   text-align: left;
-  box-shadow: 0 6px 12px rgba(255, 214, 231, 0.15);
-  transition: background 160ms ease, box-shadow 160ms ease;
+  box-shadow: 0 2px 8px rgba(255, 214, 231, 0.16);
+  transition: background 160ms ease, border-color 160ms ease;
 }
 
 .timeline-card:hover {
   background: #fffafc;
-  box-shadow: 0 8px 16px rgba(255, 214, 231, 0.28);
+  border-color: #f8bed9;
 }
 
 .timeline-card__recorder {
@@ -302,7 +309,7 @@
   flex-shrink: 0;
 }
 
-.timeline-card__content p {
+.timeline-card__summary {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
@@ -324,15 +331,13 @@
 
 .timeline-editor {
   width: min(520px, 100%);
-  background:
-    radial-gradient(circle at 0 0, rgba(255, 233, 244, 0.6), transparent 30%),
-    #fff;
+  background: #fff;
   border: 1px solid rgba(255, 214, 231, 0.9);
   border-radius: 20px;
-  padding: 14px;
+  padding: 16px;
   display: grid;
-  gap: 10px;
-  box-shadow: 0 14px 28px rgba(255, 214, 231, 0.24);
+  gap: 12px;
+  box-shadow: 0 14px 28px rgba(255, 214, 231, 0.2);
 }
 
 .timeline-editor h2 {
@@ -352,13 +357,20 @@
 .timeline-editor input,
 .timeline-editor textarea,
 .timeline-editor select {
+  appearance: none;
+  -webkit-appearance: none;
   width: 100%;
+  box-sizing: border-box;
   border-radius: 12px;
-  border: 1px solid rgba(255, 214, 231, 0.88);
+  border: 1px solid #f7c6dd;
   padding: 10px;
   font: inherit;
   color: #4f3f4a;
-  background: #fffafd;
+  background: #fff;
+}
+
+.timeline-editor input[type='date'] {
+  min-height: 42px;
 }
 
 .timeline-editor textarea {

--- a/src/pages/TimelinePage.tsx
+++ b/src/pages/TimelinePage.tsx
@@ -278,38 +278,38 @@ const TimelinePage = () => {
       {error ? <p className="timeline-error">{error}</p> : null}
 
       <section className="timeline-list" aria-label="时间轴列表">
-        {loading ? <p className="tips">加载中…</p> : null}
-        {!loading && groupedList.length === 0 ? <p className="timeline-empty">当前月份暂无记录</p> : null}
-        {!loading && groupedList.length > 0 && !selectedDate ? <p className="timeline-empty">请选择日期查看记录</p> : null}
-        {!loading && selectedDate ? (
-          <article className="timeline-date-group">
-            <h2>{selectedDate}</h2>
-            {selectedEntries.length === 0 ? (
-              <p className="timeline-empty">当天暂无记录</p>
-            ) : (
-              <div className="timeline-date-group__entries">
-                {selectedEntries.map((entry) => {
-                  const recorderMeta = RECORDER_META[entry.recorder]
-                  return (
-                    <button
-                      key={entry.id}
-                      type="button"
-                      className="timeline-card"
-                      onClick={() => setEditor(buildEditorState(entry))}
-                    >
-                      <span className="timeline-card__recorder" title={recorderMeta.label}>
-                        {recorderMeta.emoji}
-                      </span>
-                      <div className="timeline-card__content">
-                        <p>{entry.summary}</p>
-                      </div>
-                    </button>
-                  )
-                })}
-              </div>
-            )}
-          </article>
-        ) : null}
+        <div className="timeline-list__body">
+          {loading ? <p className="tips">加载中…</p> : null}
+          {!loading && groupedList.length === 0 ? <p className="timeline-empty">当前月份暂无记录</p> : null}
+          {!loading && groupedList.length > 0 && !selectedDate ? <p className="timeline-empty">请选择日期查看记录</p> : null}
+          {!loading && selectedDate ? (
+            <article className="timeline-date-group">
+              <h2>{selectedDate}</h2>
+              {selectedEntries.length === 0 ? (
+                <p className="timeline-empty">当天暂无记录</p>
+              ) : (
+                <div className="timeline-date-group__entries">
+                  {selectedEntries.map((entry) => {
+                    const recorderMeta = RECORDER_META[entry.recorder]
+                    return (
+                      <button
+                        key={entry.id}
+                        type="button"
+                        className="timeline-card"
+                        onClick={() => setEditor(buildEditorState(entry))}
+                      >
+                        <span className="timeline-card__recorder" title={recorderMeta.label}>
+                          {recorderMeta.emoji}
+                        </span>
+                        <p className="timeline-card__summary">{entry.summary}</p>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </article>
+          ) : null}
+        </div>
       </section>
 
       {editor ? (


### PR DESCRIPTION
### Motivation
- Reduce excessive nested bordered containers on the Timeline page to eliminate misaligned/protruding borders, date-field double-frame artifacts in the editor modal, and the narrow empty-month strip while keeping existing behavior unchanged.
- Favor a simpler visual hierarchy (single lower content card, per-entry cards, and a single clean modal surface) to make the UI feel softer and more stable.
- No external skills were used for this change.

### Description
- Render structure: introduced a single `.timeline-list__body` wrapper for the lower content area and removed an extra inner entry wrapper, replacing `.timeline-card__content` with a direct `.timeline-card__summary` element in `src/pages/TimelinePage.tsx` to reduce nested cards.
- Layout/empty state: increased `.timeline-list` minimum height and made `.timeline-empty` full-width with consistent padding and background so the empty-month area maintains a stable card footprint (`src/pages/TimelinePage.css`).
- Visual flattening: softened shadows, simplified backgrounds, and removed layered radial gradients from the modal surface to avoid stacked frames and border collisions (`src/pages/TimelinePage.css`).
- Form normalization: normalized form control chrome by setting `appearance: none`, `box-sizing: border-box`, a single input border color, and an explicit `min-height` for `input[type=date]` to prevent double-frame/overflow artifacts (`src/pages/TimelinePage.css`).

### Testing
- Ran the production build with `npm run build` which runs `tsc -b && vite build`, and the build completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7457aa5d88330b6109e1cd55b4e1e)