### PR TITLE
Render frontend-only dashed dividers at AI continuation append points in Novel chapters

### DIFF
--- a/src/pages/NovelPage.css
+++ b/src/pages/NovelPage.css
@@ -80,7 +80,7 @@
 .novel-reader-content{font-family:'Noto Serif SC','Source Han Serif SC','Songti SC',serif;font-size:15px;line-height:1.9;letter-spacing:.01em;color:#3f3749;min-height:60px}
 .novel-reader-content p{margin:0 0 12px}
 .novel-reader-content h1,.novel-reader-content h2,.novel-reader-content h3{color:#5c4152;margin:14px 0 8px}
-.novel-continuation-divider{border-top:2px dashed #c5c5c5;margin:12px 0 16px;opacity:.9}
+.novel-continuation-divider{border-top:1px dashed rgba(120,120,120,.45);margin:16px 0}
 .novel-reader-empty{margin:0;color:#a89eb0;font-style:italic;font-size:13px;font-family:inherit}
 .novel-reader-editor{width:100%;min-height:40dvh;padding:12px;border-radius:10px;border:1px solid #e4dbe8;background:#fff;font-family:'Noto Serif SC','Source Han Serif SC','Songti SC',serif;font-size:15px;line-height:1.9;color:#3f3749;resize:vertical;box-sizing:border-box}
 

--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -20,6 +20,31 @@ type DraftState = {
 
 const emptyDraft: DraftState = { title: '', summary: '', outline: '', worldSetting: '', characters: [] }
 
+
+const continuationDividerKey = (novelId: string, chapterId: string) => `novelContinuationDividers:${novelId}:${chapterId}`
+
+const readContinuationDividers = (novelId: string, chapterId: string) => {
+  if (typeof window === 'undefined') return [] as number[]
+  try {
+    const raw = window.localStorage.getItem(continuationDividerKey(novelId, chapterId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((item): item is number => typeof item === 'number' && Number.isFinite(item)) : []
+  } catch {
+    return []
+  }
+}
+
+const writeContinuationDividers = (novelId: string, chapterId: string, offsets: number[]) => {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(continuationDividerKey(novelId, chapterId), JSON.stringify(offsets))
+}
+
+const normalizeContinuationDividers = (offsets: number[], contentLength: number) => {
+  const uniqueSorted = Array.from(new Set(offsets.map((offset) => Math.trunc(offset)))).sort((a, b) => a - b)
+  return uniqueSorted.filter((offset) => offset > 0 && offset < contentLength)
+}
+
 const NovelPage = ({ user }: { user: User | null }) => {
   const navigate = useNavigate()
   const { enabledModelIds, defaultModelId } = useEnabledModels(user)
@@ -47,7 +72,6 @@ const NovelPage = ({ user }: { user: User | null }) => {
   const [bookTitleSaving, setBookTitleSaving] = useState(false)
   const [summaryEditing, setSummaryEditing] = useState(false)
   const [summaryDraft, setSummaryDraft] = useState('')
-  const [lastContinuationStart, setLastContinuationStart] = useState<number | null>(null)
 
   // Book-meta editing state
   type MetaField = 'summary' | 'worldSetting' | 'outline' | 'characters'
@@ -108,7 +132,6 @@ const NovelPage = ({ user }: { user: User | null }) => {
     setContentDraft(chapter?.content ?? '')
     setSummaryEditing(false)
     setSummaryDraft(chapter?.summary ?? '')
-    setLastContinuationStart(null)
   }, [chapter?.id])
 
   const reloadBooks = async () => {
@@ -410,14 +433,18 @@ const NovelPage = ({ user }: { user: User | null }) => {
         setChapterError('AI 未返回内容，请稍后重试')
         return
       }
-      const continuationStart = chapter.content ? chapter.content.length + 2 : 0
+      const continuationStart = chapter.content.length
       const nextContent = chapter.content ? `${chapter.content}\n\n${generated}` : generated
       const nextDirectorNote = chapter.directorNote ? `${chapter.directorNote}\n${directive}` : directive
       const updated = await updateNovelChapter(chapter.id, { content: nextContent, directorNote: nextDirectorNote })
       setChapter(updated)
       setChapters((prev) => prev.map((c) => (c.id === updated.id ? updated : c)))
       setContentDraft(updated.content)
-      setLastContinuationStart(continuationStart)
+      if (continuationStart > 0) {
+        const stored = readContinuationDividers(book.id, chapter.id)
+        const nextDividers = normalizeContinuationDividers([...stored, continuationStart], nextContent.length)
+        writeContinuationDividers(book.id, chapter.id, nextDividers)
+      }
       setDirectorInput('')
     } catch (error) {
       setChapterError(error instanceof Error ? error.message : 'AI 续写失败')
@@ -450,9 +477,15 @@ const NovelPage = ({ user }: { user: User | null }) => {
   }
 
   const onSaveEditedContent = async () => {
-    if (!chapter) return
+    if (!chapter || !book) return
     try {
       const updated = await updateNovelChapter(chapter.id, { content: contentDraft })
+      const validDividers = normalizeContinuationDividers(readContinuationDividers(book.id, chapter.id), updated.content.length)
+      if (validDividers.length > 0) {
+        writeContinuationDividers(book.id, chapter.id, validDividers)
+      } else if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(continuationDividerKey(book.id, chapter.id))
+      }
       setChapter(updated)
       setChapters((prev) => prev.map((c) => (c.id === updated.id ? updated : c)))
       setEditingContent(false)
@@ -471,6 +504,12 @@ const NovelPage = ({ user }: { user: User | null }) => {
       setChapterError(error instanceof Error ? error.message : '摘要保存失败')
     }
   }
+
+
+  const chapterDividers = useMemo(() => {
+    if (!book || !chapter?.content) return []
+    return normalizeContinuationDividers(readContinuationDividers(book.id, chapter.id), chapter.content.length)
+  }, [book, chapter?.id, chapter?.content])
 
   if (!book) return <div className='novel-page'>
     <div className='novel-header novel-card-shell'>
@@ -716,12 +755,22 @@ const NovelPage = ({ user }: { user: User | null }) => {
         <article className='novel-reader-content'>
           {chapter.content
             ? (
-              lastContinuationStart !== null && lastContinuationStart > 0 && lastContinuationStart < chapter.content.length
-                ? <>
-                  <MarkdownRenderer content={chapter.content.slice(0, lastContinuationStart - 2)} />
-                  <div className='novel-continuation-divider' aria-label='AI 续写分割线' />
-                  <MarkdownRenderer content={chapter.content.slice(lastContinuationStart)} />
-                </>
+              chapterDividers.length > 0
+                ? (() => {
+                  const segments = [] as { content: string; showDivider: boolean }[]
+                  let start = 0
+                  for (const offset of chapterDividers) {
+                    segments.push({ content: chapter.content.slice(start, offset), showDivider: start !== 0 })
+                    start = offset
+                  }
+                  segments.push({ content: chapter.content.slice(start), showDivider: start !== 0 })
+                  return segments.map((segment, index) => (
+                    <div key={`${index}-${segment.showDivider ? 'cont' : 'base'}`}>
+                      {segment.showDivider ? <div className='novel-continuation-divider' aria-label='AI 续写分割线' /> : null}
+                      <MarkdownRenderer content={segment.content} />
+                    </div>
+                  ))
+                })()
                 : <MarkdownRenderer content={chapter.content} />
             )
             : <p className='novel-reader-empty'>本章尚未生成任何正文。在下方输入导演指令并点击「AI 续写」开始。</p>}


### PR DESCRIPTION
### Motivation
- Provide a visual, frontend-only marker showing where each successful AI continuation was appended inside a single `novel_chapters.content` field without mutating stored content or schema.
- Ensure markers are only recorded when the user explicitly triggers AI 续写 and generation succeeds, avoiding heuristic guesses or `content.includes()` based detection.
- Keep divider persistence local to the browser so UI markers survive refresh on the same device but do not affect Supabase data or cross-device state.

### Description
- Added localStorage helpers `continuationDividerKey`, `readContinuationDividers`, `writeContinuationDividers` and `normalizeContinuationDividers` to persist and validate per-chapter divider offsets keyed as `novelContinuationDividers:${novelId}:${chapterId}`.
- When AI continuation succeeds, record the pre-append offset (`continuationStart = chapter.content.length`) and persist validated offsets (deduped, sorted, and filtered to `0 < offset < content.length`) to localStorage; no divider text is written to the DB or `novel_chapters.content`.
- Reworked the reader rendering to `useMemo`-derive `chapterDividers`, split `chapter.content` at validated offsets, and render subtle dashed divider elements between continuation chunks while keeping the first chunk divider-free and using `MarkdownRenderer` for each chunk.
- Added edit-safety: after manual content saves, stored offsets are revalidated and pruned (or the key removed if none remain) so invalid offsets never break rendering; updated CSS `.novel-continuation-divider` to the requested subtle gray dashed style.

### Testing
- Ran `npm run build` which completed successfully (TypeScript compilation and Vite production build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13fbddc0a48330a0c22dc5e3704a0f)