### PR TITLE
fix(novel): handle non-JSON responses from openrouter-chat

### DIFF
--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -145,11 +145,26 @@ const NovelPage = ({ user }: { user: User | null }) => {
       const errorText = await response.text().catch(() => '')
       throw new Error(`AI 生成失败: ${response.status} ${errorText}`)
     }
-    const data = await response.json()
-    const choice = data?.choices?.[0]
-    const message = choice?.message ?? choice ?? {}
-    const content = typeof message?.content === 'string' ? message.content : ''
-    return content || String(data?.text ?? data?.content ?? '')
+    const responseText = await response.text()
+    const parseResponseJson = () => {
+      try {
+        return JSON.parse(responseText) as Record<string, unknown>
+      } catch (error) {
+        console.warn('[novel] openrouter-chat 返回了非 JSON 响应，将按纯文本处理。', error, { responseText })
+        return null
+      }
+    }
+
+    const data = parseResponseJson()
+    if (!data) return responseText.trim()
+
+    const choice = Array.isArray(data.choices) ? data.choices[0] : null
+    const message = (choice as Record<string, unknown> | null)?.message ?? choice ?? {}
+    const content = typeof (message as Record<string, unknown>)?.content === 'string'
+      ? String((message as Record<string, unknown>).content)
+      : ''
+
+    return content || String(data.text ?? data.content ?? responseText)
   }
 
   const onAiGenerate = async () => {


### PR DESCRIPTION
### Motivation
- Novel AI generation could crash when the upstream `openrouter-chat` function returned plain text or otherwise non-JSON content, because `invokeModel` unconditionally called `response.json()` and threw a parse error.
- This caused `Unexpected token` exceptions during novel setup/generation flows and prevented users from creating settings/characters.

### Description
- Changed `invokeModel` in `src/pages/NovelPage.tsx` to read `response.text()` first and attempt `JSON.parse` inside a `try/catch` to avoid uncaught parse errors.
- If parsing fails, the code now logs a warning and falls back to returning trimmed plain text, preserving behavior for non-JSON responses.
- If parsing succeeds, the original JSON handling is preserved: prefer `choices[0].message.content` and then fallback to `text`/`content` fields or the raw response text.

### Testing
- Ran a production build with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ac64be248330a6bb507a51cec82b)