### PR TITLE
feat: 新增 Wiki 知识库页面（导航+阅读+编辑+新建）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ import TimelinePage from './pages/TimelinePage'
 import HamsterConsolePage from './pages/HamsterConsolePage'
 import AgentCouncilPage from './pages/AgentCouncilPage'
 import WalletPage from './pages/WalletPage'
+import WikiPage from './pages/WikiPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1963,6 +1964,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <WalletPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/wiki"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <WikiPage />
             </RequireAuth>
           }
         />

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -3,10 +3,28 @@ import remarkGfm from 'remark-gfm'
 
 type MarkdownRendererProps = {
   content: string
+  onWikiLinkClick?: (title: string) => void
 }
 
-const MarkdownRenderer = ({ content }: MarkdownRendererProps) => (
-  <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+const MarkdownRenderer = ({ content, onWikiLinkClick }: MarkdownRendererProps) => (
+  <ReactMarkdown
+    remarkPlugins={[remarkGfm]}
+    components={{
+      a: ({ href, children }) => {
+        if (href?.startsWith('wiki://') && onWikiLinkClick) {
+          const title = decodeURIComponent(href.replace('wiki://', ''))
+          return (
+            <button type="button" onClick={() => onWikiLinkClick(title)}>
+              {children}
+            </button>
+          )
+        }
+        return <a href={href}>{children}</a>
+      },
+    }}
+  >
+    {content}
+  </ReactMarkdown>
 )
 
 export default MarkdownRenderer

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "council", "hamster-wallet", "hamster-console"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "wiki", "council", "hamster-wallet", "hamster-console"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -266,6 +266,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "letters", defaultEmoji: "💌", label: "Letters", route: "/letters" },
       { id: "memo", defaultEmoji: "📝", label: "备忘录", route: "/memo" },
       { id: "timeline", defaultEmoji: "🗓️", label: "时间轴", route: "/timeline" },
+      { id: "wiki", defaultEmoji: "📚", label: "Wiki", route: "/wiki" },
       { id: "council", defaultEmoji: "🏛️", label: "议事厅", route: "/council" },
       { id: "hamster-wallet", defaultEmoji: "💰", label: "仓鼠钱包", route: "/wallet" },
       { id: "hamster-console", defaultEmoji: "🎛️", label: "仓鼠机", route: "/hamster-console" },

--- a/src/pages/WikiPage.css
+++ b/src/pages/WikiPage.css
@@ -1,0 +1,16 @@
+.wiki-page {display:grid;grid-template-columns:320px 1fr;gap:12px;min-height:100dvh;padding:12px;background:linear-gradient(180deg,#fff7fb,#f7f4f6)}
+.wiki-nav{border:1px solid #ffd6e7;background:#fff;border-radius:16px;padding:10px;display:grid;gap:8px;position:sticky;top:8px;max-height:calc(100dvh - 24px);overflow:auto}
+.wiki-nav-top{display:flex;justify-content:space-between;gap:8px}
+.wiki-input,.wiki-textarea{width:100%;box-sizing:border-box;border:1px solid #f2c8dc;border-radius:12px;padding:9px;background:#fffdfd}
+.wiki-tags{display:flex;flex-wrap:wrap;gap:6px}.pill{border:1px solid #f4cce0;background:#fff;border-radius:999px;padding:4px 10px}.pill.active{background:#ffe4f0}
+.wiki-group-title,.wiki-item{width:100%;text-align:left;border:0;background:transparent;padding:6px 8px;border-radius:10px}
+.wiki-item.active,.wiki-item:hover{background:#fff1f8}
+.wiki-main{border:1px solid #ffd6e7;background:#fff;border-radius:16px;padding:16px;position:relative}
+.wiki-reader{max-width:860px;margin:0 auto;line-height:1.85;color:#3c3340}
+.wiki-reader-head{display:flex;justify-content:space-between;align-items:center;gap:8px}
+.wiki-meta{color:#a36f8e}
+.wiki-editor{display:grid;gap:10px;max-width:860px;margin:0 auto;padding-bottom:76px}
+.wiki-textarea{min-height:52dvh;line-height:1.8;background:repeating-linear-gradient(0deg,#fff,#fff 26px,#f8f8f8 27px)}
+.wiki-editor-actions{position:sticky;bottom:0;display:flex;justify-content:flex-end;gap:8px;padding:10px 0;background:linear-gradient(180deg,rgba(255,255,255,0),#fff 36%)}
+.wiki-back,.wiki-create{border:1px solid #f0c0d7;border-radius:999px;padding:7px 12px;background:#fff}.wiki-create{background:#ffe6f2}
+@media (max-width: 900px){.wiki-page{grid-template-columns:1fr}.wiki-nav{position:relative;max-height:none}}

--- a/src/pages/WikiPage.tsx
+++ b/src/pages/WikiPage.tsx
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { WikiEntry, WikiEntryStatus } from '../types'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+import { createWikiEntry, listWikiEntries, updateWikiEntry } from '../storage/supabaseSync'
+import './WikiPage.css'
+
+type EditorState = {
+  id?: string
+  title: string
+  content: string
+  category: string
+  tags: string
+  status: WikiEntryStatus
+}
+
+const emptyEditor = (): EditorState => ({ title: '', content: '', category: '', tags: '', status: 'draft' })
+
+const parseTags = (value: string) =>
+  value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+
+const toEditorState = (entry: WikiEntry): EditorState => ({
+  id: entry.id,
+  title: entry.title,
+  content: entry.content,
+  category: entry.category,
+  tags: entry.tags.join(', '),
+  status: entry.status,
+})
+
+const WikiPage = () => {
+  const navigate = useNavigate()
+  const [entries, setEntries] = useState<WikiEntry[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState('all')
+  const [tagFilter, setTagFilter] = useState<string | null>(null)
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState(false)
+  const [editor, setEditor] = useState<EditorState>(emptyEditor())
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await listWikiEntries()
+      setEntries(data)
+      if (!selectedId && data[0]) setSelectedId(data[0].id)
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedId])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const categories = useMemo(() => Array.from(new Set(entries.map((e) => e.category))).sort(), [entries])
+  const allTags = useMemo(() => Array.from(new Set(entries.flatMap((e) => e.tags))).sort(), [entries])
+
+  const filtered = useMemo(() => {
+    const keyword = search.trim().toLowerCase()
+    return entries.filter((entry) => {
+      if (categoryFilter !== 'all' && entry.category !== categoryFilter) return false
+      if (tagFilter && !entry.tags.includes(tagFilter)) return false
+      if (!keyword) return true
+      return (
+        entry.title.toLowerCase().includes(keyword) ||
+        entry.content.toLowerCase().includes(keyword) ||
+        entry.tags.some((tag) => tag.toLowerCase().includes(keyword))
+      )
+    })
+  }, [entries, search, categoryFilter, tagFilter])
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, WikiEntry[]>()
+    filtered.forEach((entry) => {
+      const list = map.get(entry.category) ?? []
+      list.push(entry)
+      map.set(entry.category, list)
+    })
+    return Array.from(map.entries())
+  }, [filtered])
+
+  const selected = entries.find((entry) => entry.id === selectedId) ?? null
+
+  const linkedTitles = useMemo(() => {
+    if (!selected) return []
+    const re = /\[\[([^\]]+)\]\]/g
+    const found = new Set<string>()
+    let m: RegExpExecArray | null
+    while ((m = re.exec(selected.content))) found.add(m[1].trim())
+    return Array.from(found)
+  }, [selected])
+
+  const backlinkEntries = useMemo(() => {
+    if (!selected) return []
+    const marker = `[[${selected.title}]]`
+    return entries.filter((entry) => entry.id !== selected.id && entry.content.includes(marker))
+  }, [selected, entries])
+
+  const renderedContent = useMemo(() => {
+    if (!selected) return ''
+    return selected.content.replace(
+      /\[\[([^\]]+)\]\]/g,
+      (_full, title: string) => `[${title.trim()}](wiki://${encodeURIComponent(title.trim())})`,
+    )
+  }, [selected])
+
+  const openEntry = (entry: WikiEntry) => {
+    setSelectedId(entry.id)
+    setEditing(false)
+  }
+
+  const startCreate = () => {
+    setSelectedId(null)
+    setEditor(emptyEditor())
+    setEditing(true)
+  }
+
+  const startEdit = () => {
+    if (!selected) return
+    setEditor(toEditorState(selected))
+    setEditing(true)
+  }
+
+  const save = async () => {
+    const payload = {
+      title: editor.title.trim(),
+      content: editor.content,
+      category: editor.category.trim(),
+      tags: parseTags(editor.tags),
+      status: editor.status,
+    }
+    if (!payload.title || !payload.category) return
+    if (editor.id) {
+      await updateWikiEntry(editor.id, payload)
+      setSelectedId(editor.id)
+    } else {
+      await createWikiEntry(payload)
+    }
+    setEditing(false)
+    await refresh()
+  }
+
+  return (
+    <div className="wiki-page">
+      <aside className="wiki-nav">
+        <div className="wiki-nav-top">
+          <button type="button" className="wiki-back" onClick={() => navigate(-1)}>← 返回</button>
+          <button type="button" className="wiki-create" onClick={startCreate}>+ 新建</button>
+        </div>
+        <input className="wiki-input" placeholder="搜索标题/正文/tag" value={search} onChange={(e) => setSearch(e.target.value)} />
+        <select className="wiki-input" value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}>
+          <option value="all">全部分类</option>
+          {categories.map((category) => <option key={category} value={category}>{category}</option>)}
+        </select>
+        <div className="wiki-tags">
+          <button type="button" className={!tagFilter ? 'pill active' : 'pill'} onClick={() => setTagFilter(null)}>全部</button>
+          {allTags.map((tag) => (
+            <button key={tag} type="button" className={tagFilter === tag ? 'pill active' : 'pill'} onClick={() => setTagFilter(tag)}>{tag}</button>
+          ))}
+        </div>
+        <div className="wiki-groups">
+          {grouped.map(([category, list]) => (
+            <section key={category}>
+              <button type="button" className="wiki-group-title" onClick={() => setCollapsed((prev) => ({ ...prev, [category]: !prev[category] }))}>{collapsed[category] ? '▸' : '▾'} {category}</button>
+              {!collapsed[category] && list.map((entry) => <button type="button" key={entry.id} className={entry.id === selectedId ? 'wiki-item active' : 'wiki-item'} onClick={() => openEntry(entry)}>{entry.title}</button>)}
+            </section>
+          ))}
+          {!loading && grouped.length === 0 && <p className="wiki-empty">暂无条目</p>}
+        </div>
+      </aside>
+
+      <main className="wiki-main">
+        {!editing && selected && (
+          <article className="wiki-reader">
+            <header className="wiki-reader-head">
+              <h1>{selected.title}</h1>
+              <button type="button" className="wiki-create" onClick={startEdit}>编辑</button>
+            </header>
+            <p className="wiki-meta">{selected.category} · {selected.status}</p>
+            <MarkdownRenderer
+              content={renderedContent}
+              onWikiLinkClick={(title) => {
+                const target = entries.find((entry) => entry.title === title)
+                if (target) openEntry(target)
+              }}
+            />
+            {linkedTitles.length > 0 && <p className="wiki-linked">链接到：{linkedTitles.join('、')}</p>}
+            <section className="wiki-backlinks">
+              <h3>反向链接</h3>
+              {backlinkEntries.length === 0 ? <p>暂无反向链接</p> : backlinkEntries.map((entry) => <button type="button" key={entry.id} className="wiki-item" onClick={() => openEntry(entry)}>{entry.title}</button>)}
+            </section>
+          </article>
+        )}
+        {editing && (
+          <section className="wiki-editor">
+            <input className="wiki-input" placeholder="标题" value={editor.title} onChange={(e) => setEditor((prev) => ({ ...prev, title: e.target.value }))} />
+            <input className="wiki-input" placeholder="分类" value={editor.category} onChange={(e) => setEditor((prev) => ({ ...prev, category: e.target.value }))} />
+            <input className="wiki-input" placeholder="标签（英文逗号分隔）" value={editor.tags} onChange={(e) => setEditor((prev) => ({ ...prev, tags: e.target.value }))} />
+            <select className="wiki-input" value={editor.status} onChange={(e) => setEditor((prev) => ({ ...prev, status: e.target.value as WikiEntryStatus }))}>
+              <option value="draft">draft</option>
+              <option value="published">published</option>
+            </select>
+            <textarea className="wiki-textarea" placeholder="Markdown 正文，支持 [[词条]]" value={editor.content} onChange={(e) => setEditor((prev) => ({ ...prev, content: e.target.value }))} />
+            <div className="wiki-editor-actions">
+              <button type="button" className="wiki-create" onClick={save}>保存</button>
+              <button type="button" className="wiki-back" onClick={() => setEditing(false)}>取消</button>
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default WikiPage

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -34,6 +34,8 @@ import type {
   WalletQuestStatus,
   WalletTransaction,
   WalletTransactionType,
+  WikiEntry,
+  WikiEntryStatus,
 } from '../types'
 import { supabase } from '../supabase/client'
 
@@ -148,6 +150,18 @@ type TimelineEntryRow = {
   summary: string
   recorder: TimelineRecorder
   source: string
+  created_at: string
+  updated_at: string
+}
+
+type WikiEntryRow = {
+  id: string
+  user_id: string
+  title: string
+  content: string
+  category: string
+  tags: string[] | null
+  status: WikiEntryStatus
   created_at: string
   updated_at: string
 }
@@ -423,6 +437,18 @@ const mapTimelineEntryRow = (row: TimelineEntryRow): TimelineEntry => ({
   summary: row.summary,
   recorder: row.recorder,
   source: row.source,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const mapWikiEntryRow = (row: WikiEntryRow): WikiEntry => ({
+  id: row.id,
+  userId: row.user_id,
+  title: row.title,
+  content: row.content,
+  category: row.category,
+  tags: row.tags ?? [],
+  status: row.status,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
 })
@@ -2572,6 +2598,76 @@ export const deleteTimelineEntry = async (entryId: string): Promise<void> => {
     throw new Error('Supabase 客户端未配置')
   }
   const { error } = await supabase.from('timeline_entries').delete().eq('id', entryId)
+  if (error) {
+    throw error
+  }
+}
+
+export const listWikiEntries = async (): Promise<WikiEntry[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('wiki_entries')
+    .select('id,user_id,title,content,category,tags,status,created_at,updated_at')
+    .eq('user_id', userId)
+    .order('category', { ascending: true })
+    .order('title', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapWikiEntryRow(row as WikiEntryRow))
+}
+
+export const createWikiEntry = async (payload: {
+  title: string
+  content: string
+  category: string
+  tags: string[]
+  status?: WikiEntryStatus
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase.from('wiki_entries').insert({
+    user_id: userId,
+    title: payload.title,
+    content: payload.content,
+    category: payload.category,
+    tags: payload.tags,
+    status: payload.status ?? 'draft',
+  })
+  if (error) {
+    throw error
+  }
+}
+
+export const updateWikiEntry = async (
+  entryId: string,
+  payload: {
+    title: string
+    content: string
+    category: string
+    tags: string[]
+    status: WikiEntryStatus
+  },
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('wiki_entries')
+    .update({
+      title: payload.title,
+      content: payload.content,
+      category: payload.category,
+      tags: payload.tags,
+      status: payload.status,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', entryId)
   if (error) {
     throw error
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -323,6 +323,20 @@ export type TimelineEntry = {
   updatedAt: string
 }
 
+export type WikiEntryStatus = 'draft' | 'published'
+
+export type WikiEntry = {
+  id: string
+  userId: string
+  title: string
+  content: string
+  category: string
+  tags: string[]
+  status: WikiEntryStatus
+  createdAt: string
+  updatedAt: string
+}
+
 export type WalletQuestStatus = 'open' | 'completed' | 'cancelled'
 export type WalletQuestCreator = 'chuanchuan' | 'syzygy'
 


### PR DESCRIPTION
### Motivation
- 增加一个结构化的知识库页面，方便在应用内维护可互链的文档条目并支持编辑与新建。 
- 将 Wiki 数据与已有 `wiki_entries` 表接入，使条目可持久化并与当前用户关联。

### Description
- 新增类型：添加 `WikiEntry` 和 `WikiEntryStatus` 到 `src/types.ts`，定义 `title/content/category/tags/status/createdAt/updatedAt` 等字段。 
- 后端数据接口：在 `src/storage/supabaseSync.ts` 新增 `listWikiEntries`、`createWikiEntry`、`updateWikiEntry`，并实现客户端-用户绑定与默认 `draft` 状态写入。 
- 前端页面：新增 `src/pages/WikiPage.tsx` 与样式 `src/pages/WikiPage.css`，实现左侧抽屉式导航（搜索、分类下拉、tag 胶囊、按 category 折叠分组）、右侧阅读区（Markdown 渲染、反向链接展示）与编辑区（可编辑 `title/category/tags/content/status`，底部固定保存/取消）。 
- Markdown 内链支持：在渲染前把 `[[标题]]` 转为 `wiki://` 内链，并在 `src/components/MarkdownRenderer.tsx` 拦截 `wiki://` 链接回调以在当前条目集合中打开目标条目。 
- 集成与入口：在首页 `page2` 图标中新增 `Wiki`（`/wiki`），并在 `src/App.tsx` 注册受保护的 `/wiki` 路由以供导航访问。 

### Testing
- 执行了构建验证 `npm run build`（含 `tsc -b` 和 `vite build`），构建完成且产物生成成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11845fa51483308f477c39bb4f8cb6)