### PR TITLE
fix(novel): robust JSON extraction from AI response

### DIFF
--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -82,10 +82,48 @@ const NovelPage = ({ user }: { user: User | null }) => {
 
   useEffect(() => { void reloadBooks() }, [user?.id])
 
+  const stripCodeFences = (content: string) => {
+    const fenceMatch = content.match(/```(?:json|JSON)?\s*([\s\S]*?)```/)
+    return fenceMatch ? fenceMatch[1] : content
+  }
+
+  const sliceBalanced = (content: string, open: '{' | '[') => {
+    const close = open === '{' ? '}' : ']'
+    const start = content.indexOf(open)
+    if (start === -1) return null
+    let depth = 0
+    let inString = false
+    let escape = false
+    for (let i = start; i < content.length; i++) {
+      const ch = content[i]
+      if (escape) { escape = false; continue }
+      if (ch === '\\') { escape = true; continue }
+      if (ch === '"') { inString = !inString; continue }
+      if (inString) continue
+      if (ch === open) depth++
+      else if (ch === close) {
+        depth--
+        if (depth === 0) return content.slice(start, i + 1)
+      }
+    }
+    return null
+  }
+
   const extractJson = (content: string) => {
-    const objectMatch = content.match(/\{[\s\S]*\}/)
-    const arrayMatch = content.match(/\[[\s\S]*\]/)
-    return { objectText: objectMatch?.[0] ?? '{}', arrayText: arrayMatch?.[0] ?? '[]' }
+    const cleaned = stripCodeFences(content)
+    return {
+      objectText: sliceBalanced(cleaned, '{') ?? '{}',
+      arrayText: sliceBalanced(cleaned, '[') ?? '[]',
+    }
+  }
+
+  const parseJsonSafely = <T,>(text: string, fallback: T, label: string, raw: string): T => {
+    try {
+      return JSON.parse(text) as T
+    } catch (error) {
+      console.warn(`[novel] ${label} JSON 解析失败:`, error, { extracted: text, raw })
+      return fallback
+    }
   }
 
   const invokeModel = async (model: string, prompt: string) => {
@@ -119,13 +157,14 @@ const NovelPage = ({ user }: { user: User | null }) => {
     setAiGenerating(true)
     try {
       const model = globalConfig.writing_model || defaultModelId || 'openrouter/auto'
-      const outlinePrompt = `${globalConfig.prompts.outline_prompt}\n\n关键词/简介:\n${brief}`
-      const charsPrompt = `${globalConfig.prompts.character_gen_prompt}\n\n关键词/简介:\n${brief}`
+      const jsonGuard = '\n\n严格只输出 JSON 本身，不要任何解释、前后缀文字或 markdown 代码块包裹。'
+      const outlinePrompt = `${globalConfig.prompts.outline_prompt}${jsonGuard}\n\n关键词/简介:\n${brief}`
+      const charsPrompt = `${globalConfig.prompts.character_gen_prompt}${jsonGuard}\n\n关键词/简介:\n${brief}`
       const [outlineText, charsText] = await Promise.all([invokeModel(model, outlinePrompt), invokeModel(model, charsPrompt)])
       const extractedOutline = extractJson(outlineText)
       const extractedChars = extractJson(charsText)
-      const outlineJson = JSON.parse(extractedOutline.objectText) as Record<string, unknown>
-      const charArray = JSON.parse(extractedChars.arrayText) as Array<Record<string, unknown>>
+      const outlineJson = parseJsonSafely<Record<string, unknown>>(extractedOutline.objectText, {}, '大纲', outlineText)
+      const charArray = parseJsonSafely<Array<Record<string, unknown>>>(extractedChars.arrayText, [], '角色卡', charsText)
       const normalizedCharacters: NovelCharacterCard[] = Array.isArray(charArray)
         ? charArray.map((item) => ({ name: String(item.name ?? ''), description: String(item.description ?? ''), personality: String(item.personality ?? '') }))
         : []


### PR DESCRIPTION
## Summary

CORS / 鉴权问题修复后，小说工坊 AI 生成在解析阶段抛 `SyntaxError: Unexpected token ':' ... is not valid JSON`。原 `extractJson` 用贪婪正则 `\{[\s\S]*\}` 从首个 `{` 抓到末个 `}`，会把模型返回的多段 JSON 或前后解释文字粘成非法字符串。

改动：

- `extractJson` 先剥 markdown ` ```json ``` ` 代码块再做提取
- 新增 `sliceBalanced` 用花括号/方括号配平算法提取首个完整 JSON 块，能正确忽略字符串内部的 `{` `}` 与转义字符
- 新增 `parseJsonSafely`：解析失败时不再抛出阻断整个生成流程，而是 fallback 到空对象/空数组，并把 raw 内容打到 console 方便排查
- 给 outline / character_gen prompt 追加硬性提示「严格只输出 JSON 本身，不要任何解释、前后缀文字或 markdown 代码块包裹」

## Test plan

- [ ] 小说工坊输入关键词点 AI 生成，确认 outline / 角色卡正确回填
- [ ] 在 console 观察：若模型返回了非纯 JSON，是否能仍部分回填且看到 `[novel] ... JSON 解析失败` 日志
- [ ] 已有书的续写流程不受影响

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzQMHgtrDo5PJ6XWrxUWUL)_