### PR TITLE
Rename todo creator to 串串 and add delete for todos and categories with confirmation

### DIFF
--- a/src/pages/TodoPage.css
+++ b/src/pages/TodoPage.css
@@ -142,7 +142,7 @@
 
 .todo-item {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   gap: 10px;
   align-items: center;
   border: 1px solid rgba(255, 214, 231, 0.78);
@@ -223,4 +223,55 @@
   .todo-category-card__head {
     align-items: flex-start;
   }
+
+  .todo-category-card__head {
+    flex-direction: column;
+  }
+
+  .todo-category-card__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .todo-item {
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .todo-item__delete {
+    grid-column: 2 / 4;
+    justify-self: start;
+  }
+}
+
+.todo-category-card__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.todo-danger-btn,
+.todo-item__delete {
+  border-radius: 999px;
+  border: 1px solid rgba(225, 104, 139, 0.42);
+  background: linear-gradient(180deg, #fff7f8 0%, #ffe4ea 100%);
+  color: #ad3f61;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.todo-danger-btn {
+  padding: 7px 12px;
+}
+
+.todo-item__delete {
+  padding: 6px 10px;
+}
+
+.todo-danger-btn:disabled,
+.todo-item__delete:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
 }

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -4,6 +4,8 @@ import type { TodoCategory, TodoCreatedBy, TodoItem } from '../types'
 import {
   createTodoCategory,
   createTodoItem,
+  deleteTodoCategory,
+  deleteTodoItem,
   listTodoCategoriesByDate,
   listTodosByDate,
   listTodosByMonth,
@@ -29,7 +31,7 @@ type CalendarTodoMeta = {
 }
 
 const CREATED_BY_META: Record<TodoCreatedBy, { emoji: string; label: string }> = {
-  chuan: { emoji: '🐹', label: 'chuan' },
+  串串: { emoji: '🐹', label: '串串' },
   syzygy: { emoji: '💙', label: 'syzygy' },
 }
 
@@ -199,7 +201,7 @@ const TodoPage = () => {
   }
 
   const openCreateTodo = (categoryId: string) => {
-    setEditor({ mode: 'create', categoryId, title: '', notes: '', createdBy: 'chuan' })
+    setEditor({ mode: 'create', categoryId, title: '', notes: '', createdBy: '串串' })
   }
 
   const openEditTodo = (todo: TodoItem) => {
@@ -247,6 +249,49 @@ const TodoPage = () => {
     } catch (saveError) {
       console.warn('保存待办失败', saveError)
       setError('保存待办失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDeleteTodo = async (todo: TodoItem) => {
+    const confirmed = window.confirm(`确认删除待办「${todo.title}」吗？此操作不可撤销。`)
+    if (!confirmed) {
+      return
+    }
+    setSaving(true)
+    try {
+      await deleteTodoItem(todo.id)
+      setNotice('待办已删除')
+      setError(null)
+      await refreshAll()
+    } catch (deleteError) {
+      console.warn('删除待办失败', deleteError)
+      setError('删除待办失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDeleteCategory = async (category: TodoCategory) => {
+    const categoryTodos = todosByCategory.get(category.id) ?? []
+    const confirmed = window.confirm(
+      categoryTodos.length > 0
+        ? `确认删除类目「${category.name}」吗？该类目下的 ${categoryTodos.length} 条待办也会一起删除，此操作不可撤销。`
+        : `确认删除类目「${category.name}」吗？此操作不可撤销。`,
+    )
+    if (!confirmed) {
+      return
+    }
+    setSaving(true)
+    try {
+      await deleteTodoCategory(category.id)
+      setNotice('类目已删除')
+      setError(null)
+      await refreshAll()
+    } catch (deleteError) {
+      console.warn('删除类目失败', deleteError)
+      setError('删除类目失败，请稍后重试')
     } finally {
       setSaving(false)
     }
@@ -374,16 +419,26 @@ const TodoPage = () => {
                 <article className="todo-category-card" key={category.id}>
                   <div className="todo-category-card__head">
                     <h3>{category.name}</h3>
-                    <button type="button" className="todo-soft-btn" onClick={() => openCreateTodo(category.id)}>
-                      + 待办
-                    </button>
+                    <div className="todo-category-card__actions">
+                      <button type="button" className="todo-soft-btn" onClick={() => openCreateTodo(category.id)}>
+                        + 待办
+                      </button>
+                      <button
+                        type="button"
+                        className="todo-danger-btn"
+                        onClick={() => handleDeleteCategory(category)}
+                        disabled={saving}
+                      >
+                        删除类目
+                      </button>
+                    </div>
                   </div>
                   {categoryTodos.length === 0 ? (
                     <p className="todo-category-empty">这个类目下还没有待办。</p>
                   ) : (
                     <div className="todo-items">
                       {categoryTodos.map((todo) => {
-                        const creator = CREATED_BY_META[todo.createdBy] ?? CREATED_BY_META.chuan
+                        const creator = CREATED_BY_META[todo.createdBy] ?? CREATED_BY_META.串串
                         const completed = todo.status === 'completed'
                         return (
                           <article className={['todo-item', completed && 'todo-item--completed'].filter(Boolean).join(' ')} key={todo.id}>
@@ -401,6 +456,15 @@ const TodoPage = () => {
                               {todo.notes ? <span className="todo-item__notes">{todo.notes}</span> : null}
                             </button>
                             <span className="todo-item__creator" title={creator.label}>{creator.emoji}</span>
+                            <button
+                              type="button"
+                              className="todo-item__delete"
+                              onClick={() => handleDeleteTodo(todo)}
+                              disabled={saving}
+                              aria-label={`删除待办：${todo.title}`}
+                            >
+                              删除
+                            </button>
                           </article>
                         )
                       })}
@@ -441,7 +505,7 @@ const TodoPage = () => {
                 value={editor.createdBy}
                 onChange={(event) => setEditor({ ...editor, createdBy: event.target.value as TodoCreatedBy })}
               >
-                <option value="chuan">🐹 chuan</option>
+                <option value="串串">🐹 串串</option>
                 <option value="syzygy">💙 syzygy</option>
               </select>
             </label>

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -178,7 +178,7 @@ type TodoItemRow = {
   title: string
   notes: string | null
   status: TodoStatus
-  created_by: TodoCreatedBy
+  created_by: TodoCreatedBy | 'chuan'
   sort_order: number | null
   created_at: string
   completed_at: string | null
@@ -480,6 +480,10 @@ const mapTodoCategoryRow = (row: TodoCategoryRow): TodoCategory => ({
   createdAt: row.created_at,
 })
 
+const normalizeTodoCreatedBy = (createdBy: TodoItemRow['created_by']): TodoCreatedBy => (
+  createdBy === 'chuan' ? '串串' : createdBy
+)
+
 const mapTodoItemRow = (row: TodoItemRow): TodoItem => ({
   id: row.id,
   userId: row.user_id,
@@ -488,7 +492,7 @@ const mapTodoItemRow = (row: TodoItemRow): TodoItem => ({
   title: row.title,
   notes: row.notes,
   status: row.status,
-  createdBy: row.created_by,
+  createdBy: normalizeTodoCreatedBy(row.created_by),
   sortOrder: row.sort_order ?? 0,
   createdAt: row.created_at,
   completedAt: row.completed_at,
@@ -2778,6 +2782,45 @@ export const updateTodoItem = async (
     .eq('user_id', userId)
   if (error) {
     throw error
+  }
+}
+
+
+export const deleteTodoItem = async (todoId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('todos')
+    .delete()
+    .eq('id', todoId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
+export const deleteTodoCategory = async (categoryId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error: todoError } = await supabase
+    .from('todos')
+    .delete()
+    .eq('category_id', categoryId)
+    .eq('user_id', userId)
+  if (todoError) {
+    throw todoError
+  }
+  const { error: categoryError } = await supabase
+    .from('todo_categories')
+    .delete()
+    .eq('id', categoryId)
+    .eq('user_id', userId)
+  if (categoryError) {
+    throw categoryError
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -323,7 +323,7 @@ export type TimelineEntry = {
   updatedAt: string
 }
 
-export type TodoCreatedBy = 'chuan' | 'syzygy'
+export type TodoCreatedBy = '串串' | 'syzygy'
 export type TodoStatus = 'pending' | 'completed'
 
 export type TodoCategory = {


### PR DESCRIPTION
### Motivation
- Standardize the To do creator label from `chuan` to `串串` and avoid showing legacy `chuan` values in the UI. 
- Provide users the ability to delete individual todos and whole categories (with cascade delete of items) and require a confirmation prompt before destructive actions.

### Description
- Change the `TodoCreatedBy` type and UI labels to use `串串` instead of `chuan`, set new todos default creator to `串串`, and update the editor select option to `🐹 串串` (`src/types.ts`, `src/pages/TodoPage.tsx`).
- Add `normalizeTodoCreatedBy` in `src/storage/supabaseSync.ts` to map legacy `'chuan'` rows to the new `串串` value when reading data.
- Implement `deleteTodoItem` and `deleteTodoCategory` Supabase helpers where deleting a category first removes its todos and then the category (`src/storage/supabaseSync.ts`).
- Add UI delete buttons for todos and categories with `window.confirm` two-step confirmation and danger button styles and mobile layout adjustments (`src/pages/TodoPage.tsx`, `src/pages/TodoPage.css`).

### Testing
- Ran `npm run build` which completed successfully (Vite emitted chunk-size warnings but build succeeded).
- Ran `git diff --check` which passed.
- Ran `npm run lint` which reported unrelated existing lint problems (1 error and several warnings in other pages) so lint did not fully pass.
- Attempted Playwright-based page screenshot / `npx playwright install chromium` which failed due to environment browser download being blocked (403), so end-to-end screenshot verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf964a1e88330bc42d6512afa1dd8)