### PR TITLE
Add 仓鼠机 (🎛️) frontend panel with Supabase controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ import RagSettingsPage from './pages/RagSettingsPage'
 import StoryGroupPage from './pages/StoryGroupPage'
 import MemoPage from './pages/MemoPage'
 import TimelinePage from './pages/TimelinePage'
+import HamsterConsolePage from './pages/HamsterConsolePage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1945,6 +1946,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <TimelinePage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/hamster-console"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <HamsterConsolePage user={user} />
             </RequireAuth>
           }
         />

--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -1,0 +1,244 @@
+.hamster-console-page {
+  min-height: 100%;
+  padding: 1rem;
+  padding-bottom: calc(1.5rem + env(safe-area-inset-bottom));
+  color: #111827;
+}
+
+.hamster-console-page__header {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.hamster-console-page__header h1 {
+  margin: 0;
+  font-size: clamp(1.4rem, 5vw, 1.9rem);
+}
+
+.hamster-console-page__header p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.92rem;
+}
+
+.hamster-console-page__back {
+  width: fit-content;
+  text-decoration: none;
+  color: #374151;
+  font-weight: 600;
+}
+
+.hamster-console-alert,
+.hamster-console-toast,
+.hamster-console-loading {
+  border-radius: 14px;
+  padding: 0.65rem 0.8rem;
+  margin-bottom: 0.8rem;
+}
+
+.hamster-console-alert {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.hamster-console-toast {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.hamster-console-loading {
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.hamster-console-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.hamster-console-card {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.hamster-console-card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.hamster-console-card__hint {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.88rem;
+}
+
+.hamster-console-channel-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.hamster-console-channel-row {
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.hamster-console-channel-title {
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.hamster-console-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.hamster-toggle {
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: #fff;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+}
+
+.hamster-toggle.enabled {
+  background: #dcfce7;
+  border-color: #86efac;
+  color: #14532d;
+}
+
+.hamster-console-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 0.6rem;
+}
+
+.hamster-console-input {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: #4b5563;
+}
+
+.hamster-console-json,
+.hamster-console-template-editor {
+  width: 100%;
+  resize: vertical;
+}
+
+.hamster-console-template-list {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
+}
+
+.hamster-template-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.5rem 0.65rem;
+  min-width: 128px;
+  text-align: left;
+  display: grid;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.hamster-template-item.active {
+  border-color: #f9a8d4;
+  box-shadow: 0 0 0 2px rgba(249, 168, 212, 0.22);
+}
+
+.hamster-template-item small {
+  color: #6b7280;
+}
+
+.hamster-console-template-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.hamster-console-section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.hamster-console-command-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.hamster-command-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.hamster-command-header {
+  width: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  padding: 0.6rem;
+  display: grid;
+  gap: 0.3rem;
+  grid-template-columns: 1.1fr auto auto auto;
+  align-items: center;
+}
+
+.hamster-command-status {
+  border-radius: 999px;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.78rem;
+}
+
+.hamster-command-status.pending { background: #fef3c7; color: #92400e; }
+.hamster-command-status.running { background: #dbeafe; color: #1d4ed8; }
+.hamster-command-status.done { background: #dcfce7; color: #166534; }
+.hamster-command-status.failed { background: #fee2e2; color: #b91c1c; }
+
+.hamster-command-body {
+  padding: 0.2rem 0.6rem 0.7rem;
+}
+
+.hamster-command-body h4 {
+  margin: 0.35rem 0;
+  font-size: 0.83rem;
+  color: #4b5563;
+}
+
+.hamster-command-body pre {
+  margin: 0;
+  background: #111827;
+  color: #f9fafb;
+  border-radius: 10px;
+  padding: 0.55rem;
+  overflow: auto;
+  font-size: 0.76rem;
+}
+
+@media (max-width: 680px) {
+  .hamster-console-page {
+    padding: 0.8rem;
+  }
+
+  .hamster-console-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hamster-console-channel-row,
+  .hamster-command-header {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -1,0 +1,527 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { Link } from 'react-router-dom'
+import { supabase } from '../supabase/client'
+import './HamsterConsolePage.css'
+
+type ChannelConfigRow = {
+  user_id: string
+  channel_name: string
+  active_model: string | null
+}
+
+type AgentSettingsRow = {
+  user_id: string
+  checkin_enabled: boolean
+  day_mode_start_hour: number | null
+  day_mode_end_hour: number | null
+  day_min_interval_minutes: number | null
+  day_max_interval_minutes: number | null
+  night_mode_start_hour: number | null
+  night_mode_end_hour: number | null
+  night_min_interval_minutes: number | null
+  night_max_interval_minutes: number | null
+  quiet_hours_start_hour: number | null
+  quiet_hours_end_hour: number | null
+  cooldown_after_interaction_minutes: number | null
+  max_daily_checkins_day: number | null
+  max_daily_checkins_night: number | null
+  per_channel_schedule: Record<string, unknown> | null
+}
+
+type PromptTemplateRow = {
+  id: string
+  name: string
+  category: 'base' | 'scenario' | 'style' | string
+  content: string
+  version: number | null
+  active: boolean
+}
+
+type SyzygyCommandRow = {
+  id: string
+  command_type: string
+  status: string
+  payload: unknown
+  result: unknown
+  created_at: string
+  completed_at: string | null
+}
+
+const TARGET_USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'
+
+const MODEL_OPTIONS = [
+  'openai/gpt-4.1-mini',
+  'openai/gpt-4.1',
+  'openai/gpt-5',
+  'anthropic/claude-sonnet-4.5',
+  'anthropic/claude-opus-4.7',
+  'anthropic/claude-haiku-4.5',
+  'google/gemini-2.5-pro',
+]
+
+const categoryLabelMap: Record<string, string> = {
+  base: '基础',
+  scenario: '场景',
+  style: '风格',
+}
+
+const formatDateTime = (value: string | null) => {
+  if (!value) return '--'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+const parseNumberField = (value: string, fallback: number | null = null) => {
+  if (value.trim() === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const HamsterConsolePage = ({ user }: { user: User | null }) => {
+  const scopedUserId = user?.id ?? TARGET_USER_ID
+  const [loading, setLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  const [channels, setChannels] = useState<ChannelConfigRow[]>([])
+  const [savingChannelName, setSavingChannelName] = useState<string | null>(null)
+
+  const [agentSettings, setAgentSettings] = useState<AgentSettingsRow | null>(null)
+  const [agentForm, setAgentForm] = useState<Record<string, string>>({})
+  const [perChannelScheduleText, setPerChannelScheduleText] = useState('{}')
+  const [savingAgentSettings, setSavingAgentSettings] = useState(false)
+
+  const [promptTemplates, setPromptTemplates] = useState<PromptTemplateRow[]>([])
+  const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null)
+  const [templateDraft, setTemplateDraft] = useState('')
+  const [savingTemplateId, setSavingTemplateId] = useState<string | null>(null)
+
+  const [commands, setCommands] = useState<SyzygyCommandRow[]>([])
+  const [expandedCommandId, setExpandedCommandId] = useState<string | null>(null)
+  const [commandsLoading, setCommandsLoading] = useState(false)
+
+  const activeTemplate = useMemo(
+    () => promptTemplates.find((item) => item.id === activeTemplateId) ?? null,
+    [promptTemplates, activeTemplateId],
+  )
+
+  const showToast = useCallback((message: string) => {
+    setToast(message)
+    window.setTimeout(() => {
+      setToast((current) => (current === message ? null : current))
+    }, 2200)
+  }, [])
+
+  const loadCommands = useCallback(async () => {
+    if (!supabase) {
+      setErrorMessage('Supabase 未配置，请检查环境变量。')
+      return
+    }
+    setCommandsLoading(true)
+    const { data, error } = await supabase
+      .from('syzygy_commands')
+      .select('id, command_type, status, payload, result, created_at, completed_at')
+      .eq('user_id', scopedUserId)
+      .order('created_at', { ascending: false })
+      .limit(20)
+
+    if (error) {
+      setErrorMessage(error.message)
+      setCommandsLoading(false)
+      return
+    }
+
+    setCommands(data ?? [])
+    setCommandsLoading(false)
+  }, [scopedUserId])
+
+  const loadAll = useCallback(async () => {
+    if (!supabase) {
+      setErrorMessage('Supabase 未配置，请检查环境变量。')
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setErrorMessage(null)
+
+    const [channelRes, settingsRes, templateRes, commandsRes] = await Promise.all([
+      supabase
+        .from('channel_config')
+        .select('user_id, channel_name, active_model')
+        .eq('user_id', scopedUserId)
+        .order('channel_name', { ascending: true }),
+      supabase
+        .from('agent_settings')
+        .select(
+          'user_id, checkin_enabled, day_mode_start_hour, day_mode_end_hour, day_min_interval_minutes, day_max_interval_minutes, night_mode_start_hour, night_mode_end_hour, night_min_interval_minutes, night_max_interval_minutes, quiet_hours_start_hour, quiet_hours_end_hour, cooldown_after_interaction_minutes, max_daily_checkins_day, max_daily_checkins_night, per_channel_schedule',
+        )
+        .eq('user_id', scopedUserId)
+        .maybeSingle(),
+      supabase
+        .from('prompt_templates')
+        .select('id, name, category, content, version, active')
+        .eq('user_id', scopedUserId)
+        .eq('active', true)
+        .order('name', { ascending: true }),
+      supabase
+        .from('syzygy_commands')
+        .select('id, command_type, status, payload, result, created_at, completed_at')
+        .eq('user_id', scopedUserId)
+        .order('created_at', { ascending: false })
+        .limit(20),
+    ])
+
+    if (channelRes.error || settingsRes.error || templateRes.error || commandsRes.error) {
+      setErrorMessage(
+        channelRes.error?.message ||
+          settingsRes.error?.message ||
+          templateRes.error?.message ||
+          commandsRes.error?.message ||
+          '加载失败',
+      )
+      setLoading(false)
+      return
+    }
+
+    const channelRows = channelRes.data ?? []
+    setChannels(channelRows)
+
+    const settingsRow = settingsRes.data
+    setAgentSettings(settingsRow)
+    if (settingsRow) {
+      setAgentForm({
+        day_mode_start_hour: String(settingsRow.day_mode_start_hour ?? 8),
+        day_mode_end_hour: String(settingsRow.day_mode_end_hour ?? 23),
+        day_min_interval_minutes: String(settingsRow.day_min_interval_minutes ?? 3),
+        day_max_interval_minutes: String(settingsRow.day_max_interval_minutes ?? 60),
+        night_mode_start_hour: String(settingsRow.night_mode_start_hour ?? 23),
+        night_mode_end_hour: String(settingsRow.night_mode_end_hour ?? 8),
+        night_min_interval_minutes: String(settingsRow.night_min_interval_minutes ?? 60),
+        night_max_interval_minutes: String(settingsRow.night_max_interval_minutes ?? 180),
+        quiet_hours_start_hour: settingsRow.quiet_hours_start_hour == null ? '' : String(settingsRow.quiet_hours_start_hour),
+        quiet_hours_end_hour: settingsRow.quiet_hours_end_hour == null ? '' : String(settingsRow.quiet_hours_end_hour),
+        cooldown_after_interaction_minutes: String(settingsRow.cooldown_after_interaction_minutes ?? 15),
+        max_daily_checkins_day: String(settingsRow.max_daily_checkins_day ?? 10),
+        max_daily_checkins_night: String(settingsRow.max_daily_checkins_night ?? 3),
+      })
+      setPerChannelScheduleText(JSON.stringify(settingsRow.per_channel_schedule ?? {}, null, 2))
+    }
+
+    const templates = templateRes.data ?? []
+    setPromptTemplates(templates)
+    const firstTemplate = templates[0] ?? null
+    setActiveTemplateId(firstTemplate?.id ?? null)
+    setTemplateDraft(firstTemplate?.content ?? '')
+
+    setCommands(commandsRes.data ?? [])
+
+    setLoading(false)
+  }, [scopedUserId])
+
+  useEffect(() => {
+    void loadAll()
+  }, [loadAll])
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      void loadCommands()
+    }, 30_000)
+
+    return () => window.clearInterval(timer)
+  }, [loadCommands])
+
+  const handleChannelModelChange = (channelName: string, model: string) => {
+    setChannels((current) =>
+      current.map((row) => (row.channel_name === channelName ? { ...row, active_model: model } : row)),
+    )
+  }
+
+  const handleSaveChannelModel = async (channelName: string) => {
+    if (!supabase) return
+    const row = channels.find((item) => item.channel_name === channelName)
+    if (!row?.active_model) return
+
+    setSavingChannelName(channelName)
+    const { error } = await supabase
+      .from('channel_config')
+      .update({ active_model: row.active_model })
+      .eq('user_id', scopedUserId)
+      .eq('channel_name', channelName)
+
+    setSavingChannelName(null)
+    if (error) {
+      setErrorMessage(error.message)
+      return
+    }
+
+    showToast(`模型已更新：${channelName}`)
+  }
+
+  const handleAgentFieldChange = (field: string, value: string) => {
+    setAgentForm((current) => ({ ...current, [field]: value }))
+  }
+
+  const handleSaveAgentSettings = async () => {
+    if (!supabase || !agentSettings) return
+
+    let parsedSchedule: Record<string, unknown> | null = null
+    if (perChannelScheduleText.trim()) {
+      try {
+        parsedSchedule = JSON.parse(perChannelScheduleText) as Record<string, unknown>
+      } catch {
+        setErrorMessage('每渠道计划 JSON 解析失败，请检查格式。')
+        return
+      }
+    }
+
+    setSavingAgentSettings(true)
+    const { error } = await supabase
+      .from('agent_settings')
+      .update({
+        checkin_enabled: agentSettings.checkin_enabled,
+        day_mode_start_hour: parseNumberField(agentForm.day_mode_start_hour, 8),
+        day_mode_end_hour: parseNumberField(agentForm.day_mode_end_hour, 23),
+        day_min_interval_minutes: parseNumberField(agentForm.day_min_interval_minutes, 3),
+        day_max_interval_minutes: parseNumberField(agentForm.day_max_interval_minutes, 60),
+        night_mode_start_hour: parseNumberField(agentForm.night_mode_start_hour, 23),
+        night_mode_end_hour: parseNumberField(agentForm.night_mode_end_hour, 8),
+        night_min_interval_minutes: parseNumberField(agentForm.night_min_interval_minutes, 60),
+        night_max_interval_minutes: parseNumberField(agentForm.night_max_interval_minutes, 180),
+        quiet_hours_start_hour: parseNumberField(agentForm.quiet_hours_start_hour),
+        quiet_hours_end_hour: parseNumberField(agentForm.quiet_hours_end_hour),
+        cooldown_after_interaction_minutes: parseNumberField(agentForm.cooldown_after_interaction_minutes, 15),
+        max_daily_checkins_day: parseNumberField(agentForm.max_daily_checkins_day, 10),
+        max_daily_checkins_night: parseNumberField(agentForm.max_daily_checkins_night, 3),
+        per_channel_schedule: parsedSchedule,
+      })
+      .eq('user_id', scopedUserId)
+
+    setSavingAgentSettings(false)
+    if (error) {
+      setErrorMessage(error.message)
+      return
+    }
+
+    showToast('主动消息设置已保存')
+  }
+
+  const handleSelectTemplate = (templateId: string) => {
+    const template = promptTemplates.find((item) => item.id === templateId)
+    setActiveTemplateId(templateId)
+    setTemplateDraft(template?.content ?? '')
+  }
+
+  const handleSaveTemplate = async () => {
+    if (!supabase || !activeTemplate) return
+    setSavingTemplateId(activeTemplate.id)
+
+    const { error } = await supabase
+      .from('prompt_templates')
+      .update({ content: templateDraft })
+      .eq('id', activeTemplate.id)
+      .eq('user_id', scopedUserId)
+
+    setSavingTemplateId(null)
+    if (error) {
+      setErrorMessage(error.message)
+      return
+    }
+
+    setPromptTemplates((current) =>
+      current.map((item) => (item.id === activeTemplate.id ? { ...item, content: templateDraft } : item)),
+    )
+    showToast(`Prompt 已保存：${activeTemplate.name}`)
+  }
+
+  return (
+    <div className="hamster-console-page">
+      <header className="hamster-console-page__header">
+        <Link to="/" className="hamster-console-page__back">← 返回小窝</Link>
+        <h1 className="ui-title">🎛️ 仓鼠机</h1>
+        <p>远程控制 Mini Agent（用户：{scopedUserId.slice(0, 8)}...）</p>
+      </header>
+
+      {errorMessage ? <div className="hamster-console-alert">{errorMessage}</div> : null}
+      {toast ? <div className="hamster-console-toast">{toast}</div> : null}
+
+      {loading ? <div className="hamster-console-loading">正在加载仓鼠机面板...</div> : null}
+
+      {!loading ? (
+        <main className="hamster-console-grid">
+          <section className="hamster-console-card glass-card" aria-label="模型切换">
+            <h2>模型切换</h2>
+            <p className="hamster-console-card__hint">按渠道配置 active_model，保存后立即生效。</p>
+            <div className="hamster-console-channel-list">
+              {channels.map((row) => (
+                <div className="hamster-console-channel-row" key={row.channel_name}>
+                  <div className="hamster-console-channel-title">{row.channel_name}</div>
+                  <select
+                    className="input-glass"
+                    value={row.active_model ?? MODEL_OPTIONS[0]}
+                    onChange={(event) => handleChannelModelChange(row.channel_name, event.target.value)}
+                  >
+                    {MODEL_OPTIONS.map((model) => (
+                      <option key={model} value={model}>{model}</option>
+                    ))}
+                  </select>
+                  <button
+                    className="btn-primary"
+                    onClick={() => void handleSaveChannelModel(row.channel_name)}
+                    disabled={savingChannelName === row.channel_name}
+                  >
+                    {savingChannelName === row.channel_name ? '保存中...' : '保存'}
+                  </button>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="hamster-console-card glass-card" aria-label="主动消息控制">
+            <h2>主动消息</h2>
+            <div className="hamster-console-toggle">
+              <span>checkin_enabled</span>
+              <button
+                className={`hamster-toggle ${agentSettings?.checkin_enabled ? 'enabled' : ''}`}
+                onClick={() =>
+                  setAgentSettings((current) => (current ? { ...current, checkin_enabled: !current.checkin_enabled } : current))
+                }
+                disabled={!agentSettings}
+              >
+                {agentSettings?.checkin_enabled ? '开启' : '关闭'}
+              </button>
+            </div>
+
+            <div className="hamster-console-form-grid">
+              {[
+                ['day_mode_start_hour', '日间开始'],
+                ['day_mode_end_hour', '日间结束'],
+                ['day_min_interval_minutes', '日间最小间隔(分)'],
+                ['day_max_interval_minutes', '日间最大间隔(分)'],
+                ['night_mode_start_hour', '夜间开始'],
+                ['night_mode_end_hour', '夜间结束'],
+                ['night_min_interval_minutes', '夜间最小间隔(分)'],
+                ['night_max_interval_minutes', '夜间最大间隔(分)'],
+                ['quiet_hours_start_hour', '静默开始(可空)'],
+                ['quiet_hours_end_hour', '静默结束(可空)'],
+                ['cooldown_after_interaction_minutes', '互动后冷却(分)'],
+                ['max_daily_checkins_day', '日间每天上限'],
+                ['max_daily_checkins_night', '夜间每天上限'],
+              ].map(([field, label]) => (
+                <label className="hamster-console-input" key={field}>
+                  <span>{label}</span>
+                  <input
+                    className="input-glass"
+                    type="number"
+                    inputMode="numeric"
+                    value={agentForm[field] ?? ''}
+                    onChange={(event) => handleAgentFieldChange(field, event.target.value)}
+                  />
+                </label>
+              ))}
+            </div>
+
+            <label className="hamster-console-input">
+              <span>每渠道计划（JSON）</span>
+              <textarea
+                className="textarea-glass hamster-console-json"
+                rows={7}
+                value={perChannelScheduleText}
+                onChange={(event) => setPerChannelScheduleText(event.target.value)}
+              />
+            </label>
+
+            <button className="btn-primary" onClick={() => void handleSaveAgentSettings()} disabled={savingAgentSettings || !agentSettings}>
+              {savingAgentSettings ? '保存中...' : '保存主动消息设置'}
+            </button>
+          </section>
+
+          <section className="hamster-console-card glass-card" aria-label="Prompt 编辑器">
+            <h2>Prompt 编辑器</h2>
+            <div className="hamster-console-template-list">
+              {promptTemplates.map((template) => {
+                const isActive = template.id === activeTemplateId
+                return (
+                  <button
+                    key={template.id}
+                    className={`hamster-template-item ${isActive ? 'active' : ''}`}
+                    onClick={() => handleSelectTemplate(template.id)}
+                  >
+                    <span>{template.name}</span>
+                    <small>{categoryLabelMap[template.category] ?? template.category}</small>
+                  </button>
+                )
+              })}
+            </div>
+
+            {activeTemplate ? (
+              <>
+                <div className="hamster-console-template-meta">
+                  <span>{activeTemplate.name}</span>
+                  <span>v{activeTemplate.version ?? '-'}</span>
+                </div>
+                <textarea
+                  className="textarea-glass hamster-console-template-editor"
+                  rows={12}
+                  value={templateDraft}
+                  onChange={(event) => setTemplateDraft(event.target.value)}
+                />
+                <button className="btn-primary" onClick={() => void handleSaveTemplate()} disabled={savingTemplateId === activeTemplate.id}>
+                  {savingTemplateId === activeTemplate.id ? '保存中...' : '保存 Prompt'}
+                </button>
+              </>
+            ) : (
+              <p className="hamster-console-card__hint">暂无 active prompt 模板。</p>
+            )}
+          </section>
+
+          <section className="hamster-console-card glass-card" aria-label="指令记录">
+            <div className="hamster-console-section-title">
+              <h2>指令记录</h2>
+              <button className="btn-secondary" onClick={() => void loadCommands()} disabled={commandsLoading}>
+                {commandsLoading ? '刷新中...' : '手动刷新'}
+              </button>
+            </div>
+            <p className="hamster-console-card__hint">自动每 30 秒刷新一次，展示最近 20 条。</p>
+            <div className="hamster-console-command-list">
+              {commands.map((command) => {
+                const expanded = expandedCommandId === command.id
+                return (
+                  <article key={command.id} className="hamster-command-item">
+                    <button
+                      className="hamster-command-header"
+                      onClick={() => setExpandedCommandId(expanded ? null : command.id)}
+                    >
+                      <strong>{command.command_type}</strong>
+                      <span className={`hamster-command-status ${command.status}`}>{command.status}</span>
+                      <span>{formatDateTime(command.created_at)}</span>
+                      <span>{formatDateTime(command.completed_at)}</span>
+                    </button>
+                    {expanded ? (
+                      <div className="hamster-command-body">
+                        <h4>payload</h4>
+                        <pre>{JSON.stringify(command.payload ?? {}, null, 2)}</pre>
+                        <h4>result</h4>
+                        <pre>{JSON.stringify(command.result ?? {}, null, 2)}</pre>
+                      </div>
+                    ) : null}
+                  </article>
+                )
+              })}
+              {commands.length === 0 ? <p className="hamster-console-card__hint">暂无指令记录。</p> : null}
+            </div>
+          </section>
+        </main>
+      ) : null}
+    </div>
+  )
+}
+
+export default HamsterConsolePage

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "rag", "memo", "timeline"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "rag", "memo", "timeline", "hamster-console"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -267,6 +267,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "rag", defaultEmoji: "🔮", label: "记忆引擎", route: "/rag-settings" },
       { id: "memo", defaultEmoji: "📝", label: "备忘录", route: "/memo" },
       { id: "timeline", defaultEmoji: "🗓️", label: "时间轴", route: "/timeline" },
+      { id: "hamster-console", defaultEmoji: "🎛️", label: "仓鼠机", route: "/hamster-console" },
     ],
     [onOpenChat],
   );


### PR DESCRIPTION
### Motivation
- Provide 串串 a browser-accessible control panel named “仓鼠机” to remotely read/update Mini Agent runtime configuration via Supabase without adding any backend code. 
- Surface model selection, proactive checkin scheduling, prompt templates and recent commands so the local Mini Agent can react instantly to changes by reading the same Supabase tables. 
- Integrate the panel into the existing Pages 2 launcher/tab pattern so it is reachable from the app home UI. 

### Description
- Added a new page component `src/pages/HamsterConsolePage.tsx` and styles `src/pages/HamsterConsolePage.css` implementing four panels backed by Supabase: 模型切换 (`channel_config`), 主动消息 (`agent_settings`), Prompt 编辑器 (`prompt_templates`), and 指令记录 (`syzygy_commands`) with 30s auto-refresh and manual refresh. 
- Registered the route `/hamster-console` in `src/App.tsx` and added a new emoji app icon entry (`🎛️ 仓鼠机`) to Page 2 in `src/pages/HomePage.tsx` so the panel follows the existing tab/icon launcher pattern. 
- Implemented client-side Supabase reads and `UPDATE` writes (no table schema changes, no backend or Edge Functions), scoped to the configured user ID (`TARGET_USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'`), and hardcoded model options in `MODEL_OPTIONS`. 
- UX details include Chinese labels, mobile-friendly responsive layout, loading/saving states, toast notifications on successful saves, expandable JSON payload/result rendering, and status color-coding for command statuses. 

### Testing
- Ran the full production build via `npm run build` which executed TypeScript compilation and Vite bundling and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a6c317f48330abb42e9037b76bfc)