### PR TITLE
Optimize mobile todo item layout

### DIFF
--- a/src/pages/TodoPage.css
+++ b/src/pages/TodoPage.css
@@ -142,7 +142,7 @@
 
 .todo-item {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
   border: 1px solid rgba(255, 214, 231, 0.78);
@@ -198,6 +198,17 @@
   line-height: 1.4;
   white-space: pre-wrap;
   word-break: break-word;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.todo-item__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
 }
 
 .todo-item__creator {
@@ -233,13 +244,59 @@
     justify-content: flex-start;
   }
 
+  .todo-category-list {
+    gap: 10px;
+  }
+
+  .todo-category-card {
+    gap: 8px;
+    padding: 10px;
+    border-radius: 16px;
+  }
+
+  .todo-items {
+    gap: 6px;
+  }
+
   .todo-item {
-    grid-template-columns: auto 1fr auto;
+    gap: 7px;
+    border-radius: 14px;
+    padding: 7px 8px;
+  }
+
+  .todo-item__status {
+    width: 22px;
+    height: 22px;
+    border-width: 1.5px;
+    font-size: 13px;
+  }
+
+  .todo-item__title {
+    line-height: 1.25;
+  }
+
+  .todo-item__notes {
+    font-size: 11px;
+    line-height: 1.3;
+    -webkit-line-clamp: 1;
+  }
+
+  .todo-item__actions {
+    gap: 5px;
+  }
+
+  .todo-item__creator {
+    width: 24px;
+    height: 24px;
+    font-size: 14px;
   }
 
   .todo-item__delete {
-    grid-column: 2 / 4;
-    justify-self: start;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    font-size: 17px;
+    line-height: 1;
   }
 }
 
@@ -267,7 +324,13 @@
 }
 
 .todo-item__delete {
-  padding: 6px 10px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  line-height: 1;
 }
 
 .todo-danger-btn:disabled,

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -455,16 +455,19 @@ const TodoPage = () => {
                               <span className="todo-item__title">{todo.title}</span>
                               {todo.notes ? <span className="todo-item__notes">{todo.notes}</span> : null}
                             </button>
-                            <span className="todo-item__creator" title={creator.label}>{creator.emoji}</span>
-                            <button
-                              type="button"
-                              className="todo-item__delete"
-                              onClick={() => handleDeleteTodo(todo)}
-                              disabled={saving}
-                              aria-label={`删除待办：${todo.title}`}
-                            >
-                              删除
-                            </button>
+                            <div className="todo-item__actions">
+                              <span className="todo-item__creator" title={creator.label}>{creator.emoji}</span>
+                              <button
+                                type="button"
+                                className="todo-item__delete"
+                                onClick={() => handleDeleteTodo(todo)}
+                                disabled={saving}
+                                aria-label={`删除待办：${todo.title}`}
+                                title="删除"
+                              >
+                                <span aria-hidden="true">×</span>
+                              </button>
+                            </div>
                           </article>
                         )
                       })}


### PR DESCRIPTION
### Motivation
- Make To do list items denser and more compact on mobile while preserving existing behavior and the soft pink, rounded aesthetic.
- Right now each todo card is too tall, the delete button occupies its own line, and creator emoji / actions feel loosely arranged.

### Description
- Restructure todo item DOM so main row is `status circle / title (content) / right action area` by grouping creator emoji and delete control into a `.todo-item__actions` container in `src/pages/TodoPage.tsx`.
- Replace the full-text delete button with a small icon-style button (`×`) and keep `aria-label` and `title` for accessibility in `src/pages/TodoPage.tsx`.
- Adjust layout and spacing in `src/pages/TodoPage.css`: change `.todo-item` grid to `auto minmax(0, 1fr) auto`, add `.todo-item__actions` rules, clamp `.todo-item__notes` to at most 1–2 lines, and tighten paddings, radii and gaps at the mobile `@media (max-width: 560px)` breakpoint.
- All behavior and logic are unchanged (no DB or JS logic modifications): create/edit/complete/toggle/delete flows remain intact.

### Testing
- Ran `npm run build`, which completed successfully and produced the production build.
- Ran `git diff --check` as part of verification with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d25ea93e083309a928e63f7057c00)