### PR TITLE
feat(novel): 将阅读页元信息卡片改为可下拉展开

### DIFF
--- a/src/pages/NovelPage.css
+++ b/src/pages/NovelPage.css
@@ -32,6 +32,10 @@
 .novel-info-card{border:1px solid rgba(255,214,231,.88);border-radius:16px;background:#fff;box-shadow:0 6px 14px rgba(255,214,231,.14);padding:14px 16px;display:grid;gap:8px}
 .novel-info-card h3{margin:0;font-size:14px;color:#7d5d70;letter-spacing:.04em}
 .novel-info-card__head{display:flex;justify-content:space-between;align-items:center;gap:8px}
+.novel-info-toggle{display:inline-flex;align-items:center;gap:8px;border:0;background:transparent;padding:0;color:inherit;cursor:pointer}
+.novel-info-toggle h3{margin:0}
+.novel-info-toggle__chevron{font-size:12px;color:#a08496;transition:transform .2s ease}
+.novel-info-toggle__chevron.is-open{transform:rotate(180deg)}
 .novel-info-card__actions{display:flex;gap:6px}
 .novel-info-textarea{width:100%;box-sizing:border-box;padding:10px 12px;border-radius:10px;border:1px solid #e4dbe8;background:#fff;font:inherit;font-size:14px;line-height:1.65;color:#3f3749;resize:vertical;min-height:64px}
 .novel-character-chip--editing{display:grid;gap:6px;background:#fffaff;border-color:#f3dde9}

--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -50,6 +50,12 @@ const NovelPage = ({ user }: { user: User | null }) => {
   const [metaDraftChars, setMetaDraftChars] = useState<NovelCharacterCard[]>([])
   const [metaSaving, setMetaSaving] = useState(false)
   const [metaError, setMetaError] = useState<string | null>(null)
+  const [metaSectionOpen, setMetaSectionOpen] = useState<Record<MetaField, boolean>>({
+    summary: false,
+    worldSetting: false,
+    outline: false,
+    characters: false,
+  })
 
   const baseConfig: NovelModelConfig = useMemo(() => ({
     writing_model: defaultModelId ?? 'openrouter/auto',
@@ -263,6 +269,7 @@ const NovelPage = ({ user }: { user: User | null }) => {
   const startEditMeta = (field: MetaField) => {
     if (!book) return
     setMetaError(null)
+    setMetaSectionOpen((prev) => ({ ...prev, [field]: true }))
     setEditingField(field)
     if (field === 'characters') {
       setMetaDraftChars((book.characters ?? []).map((c) => ({ ...c })))
@@ -276,6 +283,11 @@ const NovelPage = ({ user }: { user: User | null }) => {
   }
 
   const cancelEditMeta = () => { setEditingField(null); setMetaError(null) }
+
+  const toggleMetaSection = (field: MetaField) => {
+    if (editingField === field) return
+    setMetaSectionOpen((prev) => ({ ...prev, [field]: !prev[field] }))
+  }
 
   const saveEditMeta = async () => {
     if (!book || !editingField) return
@@ -478,7 +490,10 @@ const NovelPage = ({ user }: { user: User | null }) => {
 
     <section className='novel-info-card'>
       <div className='novel-info-card__head'>
-        <h3>简介</h3>
+        <button className='novel-info-toggle' onClick={() => toggleMetaSection('summary')}>
+          <h3>简介</h3>
+          <span className={`novel-info-toggle__chevron ${metaSectionOpen.summary ? 'is-open' : ''}`} aria-hidden>▾</span>
+        </button>
         {editingField === 'summary' ? (
           <div className='novel-info-card__actions'>
             <button className='novel-pill-btn' onClick={cancelEditMeta} disabled={metaSaving}>取消</button>
@@ -488,19 +503,22 @@ const NovelPage = ({ user }: { user: User | null }) => {
           <button className='novel-pill-btn' onClick={() => startEditMeta('summary')}>编辑</button>
         )}
       </div>
-      {editingField === 'summary' ? (
+      {metaSectionOpen.summary ? (editingField === 'summary' ? (
         <>
           <textarea className='novel-info-textarea' value={metaDraftText} onChange={(e) => setMetaDraftText(e.target.value)} rows={3} />
           {metaError ? <p className='novel-settings-error'>{metaError}</p> : null}
         </>
       ) : (
         <p className='novel-info-text'>{book.summary || '（暂无）'}</p>
-      )}
+      )) : null}
     </section>
 
     <section className='novel-info-card'>
       <div className='novel-info-card__head'>
-        <h3>世界设定</h3>
+        <button className='novel-info-toggle' onClick={() => toggleMetaSection('worldSetting')}>
+          <h3>世界设定</h3>
+          <span className={`novel-info-toggle__chevron ${metaSectionOpen.worldSetting ? 'is-open' : ''}`} aria-hidden>▾</span>
+        </button>
         {editingField === 'worldSetting' ? (
           <div className='novel-info-card__actions'>
             <button className='novel-pill-btn' onClick={cancelEditMeta} disabled={metaSaving}>取消</button>
@@ -510,19 +528,22 @@ const NovelPage = ({ user }: { user: User | null }) => {
           <button className='novel-pill-btn' onClick={() => startEditMeta('worldSetting')}>编辑</button>
         )}
       </div>
-      {editingField === 'worldSetting' ? (
+      {metaSectionOpen.worldSetting ? (editingField === 'worldSetting' ? (
         <>
           <textarea className='novel-info-textarea' value={metaDraftText} onChange={(e) => setMetaDraftText(e.target.value)} rows={6} />
           {metaError ? <p className='novel-settings-error'>{metaError}</p> : null}
         </>
       ) : (
         <pre className='novel-info-text'>{book.worldSetting || '（暂无）'}</pre>
-      )}
+      )) : null}
     </section>
 
     <section className='novel-info-card'>
       <div className='novel-info-card__head'>
-        <h3>大纲</h3>
+        <button className='novel-info-toggle' onClick={() => toggleMetaSection('outline')}>
+          <h3>大纲</h3>
+          <span className={`novel-info-toggle__chevron ${metaSectionOpen.outline ? 'is-open' : ''}`} aria-hidden>▾</span>
+        </button>
         {editingField === 'outline' ? (
           <div className='novel-info-card__actions'>
             <button className='novel-pill-btn' onClick={cancelEditMeta} disabled={metaSaving}>取消</button>
@@ -532,19 +553,22 @@ const NovelPage = ({ user }: { user: User | null }) => {
           <button className='novel-pill-btn' onClick={() => startEditMeta('outline')}>编辑</button>
         )}
       </div>
-      {editingField === 'outline' ? (
+      {metaSectionOpen.outline ? (editingField === 'outline' ? (
         <>
           <textarea className='novel-info-textarea' value={metaDraftText} onChange={(e) => setMetaDraftText(e.target.value)} rows={6} />
           {metaError ? <p className='novel-settings-error'>{metaError}</p> : null}
         </>
       ) : (
         <pre className='novel-info-text'>{book.outline || '（暂无）'}</pre>
-      )}
+      )) : null}
     </section>
 
     <section className='novel-info-card'>
       <div className='novel-info-card__head'>
-        <h3>角色卡</h3>
+        <button className='novel-info-toggle' onClick={() => toggleMetaSection('characters')}>
+          <h3>角色卡</h3>
+          <span className={`novel-info-toggle__chevron ${metaSectionOpen.characters ? 'is-open' : ''}`} aria-hidden>▾</span>
+        </button>
         {editingField === 'characters' ? (
           <div className='novel-info-card__actions'>
             <button className='novel-pill-btn' onClick={cancelEditMeta} disabled={metaSaving}>取消</button>
@@ -554,7 +578,7 @@ const NovelPage = ({ user }: { user: User | null }) => {
           <button className='novel-pill-btn' onClick={() => startEditMeta('characters')}>编辑</button>
         )}
       </div>
-      {editingField === 'characters' ? (
+      {metaSectionOpen.characters ? (editingField === 'characters' ? (
         <div className='novel-character-list'>
           {metaDraftChars.map((c, i) => (
             <div key={i} className='novel-character-chip novel-character-chip--editing'>
@@ -577,7 +601,7 @@ const NovelPage = ({ user }: { user: User | null }) => {
             </div>)}
           </div>
         ) : <p className='novel-info-text'>（暂无）</p>
-      )}
+      )) : null}
     </section>
     <section className='novel-info-card'>
       <h3>写作模型</h3>


### PR DESCRIPTION
### Motivation
- 阅读页的简介、世界设定、大纲、角色卡内容文本较多，默认全部展开会占用大量空间，改为折叠式能更方便收纳与浏览。 
- 仅修改 UI 交互，不改业务逻辑或后端数据结构。 

### Description
- 为四个元信息卡片（`summary`、`worldSetting`、`outline`、`characters`）新增折叠状态管理：添加 `metaSectionOpen` state 并实现 `toggleMetaSection`。 
- 点击卡片标题区域变为可交互的折叠按钮（加入箭头指示与旋转反馈），并在展开时渲染对应内容；保留原有的 `编辑` 按钮与编辑流程。 
- 在 `startEditMeta` 中自动展开对应区块以进入编辑态。 
- 更新样式文件 `src/pages/NovelPage.css`，新增 `.novel-info-toggle`、`.novel-info-toggle__chevron` 等样式并实现展开时箭头旋转视觉效果。 
- 修改的文件：`src/pages/NovelPage.tsx`、`src/pages/NovelPage.css`。 

### Testing
- 运行 `npm run build` 进行项目构建，构建通过（`vite build` 成功，生产包生成）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11beaee4cc83308702b8a0902c5824)