### PR TITLE
feat(openrouter-chat): add provider compatibility layer

### DIFF
--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -141,6 +141,63 @@ type ActiveProviderRow = {
   secret_name: string | null
 }
 
+type BuildProviderRequestOptions = {
+  resolvedModelId: string
+  messages: OpenAiMessage[]
+  temperature: number | undefined
+  top_p: number | undefined
+  max_tokens: number | undefined
+  reasoning: OpenRouterPayload['reasoning']
+  stream: boolean
+}
+
+const buildProviderRequestPayload = (
+  provider: RuntimeProviderConfig,
+  options: BuildProviderRequestOptions,
+): Record<string, unknown> => {
+  const { resolvedModelId, messages, temperature, top_p, max_tokens, reasoning, stream } = options
+  const isOpenRouter = provider.provider === 'openrouter'
+  const isClaudeModel = resolvedModelId.toLowerCase().includes('claude')
+
+  let outgoingMessages: OpenAiMessage[] = messages
+  let topLevelSystem: string | null = null
+
+  if (!isOpenRouter && isClaudeModel) {
+    const systemContents = messages
+      .filter((message) => message.role === 'system')
+      .map((message) => message.content)
+      .filter((content) => content.length > 0)
+    outgoingMessages = messages.filter(
+      (message) => message.role === 'user' || message.role === 'assistant',
+    )
+    if (systemContents.length > 0) {
+      topLevelSystem = systemContents.join('\n\n')
+    }
+  }
+
+  const basePayload: Record<string, unknown> = {
+    model: resolvedModelId,
+    messages: outgoingMessages,
+    temperature,
+    top_p,
+    max_tokens,
+    stream,
+  }
+
+  if (isOpenRouter) {
+    const reasoningPayload = resolveReasoningPayload(reasoning)
+    if (reasoningPayload) {
+      basePayload.reasoning = reasoningPayload
+    }
+  }
+
+  if (topLevelSystem !== null) {
+    basePayload.system = topLevelSystem
+  }
+
+  return basePayload
+}
+
 const flattenOpenRouterTextParts = (value: unknown): string => {
   if (typeof value === 'string') {
     return value
@@ -590,16 +647,20 @@ const summarizeCompressedWindow = async (
       Authorization: `Bearer ${provider.apiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      model: summarizerModel,
-      stream: false,
-      max_tokens: 550,
-      temperature: 0.2,
-      messages: [
-        { role: 'system', content: '你负责维护对话运行时摘要。只输出最终摘要文本。' },
-        { role: 'user', content: prompt },
-      ],
-    }),
+    body: JSON.stringify(
+      buildProviderRequestPayload(provider, {
+        resolvedModelId: summarizerModel,
+        messages: [
+          { role: 'system', content: '你负责维护对话运行时摘要。只输出最终摘要文本。' },
+          { role: 'user', content: prompt },
+        ],
+        temperature: 0.2,
+        top_p: undefined,
+        max_tokens: 550,
+        reasoning: undefined,
+        stream: false,
+      }),
+    ),
   })
   if (!response.ok) {
     throw new Error('summarizer failed')
@@ -1067,15 +1128,17 @@ serve(async (req) => {
         Authorization: `Bearer ${runtimeProvider.apiKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        model: resolvedModelId,
-        messages,
-        temperature,
-        top_p,
-        max_tokens,
-        ...(resolveReasoningPayload(reasoning) ? { reasoning: resolveReasoningPayload(reasoning) } : {}),
-        stream,
-      }),
+      body: JSON.stringify(
+        buildProviderRequestPayload(runtimeProvider, {
+          resolvedModelId,
+          messages,
+          temperature,
+          top_p,
+          max_tokens,
+          reasoning,
+          stream,
+        }),
+      ),
     })
 
     if (!upstream.ok) {


### PR DESCRIPTION
## 背景

#347 已将 `openrouter-chat` Edge Function 升级为按 `llm_providers` 表动态路由 provider（base_url + secret）。但实测将 provider 切到 AiHubMix（OpenAI-compatible 网关）后，两类请求直接被上游拒掉：

1. **Problem A — `reasoning` 参数**：OpenRouter 扩展参数，AiHubMix 返回 `invalid_request_error: Unknown parameter: 'reasoning'`。
2. **Problem B — Anthropic 模型 system role**：OpenRouter 会把 `messages: [{role:'system',…}]` 自动折叠成 Anthropic Messages API 需要的顶层 `system`；AiHubMix 不做转换，Claude 系列模型返回 `Unexpected role "system". The Messages API accepts a top-level 'system' parameter, not "system" as an input message role`。

本 PR 在 Edge Function 里引入一层 provider 兼容转换，只改 request 构造，不触碰 `resolveActiveProviderConfig`、memory 注入、压缩逻辑、CORS/JWT 等已验证代码。

## 改动文件清单

- `supabase/functions/openrouter-chat/index.ts`
  - 新增 `BuildProviderRequestOptions` 类型 + `buildProviderRequestPayload(provider, options)` 函数
  - 改写主聊天请求的 fetch body（原位于主 `try` 块中的 upstream 请求）
  - 改写 `summarizeCompressedWindow` 内的 summarizer fetch body

## `buildProviderRequestPayload` 行为说明

输入：
- `provider: RuntimeProviderConfig`
- `options: { resolvedModelId, messages, temperature, top_p, max_tokens, reasoning, stream }`

输出：`Record<string, unknown>`，即交给 `JSON.stringify` 的 body 对象。

逻辑：
1. `isOpenRouter = provider.provider === 'openrouter'`（`RuntimeProviderConfig.provider` 字段已在 #347 定义，默认兜底值就是 `'openrouter'`）。
2. `isClaudeModel = resolvedModelId.toLowerCase().includes('claude')`。
3. 基础 body：`{ model, messages, temperature, top_p, max_tokens, stream }`。
4. 若 `isOpenRouter`，把 `resolveReasoningPayload(reasoning)` 的返回值（若有）挂到 `reasoning` 字段；非 OpenRouter 一律不附加 `reasoning`。
5. 若 `!isOpenRouter && isClaudeModel`：
   - 从 `messages` 中筛出所有 `role === 'system'` 的消息，以 `\n\n` 拼接为顶层 `system` 字符串；
   - `messages` 只保留 `role === 'user' | 'assistant'` 的条目；
   - 如果没有任何 system 消息，不添加 `system` 字段。
6. 其他所有 provider × 模型组合保持 OpenAI-compatible 默认形态。

## Before / After

### 主请求

**Before**
```ts
body: JSON.stringify({
  model: resolvedModelId,
  messages,
  temperature,
  top_p,
  max_tokens,
  ...(resolveReasoningPayload(reasoning) ? { reasoning: resolveReasoningPayload(reasoning) } : {}),
  stream,
}),
```

**After**
```ts
body: JSON.stringify(
  buildProviderRequestPayload(runtimeProvider, {
    resolvedModelId,
    messages,
    temperature,
    top_p,
    max_tokens,
    reasoning,
    stream,
  }),
),
```

### Summarizer（`summarizeCompressedWindow`）

**Before**
```ts
body: JSON.stringify({
  model: summarizerModel,
  stream: false,
  max_tokens: 550,
  temperature: 0.2,
  messages: [
    { role: 'system', content: '你负责维护对话运行时摘要。只输出最终摘要文本。' },
    { role: 'user', content: prompt },
  ],
}),
```

**After**
```ts
body: JSON.stringify(
  buildProviderRequestPayload(provider, {
    resolvedModelId: summarizerModel,
    messages: [
      { role: 'system', content: '你负责维护对话运行时摘要。只输出最终摘要文本。' },
      { role: 'user', content: prompt },
    ],
    temperature: 0.2,
    top_p: undefined,
    max_tokens: 550,
    reasoning: undefined,
    stream: false,
  }),
),
```

## 已知限制

- `summarizerModel` 默认值仍是 `openai/gpt-4o-mini`。在非 OpenRouter provider 下，该 provider 可能不识别 `openai/` 前缀的 model id。本 PR 不触碰 summarizer 的 model id 解析，按现有行为保留；切到非 OpenRouter provider 的用户若遇到摘要失败，可在用户设置里把 summarizer 指向该 provider 支持的 model id。后续可单独开一个 PR 处理 summarizer 默认模型的 provider-aware 映射。
- 兼容层判定基于字符串匹配（provider 名 = `'openrouter'`；model id 含 `'claude'`）。若未来引入新的 OpenRouter-compatible gateway 或非 Anthropic 但 id 里带 `claude` 的模型，需要在此函数内扩展判定。
- 本 PR 不涉及前端代码、不改 `openrouter-models` 函数、不动数据库 schema。

## 验证步骤

- [ ] `npm run build` 通过（本地已验证）。
- [ ] 在 Supabase 部署新的 Edge Function 后：
  - 切 provider → AiHubMix + 模型 `claude-sonnet-4.5`（或任意含 `claude` 的 id），发一条普通聊天消息，确认：
    - 请求 body 中不再包含 `reasoning` 字段；
    - 请求 body 中 `messages` 只含 `user`/`assistant`，`system` 以顶层字符串形式出现；
    - 上游不再返回 `Unexpected role "system"` 错误。
  - 切 provider → AiHubMix + 非 Claude 模型（如 `gpt-5.4` / `gpt-4.1` 等），发消息，确认：
    - 请求 body 中不包含 `reasoning`；
    - `messages` 原样传递（含 `system` 消息），无顶层 `system` 字段；
    - 请求正常返回。
  - 切回 provider → OpenRouter，发消息（尤其是带 `reasoning: true` 的请求），确认：
    - 请求 body 中包含 `reasoning` 字段；
    - `messages` 原样传递（含 `system` 消息），无顶层 `system` 字段；
    - 行为与本 PR 之前完全一致（回归验证）。
  - 触发一次压缩摘要（用长对话），确认非 OpenRouter provider 下 summarizer fetch 也走兼容层、不报 `reasoning` 相关错误。

## 相关

- Follow-up to #347（provider 抽象）、#348（JWT 修复）。

https://claude.ai/code/session_016VtBbBiCF8uxDrjET6TPDq