### PR TITLE
feat: 在仓鼠机页面新增 Codex 控制卡片并接入实时状态

### DIFF
--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -142,6 +142,35 @@
   font-size: 0.84rem;
 }
 
+.hamster-console-codex-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: fit-content;
+  padding: 0.42rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 231, 0.65);
+  background: rgba(255, 245, 250, 0.75);
+  color: #74596c;
+  font-weight: 600;
+}
+
+.hamster-console-codex-dot {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 50%;
+}
+
+.hamster-console-codex-dot.green { background: #26b673; }
+.hamster-console-codex-dot.gray { background: #a8a9b3; }
+.hamster-console-codex-dot.yellow { background: #f1ba3b; }
+
+.hamster-console-codex-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
 .hamster-console-channel-list {
   display: grid;
   gap: 0.6rem;

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -59,6 +59,19 @@ type ProviderModelRow = {
   enabled?: boolean | null
 }
 
+type CodexControlRow = {
+  id: string
+  action: 'wake' | 'sleep' | string
+  status: 'pending' | 'executed' | string
+  created_at: string
+}
+
+type CodexControlViewState = {
+  tone: 'green' | 'gray' | 'yellow'
+  label: string
+  isRunning: boolean
+}
+
 const TARGET_USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'
 
 const categoryLabelMap: Record<string, string> = {
@@ -83,6 +96,14 @@ const parseNumberField = (value: string, fallback: number | null = null) => {
   if (value.trim() === '') return null
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const toCodexControlViewState = (row: CodexControlRow | null): CodexControlViewState => {
+  if (!row) return { tone: 'gray', label: '已关闭', isRunning: false }
+  if (row.status === 'pending') return { tone: 'yellow', label: '执行中...', isRunning: row.action === 'wake' }
+  if (row.action === 'wake' && row.status === 'executed') return { tone: 'green', label: '运行中', isRunning: true }
+  if (row.action === 'sleep' && row.status === 'executed') return { tone: 'gray', label: '已关闭', isRunning: false }
+  return { tone: 'gray', label: '已关闭', isRunning: false }
 }
 
 const HamsterConsolePage = ({ user }: { user: User | null }) => {
@@ -112,11 +133,14 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const [expandedCommandId, setExpandedCommandId] = useState<string | null>(null)
   const [commandsLoading, setCommandsLoading] = useState(false)
   const [expandedSection, setExpandedSection] = useState('model-switching')
+  const [codexControlRow, setCodexControlRow] = useState<CodexControlRow | null>(null)
+  const [codexActionLoading, setCodexActionLoading] = useState<'wake' | 'sleep' | null>(null)
 
   const activeTemplate = useMemo(
     () => promptTemplates.find((item) => item.id === activeTemplateId) ?? null,
     [promptTemplates, activeTemplateId],
   )
+  const codexControlState = useMemo(() => toCodexControlViewState(codexControlRow), [codexControlRow])
 
   const modelOptions = useMemo(() => {
     const merged = new Set<string>(availableModels)
@@ -168,7 +192,7 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     setLoading(true)
     setErrorMessage(null)
 
-    const [channelRes, settingsRes, templateRes, commandsRes, modelRes] = await Promise.all([
+    const [channelRes, settingsRes, templateRes, commandsRes, modelRes, codexRes] = await Promise.all([
       supabase
         .from('channel_config')
         .select('user_id, channel_name, active_model')
@@ -198,15 +222,23 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
         .select('model_id')
         .eq('enabled', true)
         .order('model_id', { ascending: true }),
+      supabase
+        .from('codex_control')
+        .select('id, action, status, created_at')
+        .eq('user_id', scopedUserId)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
     ])
 
-    if (channelRes.error || settingsRes.error || templateRes.error || commandsRes.error || modelRes.error) {
+    if (channelRes.error || settingsRes.error || templateRes.error || commandsRes.error || modelRes.error || codexRes.error) {
       setErrorMessage(
         channelRes.error?.message ||
           settingsRes.error?.message ||
           templateRes.error?.message ||
           commandsRes.error?.message ||
           modelRes.error?.message ||
+          codexRes.error?.message ||
           '加载失败',
       )
       setLoading(false)
@@ -218,6 +250,7 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
 
     const modelRows = (modelRes.data ?? []) as ProviderModelRow[]
     setAvailableModels(modelRows.map((item) => item.model_id).filter((item) => item.trim().length > 0))
+    setCodexControlRow((codexRes.data as CodexControlRow | null) ?? null)
 
     const settingsRow = settingsRes.data
     setAgentSettings(settingsRow)
@@ -255,6 +288,45 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
 
     setLoading(false)
   }, [scopedUserId])
+
+  useEffect(() => {
+    if (!supabase) return
+    const client = supabase
+    const channel = client
+      .channel(`codex-control-${scopedUserId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'codex_control', filter: `user_id=eq.${scopedUserId}` },
+        () => {
+          void client
+            .from('codex_control')
+            .select('id, action, status, created_at')
+            .eq('user_id', scopedUserId)
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .maybeSingle()
+            .then(({ data }) => {
+              setCodexControlRow((data as CodexControlRow | null) ?? null)
+              setCodexActionLoading(null)
+            })
+        },
+      )
+      .subscribe()
+    return () => {
+      void client.removeChannel(channel)
+    }
+  }, [scopedUserId])
+
+  const handleCodexControl = async (action: 'wake' | 'sleep') => {
+    if (!supabase) return
+    setCodexActionLoading(action)
+    setErrorMessage(null)
+    const { error } = await supabase.from('codex_control').insert({ user_id: scopedUserId, action, source: 'manual' })
+    if (error) {
+      setCodexActionLoading(null)
+      setErrorMessage(error.message)
+    }
+  }
 
   useEffect(() => {
     void loadAll()
@@ -446,6 +518,37 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
 
       {!loading ? (
         <main className="hamster-console-accordion">
+          <section className="hamster-console-card glass-card" aria-label="Codex 控制">
+            <button className="hamster-console-accordion__header" onClick={() => toggleSection('codex-control')}>
+              <h2>Codex 控制</h2>
+              <span>{expandedSection === 'codex-control' ? '▼' : '▶'}</span>
+            </button>
+            <div className={`hamster-console-accordion__content ${expandedSection === 'codex-control' ? 'expanded' : ''}`}>
+              <div className="hamster-console-accordion__inner">
+                <div className="hamster-console-codex-status">
+                  <span className={`hamster-console-codex-dot ${codexControlState.tone}`} aria-hidden />
+                  <span>{codexControlState.label}</span>
+                </div>
+                <div className="hamster-console-codex-actions">
+                  <button
+                    className="btn-primary"
+                    onClick={() => void handleCodexControl('wake')}
+                    disabled={codexControlState.isRunning || codexActionLoading !== null}
+                  >
+                    {codexActionLoading === 'wake' ? '唤醒中...' : '唤醒 Codex'}
+                  </button>
+                  <button
+                    className="btn-secondary"
+                    onClick={() => void handleCodexControl('sleep')}
+                    disabled={!codexControlState.isRunning || codexActionLoading !== null}
+                  >
+                    {codexActionLoading === 'sleep' ? '关闭中...' : '关闭 Codex'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
           <section className="hamster-console-card glass-card" aria-label="模型切换">
             <button className="hamster-console-accordion__header" onClick={() => toggleSection('model-switching')}>
               <h2>模型切换</h2>


### PR DESCRIPTION
### Motivation
- 在仓鼠机页面顶部新增一张用于手动控制 Codex 的卡片以便对 Codex 进行唤醒/关闭操作并查看实时状态。
- 状态需根据 `codex_control` 表最近一条记录的 `action`/`status` 映射为友好的 UI 表示并支持实时更新。
- 操作由人工触发并写入 `codex_control` 表，等待 Supabase Realtime 回推确认后结束按钮 loading。

### Description
- 在 `src/pages/HamsterConsolePage.tsx` 中新增 `CodexControlRow` 类型、`toCodexControlViewState` 映射函数、以及用于存储/展示的状态与 loading 标志。 
- 在页面初次加载时查询 `codex_control` 最近一条记录 (`order by created_at desc limit 1`) 并用于首屏状态展示。 
- 使用 Supabase Realtime 订阅 `codex_control` 表（按 `user_id` 过滤），在变更时重新读取最新一条记录并在回调中清理按钮 loading。 
- 实现两个控制按钮，分别插入 `{ user_id, action: 'wake'|'sleep', source: 'manual' }` 到 `codex_control` 表，按钮按当前运行态互斥禁用并在插入后显示 loading。 
- 在 `src/pages/HamsterConsolePage.css` 中新增状态胶囊、圆点和按钮区域样式以匹配现有卡片风格。 
- 小幅修复 TypeScript 空值使用点（将 `supabase` 赋值给 `client` 以避免可能的 `null` 警告）。

### Testing
- 运行 `npm run build`（`tsc -b && vite build`）构建通过，TypeScript 类型检查与 Vite 打包成功并生成产物（有 chunk size 警告但不阻塞构建）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116f517a5c83308cfacd4e006f3431)