### PR TITLE
Improve AI model invocation and response parsing in NovelPage

### DIFF
--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -132,6 +132,7 @@ const NovelPage = ({ user }: { user: User | null }) => {
     const accessToken = sessionData.session?.access_token
     const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
     if (!accessToken || !anonKey) throw new Error('AI 生成失败: 登录状态异常或环境变量未配置')
+    const messages = [{ role: 'user', content: prompt }]
     const response = await fetch('https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/openrouter-chat', {
       method: 'POST',
       headers: {
@@ -139,17 +140,32 @@ const NovelPage = ({ user }: { user: User | null }) => {
         apikey: anonKey,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }] }),
+      body: JSON.stringify({ model, messages, stream: false }),
     })
     if (!response.ok) {
       const errorText = await response.text().catch(() => '')
       throw new Error(`AI 生成失败: ${response.status} ${errorText}`)
     }
-    const data = await response.json()
-    const choice = data?.choices?.[0]
-    const message = choice?.message ?? choice ?? {}
-    const content = typeof message?.content === 'string' ? message.content : ''
-    return content || String(data?.text ?? data?.content ?? '')
+    const responseText = await response.text()
+    const parseResponseJson = () => {
+      try {
+        return JSON.parse(responseText) as Record<string, unknown>
+      } catch (error) {
+        console.warn('[novel] openrouter-chat 返回了非 JSON 响应，将按纯文本处理。', error, { responseText })
+        return null
+      }
+    }
+
+    const data = parseResponseJson()
+    if (!data) return responseText.trim()
+
+    const choice = Array.isArray(data.choices) ? data.choices[0] : null
+    const message = (choice as Record<string, unknown> | null)?.message ?? choice ?? {}
+    const content = typeof (message as Record<string, unknown>)?.content === 'string'
+      ? String((message as Record<string, unknown>).content)
+      : ''
+
+    return content || String(data.text ?? data.content ?? responseText)
   }
 
   const onAiGenerate = async () => {


### PR DESCRIPTION
### Motivation
- Make requests to the OpenRouter function more explicit and robust by extracting `messages` and disabling streaming for the current endpoint.
- Handle non-JSON or differently shaped responses from the AI endpoint gracefully and provide clearer console warnings on parse failure.
- Prevent runtime exceptions when the response structure differs from the expected OpenAI-style `choices[0].message.content` shape.

### Description
- Extracted `messages` into a local variable and include `stream: false` in the request body when calling the OpenRouter function in `invokeModel`.
- Reworked response handling to first read raw `responseText`, attempt JSON parse, log a warning if the response is not JSON, and fall back to returning trimmed plain text.
- Normalized extraction of `choices[0].message.content` with type checks to safely obtain returned text, and fall back to other fields (`text`, `content`) or raw response when necessary.
- Kept existing safety and parsing helpers (`extractJson`, `parseJsonSafely`) and preserved current error messages for missing config or auth.

### Testing
- Ran a TypeScript build with `npm run build` and the project compiled successfully.
- Executed the existing automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ac64be248330a6bb507a51cec82b)