### PR TITLE
Add To do frontend module with Supabase integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ import LettersPage from './pages/LettersPage'
 import StoryGroupPage from './pages/StoryGroupPage'
 import MemoPage from './pages/MemoPage'
 import TimelinePage from './pages/TimelinePage'
+import TodoPage from './pages/TodoPage'
 import HamsterConsolePage from './pages/HamsterConsolePage'
 import AgentCouncilPage from './pages/AgentCouncilPage'
 import WalletPage from './pages/WalletPage'
@@ -1949,6 +1950,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <TimelinePage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/todo"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <TodoPage />
             </RequireAuth>
           }
         />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "wiki", "novels", "council", "hamster-wallet", "hamster-console"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "todo", "wiki", "novels", "council", "hamster-wallet", "hamster-console"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -267,6 +267,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "letters", defaultEmoji: "💌", label: "Letters", route: "/letters" },
       { id: "memo", defaultEmoji: "📝", label: "备忘录", route: "/memo" },
       { id: "timeline", defaultEmoji: "🗓️", label: "时间轴", route: "/timeline" },
+      { id: "todo", defaultEmoji: "🌷", label: "To do", route: "/todo" },
       { id: "wiki", defaultEmoji: "📚", label: "Wiki", route: "/wiki" },
       { id: "novels", defaultEmoji: "📖", label: "小说", route: "/novels" },
       { id: "council", defaultEmoji: "🏛️", label: "议事厅", route: "/council" },

--- a/src/pages/TodoPage.css
+++ b/src/pages/TodoPage.css
@@ -1,0 +1,226 @@
+.todo-page::before {
+  background:
+    radial-gradient(circle at 12% 0%, rgba(255, 205, 226, 0.38), transparent 42%),
+    radial-gradient(circle at 88% 2%, rgba(255, 239, 246, 0.9), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.98) 0%, rgba(253, 245, 249, 0.98) 100%);
+}
+
+.todo-calendar__cell--pending i {
+  position: absolute;
+  bottom: 5px;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: #f29cc3;
+  box-shadow: 0 0 0 3px rgba(242, 156, 195, 0.16);
+}
+
+.todo-calendar__cell--done em {
+  color: #d979aa;
+}
+
+.todo-calendar-loading {
+  margin: 10px 0 0;
+  color: #a77a93;
+  font-size: 12px;
+  text-align: center;
+}
+
+.todo-detail {
+  display: grid;
+  gap: 12px;
+}
+
+.todo-detail__top,
+.todo-category-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.todo-detail__top h2,
+.todo-category-card h3 {
+  margin: 0;
+  color: #68485e;
+}
+
+.todo-detail__top h2 {
+  font-size: 16px;
+}
+
+.todo-soft-btn,
+.todo-inline-form button {
+  border-radius: 999px;
+  border: 1px solid #ffd6e7;
+  background: linear-gradient(180deg, #fff7fb 0%, #ffe8f3 100%);
+  color: #7d4f68;
+  padding: 7px 12px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.todo-inline-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  padding: 10px;
+  border: 1px dashed rgba(245, 179, 210, 0.8);
+  border-radius: 16px;
+  background: #fff8fc;
+}
+
+.todo-inline-form input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #f7c6dd;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font: inherit;
+  color: #4f3f4a;
+  background: #fff;
+}
+
+.todo-inline-form input:focus {
+  outline: none;
+  border-color: #f5b3d2;
+  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.35);
+}
+
+.todo-empty {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+}
+
+.todo-empty strong {
+  color: #68485e;
+}
+
+.todo-empty span {
+  color: #8f7285;
+  font-size: 13px;
+}
+
+.todo-category-list {
+  display: grid;
+  gap: 12px;
+}
+
+.todo-category-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid rgba(255, 214, 231, 0.82);
+  border-radius: 18px;
+  background: linear-gradient(180deg, #fff 0%, #fff8fc 100%);
+  padding: 12px;
+  box-shadow: 0 5px 14px rgba(255, 214, 231, 0.18);
+}
+
+.todo-category-card h3 {
+  padding-left: 8px;
+  border-left: 3px solid #ffd6e7;
+  font-size: 15px;
+}
+
+.todo-category-empty {
+  margin: 0;
+  border: 1px dashed rgba(255, 214, 231, 0.9);
+  border-radius: 14px;
+  padding: 12px;
+  color: #9c7b8e;
+  background: rgba(255, 255, 255, 0.72);
+  text-align: center;
+  font-size: 13px;
+}
+
+.todo-items {
+  display: grid;
+  gap: 8px;
+}
+
+.todo-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid rgba(255, 214, 231, 0.78);
+  border-radius: 16px;
+  background: #fff;
+  padding: 9px 10px;
+  box-shadow: 0 2px 8px rgba(255, 214, 231, 0.14);
+}
+
+.todo-item--completed {
+  opacity: 0.68;
+}
+
+.todo-item__status {
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 2px solid #f5b3d2;
+  background: #fff;
+  color: #df6ea5;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.todo-item__content {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  color: inherit;
+}
+
+.todo-item__title {
+  color: #4f3f4a;
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.todo-item--completed .todo-item__title {
+  text-decoration: line-through;
+  color: #8f7285;
+}
+
+.todo-item__notes {
+  color: #98798c;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.todo-item__creator {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 214, 231, 0.82);
+  background: #fff5f9;
+}
+
+.todo-editor textarea {
+  min-height: 104px;
+}
+
+@media (max-width: 560px) {
+  .todo-inline-form {
+    grid-template-columns: 1fr;
+  }
+
+  .todo-detail__top,
+  .todo-category-card__head {
+    align-items: flex-start;
+  }
+}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,0 +1,463 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { TodoCategory, TodoCreatedBy, TodoItem } from '../types'
+import {
+  createTodoCategory,
+  createTodoItem,
+  listTodoCategoriesByDate,
+  listTodosByDate,
+  listTodosByMonth,
+  updateTodoItem,
+  updateTodoItemStatus,
+} from '../storage/supabaseSync'
+import './TimelinePage.css'
+import './TodoPage.css'
+
+type TodoEditorState = {
+  mode: 'create' | 'edit'
+  categoryId: string
+  todoId?: string
+  title: string
+  notes: string
+  createdBy: TodoCreatedBy
+}
+
+type CalendarTodoMeta = {
+  total: number
+  pending: number
+  completed: number
+}
+
+const CREATED_BY_META: Record<TodoCreatedBy, { emoji: string; label: string }> = {
+  chuan: { emoji: '🐹', label: 'chuan' },
+  syzygy: { emoji: '💙', label: 'syzygy' },
+}
+
+const toLocalDateKey = (value: Date) => {
+  const year = value.getFullYear()
+  const month = `${value.getMonth() + 1}`.padStart(2, '0')
+  const day = `${value.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const getTodayDate = () => toLocalDateKey(new Date())
+
+const getMonthRange = (anchorDate: Date) => {
+  const year = anchorDate.getFullYear()
+  const month = anchorDate.getMonth()
+  return {
+    monthLabel: `${year}年${month + 1}月`,
+    start: toLocalDateKey(new Date(year, month, 1)),
+    end: toLocalDateKey(new Date(year, month + 1, 0)),
+  }
+}
+
+const TodoPage = () => {
+  const navigate = useNavigate()
+  const today = useMemo(() => getTodayDate(), [])
+  const [monthCursor, setMonthCursor] = useState(() => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), 1)
+  })
+  const [selectedDate, setSelectedDate] = useState(today)
+  const [monthTodos, setMonthTodos] = useState<TodoItem[]>([])
+  const [categories, setCategories] = useState<TodoCategory[]>([])
+  const [dayTodos, setDayTodos] = useState<TodoItem[]>([])
+  const [monthLoading, setMonthLoading] = useState(true)
+  const [dayLoading, setDayLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [categoryName, setCategoryName] = useState('')
+  const [showCategoryForm, setShowCategoryForm] = useState(false)
+  const [editor, setEditor] = useState<TodoEditorState | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const monthRange = useMemo(() => getMonthRange(monthCursor), [monthCursor])
+
+  const refreshMonth = useCallback(async () => {
+    setMonthLoading(true)
+    try {
+      const data = await listTodosByMonth(monthRange.start, monthRange.end)
+      setMonthTodos(data)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载待办月份失败', loadError)
+      setError('加载月份待办失败，请稍后重试')
+    } finally {
+      setMonthLoading(false)
+    }
+  }, [monthRange.end, monthRange.start])
+
+  const refreshSelectedDate = useCallback(async () => {
+    setDayLoading(true)
+    try {
+      const [categoryData, todoData] = await Promise.all([
+        listTodoCategoriesByDate(selectedDate),
+        listTodosByDate(selectedDate),
+      ])
+      setCategories(categoryData)
+      setDayTodos(todoData)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载当天待办失败', loadError)
+      setError('加载当天待办失败，请稍后重试')
+    } finally {
+      setDayLoading(false)
+    }
+  }, [selectedDate])
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([refreshMonth(), refreshSelectedDate()])
+  }, [refreshMonth, refreshSelectedDate])
+
+  useEffect(() => {
+    void refreshMonth()
+  }, [refreshMonth])
+
+  useEffect(() => {
+    void refreshSelectedDate()
+  }, [refreshSelectedDate])
+
+  const todosByDate = useMemo(() => {
+    const groups = new Map<string, CalendarTodoMeta>()
+    monthTodos.forEach((todo) => {
+      const current = groups.get(todo.date) ?? { total: 0, pending: 0, completed: 0 }
+      current.total += 1
+      if (todo.status === 'completed') {
+        current.completed += 1
+      } else {
+        current.pending += 1
+      }
+      groups.set(todo.date, current)
+    })
+    return groups
+  }, [monthTodos])
+
+  const todosByCategory = useMemo(() => {
+    const groups = new Map<string, TodoItem[]>()
+    dayTodos.forEach((todo) => {
+      const current = groups.get(todo.categoryId) ?? []
+      current.push(todo)
+      groups.set(todo.categoryId, current)
+    })
+    return groups
+  }, [dayTodos])
+
+  const calendarCells = useMemo(() => {
+    const first = new Date(monthCursor.getFullYear(), monthCursor.getMonth(), 1)
+    const firstWeekday = first.getDay()
+    const daysInMonth = new Date(monthCursor.getFullYear(), monthCursor.getMonth() + 1, 0).getDate()
+    const cells: Array<{ dateKey: string; day: number; meta?: CalendarTodoMeta } | null> = []
+
+    for (let i = 0; i < firstWeekday; i += 1) {
+      cells.push(null)
+    }
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const dateKey = toLocalDateKey(new Date(monthCursor.getFullYear(), monthCursor.getMonth(), day))
+      cells.push({ dateKey, day, meta: todosByDate.get(dateKey) })
+    }
+    while (cells.length % 7 !== 0) {
+      cells.push(null)
+    }
+    return cells
+  }, [monthCursor, todosByDate])
+
+  const shiftMonth = (delta: number) => {
+    setMonthCursor((current) => {
+      const next = new Date(current.getFullYear(), current.getMonth() + delta, 1)
+      const todayDate = new Date()
+      const nextSelected =
+        next.getFullYear() === todayDate.getFullYear() && next.getMonth() === todayDate.getMonth()
+          ? today
+          : toLocalDateKey(next)
+      setSelectedDate(nextSelected)
+      return next
+    })
+  }
+
+  const handleCreateCategory = async (event: FormEvent) => {
+    event.preventDefault()
+    const name = categoryName.trim()
+    if (!name) {
+      setError('类目名称不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      await createTodoCategory({ date: selectedDate, name, sortOrder: categories.length })
+      setCategoryName('')
+      setShowCategoryForm(false)
+      setNotice('类目已创建')
+      setError(null)
+      await refreshSelectedDate()
+    } catch (saveError) {
+      console.warn('创建类目失败', saveError)
+      setError('创建类目失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const openCreateTodo = (categoryId: string) => {
+    setEditor({ mode: 'create', categoryId, title: '', notes: '', createdBy: 'chuan' })
+  }
+
+  const openEditTodo = (todo: TodoItem) => {
+    setEditor({
+      mode: 'edit',
+      categoryId: todo.categoryId,
+      todoId: todo.id,
+      title: todo.title,
+      notes: todo.notes ?? '',
+      createdBy: todo.createdBy,
+    })
+  }
+
+  const handleSaveTodo = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!editor) {
+      return
+    }
+    const title = editor.title.trim()
+    const notes = editor.notes.trim()
+    if (!title) {
+      setError('待办标题不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      if (editor.mode === 'create') {
+        const categoryTodos = todosByCategory.get(editor.categoryId) ?? []
+        await createTodoItem({
+          categoryId: editor.categoryId,
+          date: selectedDate,
+          title,
+          notes: notes || null,
+          createdBy: editor.createdBy,
+          sortOrder: categoryTodos.length,
+        })
+        setNotice('待办已创建')
+      } else if (editor.todoId) {
+        await updateTodoItem(editor.todoId, { title, notes: notes || null, createdBy: editor.createdBy })
+        setNotice('待办已更新')
+      }
+      setEditor(null)
+      setError(null)
+      await refreshAll()
+    } catch (saveError) {
+      console.warn('保存待办失败', saveError)
+      setError('保存待办失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleToggleStatus = async (todo: TodoItem) => {
+    setSaving(true)
+    try {
+      await updateTodoItemStatus(todo.id, todo.status === 'completed' ? 'pending' : 'completed')
+      setNotice(todo.status === 'completed' ? '已恢复待办' : '已完成待办')
+      setError(null)
+      await refreshAll()
+    } catch (saveError) {
+      console.warn('更新待办状态失败', saveError)
+      setError('更新状态失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="timeline-page todo-page">
+      <header className="timeline-header">
+        <button type="button" className="ghost timeline-back-btn" onClick={() => navigate(-1)}>
+          ← 返回
+        </button>
+        <div className="timeline-title-wrap">
+          <p className="timeline-kicker">To do</p>
+          <h1 className="ui-title">待办小窝</h1>
+        </div>
+        <button type="button" className="timeline-create-btn" onClick={() => setShowCategoryForm(true)}>
+          + 类目
+        </button>
+      </header>
+
+      <section className="timeline-calendar" aria-label="待办月份日历">
+        <div className="timeline-calendar__dot" aria-hidden="true" />
+        <div className="timeline-calendar__top">
+          <button type="button" className="ghost" onClick={() => shiftMonth(-1)}>
+            ← 上月
+          </button>
+          <strong>{monthRange.monthLabel}</strong>
+          <button type="button" className="ghost" onClick={() => shiftMonth(1)}>
+            下月 →
+          </button>
+        </div>
+        <div className="timeline-calendar__weekdays">
+          {['日', '一', '二', '三', '四', '五', '六'].map((label) => (
+            <span key={label}>{label}</span>
+          ))}
+        </div>
+        <div className="timeline-calendar__grid">
+          {calendarCells.map((cell, index) =>
+            cell ? (
+              <button
+                key={cell.dateKey}
+                type="button"
+                className={[
+                  'timeline-calendar__cell',
+                  cell.meta && 'has-entry',
+                  cell.meta?.pending ? 'todo-calendar__cell--pending' : null,
+                  cell.meta && cell.meta.pending === 0 ? 'todo-calendar__cell--done' : null,
+                  cell.dateKey === today && 'today',
+                  cell.dateKey === selectedDate && 'selected',
+                ].filter(Boolean).join(' ')}
+                title={cell.meta ? `${cell.dateKey} 有 ${cell.meta.total} 条待办` : cell.dateKey}
+                onClick={() => setSelectedDate(cell.dateKey)}
+                aria-pressed={cell.dateKey === selectedDate}
+              >
+                <span>{cell.day}</span>
+                {cell.meta?.pending ? <i aria-label={`${cell.meta.pending} 条待完成`} /> : null}
+                {cell.meta && cell.meta.pending === 0 ? <em>✓</em> : null}
+              </button>
+            ) : (
+              <div key={`blank-${index}`} className="timeline-calendar__cell timeline-calendar__cell--blank" />
+            ),
+          )}
+        </div>
+        {monthLoading ? <p className="todo-calendar-loading">月历提示加载中…</p> : null}
+      </section>
+
+      {notice ? <p className="timeline-notice">{notice}</p> : null}
+      {error ? <p className="timeline-error">{error}</p> : null}
+
+      <section className="timeline-list todo-detail" aria-label="当天待办">
+        <div className="todo-detail__top">
+          <div>
+            <p className="timeline-kicker">Selected day</p>
+            <h2>{selectedDate}</h2>
+          </div>
+          <button type="button" className="todo-soft-btn" onClick={() => setShowCategoryForm((value) => !value)}>
+            {showCategoryForm ? '收起' : '+ 新增类目'}
+          </button>
+        </div>
+
+        {showCategoryForm ? (
+          <form className="todo-inline-form" onSubmit={handleCreateCategory}>
+            <input
+              type="text"
+              value={categoryName}
+              onChange={(event) => setCategoryName(event.target.value)}
+              placeholder="例如：今天的小事、工作、窝里清单"
+              disabled={saving}
+            />
+            <button type="submit" disabled={saving}>{saving ? '保存中…' : '保存'}</button>
+          </form>
+        ) : null}
+
+        {dayLoading ? <p className="tips">加载中…</p> : null}
+        {!dayLoading && categories.length === 0 ? (
+          <div className="timeline-empty todo-empty">
+            <strong>今天还没有类目</strong>
+            <span>先搭一个软乎乎的小分区，再把待办放进去吧。</span>
+            <button type="button" className="todo-soft-btn" onClick={() => setShowCategoryForm(true)}>
+              创建第一个类目
+            </button>
+          </div>
+        ) : null}
+
+        {!dayLoading && categories.length > 0 ? (
+          <div className="todo-category-list">
+            {categories.map((category) => {
+              const categoryTodos = todosByCategory.get(category.id) ?? []
+              return (
+                <article className="todo-category-card" key={category.id}>
+                  <div className="todo-category-card__head">
+                    <h3>{category.name}</h3>
+                    <button type="button" className="todo-soft-btn" onClick={() => openCreateTodo(category.id)}>
+                      + 待办
+                    </button>
+                  </div>
+                  {categoryTodos.length === 0 ? (
+                    <p className="todo-category-empty">这个类目下还没有待办。</p>
+                  ) : (
+                    <div className="todo-items">
+                      {categoryTodos.map((todo) => {
+                        const creator = CREATED_BY_META[todo.createdBy] ?? CREATED_BY_META.chuan
+                        const completed = todo.status === 'completed'
+                        return (
+                          <article className={['todo-item', completed && 'todo-item--completed'].filter(Boolean).join(' ')} key={todo.id}>
+                            <button
+                              type="button"
+                              className="todo-item__status"
+                              onClick={() => handleToggleStatus(todo)}
+                              aria-label={completed ? '恢复为待办' : '标记完成'}
+                              disabled={saving}
+                            >
+                              {completed ? '✓' : ''}
+                            </button>
+                            <button type="button" className="todo-item__content" onClick={() => openEditTodo(todo)}>
+                              <span className="todo-item__title">{todo.title}</span>
+                              {todo.notes ? <span className="todo-item__notes">{todo.notes}</span> : null}
+                            </button>
+                            <span className="todo-item__creator" title={creator.label}>{creator.emoji}</span>
+                          </article>
+                        )
+                      })}
+                    </div>
+                  )}
+                </article>
+              )
+            })}
+          </div>
+        ) : null}
+      </section>
+
+      {editor ? (
+        <div className="timeline-editor-backdrop" role="dialog" aria-modal="true">
+          <form className="timeline-editor todo-editor" onSubmit={handleSaveTodo}>
+            <h2>{editor.mode === 'create' ? '新建待办' : '编辑待办'}</h2>
+            <label>
+              标题
+              <input
+                type="text"
+                value={editor.title}
+                onChange={(event) => setEditor({ ...editor, title: event.target.value })}
+                required
+              />
+            </label>
+            <label>
+              备注
+              <textarea
+                value={editor.notes}
+                onChange={(event) => setEditor({ ...editor, notes: event.target.value })}
+                rows={4}
+                placeholder="可选：写一点细节"
+              />
+            </label>
+            <label>
+              创建者
+              <select
+                value={editor.createdBy}
+                onChange={(event) => setEditor({ ...editor, createdBy: event.target.value as TodoCreatedBy })}
+              >
+                <option value="chuan">🐹 chuan</option>
+                <option value="syzygy">💙 syzygy</option>
+              </select>
+            </label>
+            <div className="timeline-editor__actions">
+              <button type="button" className="secondary" onClick={() => setEditor(null)} disabled={saving}>
+                取消
+              </button>
+              <button type="submit" className="primary" disabled={saving}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default TodoPage

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -28,6 +28,10 @@ import type {
   SyzygyReply,
   TimelineEntry,
   TimelineRecorder,
+  TodoCategory,
+  TodoCreatedBy,
+  TodoItem,
+  TodoStatus,
   WalletBalance,
   WalletQuest,
   WalletQuestCreator,
@@ -155,6 +159,29 @@ type TimelineEntryRow = {
   source: string
   created_at: string
   updated_at: string
+}
+
+type TodoCategoryRow = {
+  id: string
+  user_id: string
+  date: string
+  name: string
+  sort_order: number | null
+  created_at: string
+}
+
+type TodoItemRow = {
+  id: string
+  user_id: string
+  category_id: string
+  date: string
+  title: string
+  notes: string | null
+  status: TodoStatus
+  created_by: TodoCreatedBy
+  sort_order: number | null
+  created_at: string
+  completed_at: string | null
 }
 
 type WikiEntryRow = {
@@ -442,6 +469,29 @@ const mapTimelineEntryRow = (row: TimelineEntryRow): TimelineEntry => ({
   source: row.source,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
+})
+
+const mapTodoCategoryRow = (row: TodoCategoryRow): TodoCategory => ({
+  id: row.id,
+  userId: row.user_id,
+  date: row.date,
+  name: row.name,
+  sortOrder: row.sort_order ?? 0,
+  createdAt: row.created_at,
+})
+
+const mapTodoItemRow = (row: TodoItemRow): TodoItem => ({
+  id: row.id,
+  userId: row.user_id,
+  categoryId: row.category_id,
+  date: row.date,
+  title: row.title,
+  notes: row.notes,
+  status: row.status,
+  createdBy: row.created_by,
+  sortOrder: row.sort_order ?? 0,
+  createdAt: row.created_at,
+  completedAt: row.completed_at,
 })
 
 const mapWikiEntryRow = (row: WikiEntryRow): WikiEntry => ({
@@ -2606,6 +2656,149 @@ export const deleteTimelineEntry = async (entryId: string): Promise<void> => {
   }
 }
 
+
+export const listTodosByMonth = async (
+  monthStart: string,
+  monthEnd: string,
+): Promise<TodoItem[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('todos')
+    .select('id,user_id,category_id,date,title,notes,status,created_by,sort_order,created_at,completed_at')
+    .eq('user_id', userId)
+    .gte('date', monthStart)
+    .lte('date', monthEnd)
+    .order('date', { ascending: true })
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapTodoItemRow(row as TodoItemRow))
+}
+
+export const listTodoCategoriesByDate = async (date: string): Promise<TodoCategory[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('todo_categories')
+    .select('id,user_id,date,name,sort_order,created_at')
+    .eq('user_id', userId)
+    .eq('date', date)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapTodoCategoryRow(row as TodoCategoryRow))
+}
+
+export const listTodosByDate = async (date: string): Promise<TodoItem[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('todos')
+    .select('id,user_id,category_id,date,title,notes,status,created_by,sort_order,created_at,completed_at')
+    .eq('user_id', userId)
+    .eq('date', date)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapTodoItemRow(row as TodoItemRow))
+}
+
+export const createTodoCategory = async (payload: {
+  date: string
+  name: string
+  sortOrder: number
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase.from('todo_categories').insert({
+    user_id: userId,
+    date: payload.date,
+    name: payload.name,
+    sort_order: payload.sortOrder,
+  })
+  if (error) {
+    throw error
+  }
+}
+
+export const createTodoItem = async (payload: {
+  categoryId: string
+  date: string
+  title: string
+  notes: string | null
+  createdBy: TodoCreatedBy
+  sortOrder: number
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase.from('todos').insert({
+    user_id: userId,
+    category_id: payload.categoryId,
+    date: payload.date,
+    title: payload.title,
+    notes: payload.notes,
+    status: 'pending',
+    created_by: payload.createdBy,
+    sort_order: payload.sortOrder,
+  })
+  if (error) {
+    throw error
+  }
+}
+
+export const updateTodoItem = async (
+  todoId: string,
+  payload: { title: string; notes: string | null; createdBy: TodoCreatedBy },
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('todos')
+    .update({ title: payload.title, notes: payload.notes, created_by: payload.createdBy })
+    .eq('id', todoId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
+export const updateTodoItemStatus = async (todoId: string, status: TodoStatus): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('todos')
+    .update({
+      status,
+      completed_at: status === 'completed' ? new Date().toISOString() : null,
+    })
+    .eq('id', todoId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
 export const listWikiEntries = async (): Promise<WikiEntry[]> => {
   if (!supabase) {
     return []
@@ -3135,6 +3328,7 @@ export const deleteStoryGroup = async (groupId: string): Promise<void> => {
 }
 
 export const fetchSessionGroups = async (_userId: string): Promise<RpSessionGroup[]> => {
+  void _userId
   if (!supabase) return []
   const { data, error } = await supabase
     .from('rp_session_groups')

--- a/src/types.ts
+++ b/src/types.ts
@@ -323,6 +323,32 @@ export type TimelineEntry = {
   updatedAt: string
 }
 
+export type TodoCreatedBy = 'chuan' | 'syzygy'
+export type TodoStatus = 'pending' | 'completed'
+
+export type TodoCategory = {
+  id: string
+  userId: string
+  date: string
+  name: string
+  sortOrder: number
+  createdAt: string
+}
+
+export type TodoItem = {
+  id: string
+  userId: string
+  categoryId: string
+  date: string
+  title: string
+  notes: string | null
+  status: TodoStatus
+  createdBy: TodoCreatedBy
+  sortOrder: number
+  createdAt: string
+  completedAt: string | null
+}
+
 export type WikiEntryStatus = 'draft' | 'published'
 
 export type WikiEntry = {


### PR DESCRIPTION
### Motivation

- Provide a dedicated "To do / 待办" page with the same soft, timeline-style UI so users can view and manage daily-to-dos by date. 
- Use the existing Supabase auth + RLS pattern to ensure users only read/write their own `todo_categories` and `todos` rows. 
- Support lightweight daily categories and todo items (create, edit, toggle status) as an MVP that fits the current schema and UI language.

### Description

- Add a new page component `src/pages/TodoPage.tsx` and stylesheet `src/pages/TodoPage.css` which reuses the timeline calendar and card styling to present a month calendar and a selected-date detail view. 
- Register an authenticated route and home icon: import and route at `path="/todo"` in `src/App.tsx` and add the Page 2 home entry in `src/pages/HomePage.tsx` so the page is reachable from the home layout. 
- Introduce typed domain models in `src/types.ts`: `TodoCategory`, `TodoItem`, `TodoCreatedBy`, and `TodoStatus`. 
- Implement Supabase helpers in `src/storage/supabaseSync.ts` for month/date queries and mutations: `listTodosByMonth`, `listTodoCategoriesByDate`, `listTodosByDate`, `createTodoCategory`, `createTodoItem`, `updateTodoItem`, and `updateTodoItemStatus`, all using `requireAuthenticatedUserId()` and filtering by `user_id`; map rows to typed objects and honor `sort_order`/`created_at` ordering and `completed_at` updates.

### Testing

- Ran a production build with `npm run build`, which completed successfully (build warnings about large chunks only) and produced the `dist` output. 
- Ran linter with `npm run lint`, which executed but returned pre-existing repository lint failures (unrelated hook/setState issues in `CheckinPage.tsx`, `HamsterConsolePage.tsx`, `LettersPage.tsx`, and `NovelPage.tsx`) and did not indicate errors originating from the newly added To do files. 
- Manual verification during development: the new `/todo` page loads, the month calendar and selected-date flow work locally, and creating categories/todos and toggling status trigger the implemented Supabase helpers (reads/writes scoped to authenticated user).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cef02d2548330940fbcd85c7039e8)