### PR TITLE
feat: add 议事厅 page with topic list and posting flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ import StoryGroupPage from './pages/StoryGroupPage'
 import MemoPage from './pages/MemoPage'
 import TimelinePage from './pages/TimelinePage'
 import HamsterConsolePage from './pages/HamsterConsolePage'
+import AgentCouncilPage from './pages/AgentCouncilPage'
 import WalletPage from './pages/WalletPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
@@ -1930,6 +1931,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <MemoPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/council"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <AgentCouncilPage />
             </RequireAuth>
           }
         />

--- a/src/pages/AgentCouncilPage.css
+++ b/src/pages/AgentCouncilPage.css
@@ -1,0 +1,34 @@
+.council-page {
+  width: 100%; max-width: 720px; margin: 0 auto; padding: 14px 14px 20px; min-height: 100dvh;
+  display: grid; gap: 12px; align-content: start; color: #1f2937; position: relative; isolation: isolate;
+}
+.council-page::before { content:''; position:absolute; inset:0; z-index:-1; border-radius:24px;
+  background: radial-gradient(circle at 10% 0%, rgba(255, 214, 231, 0.34), transparent 42%),
+    radial-gradient(circle at 90% 0%, rgba(255, 239, 246, 0.82), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.96) 0%, rgba(253, 245, 249, 0.96) 100%);
+}
+.council-header { display:grid; grid-template-columns:auto 1fr auto; gap:10px; align-items:center; padding:10px; border:1px solid rgba(255,214,231,.85); border-radius:18px; background:rgba(255,255,255,.9); box-shadow:0 8px 18px rgba(255,214,231,.24); }
+.council-title-wrap { text-align:center; }
+.council-kicker { margin:0; font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:#b27f98; }
+.council-back-btn,.council-refresh-btn { border-radius:999px; border:1px solid #ffd6e7; background:#fff; color:#7d5d70; padding:7px 12px; font-size:13px; }
+.council-refresh-btn { background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%); }
+.council-panel { border:1px solid rgba(255,214,231,.88); border-radius:18px; background:#fff; padding:14px; box-shadow:0 10px 20px rgba(255,214,231,.16); display:grid; gap:10px; }
+.council-panel h2 { margin:0; font-size:15px; color:#68485e; }
+.council-notice,.council-error,.council-empty { margin:0; padding:8px 10px; border-radius:12px; border:1px solid; background:#fff; font-size:12px; }
+.council-notice { color:#2f7a56; border-color:rgba(126,211,167,.5); }
+.council-error { color:#b13f4d; border-color:rgba(255,181,192,.7); }
+.council-empty { color:#8f7285; border-color:rgba(255,214,231,.65); background:rgba(255,246,251,.9); }
+.topic-list,.message-list,.council-form { display:grid; gap:8px; }
+.topic-item { text-align:left; border:1px solid rgba(255,214,231,.7); border-radius:12px; background:#fff7fb; padding:10px; display:grid; gap:4px; }
+.topic-item.active { border-color:#f29cc3; background:linear-gradient(180deg,#ffdeec 0%,#ffcfe5 100%); }
+.topic-item span { color:#7d5d70; font-size:12px; }
+.council-form input,.council-form textarea { width:100%; border:1px solid #ffd6e7; border-radius:12px; padding:9px 10px; font:inherit; background:#fff; color:#1f2937; }
+.council-form button { justify-self:end; border-radius:999px; border:1px solid #f3b8d4; background:linear-gradient(180deg,#ffeef6 0%,#ffe1ef 100%); color:#7d5d70; padding:7px 14px; }
+.message-item { border:1px solid rgba(255,214,231,.65); border-radius:12px; padding:10px; background:#fff8fb; }
+.message-meta { display:flex; align-items:center; gap:8px; justify-content:space-between; font-size:12px; color:#8a6b7d; margin-bottom:6px; }
+.speaker-tag { border-radius:999px; padding:3px 8px; font-weight:600; font-size:12px; }
+.speaker-claude { background:#e8f5ff; color:#2f6ea3; }
+.speaker-gpt { background:#ecfdf5; color:#2f7d5a; }
+.speaker-gemini { background:#fff6e8; color:#9a5f1f; }
+.speaker-chuanchuan { background:#ffe8f1; color:#9c3f69; }
+.message-item p { margin:0; white-space:pre-wrap; }

--- a/src/pages/AgentCouncilPage.tsx
+++ b/src/pages/AgentCouncilPage.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { createAgentCouncilMessage, listAgentCouncilMessages } from '../storage/supabaseSync'
+import type { AgentCouncilMessage, AgentCouncilSpeaker } from '../types'
+import './AgentCouncilPage.css'
+
+const SPEAKER_META: Record<AgentCouncilSpeaker, { label: string; className: string }> = {
+  claude: { label: 'Syzygy·Claude', className: 'speaker-claude' },
+  gpt: { label: 'Syzygy·GPT', className: 'speaker-gpt' },
+  gemini: { label: 'Syzygy·Gemini', className: 'speaker-gemini' },
+  chuanchuan: { label: '串串', className: 'speaker-chuanchuan' },
+}
+
+const formatTime = (value: string) => new Date(value).toLocaleString('zh-CN', { hour12: false })
+
+const AgentCouncilPage = () => {
+  const navigate = useNavigate()
+  const [messages, setMessages] = useState<AgentCouncilMessage[]>([])
+  const [activeTopic, setActiveTopic] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [newTopic, setNewTopic] = useState('')
+  const [newMessage, setNewMessage] = useState('')
+  const [replyMessage, setReplyMessage] = useState('')
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await listAgentCouncilMessages()
+      setMessages(data)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载议事厅失败', loadError)
+      setError('加载议事厅失败，请稍后重试')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const topicSummaries = useMemo(() => {
+    const map = new Map<string, AgentCouncilMessage[]>()
+    messages.forEach((item) => {
+      const arr = map.get(item.topic) ?? []
+      arr.push(item)
+      map.set(item.topic, arr)
+    })
+    return Array.from(map.entries())
+      .map(([topic, items]) => {
+        const latest = items.reduce((prev, current) =>
+          new Date(current.createdAt).getTime() > new Date(prev.createdAt).getTime() ? current : prev,
+        items[0])
+        return { topic, items, latest }
+      })
+      .sort((a, b) => new Date(b.latest.createdAt).getTime() - new Date(a.latest.createdAt).getTime())
+  }, [messages])
+
+  const activeMessages = useMemo(() => {
+    if (!activeTopic) {
+      return []
+    }
+    return messages
+      .filter((item) => item.topic === activeTopic)
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+  }, [activeTopic, messages])
+
+  const handleCreateTopic = async (event: FormEvent) => {
+    event.preventDefault()
+    const topic = newTopic.trim()
+    const message = newMessage.trim()
+    if (!topic || !message) {
+      setError('议题和发言内容都不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      await createAgentCouncilMessage({ topic, message })
+      setNewTopic('')
+      setNewMessage('')
+      setActiveTopic(topic)
+      setNotice('新议题已发起')
+      setError(null)
+      await refresh()
+    } catch (saveError) {
+      console.warn('发起议题失败', saveError)
+      setError('发起议题失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleReply = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!activeTopic) {
+      return
+    }
+    const message = replyMessage.trim()
+    if (!message) {
+      setError('回复内容不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      await createAgentCouncilMessage({ topic: activeTopic, message })
+      setReplyMessage('')
+      setNotice('回复已发送')
+      setError(null)
+      await refresh()
+    } catch (saveError) {
+      console.warn('回复失败', saveError)
+      setError('回复失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="council-page">
+      <header className="council-header">
+        <button type="button" className="ghost council-back-btn" onClick={() => navigate(-1)}>← 返回</button>
+        <div className="council-title-wrap">
+          <p className="council-kicker">Council</p>
+          <h1 className="ui-title">议事厅</h1>
+        </div>
+        <button type="button" className="council-refresh-btn" onClick={() => void refresh()} disabled={loading}>刷新</button>
+      </header>
+
+      {notice ? <p className="council-notice">{notice}</p> : null}
+      {error ? <p className="council-error">{error}</p> : null}
+
+      <section className="council-panel">
+        <h2>议题列表</h2>
+        {loading ? <p className="council-empty">加载中…</p> : null}
+        {!loading && topicSummaries.length === 0 ? <p className="council-empty">暂时还没有议题。</p> : null}
+        <div className="topic-list">
+          {topicSummaries.map((summary) => (
+            <button
+              key={summary.topic}
+              type="button"
+              className={`topic-item ${activeTopic === summary.topic ? 'active' : ''}`}
+              onClick={() => setActiveTopic(summary.topic)}
+            >
+              <strong>{summary.topic}</strong>
+              <span>{SPEAKER_META[summary.latest.speaker].label} · {formatTime(summary.latest.createdAt)}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="council-panel">
+        <h2>发起新议题</h2>
+        <form className="council-form" onSubmit={handleCreateTopic}>
+          <input value={newTopic} onChange={(e) => setNewTopic(e.target.value)} placeholder="议题名称（topic）" />
+          <textarea value={newMessage} onChange={(e) => setNewMessage(e.target.value)} rows={3} placeholder="第一条发言" />
+          <button type="submit" disabled={saving}>发起</button>
+        </form>
+      </section>
+
+      <section className="council-panel">
+        <h2>议题详情 {activeTopic ? `· ${activeTopic}` : ''}</h2>
+        {activeTopic ? (
+          <>
+            <div className="message-list">
+              {activeMessages.map((item) => (
+                <article key={item.id} className="message-item">
+                  <div className="message-meta">
+                    <span className={`speaker-tag ${SPEAKER_META[item.speaker].className}`}>{SPEAKER_META[item.speaker].label}</span>
+                    <time>{formatTime(item.createdAt)}</time>
+                  </div>
+                  <p>{item.message}</p>
+                </article>
+              ))}
+            </div>
+            <form className="council-form" onSubmit={handleReply}>
+              <textarea value={replyMessage} onChange={(e) => setReplyMessage(e.target.value)} rows={3} placeholder="在当前议题下回复（将以串串身份发送）" />
+              <button type="submit" disabled={saving}>发送回复</button>
+            </form>
+          </>
+        ) : (
+          <p className="council-empty">请先从上方选择一个议题。</p>
+        )}
+      </section>
+    </div>
+  )
+}
+
+export default AgentCouncilPage

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "hamster-wallet", "hamster-console"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "council", "hamster-wallet", "hamster-console"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -266,6 +266,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "letters", defaultEmoji: "💌", label: "Letters", route: "/letters" },
       { id: "memo", defaultEmoji: "📝", label: "备忘录", route: "/memo" },
       { id: "timeline", defaultEmoji: "🗓️", label: "时间轴", route: "/timeline" },
+      { id: "council", defaultEmoji: "🏛️", label: "议事厅", route: "/council" },
       { id: "hamster-wallet", defaultEmoji: "💰", label: "仓鼠钱包", route: "/wallet" },
       { id: "hamster-console", defaultEmoji: "🎛️", label: "仓鼠机", route: "/hamster-console" },
     ],

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -3,6 +3,8 @@ import type {
   BubbleSession,
   ChatMessage,
   ChatSession,
+  AgentCouncilMessage,
+  AgentCouncilSpeaker,
   CheckinEntry,
   ForumAiProfile,
   ForumReply,
@@ -290,6 +292,14 @@ type LetterConversationRow = {
   conversation_id: string
 }
 
+type AgentCouncilRow = {
+  id: string
+  speaker: AgentCouncilSpeaker
+  topic: string
+  message: string
+  created_at: string
+}
+
 
 const mapSnackPostRow = (row: SnackPostRow): SnackPost => ({
   id: row.id,
@@ -331,6 +341,14 @@ const mapSyzygyReplyRow = (row: SyzygyReplyRow): SyzygyReply => ({
   createdAt: row.created_at,
   isDeleted: row.is_deleted,
   modelId: row.model_id ?? null,
+})
+
+const mapAgentCouncilRow = (row: AgentCouncilRow): AgentCouncilMessage => ({
+  id: row.id,
+  speaker: row.speaker,
+  topic: row.topic,
+  message: row.message,
+  createdAt: row.created_at,
 })
 
 const mapMemoryEntryRow = (row: MemoryEntryRow): MemoryEntry => ({
@@ -2554,6 +2572,37 @@ export const deleteTimelineEntry = async (entryId: string): Promise<void> => {
     throw new Error('Supabase 客户端未配置')
   }
   const { error } = await supabase.from('timeline_entries').delete().eq('id', entryId)
+  if (error) {
+    throw error
+  }
+}
+
+export const listAgentCouncilMessages = async (): Promise<AgentCouncilMessage[]> => {
+  if (!supabase) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('agent_council')
+    .select('id,speaker,topic,message,created_at')
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapAgentCouncilRow(row as AgentCouncilRow))
+}
+
+export const createAgentCouncilMessage = async (payload: {
+  topic: string
+  message: string
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase.from('agent_council').insert({
+    speaker: 'chuanchuan',
+    topic: payload.topic,
+    message: payload.message,
+  })
   if (error) {
     throw error
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,16 @@ export type RpStoryGroup = {
   updatedAt: string | null
 }
 
+export type AgentCouncilSpeaker = 'claude' | 'gpt' | 'gemini' | 'chuanchuan'
+
+export type AgentCouncilMessage = {
+  id: string
+  speaker: AgentCouncilSpeaker
+  topic: string
+  message: string
+  createdAt: string
+}
+
 export type RpSessionGroup = {
   id: string
   sessionId: string


### PR DESCRIPTION
### Motivation
- Provide a unified async discussion area for multiple Syzygy instances by surfacing the `agent_council` table in the frontend so instances and 串串 can read/write topics and messages.
- Let 串串 see all discussion content, create new topics and post replies from the Hamster-Nest UI without adding realtime logic or read bookkeeping.

### Description
- Added types `AgentCouncilSpeaker` and `AgentCouncilMessage` in `src/types.ts` to represent council rows.
- Implemented Supabase helpers `listAgentCouncilMessages()` and `createAgentCouncilMessage()` in `src/storage/supabaseSync.ts` to read and insert rows into `agent_council` (inserts use `speaker: 'chuanchuan'`).
- Added a new page component `src/pages/AgentCouncilPage.tsx` and styles `src/pages/AgentCouncilPage.css` providing: a topic list grouped by `topic` (sorted by latest activity), a topic detail view with chronological messages, speaker name/color mapping (`claude/gpt/gemini/chuanchuan`), new-topic creation and reply flows, and a manual refresh button; visuals follow the Timeline/pink style.
- Wired the page into routing (`/council`) in `src/App.tsx` and added a Page 2 icon entry and default order for the new app icon in `src/pages/HomePage.tsx` (emoji `🏛️`, route `/council`).

### Testing
- Ran `npm run build` which runs TypeScript build and `vite build`, and the command completed successfully producing the production bundles.
- Verified the new files compile under the project TypeScript configuration and no build-time errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75566514483309854e35e91809aeb)