### PR TITLE
fix(supabase): disable gateway JWT verification per Edge Function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,40 @@
+# Supabase project configuration for Hamster-Nest.
+#
+# We disable the gateway-level JWT verification for every Edge Function and
+# let the function code handle authentication itself. The Supabase gateway only
+# understands HS256-signed JWTs, but the current @supabase/supabase-js client
+# issues ES256-signed JWTs, which causes the gateway to reject every request
+# with UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM before the function ever runs.
+#
+# Functions that need user identity (memory-extract, openrouter-chat,
+# openrouter-models, rag-search) re-verify the JWT internally by calling
+# `/auth/v1/user` with the caller's Authorization/apikey headers and return
+# 401 on failure, so this is not a security regression for them.
+#
+# Functions that run with SUPABASE_SERVICE_ROLE_KEY (rag-backfill, rag-embed,
+# signal-bus-consumer) never performed user-JWT verification — they rely on
+# being invoked only from trusted callers (cron jobs, other Edge Functions,
+# server-side backfill scripts) that hold the service-role key. Their
+# exposure profile is unchanged by this setting.
+project_id = "crfhiumxzmaszkapanrb"
+
+[functions.memory-extract]
+verify_jwt = false
+
+[functions.openrouter-chat]
+verify_jwt = false
+
+[functions.openrouter-models]
+verify_jwt = false
+
+[functions.rag-backfill]
+verify_jwt = false
+
+[functions.rag-embed]
+verify_jwt = false
+
+[functions.rag-search]
+verify_jwt = false
+
+[functions.signal-bus-consumer]
+verify_jwt = false


### PR DESCRIPTION
## Summary

Every Edge Function call from the frontend currently returns:

```json
{ "code": "UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM",
  "message": "Unsupported JWT algorithm: ES256" }
```

Root cause: the Supabase gateway's `verify_jwt` only accepts HS256, but
`@supabase/supabase-js` now issues ES256-signed JWTs. The gateway rejects
the request before the function ever runs.

Fix: add `supabase/config.toml` and set `verify_jwt = false` per function,
so auth is handled inside each function instead of at the gateway. This is
not a security downgrade — it eliminates duplicated verification.

## Per-function auth status after this change

| Function | In-function auth |
| --- | --- |
| `memory-extract` | Calls `/auth/v1/user` via `supabase.auth.getUser()`, returns 401 on failure |
| `openrouter-chat` | Directly `fetch('/auth/v1/user', ...)`, returns 401 on failure |
| `openrouter-models` | Directly `fetch('/auth/v1/user', ...)`, returns 401 on failure |
| `rag-search` | Calls `supabase.auth.getUser()`, returns 401 on failure |
| `rag-backfill` | Service-role only — invoked by trusted callers (cron/backend) |
| `rag-embed` | Service-role only — invoked from other Edge Functions / scripts |
| `signal-bus-consumer` | Service-role only — invoked by the signal-bus cron |

The three service-role functions never validated user JWTs; their exposure
profile is unchanged by this setting.

## What I did NOT do

- Did **not** downgrade `@supabase/supabase-js` (treats the symptom, not the cause).
- Did **not** revert the provider-abstraction refactor on `main`.
- Did **not** modify any Edge Function source logic.
- Did **not** touch RLS, schema, or Supabase secrets.

## Deploy

The Supabase CLI is not available in the automation sandbox, so deployment
is **not** done yet. After merging (or from this branch), run locally:

```bash
supabase link --project-ref crfhiumxzmaszkapanrb
supabase functions deploy --no-verify-jwt
```

Or per-function:

```bash
supabase functions deploy memory-extract       --no-verify-jwt
supabase functions deploy openrouter-chat      --no-verify-jwt
supabase functions deploy openrouter-models    --no-verify-jwt
supabase functions deploy rag-backfill         --no-verify-jwt
supabase functions deploy rag-embed            --no-verify-jwt
supabase functions deploy rag-search           --no-verify-jwt
supabase functions deploy signal-bus-consumer  --no-verify-jwt
```

## Test plan

- [ ] `supabase functions deploy --no-verify-jwt` succeeds for all 7 functions
- [ ] Open 仓鼠小窝, send a chat message, confirm the assistant replies (covers `openrouter-chat`, `openrouter-models`, `memory-extract`, `rag-search`)
- [ ] Confirm signal-bus cron continues to work (covers `signal-bus-consumer`)
- [ ] Confirm no new 401 `UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM` in Supabase logs
- [ ] Confirm that sending a request **without** a valid Authorization header still returns 401 from user-facing functions (in-function check still works)

https://claude.ai/code/session_01CHtfcdgWu7uhSXdbxxP2hp