### PR TITLE
Add TTS playback for Syzygy replies

### DIFF
--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -402,6 +402,81 @@
   font-size: 12px;
 }
 
+.reply-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.reply-footer .reply-time {
+  margin-top: 0;
+}
+
+.tts-button {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #9ca3af;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease,
+    transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+.tts-button:hover:not(:disabled) {
+  background: #fff7fb;
+  border-color: #ffd6e7;
+  color: #ec4899;
+  transform: translateY(-1px);
+}
+
+.tts-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.tts-button--playing {
+  background: #ffe4f1;
+  border-color: #f9a8d4;
+  color: #db2777;
+  box-shadow: 0 0 0 3px rgba(249, 168, 212, 0.2);
+  animation: tts-pulse 1.4s ease-in-out infinite;
+}
+
+.tts-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(156, 163, 175, 0.35);
+  border-top-color: #ec4899;
+  border-radius: 999px;
+  animation: tts-spin 0.8s linear infinite;
+}
+
+@keyframes tts-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes tts-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px rgba(249, 168, 212, 0.16);
+  }
+
+  50% {
+    box-shadow: 0 0 0 6px rgba(249, 168, 212, 0.28);
+  }
+}
+
 .reply-composer {
   display: flex;
   gap: 8px;

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -46,6 +46,16 @@ type SyzygyFeedPageProps = {
 }
 
 const maxLength = 1000
+const TTS_TEXT_LIMIT = 2000
+const TTS_GENERATE_ENDPOINT = 'https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/tts-generate'
+
+type ReplyTtsState = 'loading' | 'playing'
+
+type CachedTtsAudio = {
+  audio: HTMLAudioElement
+  objectUrl: string
+}
+
 const createPendingReplyId = (postId: string) =>
   `pending-${postId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
@@ -93,7 +103,11 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
   const [notice, setNotice] = useState<string | null>(null)
   const [deletingPermanentPostId, setDeletingPermanentPostId] = useState<string | null>(null)
   const [deletingPermanentReplyId, setDeletingPermanentReplyId] = useState<string | null>(null)
+  const [replyTtsStates, setReplyTtsStates] = useState<Record<string, ReplyTtsState>>({})
   const replyInputRefs = useRef<Record<string, HTMLTextAreaElement | null>>({})
+  const ttsCacheRef = useRef<Record<string, CachedTtsAudio>>({})
+  const activeTtsRef = useRef<{ replyId: string; audio: HTMLAudioElement } | null>(null)
+  const pendingTtsRef = useRef<{ replyId: string; controller: AbortController } | null>(null)
 
   const refreshPosts = useCallback(async () => {
     setLoading(true)
@@ -143,6 +157,142 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
       void refreshTrashPosts()
     }
   }, [refreshTrashPosts, showTrash])
+
+  const setReplyTtsState = useCallback((replyId: string, state: ReplyTtsState | null) => {
+    setReplyTtsStates((current) => {
+      const next = { ...current }
+      if (state) {
+        next[replyId] = state
+      } else {
+        delete next[replyId]
+      }
+      return next
+    })
+  }, [])
+
+  const resetActiveTts = useCallback((exceptReplyId?: string) => {
+    const current = activeTtsRef.current
+    if (!current || current.replyId === exceptReplyId) {
+      return
+    }
+
+    current.audio.pause()
+    current.audio.currentTime = 0
+    setReplyTtsState(current.replyId, null)
+    activeTtsRef.current = null
+  }, [setReplyTtsState])
+
+  const handleReplyTtsClick = useCallback(async (reply: SyzygyReply) => {
+    const text = reply.content.trim()
+    if (!text || text.length > TTS_TEXT_LIMIT || replyTtsStates[reply.id] === 'loading') {
+      return
+    }
+
+    const active = activeTtsRef.current
+    if (active?.replyId === reply.id) {
+      if (active.audio.paused) {
+        try {
+          await active.audio.play()
+          setReplyTtsState(reply.id, 'playing')
+        } catch (playError) {
+          console.warn('TTS 播放失败', playError)
+          setReplyTtsState(reply.id, null)
+        }
+      } else {
+        active.audio.pause()
+        setReplyTtsState(reply.id, null)
+      }
+      return
+    }
+
+    const pendingTts = pendingTtsRef.current
+    if (pendingTts) {
+      pendingTts.controller.abort()
+      setReplyTtsState(pendingTts.replyId, null)
+      pendingTtsRef.current = null
+    }
+    resetActiveTts()
+
+    const cached = ttsCacheRef.current[reply.id]
+    if (cached) {
+      cached.audio.currentTime = 0
+      activeTtsRef.current = { replyId: reply.id, audio: cached.audio }
+      try {
+        await cached.audio.play()
+        setReplyTtsState(reply.id, 'playing')
+      } catch (playError) {
+        console.warn('TTS 播放失败', playError)
+        activeTtsRef.current = null
+        setReplyTtsState(reply.id, null)
+      }
+      return
+    }
+
+    const controller = new AbortController()
+    pendingTtsRef.current = { replyId: reply.id, controller }
+    setReplyTtsState(reply.id, 'loading')
+
+    try {
+      const response = await fetch(TTS_GENERATE_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        throw new Error('TTS generation failed')
+      }
+
+      const blob = await response.blob()
+      if (controller.signal.aborted) {
+        return
+      }
+
+      const objectUrl = URL.createObjectURL(blob)
+      const audio = new Audio(objectUrl)
+      audio.onended = () => {
+        if (activeTtsRef.current?.replyId === reply.id) {
+          activeTtsRef.current = null
+        }
+        setReplyTtsState(reply.id, null)
+      }
+      audio.onerror = () => {
+        if (activeTtsRef.current?.replyId === reply.id) {
+          activeTtsRef.current = null
+        }
+        setReplyTtsState(reply.id, null)
+      }
+
+      ttsCacheRef.current[reply.id] = { audio, objectUrl }
+      activeTtsRef.current = { replyId: reply.id, audio }
+      await audio.play()
+      setReplyTtsState(reply.id, 'playing')
+    } catch (ttsError) {
+      if (!controller.signal.aborted) {
+        console.warn('TTS 生成失败', ttsError)
+        setReplyTtsState(reply.id, null)
+      }
+    } finally {
+      if (pendingTtsRef.current?.controller === controller) {
+        pendingTtsRef.current = null
+      }
+    }
+  }, [replyTtsStates, resetActiveTts, setReplyTtsState])
+
+  useEffect(() => {
+    return () => {
+      pendingTtsRef.current?.controller.abort()
+      activeTtsRef.current?.audio.pause()
+      Object.values(ttsCacheRef.current).forEach(({ audio, objectUrl }) => {
+        audio.pause()
+        URL.revokeObjectURL(objectUrl)
+      })
+      ttsCacheRef.current = {}
+      activeTtsRef.current = null
+      pendingTtsRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     const refreshCurrentView = () => {
@@ -838,7 +988,30 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
                             ) : (
                               <p>{reply.content}</p>
                             )}
-                            <span className="reply-time">{formatChineseTime(reply.createdAt)}</span>
+                            <div className="reply-footer">
+                              <span className="reply-time">{formatChineseTime(reply.createdAt)}</span>
+                              {reply.authorRole === 'ai' ? (() => {
+                                const ttsState = replyTtsStates[reply.id]
+                                const isTooLongForTts = reply.content.trim().length > TTS_TEXT_LIMIT
+                                return (
+                                  <button
+                                    type="button"
+                                    className={`tts-button${ttsState ? ` tts-button--${ttsState}` : ''}`}
+                                    onClick={() => void handleReplyTtsClick(reply)}
+                                    disabled={ttsState === 'loading' || isTooLongForTts}
+                                    aria-label={ttsState === 'playing' ? '暂停语音' : '播放语音'}
+                                    aria-pressed={ttsState === 'playing'}
+                                    title={isTooLongForTts ? '文本超过 2000 字符，无法生成语音' : '播放 Syzygy 回复'}
+                                  >
+                                    {ttsState === 'loading' ? (
+                                      <span className="tts-spinner" aria-hidden="true" />
+                                    ) : (
+                                      <span aria-hidden="true">{ttsState === 'playing' ? '🔊' : '🔈'}</span>
+                                    )}
+                                  </button>
+                                )
+                              })() : null}
+                            </div>
                           </div>
                           <button type="button" className="ghost danger" onClick={() => setPendingDeleteReply(reply)}>
                             删除


### PR DESCRIPTION
### Motivation
- 为 Syzygy 的 AI 回复添加一句话文本转语音播放控件，以便在观察日志中直接播放 AI 回复的语音。 
- 限制单条文本最大支持 `2000` 字符以配合后端 TTS 服务的限制。 

### Description
- 在 `src/pages/SyzygyFeedPage.tsx` 中新增 TTS 常量 `TTS_GENERATE_ENDPOINT` 与 `TTS_TEXT_LIMIT` 并引入状态与引用：`replyTtsStates`、`ttsCacheRef`、`activeTtsRef`、`pendingTtsRef`，以及管理函数 `setReplyTtsState`、`resetActiveTts`、`handleReplyTtsClick` 和卸载清理的 `useEffect`。 
- 实现行为：点击喇叭会调用 `POST` 到 `https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/tts-generate` 返回的 `audio/mpeg` 流并播放，支持缓存已生成音频、同一时间只播放一条、可中止被 superseded 的请求，以及播放结束后恢复状态并清理 `URL.revokeObjectURL()`。 
- 在每条 AI 回复底部添加喇叭按钮（仅 `authorRole === 'ai'` 显示），呈现三种状态：默认 `🔈`、加载 spinner、播放 `🔊`，并对超出 `2000` 字符的文本禁用按钮。 
- 增加样式到 `src/pages/SnacksPage.css`，包括 `.tts-button`、`.tts-spinner` 和播放态脉冲动画。 

### Testing
- 运行构建：`npm run build`，构建成功。 
- 运行代码风格检查：`npm run lint`，该命令失败但原因为仓库中已存在的、与本次改动无关的 lint 报错（`HamsterConsolePage.tsx` 的 hook 问题及若干现有警告）。 
- 针对修改文件运行 ESLint：`npx eslint src/pages/SyzygyFeedPage.tsx`，检查通过。 
- 在本地 dev 服务下使用 Playwright 截图验证页面渲染：`npx -y playwright@1.57.0 screenshot --wait-for-timeout=2000 http://127.0.0.1:5173/syzygy /tmp/syzygy-tts.png`，截图生成成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227757f1ac83309fb48c9d15de5d3e)