### PR TITLE
Fix mobile image widget picker trigger in browser and PWA

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -453,6 +453,27 @@
   background: rgba(255, 255, 255, 0.85);
   padding: 0.2rem 0.6rem;
   font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.widget-upload[aria-disabled="true"] {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.file-input-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .image-widget-placeholder {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -244,8 +244,6 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
   const [homeSettingsReady, setHomeSettingsReady] = useState(false);
   const homeBackgroundInputRef = useRef<HTMLInputElement | null>(null);
   const appIconInputRef = useRef<HTMLInputElement | null>(null);
-  const imageWidgetInputRef = useRef<HTMLInputElement | null>(null);
-  const [pendingImageWidgetId, setPendingImageWidgetId] = useState<string | null>(null);
   const [imageWidgetUploading, setImageWidgetUploading] = useState<Record<string, boolean>>({});
 
   const holdTimerRef = useRef<number | null>(null);
@@ -881,11 +879,6 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
     setWidgetOrder((current) => [...current, id]);
   };
 
-  const handleUploadImageForWidget = (widgetId: string) => {
-    setPendingImageWidgetId(widgetId);
-    imageWidgetInputRef.current?.click();
-  };
-
   const processImageWidgetFile = async (file: File) => {
     if (!file.type.startsWith("image/")) {
       throw new Error("请选择图片文件");
@@ -915,14 +908,13 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
   };
 
   const handleImageWidgetFileSelected = async (
+    widgetId: string,
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const widgetId = pendingImageWidgetId;
     const file = event.target.files?.[0];
     event.target.value = "";
-    setPendingImageWidgetId(null);
 
-    if (!widgetId || !file) {
+    if (!file) {
       return;
     }
 
@@ -1391,13 +1383,6 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
                   </button>
                 </div>
                 <input
-                  ref={imageWidgetInputRef}
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  onChange={(event) => void handleImageWidgetFileSelected(event)}
-                />
-                <input
                   ref={appIconInputRef}
                   type="file"
                   accept="image/*"
@@ -1419,6 +1404,8 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
                     const isCheckin = item.kind === "checkin";
                     const widget = item.widget;
                     const isSpacer = widget?.type === "spacer";
+                    const imageUploadInputId =
+                      widget?.type === "image" ? `image-upload-${widget.id}` : null;
 
                     return (
                       <article
@@ -1456,13 +1443,13 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
                               </select>
                             </label>
                             {widget?.type === "image" ? (
-                              <button
-                                type="button"
+                              <label
+                                htmlFor={imageUploadInputId ?? undefined}
                                 className="widget-upload"
-                                onClick={() => handleUploadImageForWidget(widget.id)}
+                                aria-disabled={imageWidgetUploading[widget.id]}
                               >
                                 {imageWidgetUploading[widget.id] ? "处理中…" : "上传图片"}
-                              </button>
+                              </label>
                             ) : null}
                             {!isCheckin && widget ? (
                               <button
@@ -1567,15 +1554,26 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
                           ) : (
                             <div className="image-widget-placeholder">
                               <p>暂无本地图片</p>
-                              <button
-                                type="button"
+                              <label
+                                htmlFor={imageUploadInputId ?? undefined}
                                 className="widget-upload"
-                                onClick={() => handleUploadImageForWidget(widget.id)}
+                                aria-disabled={imageWidgetUploading[widget.id]}
                               >
                                 {imageWidgetUploading[widget.id] ? "处理中…" : "选择图片"}
-                              </button>
+                              </label>
                             </div>
                           )
+                        ) : null}
+                        {widget?.type === "image" && imageUploadInputId ? (
+                          <input
+                            id={imageUploadInputId}
+                            type="file"
+                            accept="image/*"
+                            className="file-input-visually-hidden"
+                            onChange={(event) =>
+                              void handleImageWidgetFileSelected(widget.id, event)
+                            }
+                          />
                         ) : null}
                       </article>
                     );


### PR DESCRIPTION
### Motivation
- Mobile and PWA installs sometimes ignore programmatic `input.click()` calls, causing the image widget upload button to do nothing on tap. 
- The goal is to ensure the native image picker opens reliably on mobile while preserving desktop behavior and local-only decorative image storage. 

### Description
- Replace the shared programmatic click flow with a per-widget native file input bound to a visible `<label>` using `htmlFor` and a stable id pattern `image-upload-${widget.id}`. 
- Change the file handler to accept `widgetId` (`handleImageWidgetFileSelected(widgetId, event)`) and remove the shared `imageWidgetInputRef` and pending id state. 
- Keep the existing image processing/storage pipeline (downscale/compress/save/remove old key/cache) unchanged and preserve cancel-safe behavior (`if (!file) return`). 
- Add CSS for `.file-input-visually-hidden` to keep inputs mounted but hidden, and a disabled visual state for `.widget-upload[aria-disabled="true"]` so upload controls remain tappable and indicate processing. 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` which reported pre-existing unrelated lint errors in other files; lint failures are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13f2c64ec88330b12a9840e612b01c)