### PR TITLE
Unify Hamster Wallet and Hamster Machine page headers with Timeline header style

### DIFF
--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -24,13 +24,31 @@
 }
 
 .hamster-console-page__header {
+  position: relative;
   display: grid;
-  gap: 0.35rem;
+  justify-items: center;
+  gap: 0.3rem;
   padding: 12px;
   border: 1px solid rgba(255, 214, 231, 0.85);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.9);
   box-shadow: 0 8px 18px rgba(255, 214, 231, 0.24);
+  min-height: 80px;
+}
+
+.hamster-console-page__title-wrap {
+  display: grid;
+  gap: 2px;
+  text-align: center;
+  min-width: 0;
+}
+
+.hamster-console-page__kicker {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #b27f98;
 }
 
 .hamster-console-page__header h1 {
@@ -43,9 +61,14 @@
   margin: 0;
   color: #8b7182;
   font-size: 0.9rem;
+  text-align: center;
 }
 
 .hamster-console-page__back {
+  position: absolute;
+  top: 50%;
+  left: 12px;
+  transform: translateY(-50%);
   width: fit-content;
   text-decoration: none;
   color: #7d5d70;

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -507,7 +507,10 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     <div className="hamster-console-page">
       <header className="hamster-console-page__header">
         <Link to="/" className="hamster-console-page__back">← 返回小窝</Link>
-        <h1 className="ui-title">🎛️ 仓鼠机</h1>
+        <div className="hamster-console-page__title-wrap">
+          <p className="hamster-console-page__kicker">HAMSTER MACHINE</p>
+          <h1 className="ui-title">仓鼠机</h1>
+        </div>
         <p>远程控制 Mini Agent（用户：{scopedUserId.slice(0, 8)}...）</p>
       </header>
 

--- a/src/pages/WalletPage.css
+++ b/src/pages/WalletPage.css
@@ -25,20 +25,23 @@
 }
 
 .wallet-header {
+  position: relative;
   display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 10px;
+  justify-items: center;
+  gap: 2px;
   padding: 10px;
   border: 1px solid rgba(255, 214, 231, 0.85);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 8px 18px rgba(255, 214, 231, 0.24);
+  min-height: 64px;
 }
 
 .wallet-title-wrap {
   display: grid;
   gap: 2px;
+  text-align: center;
+  min-width: 0;
 }
 
 .wallet-kicker {
@@ -55,6 +58,10 @@
 }
 
 .wallet-back-btn {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  transform: translateY(-50%);
   border-radius: 999px;
   border: 1px solid #ffd6e7;
   background: #fff;

--- a/src/pages/WalletPage.tsx
+++ b/src/pages/WalletPage.tsx
@@ -251,7 +251,7 @@ const WalletPage = () => {
           ← 返回
         </button>
         <div className="wallet-title-wrap">
-          <p className="wallet-kicker">Hamster Wallet</p>
+          <p className="wallet-kicker">HAMSTER WALLET</p>
           <h1 className="ui-title">仓鼠钱包</h1>
         </div>
       </header>


### PR DESCRIPTION
### Motivation
- Bring the Hamster Wallet and Hamster Machine page headers into visual parity with the existing Timeline header for consistent page chrome and responsive behavior.
- Use the Timeline header visual hierarchy: centered title block, small uppercase kicker above a large Chinese title, and a left-anchored back control that does not shift the centered title.

### Description
- Updated Wallet header kicker text to `HAMSTER WALLET` and adjusted `WalletPage` CSS to center the title block while anchoring the back button at the top-left via absolute positioning (files changed: `src/pages/WalletPage.tsx`, `src/pages/WalletPage.css`).
- Reworked Hamster Machine header markup to add a kicker (`HAMSTER MACHINE`) and a title wrap, and updated its CSS to match the Timeline-style centered title with a left-anchored back link (files changed: `src/pages/HamsterConsolePage.tsx`, `src/pages/HamsterConsolePage.css`).
- Kept all page business logic, data fetching, and Timeline behavior unchanged; changes are strictly UI/markup and CSS scoped to the two page headers.

### Testing
- Ran the production build with `npm run build`, which completed successfully (no build errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13febd5c588330bd09515ff4cd3c59)