### PR TITLE
fix(edge-function): drop top_p for AiHubMix+Claude to satisfy Anthropic exclusive rule

### DIFF
--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -266,6 +266,17 @@ const buildProviderRequestPayload = (
     }
     // AiHubMix documents GPT-5 as a reasoning-oriented family with
     // temperature/top_p no longer supported on the standard path.
+  } else if (isAiHubMix && isClaudeModel) {
+    // AiHubMix's Claude bridge enforces Anthropic Messages API semantics,
+    // which forbid specifying both `temperature` and `top_p` in the same
+    // request. Prefer `temperature` (the more commonly set control) and
+    // drop `top_p` to avoid the `invalid_request_error`.
+    if (temperature !== undefined) {
+      basePayload.temperature = temperature
+    }
+    if (max_tokens !== undefined) {
+      basePayload.max_tokens = max_tokens
+    }
   } else {
     if (temperature !== undefined) {
       basePayload.temperature = temperature


### PR DESCRIPTION
### Motivation
- 部署 AiHubMix 兼容热修补后，AiHubMix + Claude 请求收到后端错误：`temperature and top_p cannot both be specified for this model. Please use only one.`
- 根因是 AiHubMix 的 Claude 桥接遵循 Anthropic Messages API 语义，而该 API 禁止在同一请求中同时指定 `temperature` 与 `top_p`，现有逻辑把两者都透传给了后端。

### Description
- 在 `supabase/functions/openrouter-chat/index.ts` 的 `buildProviderRequestPayload` 中，在现有 `isAiHubMix && isGpt5Family` 分支与默认 `else` 之间新增 `else if (isAiHubMix && isClaudeModel)` 分支以单独处理 AiHubMix+Claude 场景。
- 对 AiHubMix+Claude 分支的行为是优先保留 `temperature`（如果存在）并显式不写入 `top_p`，同时保留 `max_tokens` 映射；其它分支行为不变。
- 此次改动仅修改了 `buildProviderRequestPayload` 相关逻辑，未触碰 `normalizeModelIdForProvider` / `normalizeProviderName` / `isClaudeModelId` / `isGpt5FamilyModelId`、`buildUpstreamHeaders`、授权、注入或前端/DB schema 等禁止修改的部分。
- 已在 PR 描述中包含变更前/变更后说明及已知局限：这是兼容层的一次针对性修复，如果继续出现错误说明 AiHubMix 的 Claude 桥接仍有未替换的 Anthropic 语义需要进一步处理。

### Testing
- 运行 `npm run build`（内部包含 `tsc -b && vite build`）通过且没有 TypeScript 编译错误。
- 变更已提交并生成 Draft PR（标题为 `fix(edge-function): drop top_p for AiHubMix+Claude to satisfy Anthropic exclusive rule`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fba6c0a48330b1d526881f9c4543)