### PR TITLE
NovelPage: redesign layout, add settings modal and save flow

### DIFF
--- a/src/pages/NovelPage.css
+++ b/src/pages/NovelPage.css
@@ -1,10 +1,23 @@
-.novel-page,.novel-reader{padding:16px;color:#4a4452}
-.novel-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
-.novel-settings-btn,.novel-ai-btn,.novel-characters__header button,.novel-character-card button{border:1px solid #e5d7e6;background:#fff;border-radius:10px;padding:8px 12px}
+.novel-page,.novel-reader{width:100%;max-width:720px;margin:0 auto;padding:14px 14px 20px;min-height:100dvh;display:grid;gap:12px;align-content:start;color:#4a4452;position:relative;isolation:isolate}
+.novel-page::before{content:'';position:absolute;inset:0;z-index:-1;border-radius:24px;background:radial-gradient(circle at 10% 0%, rgba(255,214,231,.34), transparent 42%),radial-gradient(circle at 90% 0%, rgba(255,239,246,.82), transparent 52%),linear-gradient(180deg, rgba(255,252,254,.96) 0%, rgba(253,245,249,.96) 100%)}
+.novel-header{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:10px}
+.novel-card-shell,.novel-create,.novel-card,.novel-character-card,.novel-shelf{border:1px solid rgba(255,214,231,.88);border-radius:18px;background:#fff;box-shadow:0 10px 20px rgba(255,214,231,.18)}
+.novel-card-shell{padding:10px}
+.novel-title-wrap{text-align:center}.novel-kicker{margin:0;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#b27f98}.novel-header-spacer{width:56px;height:1px}
+.novel-pill-btn,.novel-ai-btn,.novel-characters__header button,.novel-character-card button{border-radius:999px;border:1px solid #ffd6e7;background:#fff;color:#7d5d70;padding:7px 12px}
+.novel-pill-btn--primary{background:linear-gradient(180deg,#ffeef6 0%,#ffe1ef 100%);font-weight:600}
+.novel-create-btn{justify-self:start;min-width:112px;padding:9px 18px;box-shadow:0 3px 7px rgba(255,185,216,.38)}
 .novel-settings-panel,.novel-create,.novel-shelf,.novel-detail-grid{display:grid;gap:12px}
-.novel-settings-panel,.novel-create,.novel-card,.novel-character-card{background:#fff;border:1px solid #eadde9;border-radius:14px;padding:12px}
+.novel-create,.novel-card,.novel-character-card{padding:12px}
 .novel-settings-panel label,.novel-create label{display:grid;gap:6px;font-size:13px;color:#6a6473}
 .novel-create textarea,.novel-create input,.novel-settings-panel textarea,.novel-settings-panel input,.novel-settings-panel select,.novel-character-card textarea,.novel-character-card input{width:100%;padding:10px;border-radius:10px;border:1px solid #e4dbe8;background:#fff}
 .novel-card{display:grid;gap:6px;text-align:left;background:linear-gradient(180deg,#fff,#fff8fb)}
 .novel-characters__header{display:flex;justify-content:space-between;align-items:center}
 .novel-reader article{line-height:1.9;max-width:860px;margin:0 auto;background:#fff;padding:20px;border-radius:12px}
+
+.novel-modal-mask{position:fixed;inset:0;background:rgba(30,20,28,.35);backdrop-filter:blur(1px);display:grid;place-items:center;padding:16px;z-index:20}
+.novel-settings-modal{width:min(680px,100%);max-height:min(86dvh,720px);overflow:auto;border-radius:18px;border:1px solid rgba(255,214,231,.9);background:#fff;padding:12px;display:grid;gap:10px;box-shadow:0 20px 35px rgba(54,25,40,.2)}
+.novel-settings-modal__header,.novel-settings-modal__footer{display:flex;justify-content:space-between;align-items:center;gap:8px}
+.novel-settings-modal__footer{justify-content:flex-end;position:sticky;bottom:-12px;padding:10px 0 2px;background:linear-gradient(180deg, rgba(255,255,255,0), #fff 36%)}
+.novel-settings-error{margin:0;color:#b13f4d;font-size:12px}
+.novel-pill-btn:disabled{opacity:.55;cursor:not-allowed}

--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
 import { useEnabledModels } from '../hooks/useEnabledModels'
 import { supabase } from '../supabase/client'
 import type { NovelBook, NovelChapter, NovelCharacterCard, NovelModelConfig } from '../types'
@@ -19,6 +20,7 @@ type DraftState = {
 const emptyDraft: DraftState = { title: '', summary: '', outline: '', worldSetting: '', characters: [] }
 
 const NovelPage = ({ user }: { user: User | null }) => {
+  const navigate = useNavigate()
   const { enabledModelIds, defaultModelId } = useEnabledModels(user)
   const [books, setBooks] = useState<NovelBook[]>([])
   const [globalConfigBook, setGlobalConfigBook] = useState<NovelBook | null>(null)
@@ -29,6 +31,8 @@ const NovelPage = ({ user }: { user: User | null }) => {
   const [draft, setDraft] = useState<DraftState>(emptyDraft)
   const [aiGenerating, setAiGenerating] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [settingsSaving, setSettingsSaving] = useState(false)
+  const [settingsError, setSettingsError] = useState<string | null>(null)
 
   const baseConfig: NovelModelConfig = useMemo(() => ({
     writing_model: defaultModelId ?? 'openrouter/auto',
@@ -41,6 +45,7 @@ const NovelPage = ({ user }: { user: User | null }) => {
       character_gen_prompt: '根据关键词/简介返回角色 JSON 数组: [{"name":"","description":"","personality":""}]',
     },
   }), [defaultModelId])
+  const [settingsDraft, setSettingsDraft] = useState<NovelModelConfig>(baseConfig)
 
   const globalConfig: NovelModelConfig = useMemo(() => {
     const raw = (globalConfigBook?.modelConfig ?? {}) as Partial<NovelModelConfig>
@@ -61,6 +66,11 @@ const NovelPage = ({ user }: { user: User | null }) => {
   }, [book?.modelConfig, globalConfig])
 
   const modelOptions = enabledModelIds.length > 0 ? enabledModelIds : [globalConfig.writing_model]
+
+  useEffect(() => {
+    if (!settingsOpen) return
+    setSettingsDraft(activeBookConfig)
+  }, [activeBookConfig, settingsOpen])
 
   const reloadBooks = async () => {
     if (!user) return
@@ -164,21 +174,51 @@ const NovelPage = ({ user }: { user: User | null }) => {
     setChapters((prev) => [...prev, created]); setChapter(created)
   }
 
+  const onSaveSettings = async () => {
+    setSettingsSaving(true)
+    setSettingsError(null)
+    try {
+      await saveGlobalConfig(settingsDraft)
+      setSettingsOpen(false)
+    } catch (error) {
+      setSettingsError(error instanceof Error ? error.message : '保存失败，请稍后重试')
+    } finally {
+      setSettingsSaving(false)
+    }
+  }
+
   if (!book) return <div className='novel-page'>
-    <div className='novel-header'>
-      <h1 className='ui-title'>📖 小说</h1>
-      <button className='novel-settings-btn' onClick={() => setSettingsOpen((v) => !v)}>⚙️ 设置</button>
+    <div className='novel-header novel-card-shell'>
+      <button className='novel-pill-btn' onClick={() => navigate('/')}>← 返回</button>
+      <div className='novel-title-wrap'>
+        <p className='novel-kicker'>Story Studio</p>
+        <h1 className='ui-title'>📖 小说工坊</h1>
+      </div>
+      <button className='novel-pill-btn' onClick={() => setSettingsOpen(true)}>⚙️ 设置</button>
     </div>
 
-    {settingsOpen ? <section className='novel-settings-panel'>
-      <label>写作模型<select value={globalConfig.writing_model} onChange={(e) => void saveGlobalConfig({ ...globalConfig, writing_model: e.target.value })}>{modelOptions.map((m) => <option key={m} value={m}>{m}</option>)}</select></label>
-      <label>摘要模型<select value={globalConfig.summary_model} onChange={(e) => void saveGlobalConfig({ ...globalConfig, summary_model: e.target.value })}>{modelOptions.map((m) => <option key={m} value={m}>{m}</option>)}</select></label>
-      <label>上下文章节数<input type='number' min={1} value={globalConfig.context_window_chapters} onChange={(e) => void saveGlobalConfig({ ...globalConfig, context_window_chapters: Number(e.target.value) || 1 })} /></label>
-      <label>outline_prompt<textarea value={globalConfig.prompts.outline_prompt} onChange={(e) => void saveGlobalConfig({ ...globalConfig, prompts: { ...globalConfig.prompts, outline_prompt: e.target.value } })} /></label>
-      <label>writing_prompt<textarea value={globalConfig.prompts.writing_prompt} onChange={(e) => void saveGlobalConfig({ ...globalConfig, prompts: { ...globalConfig.prompts, writing_prompt: e.target.value } })} /></label>
-      <label>summary_prompt<textarea value={globalConfig.prompts.summary_prompt} onChange={(e) => void saveGlobalConfig({ ...globalConfig, prompts: { ...globalConfig.prompts, summary_prompt: e.target.value } })} /></label>
-      <label>character_gen_prompt<textarea value={globalConfig.prompts.character_gen_prompt} onChange={(e) => void saveGlobalConfig({ ...globalConfig, prompts: { ...globalConfig.prompts, character_gen_prompt: e.target.value } })} /></label>
-    </section> : null}
+    {settingsOpen ? <div className='novel-modal-mask' onClick={() => setSettingsOpen(false)}>
+      <section className='novel-settings-modal' onClick={(e) => e.stopPropagation()}>
+        <header className='novel-settings-modal__header'>
+          <h2>小说设置</h2>
+          <button className='novel-pill-btn' onClick={() => setSettingsOpen(false)}>关闭</button>
+        </header>
+        <div className='novel-settings-panel'>
+          <label>写作模型<select value={settingsDraft.writing_model} onChange={(e) => setSettingsDraft((p) => ({ ...p, writing_model: e.target.value }))}>{modelOptions.map((m) => <option key={m} value={m}>{m}</option>)}</select></label>
+          <label>摘要模型<select value={settingsDraft.summary_model} onChange={(e) => setSettingsDraft((p) => ({ ...p, summary_model: e.target.value }))}>{modelOptions.map((m) => <option key={m} value={m}>{m}</option>)}</select></label>
+          <label>上下文章节数<input type='number' min={1} value={settingsDraft.context_window_chapters} onChange={(e) => setSettingsDraft((p) => ({ ...p, context_window_chapters: Number(e.target.value) || 1 }))} /></label>
+          <label>outline_prompt<textarea value={settingsDraft.prompts.outline_prompt} onChange={(e) => setSettingsDraft((p) => ({ ...p, prompts: { ...p.prompts, outline_prompt: e.target.value } }))} /></label>
+          <label>writing_prompt<textarea value={settingsDraft.prompts.writing_prompt} onChange={(e) => setSettingsDraft((p) => ({ ...p, prompts: { ...p.prompts, writing_prompt: e.target.value } }))} /></label>
+          <label>summary_prompt<textarea value={settingsDraft.prompts.summary_prompt} onChange={(e) => setSettingsDraft((p) => ({ ...p, prompts: { ...p.prompts, summary_prompt: e.target.value } }))} /></label>
+          <label>character_gen_prompt<textarea value={settingsDraft.prompts.character_gen_prompt} onChange={(e) => setSettingsDraft((p) => ({ ...p, prompts: { ...p.prompts, character_gen_prompt: e.target.value } }))} /></label>
+          {settingsError ? <p className='novel-settings-error'>{settingsError}</p> : null}
+        </div>
+        <footer className='novel-settings-modal__footer'>
+          <button className='novel-pill-btn' onClick={() => setSettingsOpen(false)} disabled={settingsSaving}>取消</button>
+          <button className='novel-pill-btn novel-pill-btn--primary' onClick={() => void onSaveSettings()} disabled={settingsSaving}>{settingsSaving ? '保存中...' : '保存'}</button>
+        </footer>
+      </section>
+    </div> : null}
 
     <section className='novel-create'>
       <textarea value={brief} onChange={(e) => setBrief(e.target.value)} placeholder='关键词/简要描述' />
@@ -196,7 +236,7 @@ const NovelPage = ({ user }: { user: User | null }) => {
           <button onClick={()=>setDraft((p)=>({...p,characters:p.characters.filter((_,i)=>i!==index)}))}>删除</button>
         </div>)}
       </section>
-      <button onClick={() => void onCreate()}>确认创建</button>
+      <button className='novel-pill-btn novel-pill-btn--primary novel-create-btn' onClick={() => void onCreate()}>确认创建</button>
     </section>
 
     <section className='novel-shelf'>{books.map((item)=><button key={item.id} className='novel-card' onClick={()=>void openDetail(item)}><h3>{item.title}</h3><p>{item.summary}</p><span>{item.status}</span><span>{item.updatedAt}</span></button>)}</section>


### PR DESCRIPTION
### Motivation
- Refresh the Novel page UI with a centered, card-style layout and improved visual hierarchy for readability and usability.
- Replace the inline settings panel with a dedicated modal to allow editing model configuration safely and provide save/error states.

### Description
- Reworked `NovelPage.css` with new layout, card shells, pill buttons, background gradients, and modal styles including `.novel-modal-mask` and `.novel-settings-modal`.
- Updated `NovelPage.tsx` to use `useNavigate`, added navigation/back button, and modernized the header and create UI including `novel-pill-btn` and `novel-create-btn` classes.
- Implemented settings editing flow with `settingsDraft`, `settingsSaving`, and `settingsError` state, an effect to populate the draft when opening, and `onSaveSettings` which calls `saveGlobalConfig` to persist changes.
- Replaced the inline settings section with a modal dialog that stops propagation on inner clicks, shows errors, and disables buttons while saving, and adjusted text/UI strings for the novel workflow.

### Testing
- Ran a production build with `npm run build` and the build completed successfully.
- Executed the test suite with `npm test` and all tests passed.
- Performed a TypeScript check with `tsc --noEmit` and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119a0ae35883308dd7e5d13f354a8e)