### PR TITLE
Improve novel detail/reader UI and make AI invocation/response handling more robust

### DIFF
--- a/src/pages/NovelPage.css
+++ b/src/pages/NovelPage.css
@@ -21,3 +21,28 @@
 .novel-settings-modal__footer{justify-content:flex-end;position:sticky;bottom:-12px;padding:10px 0 2px;background:linear-gradient(180deg, rgba(255,255,255,0), #fff 36%)}
 .novel-settings-error{margin:0;color:#b13f4d;font-size:12px}
 .novel-pill-btn:disabled{opacity:.55;cursor:not-allowed}
+
+
+.novel-page--detail{max-width:1080px}
+.novel-nav-btn{border:1px solid rgba(214,194,207,.9);border-radius:10px;background:rgba(255,255,255,.75);padding:10px 14px;color:#4b4351}
+.novel-book-header{padding:22px}
+.novel-book-header h1{margin:0;font-size:48px;line-height:1.2}
+.novel-book-header p{margin:10px 0 0;color:#6f6775;font-size:18px}
+.novel-detail-grid{grid-template-columns:1fr;gap:16px}
+.novel-info-card{background:rgba(255,255,255,.85);border:1px solid rgba(241,228,235,.95);border-radius:16px;padding:20px;display:grid;gap:10px}
+.novel-info-card h3{margin:0;font-size:34px;color:#494357}
+.novel-info-card pre{margin:0;white-space:pre-wrap;line-height:1.9;font-size:28px;color:#5a5362;font-family:'Noto Serif SC','Source Han Serif SC','Songti SC',serif}
+.novel-chapter-list{padding:18px;display:grid;gap:8px}
+.novel-chapter-list h3{margin:0 0 8px;color:#5c5563}
+.novel-chapter-row{text-align:left;border:1px solid rgba(225,209,219,.9);padding:11px 12px;border-radius:10px;background:#fff;color:#50495a}
+.novel-reader{max-width:920px;margin:0 auto;padding:18px 14px 30px;display:grid;gap:14px;min-height:100dvh}
+.novel-reader-paper{background:linear-gradient(180deg,#fffefc,#fffcff);border:1px solid rgba(231,216,226,.95);border-radius:18px;padding:26px 24px;display:grid;gap:18px;box-shadow:0 10px 24px rgba(194,166,184,.16)}
+.novel-reader-title{margin:0;font-size:44px;letter-spacing:.03em;color:#433c4d;padding-bottom:14px;border-bottom:1px solid rgba(230,217,227,.9)}
+.novel-director-note{border-radius:12px;border:1px solid rgba(226,219,227,.9);background:rgba(245,241,246,.7);padding:10px 12px}
+.novel-director-note summary{cursor:pointer;color:#807887;font-size:14px}
+.novel-director-note p{margin:8px 0 0;color:#7b7383;font-size:13px;line-height:1.75}
+.novel-reader-content{white-space:pre-wrap;font-family:'Noto Serif SC','Source Han Serif SC','Songti SC',serif;font-size:20px;line-height:2.15;letter-spacing:.01em;color:#3f3749}
+@media (min-width:900px){
+  .novel-detail-grid{grid-template-columns:1fr 1fr}
+  .novel-info-card:last-child{grid-column:1 / -1}
+}

--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -132,6 +132,7 @@ const NovelPage = ({ user }: { user: User | null }) => {
     const accessToken = sessionData.session?.access_token
     const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
     if (!accessToken || !anonKey) throw new Error('AI 生成失败: 登录状态异常或环境变量未配置')
+    const messages = [{ role: 'user', content: prompt }]
     const response = await fetch('https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/openrouter-chat', {
       method: 'POST',
       headers: {
@@ -139,17 +140,32 @@ const NovelPage = ({ user }: { user: User | null }) => {
         apikey: anonKey,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }] }),
+      body: JSON.stringify({ model, messages, stream: false }),
     })
     if (!response.ok) {
       const errorText = await response.text().catch(() => '')
       throw new Error(`AI 生成失败: ${response.status} ${errorText}`)
     }
-    const data = await response.json()
-    const choice = data?.choices?.[0]
-    const message = choice?.message ?? choice ?? {}
-    const content = typeof message?.content === 'string' ? message.content : ''
-    return content || String(data?.text ?? data?.content ?? '')
+    const responseText = await response.text()
+    const parseResponseJson = () => {
+      try {
+        return JSON.parse(responseText) as Record<string, unknown>
+      } catch (error) {
+        console.warn('[novel] openrouter-chat 返回了非 JSON 响应，将按纯文本处理。', error, { responseText })
+        return null
+      }
+    }
+
+    const data = parseResponseJson()
+    if (!data) return responseText.trim()
+
+    const choice = Array.isArray(data.choices) ? data.choices[0] : null
+    const message = (choice as Record<string, unknown> | null)?.message ?? choice ?? {}
+    const content = typeof (message as Record<string, unknown>)?.content === 'string'
+      ? String((message as Record<string, unknown>).content)
+      : ''
+
+    return content || String(data.text ?? data.content ?? responseText)
   }
 
   const onAiGenerate = async () => {
@@ -294,9 +310,36 @@ const NovelPage = ({ user }: { user: User | null }) => {
     <section className='novel-shelf'>{books.map((item)=><button key={item.id} className='novel-card' onClick={()=>void openDetail(item)}><h3>{item.title}</h3><p>{item.summary}</p><span>{item.status}</span><span>{item.updatedAt}</span></button>)}</section>
   </div>
 
-  if (!chapter) return <div className='novel-page'><button onClick={()=>setBook(null)}>← 书架</button><h1>{book.title}</h1><p>{book.status}</p><div className='novel-detail-grid'><section><h3>设定</h3><pre>{book.worldSetting}</pre></section><section><h3>大纲</h3><pre>{book.outline}</pre></section><section><h3>配置</h3><select value={activeBookConfig.writing_model} onChange={(e)=>void updateNovelBookModelConfig(book.id,{...activeBookConfig,writing_model:e.target.value})}>{modelOptions.map((m)=><option key={m} value={m}>{m}</option>)}</select></section></div><section>{chapters.map((c)=><button key={c.id} onClick={()=>setChapter(c)}>第{c.chapterNumber}章 {c.title}</button>)}</section><button onClick={()=>void onContinue()}>续写下一章</button></div>
+  if (!chapter) return <div className='novel-page novel-page--detail'>
+    <button className='novel-nav-btn' onClick={()=>setBook(null)}>← 书架</button>
+    <header className='novel-book-header novel-card-shell'>
+      <h1>{book.title}</h1>
+      <p>{book.status}</p>
+    </header>
+    <div className='novel-detail-grid'>
+      <section className='novel-info-card'><h3>设定</h3><pre>{book.worldSetting}</pre></section>
+      <section className='novel-info-card'><h3>大纲</h3><pre>{book.outline}</pre></section>
+      <section className='novel-info-card'><h3>配置</h3><select value={activeBookConfig.writing_model} onChange={(e)=>void updateNovelBookModelConfig(book.id,{...activeBookConfig,writing_model:e.target.value})}>{modelOptions.map((m)=><option key={m} value={m}>{m}</option>)}</select></section>
+    </div>
+    <section className='novel-chapter-list novel-card-shell'>
+      <h3>章节列表</h3>
+      {chapters.map((c)=><button key={c.id} className='novel-chapter-row' onClick={()=>setChapter(c)}>第{c.chapterNumber}章 {c.title}</button>)}
+    </section>
+    <button className='novel-pill-btn novel-pill-btn--primary' onClick={()=>void onContinue()}>续写下一章</button>
+  </div>
 
-  return <div className='novel-reader'><button onClick={()=>setChapter(null)}>← 返回章节列表</button><h2>{chapter.title}</h2><details><summary>导演备注</summary><p>{chapter.directorNote || '暂无'}</p></details><article style={{ whiteSpace: 'pre-wrap' }}>{chapter.content}</article><button onClick={async ()=>{ const updated=await updateNovelChapter(chapter.id,{content:chapter.content, directorNote:chapter.directorNote}); setChapter(updated)}}>保存本章</button></div>
+  return <div className='novel-reader'>
+    <button className='novel-nav-btn' onClick={()=>setChapter(null)}>← 返回章节列表</button>
+    <section className='novel-reader-paper'>
+      <h2 className='novel-reader-title'>{chapter.title}</h2>
+      <details className='novel-director-note'>
+        <summary>导演备注</summary>
+        <p>{chapter.directorNote || '暂无'}</p>
+      </details>
+      <article className='novel-reader-content'>{chapter.content}</article>
+      <button className='novel-pill-btn novel-pill-btn--primary' onClick={async ()=>{ const updated=await updateNovelChapter(chapter.id,{content:chapter.content, directorNote:chapter.directorNote}); setChapter(updated)}}>保存本章</button>
+    </section>
+  </div>
 }
 
 export default NovelPage


### PR DESCRIPTION
### Motivation
- Polish the novel detail and reader screens with a clearer layout and improved styling for better readability and navigation.
- Make AI model invocation more reliable by explicitly sending `messages` and `stream` flags and handling non-JSON responses gracefully.
- Provide more resilient parsing/logging when the AI returns unexpected or malformed content.

### Description
- Added new styles in `NovelPage.css` for detail and reader views including `.novel-page--detail`, `.novel-nav-btn`, `.novel-book-header`, `.novel-info-card`, `.novel-chapter-list`, `.novel-reader-paper`, `.novel-reader-title`, `.novel-reader-content` and a responsive media query to lay out the detail grid.
- Updated `invokeModel` in `NovelPage.tsx` to build a `messages` array, include `stream: false` in the request body, and parse the response by first attempting to `JSON.parse` the response text and falling back to trimmed plain text while emitting a console warning on parse failure.
- Adjusted the novel detail and chapter UI markup in `NovelPage.tsx` to use the new styles and components (improved navigation buttons, info cards, chapter list, reader paper, director note, and save/continue buttons) and kept existing JSON extraction and parsing logic for AI-generated content.

### Testing
- Performed TypeScript type-checking with `tsc --noEmit`, which completed without type errors.
- No automated unit tests were present or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ac64be248330a6bb507a51cec82b)