### PR TITLE
fix(wiki): render [[xxx]] as inline clickable text and remove content…

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,3 +1,4 @@
+import { Fragment, type ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -6,25 +7,47 @@ type MarkdownRendererProps = {
   onWikiLinkClick?: (title: string) => void
 }
 
-const MarkdownRenderer = ({ content, onWikiLinkClick }: MarkdownRendererProps) => (
-  <ReactMarkdown
-    remarkPlugins={[remarkGfm]}
-    components={{
-      a: ({ href, children }) => {
-        if (href?.startsWith('wiki://') && onWikiLinkClick) {
-          const title = decodeURIComponent(href.replace('wiki://', ''))
-          return (
-            <button type="button" onClick={() => onWikiLinkClick(title)}>
-              {children}
-            </button>
-          )
-        }
-        return <a href={href}>{children}</a>
-      },
-    }}
-  >
-    {content}
-  </ReactMarkdown>
-)
+const WIKI_LINK_HREF = '#__wikilink__'
+const WIKI_LINK_PATTERN = /\[\[([^\]]+)\]\]/g
+
+const extractText = (node: ReactNode): string => {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (typeof node === 'object' && 'props' in node) {
+    return extractText((node as { props: { children?: ReactNode } }).props.children)
+  }
+  return ''
+}
+
+const MarkdownRenderer = ({ content, onWikiLinkClick }: MarkdownRendererProps) => {
+  const processed = content.replace(WIKI_LINK_PATTERN, (_match, title: string) => {
+    return `[${title.trim()}](${WIKI_LINK_HREF})`
+  })
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a: ({ href, children }) => {
+          if (href === WIKI_LINK_HREF) {
+            const title = extractText(children).trim()
+            if (!onWikiLinkClick) {
+              return <Fragment>{children}</Fragment>
+            }
+            return (
+              <button type="button" className="wiki-link" onClick={() => onWikiLinkClick(title)}>
+                {children}
+              </button>
+            )
+          }
+          return <a href={href}>{children}</a>
+        },
+      }}
+    >
+      {processed}
+    </ReactMarkdown>
+  )
+}
 
 export default MarkdownRenderer

--- a/src/pages/WikiPage.css
+++ b/src/pages/WikiPage.css
@@ -142,28 +142,41 @@
 .wiki-reader h1 { margin: 0; color: #5c4152; }
 .wiki-meta { margin: 6px 0 14px; color: #a36f8e; font-size: 13px; }
 .wiki-linked { color: #8d6280; font-size: 13px; }
-.wiki-content-sections { display: grid; gap: 10px; }
-.wiki-content-section {
-  border: 1px solid rgba(255, 214, 231, 0.75);
-  border-radius: 12px;
-  background: rgba(255, 252, 254, 0.8);
-  overflow: hidden;
+.wiki-content-body { margin-top: 4px; }
+.wiki-content-body h1,
+.wiki-content-body h2,
+.wiki-content-body h3,
+.wiki-content-body h4 {
+  color: #5c4152;
+  margin: 18px 0 8px;
 }
-.wiki-content-section__header {
-  width: 100%;
-  text-align: left;
-  border: 0;
-  border-bottom: 1px solid rgba(255, 214, 231, 0.6);
+.wiki-content-body p { margin: 8px 0; }
+.wiki-content-body ul,
+.wiki-content-body ol { padding-left: 22px; }
+.wiki-content-body code {
+  background: #fff1f8;
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-size: 0.92em;
+}
+.wiki-content-body pre {
   background: #fff6fb;
-  color: #6e4d63;
+  border: 1px solid rgba(255, 214, 231, 0.7);
+  border-radius: 10px;
   padding: 10px 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  overflow-x: auto;
 }
-.wiki-content-section__body {
-  padding: 10px 12px 4px;
+.wiki-link {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #c45e8d;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
 }
+.wiki-link:hover { color: #8e3866; }
 .wiki-backlinks { margin-top: 16px; border-top: 1px dashed #f0ccdd; padding-top: 12px; }
 .wiki-backlinks h3 { margin: 0 0 10px; color: #6d4e63; }
 

--- a/src/pages/WikiPage.tsx
+++ b/src/pages/WikiPage.tsx
@@ -14,12 +14,6 @@ type EditorState = {
   status: WikiEntryStatus
 }
 
-type WikiContentSection = {
-  id: string
-  title: string
-  content: string
-}
-
 const emptyEditor = (): EditorState => ({ title: '', content: '', category: '', tags: '', status: 'draft' })
 
 const parseTags = (value: string) =>
@@ -37,44 +31,6 @@ const toEditorState = (entry: WikiEntry): EditorState => ({
   status: entry.status,
 })
 
-const splitWikiContentSections = (content: string): WikiContentSection[] => {
-  const lines = content.split('\n')
-  const sections: WikiContentSection[] = []
-  let currentTitle = '概览'
-  let currentLines: string[] = []
-  let counter = 0
-
-  const pushSection = () => {
-    const text = currentLines.join('\n').trim()
-    if (!text) {
-      return
-    }
-    sections.push({
-      id: `section-${counter}`,
-      title: currentTitle,
-      content: text,
-    })
-    counter += 1
-  }
-
-  lines.forEach((line) => {
-    const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line.trim())
-    if (headingMatch) {
-      pushSection()
-      currentTitle = headingMatch[2].trim()
-      currentLines = []
-      return
-    }
-    currentLines.push(line)
-  })
-
-  pushSection()
-  if (sections.length === 0) {
-    return [{ id: 'section-0', title: '正文', content: content.trim() }]
-  }
-  return sections
-}
-
 const WikiPage = () => {
   const navigate = useNavigate()
   const [entries, setEntries] = useState<WikiEntry[]>([])
@@ -83,7 +39,6 @@ const WikiPage = () => {
   const [categoryFilter, setCategoryFilter] = useState('all')
   const [tagFilter, setTagFilter] = useState<string | null>(null)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
-  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({})
   const [loading, setLoading] = useState(true)
   const [editing, setEditing] = useState(false)
   const [editor, setEditor] = useState<EditorState>(emptyEditor())
@@ -146,28 +101,6 @@ const WikiPage = () => {
     const marker = `[[${selected.title}]]`
     return entries.filter((entry) => entry.id !== selected.id && entry.content.includes(marker))
   }, [selected, entries])
-
-  const renderedContent = useMemo(() => {
-    if (!selected) return ''
-    return selected.content.replace(
-      /\[\[([^\]]+)\]\]/g,
-      (_full, title: string) => `[${title.trim()}](wiki://${encodeURIComponent(title.trim())})`,
-    )
-  }, [selected])
-
-  const contentSections = useMemo(() => splitWikiContentSections(renderedContent), [renderedContent])
-
-  useEffect(() => {
-    if (contentSections.length === 0) {
-      setCollapsedSections({})
-      return
-    }
-    const nextState: Record<string, boolean> = {}
-    contentSections.forEach((section, index) => {
-      nextState[section.id] = index !== 0
-    })
-    setCollapsedSections(nextState)
-  }, [selectedId, contentSections])
 
   const openEntry = (entry: WikiEntry) => {
     setSelectedId(entry.id)
@@ -251,32 +184,14 @@ const WikiPage = () => {
               <button type="button" className="wiki-create" onClick={startEdit}>编辑</button>
             </header>
             <p className="wiki-meta">{selected.category} · {selected.status}</p>
-            <div className="wiki-content-sections">
-              {contentSections.map((section) => (
-                <section key={section.id} className="wiki-content-section">
-                  <button
-                    type="button"
-                    className="wiki-content-section__header"
-                    onClick={() =>
-                      setCollapsedSections((prev) => ({ ...prev, [section.id]: !prev[section.id] }))
-                    }
-                  >
-                    <span>{collapsedSections[section.id] ? '▸' : '▾'}</span>
-                    <strong>{section.title}</strong>
-                  </button>
-                  {!collapsedSections[section.id] && (
-                    <div className="wiki-content-section__body">
-                      <MarkdownRenderer
-                        content={section.content}
-                        onWikiLinkClick={(title) => {
-                          const target = entries.find((entry) => entry.title === title)
-                          if (target) openEntry(target)
-                        }}
-                      />
-                    </div>
-                  )}
-                </section>
-              ))}
+            <div className="wiki-content-body">
+              <MarkdownRenderer
+                content={selected.content}
+                onWikiLinkClick={(title) => {
+                  const target = entries.find((entry) => entry.title === title)
+                  if (target) openEntry(target)
+                }}
+              />
             </div>
             {linkedTitles.length > 0 && <p className="wiki-linked">链接到：{linkedTitles.join('、')}</p>}
             <section className="wiki-backlinks">


### PR DESCRIPTION
… folding

- 解析 [[xxx]] 时不再产出 wiki:// URL，直接渲染为可点击按钮文本， 点击后在 wiki 页面内跳转到 title 匹配的条目，避免中文 URL 编码。
- 正文区移除按标题折叠的结构，直接完整渲染 Markdown， 侧边栏分类的折叠/展开行为保留。