### PR TITLE
Add LLM Provider support with per-provider model management and runtime selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
 } from './storage/userSettings'
 import { formatLocalTimestamp } from './utils/time'
 import { invokeMemoryExtraction } from './storage/memoryExtraction'
+import { useEnabledModels } from './hooks/useEnabledModels'
 import {
   addRemoteMessage,
   createRemoteSession,
@@ -271,16 +272,23 @@ const App = () => {
     [user?.id],
   )
   const activeSettings = userSettings ?? fallbackSettings
-  const defaultModelId =
+  const { enabledModelIds, defaultModelId: enabledDefaultModelId } = useEnabledModels(user)
+  const fallbackDefaultModelId =
     activeSettings.defaultModel?.trim().length > 0
       ? activeSettings.defaultModel
       : defaultOpenRouterModel
+  const defaultModelId = enabledDefaultModelId ?? fallbackDefaultModelId
   const enabledModels = useMemo(() => {
+    if (enabledModelIds.length > 0) {
+      const unique = new Set<string>(enabledModelIds)
+      unique.add(defaultModelId)
+      return Array.from(unique)
+    }
     const unique = new Set<string>()
     activeSettings.enabledModels.forEach((model) => unique.add(model))
     unique.add(defaultModelId)
     return Array.from(unique)
-  }, [activeSettings.enabledModels, defaultModelId])
+  }, [activeSettings.enabledModels, defaultModelId, enabledModelIds])
 
   const latestSession = useMemo(() => selectMostRecentSession(sessions), [sessions])
 

--- a/src/hooks/useEnabledModels.ts
+++ b/src/hooks/useEnabledModels.ts
@@ -1,12 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
-import { ensureUserSettings } from '../storage/userSettings'
-import { supabase } from '../supabase/client'
-
-type OpenRouterModel = {
-  id: string
-  name?: string
-}
+import { fetchEnabledModelsWithProviders, fetchLlmProviders } from '../storage/llmProviders'
 
 export type EnabledModelOption = {
   id: string
@@ -15,7 +9,8 @@ export type EnabledModelOption = {
 
 export const useEnabledModels = (user: User | null) => {
   const [enabledModelIds, setEnabledModelIds] = useState<string[]>([])
-  const [catalog, setCatalog] = useState<OpenRouterModel[]>([])
+  const [enabledModelOptions, setEnabledModelOptions] = useState<EnabledModelOption[]>([])
+  const [defaultModelId, setDefaultModelId] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
@@ -25,62 +20,56 @@ export const useEnabledModels = (user: User | null) => {
       }
     }
 
-    ensureUserSettings(user.id).then((settings) => {
-      if (!active) {
-        return
+    const load = async () => {
+      try {
+        const providers = await fetchLlmProviders(user.id)
+        const activeProvider = providers.find((item) => item.active) ?? providers[0] ?? null
+        if (!activeProvider) {
+          if (!active) return
+          setEnabledModelIds([])
+          setEnabledModelOptions([])
+          setDefaultModelId(null)
+          return
+        }
+
+        const rows = await fetchEnabledModelsWithProviders(user.id)
+        const scoped = rows.filter((item) => item.providerId === activeProvider.id)
+        const ids = scoped.map((item) => item.modelId)
+        const options = scoped.map((item) => ({
+          id: item.modelId,
+          label: `${item.displayName || item.modelId} (via ${item.providerDisplayName})`,
+        }))
+        const defaultRow = scoped.find((item) => item.isDefault) ?? scoped[0] ?? null
+        if (!active) {
+          return
+        }
+        setEnabledModelIds(ids)
+        setEnabledModelOptions(options)
+        setDefaultModelId(defaultRow?.modelId ?? null)
+      } catch {
+        if (!active) {
+          return
+        }
+        setEnabledModelIds([])
+        setEnabledModelOptions([])
+        setDefaultModelId(null)
       }
-      setEnabledModelIds(settings.enabledModels)
-    })
+    }
+
+    void load()
 
     return () => {
       active = false
     }
   }, [user])
-
-  useEffect(() => {
-    let active = true
-    if (!user || !supabase) {
-      return () => {
-        active = false
-      }
-    }
-
-    supabase.functions
-      .invoke<{ data?: OpenRouterModel[] }>('openrouter-models', { body: {} })
-      .then(({ data }) => {
-        if (!active) {
-          return
-        }
-        const models = Array.isArray(data?.data) ? data.data : []
-        setCatalog(models)
-      })
-      .catch(() => {
-        if (!active) {
-          return
-        }
-        setCatalog([])
-      })
-
-    return () => {
-      active = false
-    }
-  }, [user])
-
-  const catalogMap = useMemo(() => {
-    return new Map(catalog.map((model) => [model.id, model.name ?? model.id]))
-  }, [catalog])
 
   const safeEnabledIds = useMemo(() => (user ? enabledModelIds : []), [enabledModelIds, user])
-
-  const enabledModelOptions = useMemo<EnabledModelOption[]>(() => {
-    return safeEnabledIds.map((id) => ({
-      id,
-      label: catalogMap.get(id) ?? id,
-    }))
-  }, [catalogMap, safeEnabledIds])
+  const safeEnabledOptions = useMemo(() => (user ? enabledModelOptions : []), [enabledModelOptions, user])
+  const safeDefaultModelId = user ? defaultModelId : null
 
   return {
     enabledModelIds: safeEnabledIds,
-    enabledModelOptions,
+    enabledModelOptions: safeEnabledOptions,
+    defaultModelId: safeDefaultModelId,
   }
 }

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -11,6 +11,7 @@ import {
   markLetterAsRead,
 } from '../storage/supabaseSync'
 import { ensureUserSettings } from '../storage/userSettings'
+import { fetchActiveProviderModelConfig } from '../storage/llmProviders'
 import { formatLocalTimestamp } from '../utils/time'
 import './LettersPage.css'
 import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
@@ -146,11 +147,14 @@ const LettersPage = ({
         if (error || !data.user) {
           return
         }
-        const settings = await ensureUserSettings(data.user.id)
+        const [settings, providerModels] = await Promise.all([
+          ensureUserSettings(data.user.id),
+          fetchActiveProviderModelConfig(data.user.id),
+        ])
         if (!active) {
           return
         }
-        setDefaultModelId(settings.defaultModel.trim() || 'openrouter/auto')
+        setDefaultModelId(providerModels.defaultModelId?.trim() || settings.defaultModel.trim() || 'openrouter/auto')
       } catch (settingsError) {
         console.warn('加载默认模型失败', settingsError)
       }
@@ -203,13 +207,14 @@ const LettersPage = ({
         throw new Error('登录状态异常')
       }
 
-      const [settings, memoryContext] = await Promise.all([
+      const [settings, memoryContext, providerModels] = await Promise.all([
         ensureUserSettings(user.id),
         buildMemoryContext(),
+        fetchActiveProviderModelConfig(user.id),
       ])
       const appSystemPrompt = settings.systemPrompt.trim()
       const letterReplyPrompt = settings.letterReplySystemPrompt.trim()
-      const modelId = settings.defaultModel.trim() || 'openrouter/auto'
+      const modelId = providerModels.defaultModelId?.trim() || settings.defaultModel.trim() || 'openrouter/auto'
       setDefaultModelId(modelId)
 
       const messages = await maybeInjectTimelineContext(

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -24,6 +24,17 @@ import {
   getPushSupportStatus,
   type NotificationPermissionState,
 } from '../lib/pushNotifications'
+import {
+  createLlmProvider,
+  deleteProviderAndModels,
+  disableModelForProvider,
+  enableModelForProvider,
+  fetchEnabledModelsForProvider,
+  fetchLlmProviders,
+  type LlmProvider,
+  setActiveProvider,
+  setDefaultModelForProvider,
+} from '../storage/llmProviders'
 
 type OpenRouterModel = {
   id: string
@@ -176,6 +187,13 @@ const SettingsPage = ({
     actionStatus: 'idle',
     error: null,
   })
+  const [providers, setProviders] = useState<LlmProvider[]>([])
+  const [providerStatus, setProviderStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [providerError, setProviderError] = useState<string | null>(null)
+  const [newProviderName, setNewProviderName] = useState('')
+  const [newProviderDisplayName, setNewProviderDisplayName] = useState('')
+  const [newProviderBaseUrl, setNewProviderBaseUrl] = useState('')
+  const [newProviderSecretName, setNewProviderSecretName] = useState('')
   const [errors, setErrors] = useState<{ temperature?: string; topP?: string; maxTokens?: string; compressionRatio?: string; compressionKeepRecent?: string }>(
     {},
   )
@@ -200,8 +218,6 @@ const SettingsPage = ({
       setTemperatureInput(settings.temperature.toString())
       setTopPInput(settings.topP.toString())
       setMaxTokensInput(settings.maxTokens.toString())
-      setDraftEnabledModels(settings.enabledModels)
-      setDraftDefaultModel(settings.defaultModel)
       setCompressionEnabled(settings.compressionEnabled)
       setCompressionRatioInput(settings.compressionTriggerRatio.toString())
       setCompressionKeepRecentInput(settings.compressionKeepRecentMessages.toString())
@@ -423,7 +439,39 @@ const SettingsPage = ({
   }, [user])
 
   useEffect(() => {
-    if (!user || !supabase) {
+    if (!user) {
+      return
+    }
+    let active = true
+    const loadProviders = async () => {
+      try {
+        const rows = await fetchLlmProviders(user.id)
+        if (!active) {
+          return
+        }
+        setProviders(rows)
+      } catch (error) {
+        if (!active) {
+          return
+        }
+        console.warn('加载 Provider 失败', error)
+        setProviderError('加载 Provider 失败')
+      }
+    }
+    void loadProviders()
+    return () => {
+      active = false
+    }
+  }, [user])
+
+  const activeProvider = useMemo(
+    () => providers.find((item) => item.active) ?? providers[0] ?? null,
+    [providers],
+  )
+
+  useEffect(() => {
+    const client = supabase
+    if (!user || !client || !activeProvider) {
       return
     }
     let active = true
@@ -431,33 +479,43 @@ const SettingsPage = ({
       setCatalogStatus('loading')
       setCatalogError(null)
     }, 0)
-    supabase.functions
-      .invoke('openrouter-models')
-      .then(({ data, error }) => {
+
+    const loadCatalogAndEnabled = async () => {
+      try {
+        const [{ data, error }, enabledRows] = await Promise.all([
+          client.functions.invoke('openrouter-models', { body: { provider_id: activeProvider.id } }),
+          fetchEnabledModelsForProvider(user.id, activeProvider.id),
+        ])
         if (!active) {
           return
         }
         if (error) {
           setCatalogStatus('error')
-          setCatalogError('无法加载 OpenRouter 模型库')
-          return
+          setCatalogError('无法加载模型库')
+        } else {
+          const models = (data?.models ?? []) as OpenRouterModel[]
+          setCatalog(models)
+          setCatalogStatus('idle')
         }
-        const models = (data?.models ?? []) as OpenRouterModel[]
-        setCatalog(models)
-        setCatalogStatus('idle')
-      })
-      .catch(() => {
+        setDraftEnabledModels(enabledRows.map((row) => row.modelId))
+        setDraftDefaultModel(enabledRows.find((row) => row.isDefault)?.modelId ?? enabledRows[0]?.modelId ?? defaultModelId)
+      } catch (error) {
         if (!active) {
           return
         }
+        console.warn('加载模型库失败', error)
         setCatalogStatus('error')
-        setCatalogError('无法加载 OpenRouter 模型库')
-      })
+        setCatalogError('无法加载模型库')
+      }
+    }
+
+    void loadCatalogAndEnabled()
+
     return () => {
       active = false
       window.clearTimeout(timer)
     }
-  }, [user])
+  }, [activeProvider, user])
 
   const catalogMap = useMemo(() => {
     return new Map(catalog.map((model) => [model.id, model.name ?? model.id]))
@@ -505,10 +563,7 @@ const SettingsPage = ({
   const compressionKeepRecentValid = !Number.isNaN(parsedCompressionKeepRecent) && parsedCompressionKeepRecent >= 1 && parsedCompressionKeepRecent <= 200
   const generationDraftValid = temperatureValid && topPValid && maxTokensValid && compressionRatioValid && compressionKeepRecentValid
 
-  const hasUnsavedModelSettings = settings
-    ? settings.defaultModel !== draftDefaultModel ||
-      settings.enabledModels.join('|') !== draftEnabledModels.join('|')
-    : false
+  const hasUnsavedModelSettings = false
 
   const hasUnsavedGeneration = settings
     ? settings.temperature !== parsedTemperature ||
@@ -574,66 +629,157 @@ const SettingsPage = ({
     }
   }, [hasUnsavedPrompt])
 
-  const handleDisableModel = () => {
-    if (!settings || !pendingDisable) {
+  const handleDisableModel = async () => {
+    if (!user || !activeProvider || !pendingDisable) {
       return
     }
     const modelId = pendingDisable
-    const nextEnabled = draftEnabledModels.filter((id) => id !== modelId)
-    const nextDefault = draftDefaultModel === modelId ? nextEnabled[0] ?? defaultModelId : draftDefaultModel
-    setDraftEnabledModels(nextEnabled)
-    setDraftDefaultModel(nextDefault)
-    setModelStatus('idle')
-    setPendingDisable(null)
+    setModelStatus('saving')
+    setModelError(null)
+    try {
+      await disableModelForProvider(user.id, activeProvider.id, modelId)
+      const nextEnabled = draftEnabledModels.filter((id) => id !== modelId)
+      const nextDefault = draftDefaultModel === modelId ? nextEnabled[0] ?? defaultModelId : draftDefaultModel
+      setDraftEnabledModels(nextEnabled)
+      setDraftDefaultModel(nextDefault)
+      if (nextDefault) {
+        await setDefaultModelForProvider(user.id, activeProvider.id, nextDefault)
+      }
+      setModelStatus('saved')
+    } catch (error) {
+      console.warn('停用模型失败', error)
+      setModelStatus('error')
+      setModelError('停用失败，请稍后重试。')
+    } finally {
+      setPendingDisable(null)
+    }
   }
 
-  const handleEnableModel = (modelId: string, setDefault: boolean) => {
-    if (!settings) {
-      return
-    }
-    const alreadyEnabled = draftEnabledModels.includes(modelId)
-    const nextEnabled = alreadyEnabled ? draftEnabledModels : [...draftEnabledModels, modelId]
-    const nextDefault = setDefault ? modelId : draftDefaultModel || (alreadyEnabled ? draftDefaultModel : modelId)
-    setDraftEnabledModels(nextEnabled)
-    setDraftDefaultModel(nextDefault)
-    setModelStatus('idle')
-  }
-
-  const handleSetDefault = (modelId: string) => {
-    if (!settings) {
-      return
-    }
-    const nextEnabled = draftEnabledModels.includes(modelId)
-      ? draftEnabledModels
-      : [...draftEnabledModels, modelId]
-    setDraftEnabledModels(nextEnabled)
-    setDraftDefaultModel(modelId)
-    setModelStatus('idle')
-  }
-
-  const handleSaveModelSettings = async () => {
-    if (!settings || !hasUnsavedModelSettings) {
-      return
-    }
-    const nextEnabledModels = draftEnabledModels.includes(draftDefaultModel)
-      ? draftEnabledModels
-      : [...draftEnabledModels, draftDefaultModel]
-    const nextSettings = buildNextSettings({
-      enabledModels: nextEnabledModels,
-      defaultModel: draftDefaultModel,
-    })
-    if (!nextSettings) {
+  const handleEnableModel = async (modelId: string, modelName: string, setDefault: boolean) => {
+    if (!user || !activeProvider) {
       return
     }
     setModelStatus('saving')
     setModelError(null)
     try {
-      await onSaveSettings(nextSettings)
+      await enableModelForProvider(user.id, activeProvider.id, modelId, modelName || modelId)
+      const alreadyEnabled = draftEnabledModels.includes(modelId)
+      const nextEnabled = alreadyEnabled ? draftEnabledModels : [...draftEnabledModels, modelId]
+      const nextDefault = setDefault ? modelId : draftDefaultModel || modelId
+      setDraftEnabledModels(nextEnabled)
+      setDraftDefaultModel(nextDefault)
+      if (setDefault || !draftDefaultModel) {
+        await setDefaultModelForProvider(user.id, activeProvider.id, nextDefault)
+      }
       setModelStatus('saved')
     } catch (error) {
-      console.warn('保存模型库设置失败', error)
+      console.warn('启用模型失败', error)
       setModelStatus('error')
-      setModelError('保存失败，请稍后重试。')
+      setModelError('启用失败，请稍后重试。')
+    }
+  }
+
+  const handleSetDefault = async (modelId: string) => {
+    if (!user || !activeProvider) {
+      return
+    }
+    const nextEnabled = draftEnabledModels.includes(modelId) ? draftEnabledModels : [...draftEnabledModels, modelId]
+    setModelStatus('saving')
+    setModelError(null)
+    try {
+      if (!draftEnabledModels.includes(modelId)) {
+        await enableModelForProvider(user.id, activeProvider.id, modelId, modelId)
+      }
+      await setDefaultModelForProvider(user.id, activeProvider.id, modelId)
+      setDraftEnabledModels(nextEnabled)
+      setDraftDefaultModel(modelId)
+      setModelStatus('saved')
+    } catch (error) {
+      console.warn('设置默认模型失败', error)
+      setModelStatus('error')
+      setModelError('设置默认失败，请稍后重试。')
+    }
+  }
+
+  const handleSaveModelSettings = async () => {
+    if (!user || !activeProvider) {
+      return
+    }
+    setModelStatus('saving')
+    setModelError(null)
+    try {
+      const enabledRows = await fetchEnabledModelsForProvider(user.id, activeProvider.id)
+      setDraftEnabledModels(enabledRows.map((row) => row.modelId))
+      setDraftDefaultModel(enabledRows.find((row) => row.isDefault)?.modelId ?? enabledRows[0]?.modelId ?? defaultModelId)
+      setModelStatus('saved')
+    } catch (error) {
+      console.warn('刷新模型库失败', error)
+      setModelStatus('error')
+      setModelError('刷新失败，请稍后重试。')
+    }
+  }
+
+  const handleCreateProvider = async () => {
+    if (!user) {
+      return
+    }
+    const name = newProviderName.trim()
+    const displayName = newProviderDisplayName.trim()
+    const baseUrl = newProviderBaseUrl.trim()
+    const secretName = newProviderSecretName.trim()
+    if (!name || !displayName || !baseUrl || !secretName) {
+      setProviderStatus('error')
+      setProviderError('请完整填写 provider 信息。')
+      return
+    }
+    setProviderStatus('saving')
+    setProviderError(null)
+    try {
+      const created = await createLlmProvider(user.id, { name, displayName, baseUrl, secretName })
+      setProviders((current) => [...current, created])
+      setNewProviderName('')
+      setNewProviderDisplayName('')
+      setNewProviderBaseUrl('')
+      setNewProviderSecretName('')
+      setProviderStatus('saved')
+    } catch (error) {
+      console.warn('新建 Provider 失败', error)
+      setProviderStatus('error')
+      setProviderError('新建 Provider 失败，请稍后重试。')
+    }
+  }
+
+  const handleToggleProviderActive = async (providerId: string) => {
+    if (!user) {
+      return
+    }
+    setProviderStatus('saving')
+    setProviderError(null)
+    try {
+      await setActiveProvider(user.id, providerId)
+      setProviders((current) => current.map((item) => ({ ...item, active: item.id === providerId })))
+      setProviderStatus('saved')
+    } catch (error) {
+      console.warn('切换 Provider 失败', error)
+      setProviderStatus('error')
+      setProviderError('切换 Provider 失败，请稍后重试。')
+    }
+  }
+
+  const handleDeleteProvider = async (providerId: string) => {
+    if (!user) {
+      return
+    }
+    setProviderStatus('saving')
+    setProviderError(null)
+    try {
+      await deleteProviderAndModels(user.id, providerId)
+      setProviders((current) => current.filter((item) => item.id !== providerId))
+      setProviderStatus('saved')
+    } catch (error) {
+      console.warn('删除 Provider 失败', error)
+      setProviderStatus('error')
+      setProviderError('删除 Provider 失败，请稍后重试。')
     }
   }
 
@@ -966,8 +1112,6 @@ const SettingsPage = ({
       setTemperatureInput(settings.temperature.toString())
       setTopPInput(settings.topP.toString())
       setMaxTokensInput(settings.maxTokens.toString())
-      setDraftEnabledModels(settings.enabledModels)
-      setDraftDefaultModel(settings.defaultModel)
       setDraftMemoryExtractModel(settings.memoryExtractModel)
       setDraftChatReasoning(settings.chatReasoningEnabled)
       setDraftRpReasoning(settings.rpReasoningEnabled)
@@ -1747,6 +1891,51 @@ const SettingsPage = ({
         </button>
         {modelSectionExpanded ? (
           <div className="accordion-content">
+            <div className="section-title nested-prompt-title">
+              <h2 className="ui-title">API Provider</h2>
+              <p>管理 Provider。API Key 请在 Supabase Dashboard → Edge Functions → Secrets 中配置。</p>
+            </div>
+            <div className="catalog-dropdown">
+              {providers.length === 0 ? <div className="catalog-empty">暂无 Provider 记录。</div> : null}
+              <ul className="catalog-results">
+                {providers.map((provider) => (
+                  <li key={provider.id} className="catalog-result-item">
+                    <div className="catalog-meta">
+                      <strong>{provider.displayName}</strong>
+                      <span className="model-id">{provider.baseUrl}</span>
+                      <span className="model-id">Secret: {provider.secretName}</span>
+                      <span className="context-length">{provider.active ? 'active' : 'inactive'}</span>
+                    </div>
+                    <div className="catalog-actions">
+                      <button type="button" className="ghost" onClick={() => void handleToggleProviderActive(provider.id)}>
+                        设为 active
+                      </button>
+                      <button type="button" className="ghost danger" onClick={() => void handleDeleteProvider(provider.id)}>
+                        删除
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="field-group">
+              <label>新增 Provider（name / display_name / base_url / secret_name）</label>
+              <input value={newProviderName} onChange={(event) => setNewProviderName(event.target.value)} placeholder="name (如 aihubmix)" />
+              <input value={newProviderDisplayName} onChange={(event) => setNewProviderDisplayName(event.target.value)} placeholder="display_name" />
+              <input value={newProviderBaseUrl} onChange={(event) => setNewProviderBaseUrl(event.target.value)} placeholder="base_url (含 /v1)" />
+              <input value={newProviderSecretName} onChange={(event) => setNewProviderSecretName(event.target.value)} placeholder="secret_name (如 AIHUBMIX_API_KEY)" />
+              <p className="settings-helper-text">
+                新建后请在 Supabase Dashboard → Edge Functions → Secrets 中添加同名 secret：{newProviderSecretName || '{secret_name}'}。
+              </p>
+              <div className="system-prompt-actions">
+                <button type="button" className="primary" onClick={() => void handleCreateProvider()} disabled={providerStatus === 'saving'}>
+                  {providerStatus === 'saving' ? '处理中…' : '新建 Provider'}
+                </button>
+                {providerStatus === 'saved' ? <span className="system-prompt-status">已更新</span> : null}
+                {providerStatus === 'error' && providerError ? <span className="field-error">{providerError}</span> : null}
+              </div>
+            </div>
+
             {draftEnabledModels.length === 0 ? (
               <div className="empty-state">暂无启用模型，请从下方模型库启用。</div>
             ) : (
@@ -1756,7 +1945,7 @@ const SettingsPage = ({
                   <select
                     id="enabled-models"
                     value={selectedModelId}
-                    onChange={(event) => handleSetDefault(event.target.value)}
+                    onChange={(event) => void handleSetDefault(event.target.value)}
                   >
                     {draftEnabledModels.map((modelId) => (
                       <option key={modelId} value={modelId}>
@@ -1767,10 +1956,10 @@ const SettingsPage = ({
                   <button
                     type="button"
                     className="ghost danger small"
-                    onClick={() => setPendingDisable(selectedModelId)}
-                  >
-                    停用
-                  </button>
+                  onClick={() => setPendingDisable(selectedModelId)}
+                >
+                  停用
+                </button>
                 </div>
                 <div className="model-selected-meta">
                   <strong>{catalogMap.get(selectedModelId) ?? selectedModelId}</strong>
@@ -1780,7 +1969,7 @@ const SettingsPage = ({
             )}
 
             <div className="section-title nested-prompt-title">
-              <h2 className="ui-title">OpenRouter 模型库</h2>
+              <h2 className="ui-title">{activeProvider ? `${activeProvider.displayName} 模型库` : '模型库'}</h2>
               <p>搜索并启用你想使用的模型。</p>
             </div>
             <input
@@ -1820,7 +2009,7 @@ const SettingsPage = ({
                           {enabled ? (
                             <span className="badge subtle">已启用</span>
                           ) : (
-                            <button type="button" onClick={() => handleEnableModel(model.id, false)}>
+                            <button type="button" onClick={() => void handleEnableModel(model.id, model.name ?? model.id, false)}>
                               启用
                             </button>
                           )}
@@ -1840,11 +2029,10 @@ const SettingsPage = ({
                 type="button"
                 className="primary"
                 onClick={() => void handleSaveModelSettings()}
-                disabled={!hasUnsavedModelSettings || modelStatus === 'saving'}
+                disabled={modelStatus === 'saving'}
               >
-                {modelStatus === 'saving' ? '保存中…' : '保存'}
+                {modelStatus === 'saving' ? '保存中…' : '刷新'}
               </button>
-              {hasUnsavedModelSettings ? <span className="system-prompt-status">有未保存修改</span> : null}
               {modelStatus === 'saved' ? <span className="system-prompt-status">已保存</span> : null}
               {modelStatus === 'error' ? <span className="field-error">{modelError}</span> : null}
             </div>

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -3,6 +3,7 @@ import { supabase } from '../supabase/client'
 import type { MemoryEntry } from '../types'
 import { ensureUserSettings } from '../storage/userSettings'
 import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
+import { fetchActiveProviderModelConfig } from '../storage/llmProviders'
 
 export const FORUM_AI_SLOTS = [1, 2, 3] as const
 export const FORUM_USER_DISPLAY_NAME = '串串'
@@ -525,8 +526,11 @@ export const loadForumGlobalAiConfig = async (): Promise<ForumGlobalAiConfig> =>
     throw error ?? new Error('登录状态异常')
   }
   const settings = await ensureUserSettings(user.id)
-  const defaultModelId = settings.defaultModel?.trim() || DEFAULT_MODEL
-  const enabled = Array.from(new Set([...settings.enabledModels, defaultModelId]))
+  const providerModels = await fetchActiveProviderModelConfig(user.id)
+  const defaultModelId = providerModels.defaultModelId?.trim() || settings.defaultModel?.trim() || DEFAULT_MODEL
+  const enabled = providerModels.enabledModelIds.length > 0
+    ? Array.from(new Set([...providerModels.enabledModelIds, defaultModelId]))
+    : Array.from(new Set([...settings.enabledModels, defaultModelId]))
   return {
     defaultModelId,
     enabledModelIds: enabled,

--- a/src/storage/llmProviders.ts
+++ b/src/storage/llmProviders.ts
@@ -1,0 +1,201 @@
+import { supabase } from '../supabase/client'
+
+export type LlmProvider = {
+  id: string
+  userId: string
+  name: string
+  displayName: string
+  baseUrl: string
+  secretName: string
+  active: boolean
+  priority: number
+}
+
+export type EnabledModelRecord = {
+  id: string
+  userId: string
+  providerId: string
+  modelId: string
+  displayName: string
+  isDefault: boolean
+  providerDisplayName: string
+}
+
+const mapProvider = (row: Record<string, unknown>): LlmProvider => ({
+  id: String(row.id ?? ''),
+  userId: String(row.user_id ?? ''),
+  name: String(row.name ?? ''),
+  displayName: String(row.display_name ?? row.name ?? ''),
+  baseUrl: String(row.base_url ?? ''),
+  secretName: String(row.secret_name ?? ''),
+  active: Boolean(row.active),
+  priority: Number(row.priority ?? 1000),
+})
+
+export const fetchLlmProviders = async (userId: string): Promise<LlmProvider[]> => {
+  if (!supabase) return []
+  const { data, error } = await supabase
+    .from('llm_providers')
+    .select('id,user_id,name,display_name,base_url,secret_name,active,priority')
+    .eq('user_id', userId)
+    .order('priority', { ascending: true })
+    .order('created_at', { ascending: true })
+  if (error) throw error
+  return (data ?? []).map((row) => mapProvider(row as Record<string, unknown>))
+}
+
+export const createLlmProvider = async (
+  userId: string,
+  payload: { name: string; displayName: string; baseUrl: string; secretName: string },
+): Promise<LlmProvider> => {
+  if (!supabase) throw new Error('Supabase client unavailable')
+  const { data, error } = await supabase
+    .from('llm_providers')
+    .insert({
+      user_id: userId,
+      name: payload.name,
+      display_name: payload.displayName,
+      base_url: payload.baseUrl,
+      secret_name: payload.secretName,
+      active: false,
+      priority: 1000,
+    })
+    .select('id,user_id,name,display_name,base_url,secret_name,active,priority')
+    .single()
+  if (error) throw error
+  return mapProvider(data as Record<string, unknown>)
+}
+
+export const setActiveProvider = async (userId: string, providerId: string) => {
+  if (!supabase) throw new Error('Supabase client unavailable')
+  const { error: disableError } = await supabase
+    .from('llm_providers')
+    .update({ active: false })
+    .eq('user_id', userId)
+  if (disableError) throw disableError
+
+  const { error: enableError } = await supabase
+    .from('llm_providers')
+    .update({ active: true })
+    .eq('user_id', userId)
+    .eq('id', providerId)
+  if (enableError) throw enableError
+}
+
+export const deleteProviderAndModels = async (userId: string, providerId: string) => {
+  if (!supabase) throw new Error('Supabase client unavailable')
+  const { error: modelError } = await supabase
+    .from('enabled_models')
+    .delete()
+    .eq('user_id', userId)
+    .eq('provider_id', providerId)
+  if (modelError) throw modelError
+
+  const { error: providerError } = await supabase
+    .from('llm_providers')
+    .delete()
+    .eq('user_id', userId)
+    .eq('id', providerId)
+  if (providerError) throw providerError
+}
+
+export const fetchEnabledModelsWithProviders = async (userId: string): Promise<EnabledModelRecord[]> => {
+  if (!supabase) return []
+  const { data: providersData, error: providersError } = await supabase
+    .from('llm_providers')
+    .select('id,display_name')
+    .eq('user_id', userId)
+  if (providersError) throw providersError
+  const providerMap = new Map((providersData ?? []).map((item) => [String(item.id), String(item.display_name ?? '')]))
+
+  const { data, error } = await supabase
+    .from('enabled_models')
+    .select('id,user_id,provider_id,model_id,display_name,is_default')
+    .eq('user_id', userId)
+    .order('enabled_at', { ascending: true })
+  if (error) throw error
+
+  return (data ?? []).map((row) => ({
+    id: String(row.id ?? ''),
+    userId: String(row.user_id ?? ''),
+    providerId: String(row.provider_id ?? ''),
+    modelId: String(row.model_id ?? ''),
+    displayName: String(row.display_name ?? row.model_id ?? ''),
+    isDefault: Boolean(row.is_default),
+    providerDisplayName: providerMap.get(String(row.provider_id ?? '')) ?? 'Unknown Provider',
+  }))
+}
+
+export const fetchEnabledModelsForProvider = async (
+  userId: string,
+  providerId: string,
+): Promise<EnabledModelRecord[]> => {
+  const all = await fetchEnabledModelsWithProviders(userId)
+  return all.filter((item) => item.providerId === providerId)
+}
+
+export const fetchActiveProviderModelConfig = async (userId: string): Promise<{
+  providerId: string | null
+  enabledModelIds: string[]
+  defaultModelId: string | null
+}> => {
+  const providers = await fetchLlmProviders(userId)
+  const activeProvider = providers.find((item) => item.active) ?? providers[0] ?? null
+  if (!activeProvider) {
+    return { providerId: null, enabledModelIds: [], defaultModelId: null }
+  }
+  const scoped = await fetchEnabledModelsForProvider(userId, activeProvider.id)
+  return {
+    providerId: activeProvider.id,
+    enabledModelIds: scoped.map((item) => item.modelId),
+    defaultModelId: scoped.find((item) => item.isDefault)?.modelId ?? scoped[0]?.modelId ?? null,
+  }
+}
+
+export const enableModelForProvider = async (
+  userId: string,
+  providerId: string,
+  modelId: string,
+  displayName: string,
+) => {
+  if (!supabase) throw new Error('Supabase client unavailable')
+  const { error } = await supabase
+    .from('enabled_models')
+    .upsert({
+      user_id: userId,
+      provider_id: providerId,
+      model_id: modelId,
+      display_name: displayName,
+      is_default: false,
+    }, { onConflict: 'user_id,provider_id,model_id' })
+  if (error) throw error
+}
+
+export const disableModelForProvider = async (userId: string, providerId: string, modelId: string) => {
+  if (!supabase) throw new Error('Supabase client unavailable')
+  const { error } = await supabase
+    .from('enabled_models')
+    .delete()
+    .eq('user_id', userId)
+    .eq('provider_id', providerId)
+    .eq('model_id', modelId)
+  if (error) throw error
+}
+
+export const setDefaultModelForProvider = async (userId: string, providerId: string, modelId: string) => {
+  if (!supabase) throw new Error('Supabase client unavailable')
+  const { error: clearError } = await supabase
+    .from('enabled_models')
+    .update({ is_default: false })
+    .eq('user_id', userId)
+    .eq('provider_id', providerId)
+  if (clearError) throw clearError
+
+  const { error } = await supabase
+    .from('enabled_models')
+    .update({ is_default: true })
+    .eq('user_id', userId)
+    .eq('provider_id', providerId)
+    .eq('model_id', modelId)
+  if (error) throw error
+}

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -129,6 +129,18 @@ const resolveReasoningPayload = (reasoning: OpenRouterPayload['reasoning']) => {
   return null
 }
 
+type RuntimeProviderConfig = {
+  provider: string
+  chatCompletionsUrl: string
+  apiKey: string
+}
+
+type ActiveProviderRow = {
+  name: string | null
+  base_url: string | null
+  secret_name: string | null
+}
+
 const flattenOpenRouterTextParts = (value: unknown): string => {
   if (typeof value === 'string') {
     return value
@@ -306,6 +318,39 @@ const buildSupabaseServiceRoleClient = () => {
   }
 
   return createClient(supabaseUrl, serviceRoleKey)
+}
+
+const resolveActiveProviderConfig = async (userId: string): Promise<RuntimeProviderConfig | null> => {
+  const supabase = buildSupabaseServiceRoleClient()
+  const { data, error } = await supabase
+    .from('llm_providers')
+    .select('name,base_url,secret_name')
+    .eq('user_id', userId)
+    .eq('active', true)
+    .order('priority', { ascending: true })
+    .limit(1)
+    .maybeSingle<ActiveProviderRow>()
+  if (error || !data) {
+    return null
+  }
+  const baseUrl = data.base_url?.trim() ?? ''
+  const secretName = data.secret_name?.trim() ?? ''
+  if (!baseUrl || !secretName) {
+    return null
+  }
+  const apiKey = Deno.env.get(secretName) ?? ''
+  if (!apiKey) {
+    return {
+      provider: data.name?.trim() || 'custom',
+      chatCompletionsUrl: `${baseUrl.replace(/\/+$/, '')}/chat/completions`,
+      apiKey: '',
+    }
+  }
+  return {
+    provider: data.name?.trim() || 'custom',
+    chatCompletionsUrl: `${baseUrl.replace(/\/+$/, '')}/chat/completions`,
+    apiKey,
+  }
 }
 
 const fetchCompressionCache = async (
@@ -521,7 +566,7 @@ const fetchRpSessionCompressionSettings = async (
 }
 
 const summarizeCompressedWindow = async (
-  apiKey: string,
+  provider: RuntimeProviderConfig,
   summarizerModel: string,
   existingSummary: string,
   newMessages: StoredMessageRow[],
@@ -539,10 +584,10 @@ const summarizeCompressedWindow = async (
     .filter(Boolean)
     .join('\n\n')
 
-  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+  const response = await fetch(provider.chatCompletionsUrl, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${provider.apiKey}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
@@ -571,7 +616,7 @@ const maybeCompressRuntimeContext = async (
   reqUrl: string,
   authHeader: string,
   apiKeyHeader: string,
-  openRouterApiKey: string,
+  provider: RuntimeProviderConfig,
   userId: string,
 ): Promise<RuntimeCompressionResult> => {
   const compressionModule = resolveCompressionModule(payload)
@@ -725,7 +770,7 @@ const maybeCompressRuntimeContext = async (
       const newCompressibleMessages = fullHistory.slice(newChunkStart, refreshBoundaryIndex + 1)
       if (newCompressibleMessages.length > 0) {
         const refreshedSummary = await summarizeCompressedWindow(
-          openRouterApiKey,
+          provider,
           summarizerModel,
           summaryText,
           newCompressibleMessages,
@@ -935,8 +980,14 @@ serve(async (req) => {
     })
   }
 
-  const apiKey = Deno.env.get('OPENROUTER_API_KEY')
-  if (!apiKey) {
+  const activeProvider = userId ? await resolveActiveProviderConfig(userId) : null
+  const runtimeProvider: RuntimeProviderConfig = activeProvider ?? {
+    provider: 'openrouter',
+    chatCompletionsUrl: 'https://openrouter.ai/api/v1/chat/completions',
+    apiKey: Deno.env.get('OPENROUTER_API_KEY') ?? '',
+  }
+
+  if (!runtimeProvider.apiKey) {
     return new Response(JSON.stringify({ error: '服务未配置' }), {
       status: 500,
       headers: {
@@ -982,7 +1033,7 @@ serve(async (req) => {
       req.url,
       authHeader,
       apiKeyHeader,
-      apiKey,
+      runtimeProvider,
       userId,
     )
     messages = compressionResult.messages
@@ -1010,10 +1061,10 @@ serve(async (req) => {
   }
 
   try {
-    const upstream = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    const upstream = await fetch(runtimeProvider.chatCompletionsUrl, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${runtimeProvider.apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({

--- a/supabase/functions/openrouter-models/index.ts
+++ b/supabase/functions/openrouter-models/index.ts
@@ -1,10 +1,38 @@
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
   'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
   'Access-Control-Max-Age': '86400',
+}
+
+type ProviderConfig = {
+  id: string
+  name: string | null
+  base_url: string | null
+  secret_name: string | null
+  active?: boolean | null
+}
+
+const resolveProvider = (value: ProviderConfig | null) => {
+  if (!value) {
+    return null
+  }
+  const baseUrl = value.base_url?.trim() ?? ''
+  const secretName = value.secret_name?.trim() ?? ''
+  if (!baseUrl || !secretName) {
+    return null
+  }
+  const normalizedBase = baseUrl.replace(/\/+$/, '')
+  const modelsUrl = `${normalizedBase}/models`
+  const apiKey = Deno.env.get(secretName) ?? ''
+  return {
+    name: value.name?.trim() || 'custom',
+    modelsUrl,
+    apiKey,
+  }
 }
 
 serve(async (req) => {
@@ -27,6 +55,7 @@ serve(async (req) => {
     })
   }
 
+  let userId = ''
   try {
     const authUrl = new URL('/auth/v1/user', new URL(req.url).origin)
     const authResponse = await fetch(authUrl, {
@@ -44,6 +73,8 @@ serve(async (req) => {
         },
       })
     }
+    const authData = await authResponse.json() as { id?: string }
+    userId = authData.id ?? ''
   } catch {
     return new Response(JSON.stringify({ error: '身份令牌无效' }), {
       status: 401,
@@ -54,7 +85,40 @@ serve(async (req) => {
     })
   }
 
-  const apiKey = Deno.env.get('OPENROUTER_API_KEY')
+  let providerId: string | null = new URL(req.url).searchParams.get('provider_id')
+  if (req.method === 'POST') {
+    try {
+      const payload = await req.json() as { provider_id?: string }
+      providerId = typeof payload.provider_id === 'string' ? payload.provider_id : null
+    } catch {
+      providerId = null
+    }
+  }
+
+  let providerRow: ProviderConfig | null = null
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+    if (supabaseUrl && serviceRoleKey && userId) {
+      const admin = createClient(supabaseUrl, serviceRoleKey)
+      let query = admin
+        .from('llm_providers')
+        .select('id,name,base_url,secret_name,active')
+        .eq('user_id', userId)
+      if (providerId) {
+        query = query.eq('id', providerId)
+      } else {
+        query = query.eq('active', true).order('priority', { ascending: true })
+      }
+      const { data } = await query.limit(1).maybeSingle<ProviderConfig>()
+      providerRow = data ?? null
+    }
+  } catch {
+    providerRow = null
+  }
+
+  const customProvider = resolveProvider(providerRow)
+  const apiKey = customProvider?.apiKey || Deno.env.get('OPENROUTER_API_KEY')
   if (!apiKey) {
     return new Response(JSON.stringify({ error: '服务未配置' }), {
       status: 500,
@@ -66,7 +130,8 @@ serve(async (req) => {
   }
 
   try {
-    const upstream = await fetch('https://openrouter.ai/api/v1/models', {
+    const modelsUrl = customProvider?.modelsUrl ?? 'https://openrouter.ai/api/v1/models'
+    const upstream = await fetch(modelsUrl, {
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',


### PR DESCRIPTION
### Motivation

- Introduce support for multiple LLM API providers and allow users to manage enabled models per provider so the app can route requests to custom provider endpoints and secrets.
- Surface provider/model management in the Settings UI and make runtime edge functions respect the active provider and its secret stored in Supabase.

### Description

- Add a new Supabase-backed provider and model layer in `src/storage/llmProviders.ts` with functions to `createLlmProvider`, `fetchLlmProviders`, `setActiveProvider`, `enableModelForProvider`, `disableModelForProvider`, `fetchEnabledModelsForProvider`, and `setDefaultModelForProvider`.
- Add a React hook `src/hooks/useEnabledModels.ts` to expose provider-scoped enabled model ids/options and a provider-scoped default model id to the app, and wire it into `src/App.tsx` to compute `enabledModels`/`defaultModelId` safely.
- Extend the Settings UI in `src/pages/SettingsPage.tsx` to manage Providers (create/toggle/delete) and provider-scoped enabled models, and update flows to enable/disable models and set defaults via the new storage APIs.
- Update letter and forum flows (`src/pages/LettersPage.tsx` and `src/pages/forumShared.ts`) to consider the active provider model config via `fetchActiveProviderModelConfig` when resolving default and enabled models.
- Update Supabase Edge functions: `supabase/functions/openrouter-models` to query provider config and return provider model lists (supporting custom provider base URL and secret), and `supabase/functions/openrouter-chat` to resolve an active provider at runtime and use its `chatCompletionsUrl` and secret from environment for upstream calls and summarization.

### Testing

- Ran the frontend build with `npm run build` and the build succeeded.
- Ran the test suite with `npm test` and all tests passed.
- Verified the Supabase Edge functions TypeScript compiles as part of the functions build process (no compile errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07e97716c833089c472d8e19d2a31)