### PR TITLE
Add client-side TTS playback hook and UI controls for chat and feed

### DIFF
--- a/src/hooks/useTtsPlayback.ts
+++ b/src/hooks/useTtsPlayback.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const TTS_GENERATE_ENDPOINT = 'https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/tts-generate'
+export const TTS_TEXT_LIMIT = 2000
+
+export type TtsPlaybackState = 'loading' | 'playing'
+
+type CachedTtsAudio = {
+  audio: HTMLAudioElement
+  objectUrl: string
+}
+
+export const useTtsPlayback = () => {
+  const [ttsStates, setTtsStates] = useState<Record<string, TtsPlaybackState>>({})
+  const ttsCacheRef = useRef<Record<string, CachedTtsAudio>>({})
+  const activeTtsRef = useRef<{ id: string; audio: HTMLAudioElement } | null>(null)
+  const pendingTtsRef = useRef<{ id: string; controller: AbortController } | null>(null)
+
+  const setTtsState = useCallback((id: string, state: TtsPlaybackState | null) => {
+    setTtsStates((current) => {
+      const next = { ...current }
+      if (state) {
+        next[id] = state
+      } else {
+        delete next[id]
+      }
+      return next
+    })
+  }, [])
+
+  const resetActiveTts = useCallback((exceptId?: string) => {
+    const current = activeTtsRef.current
+    if (!current || current.id === exceptId) {
+      return
+    }
+
+    current.audio.pause()
+    current.audio.currentTime = 0
+    setTtsState(current.id, null)
+    activeTtsRef.current = null
+  }, [setTtsState])
+
+  const abortPendingTts = useCallback(() => {
+    const pendingTts = pendingTtsRef.current
+    if (!pendingTts) {
+      return
+    }
+
+    pendingTts.controller.abort()
+    setTtsState(pendingTts.id, null)
+    pendingTtsRef.current = null
+  }, [setTtsState])
+
+  const handleTtsClick = useCallback(async (id: string, content: string) => {
+    const text = content.trim()
+    if (!text || text.length > TTS_TEXT_LIMIT || ttsStates[id] === 'loading') {
+      return
+    }
+
+    const active = activeTtsRef.current
+    if (active?.id === id) {
+      if (active.audio.paused) {
+        try {
+          await active.audio.play()
+          setTtsState(id, 'playing')
+        } catch (playError) {
+          console.warn('TTS 播放失败', playError)
+          setTtsState(id, null)
+        }
+      } else {
+        active.audio.pause()
+        setTtsState(id, null)
+      }
+      return
+    }
+
+    abortPendingTts()
+    resetActiveTts()
+
+    const cached = ttsCacheRef.current[id]
+    if (cached) {
+      cached.audio.currentTime = 0
+      activeTtsRef.current = { id, audio: cached.audio }
+      try {
+        await cached.audio.play()
+        setTtsState(id, 'playing')
+      } catch (playError) {
+        console.warn('TTS 播放失败', playError)
+        activeTtsRef.current = null
+        setTtsState(id, null)
+      }
+      return
+    }
+
+    const controller = new AbortController()
+    pendingTtsRef.current = { id, controller }
+    setTtsState(id, 'loading')
+
+    try {
+      const response = await fetch(TTS_GENERATE_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        throw new Error('TTS generation failed')
+      }
+
+      const blob = await response.blob()
+      if (controller.signal.aborted) {
+        return
+      }
+
+      const objectUrl = URL.createObjectURL(blob)
+      const audio = new Audio(objectUrl)
+      audio.onended = () => {
+        if (activeTtsRef.current?.id === id) {
+          activeTtsRef.current = null
+        }
+        setTtsState(id, null)
+      }
+      audio.onerror = () => {
+        if (activeTtsRef.current?.id === id) {
+          activeTtsRef.current = null
+        }
+        setTtsState(id, null)
+      }
+
+      ttsCacheRef.current[id] = { audio, objectUrl }
+      activeTtsRef.current = { id, audio }
+      await audio.play()
+      setTtsState(id, 'playing')
+    } catch (ttsError) {
+      if (!controller.signal.aborted) {
+        console.warn('TTS 生成失败', ttsError)
+        setTtsState(id, null)
+      }
+    } finally {
+      if (pendingTtsRef.current?.controller === controller) {
+        pendingTtsRef.current = null
+      }
+    }
+  }, [abortPendingTts, resetActiveTts, setTtsState, ttsStates])
+
+  useEffect(() => {
+    return () => {
+      pendingTtsRef.current?.controller.abort()
+      activeTtsRef.current?.audio.pause()
+      Object.values(ttsCacheRef.current).forEach(({ audio, objectUrl }) => {
+        audio.pause()
+        URL.revokeObjectURL(objectUrl)
+      })
+      ttsCacheRef.current = {}
+      activeTtsRef.current = null
+      pendingTtsRef.current = null
+    }
+  }, [])
+
+  return {
+    handleTtsClick,
+    ttsStates,
+    ttsTextLimit: TTS_TEXT_LIMIT,
+  }
+}

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -256,7 +256,72 @@
 
 .message-footer {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.message-tts-button {
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(209, 213, 219, 0.72);
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.82);
+  color: #9ca3af;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease,
+    transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+.message-tts-button:hover:not(:disabled) {
+  background: #fff7fb;
+  border-color: #f9a8d4;
+  color: #ec4899;
+  transform: translateY(-1px);
+}
+
+.message-tts-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.message-tts-button--playing {
+  background: #ffe4f1;
+  border-color: #f9a8d4;
+  color: #db2777;
+  box-shadow: 0 0 0 3px rgba(249, 168, 212, 0.2);
+  animation: message-tts-pulse 1.4s ease-in-out infinite;
+}
+
+.message-tts-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(156, 163, 175, 0.35);
+  border-top-color: #ec4899;
+  border-radius: 999px;
+  animation: message-tts-spin 0.8s linear infinite;
+}
+
+@keyframes message-tts-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes message-tts-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px rgba(249, 168, 212, 0.16);
+  }
+
+  50% {
+    box-shadow: 0 0 0 6px rgba(249, 168, 212, 0.28);
+  }
 }
 
 .bubble-meta {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -8,6 +8,7 @@ import ConfirmDialog from '../components/ConfirmDialog'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import ReasoningPanel from '../components/ReasoningPanel'
 import { fetchLettersByConversation } from '../storage/supabaseSync'
+import { useTtsPlayback } from '../hooks/useTtsPlayback'
 import './ChatPage.css'
 
 export type ChatInjectionOptions = {
@@ -84,6 +85,7 @@ const ChatPage = ({
   const actionTriggerRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const headerMenuRef = useRef<HTMLDivElement | null>(null)
   const headerMenuButtonRef = useRef<HTMLButtonElement | null>(null)
+  const { handleTtsClick, ttsStates, ttsTextLimit } = useTtsPlayback()
   const navigate = useNavigate()
 
   const submitDraft = async () => {
@@ -473,13 +475,34 @@ const ChatPage = ({
                   ) : (
                     <p>{message.content}</p>
                   )}
-                  {message.role === 'assistant' && message.meta?.model ? (
-                    <div className="message-footer">
-                      <span className="model-tag">
-                        {message.meta.model === 'mock-model' ? '模拟模型' : message.meta.model}
-                      </span>
-                    </div>
-                  ) : null}
+                  {message.role === 'assistant' ? (() => {
+                    const ttsState = ttsStates[message.id]
+                    const isTooLongForTts = message.content.trim().length > ttsTextLimit
+                    return (
+                      <div className="message-footer">
+                        {message.meta?.model ? (
+                          <span className="model-tag">
+                            {message.meta.model === 'mock-model' ? '模拟模型' : message.meta.model}
+                          </span>
+                        ) : null}
+                        <button
+                          type="button"
+                          className={`message-tts-button${ttsState ? ` message-tts-button--${ttsState}` : ''}`}
+                          onClick={() => void handleTtsClick(message.id, message.content)}
+                          disabled={ttsState === 'loading' || isTooLongForTts}
+                          aria-label={ttsState === 'playing' ? '暂停语音' : '播放语音'}
+                          aria-pressed={ttsState === 'playing'}
+                          title={isTooLongForTts ? '文本超过 2000 字符，无法生成语音' : '播放 Syzygy 回复'}
+                        >
+                          {ttsState === 'loading' ? (
+                            <span className="message-tts-spinner" aria-hidden="true" />
+                          ) : (
+                            <span aria-hidden="true">{ttsState === 'playing' ? '🔊' : '🔈'}</span>
+                          )}
+                        </button>
+                      </div>
+                    )
+                  })() : null}
                 </div>
                 <div className="bubble-meta">
                   <span className="timestamp">{formatTime(message.createdAt)}</span>

--- a/src/pages/SnacksPage.css
+++ b/src/pages/SnacksPage.css
@@ -402,6 +402,81 @@
   font-size: 12px;
 }
 
+.reply-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.reply-footer .reply-time {
+  margin-top: 0;
+}
+
+.tts-button {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #9ca3af;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease,
+    transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+.tts-button:hover:not(:disabled) {
+  background: #fff7fb;
+  border-color: #ffd6e7;
+  color: #ec4899;
+  transform: translateY(-1px);
+}
+
+.tts-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.tts-button--playing {
+  background: #ffe4f1;
+  border-color: #f9a8d4;
+  color: #db2777;
+  box-shadow: 0 0 0 3px rgba(249, 168, 212, 0.2);
+  animation: tts-pulse 1.4s ease-in-out infinite;
+}
+
+.tts-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(156, 163, 175, 0.35);
+  border-top-color: #ec4899;
+  border-radius: 999px;
+  animation: tts-spin 0.8s linear infinite;
+}
+
+@keyframes tts-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes tts-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px rgba(249, 168, 212, 0.16);
+  }
+
+  50% {
+    box-shadow: 0 0 0 6px rgba(249, 168, 212, 0.28);
+  }
+}
+
 .reply-composer {
   display: flex;
   gap: 8px;

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -28,6 +28,7 @@ import {
 } from '../constants/aiOverlays'
 import './SnacksPage.css'
 import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
+import { useTtsPlayback } from '../hooks/useTtsPlayback'
 
 type SyzygyFeedPageProps = {
   user: User | null
@@ -94,6 +95,7 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
   const [deletingPermanentPostId, setDeletingPermanentPostId] = useState<string | null>(null)
   const [deletingPermanentReplyId, setDeletingPermanentReplyId] = useState<string | null>(null)
   const replyInputRefs = useRef<Record<string, HTMLTextAreaElement | null>>({})
+  const { handleTtsClick, ttsStates, ttsTextLimit } = useTtsPlayback()
 
   const refreshPosts = useCallback(async () => {
     setLoading(true)
@@ -838,7 +840,30 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
                             ) : (
                               <p>{reply.content}</p>
                             )}
-                            <span className="reply-time">{formatChineseTime(reply.createdAt)}</span>
+                            <div className="reply-footer">
+                              <span className="reply-time">{formatChineseTime(reply.createdAt)}</span>
+                              {reply.authorRole === 'ai' ? (() => {
+                                const ttsState = ttsStates[reply.id]
+                                const isTooLongForTts = reply.content.trim().length > ttsTextLimit
+                                return (
+                                  <button
+                                    type="button"
+                                    className={`tts-button${ttsState ? ` tts-button--${ttsState}` : ''}`}
+                                    onClick={() => void handleTtsClick(reply.id, reply.content)}
+                                    disabled={ttsState === 'loading' || isTooLongForTts}
+                                    aria-label={ttsState === 'playing' ? '暂停语音' : '播放语音'}
+                                    aria-pressed={ttsState === 'playing'}
+                                    title={isTooLongForTts ? '文本超过 2000 字符，无法生成语音' : '播放 Syzygy 回复'}
+                                  >
+                                    {ttsState === 'loading' ? (
+                                      <span className="tts-spinner" aria-hidden="true" />
+                                    ) : (
+                                      <span aria-hidden="true">{ttsState === 'playing' ? '🔊' : '🔈'}</span>
+                                    )}
+                                  </button>
+                                )
+                              })() : null}
+                            </div>
                           </div>
                           <button type="button" className="ghost danger" onClick={() => setPendingDeleteReply(reply)}>
                             删除


### PR DESCRIPTION
### Motivation

- Add text-to-speech playback for AI responses so users can listen to assistant/Syzygy replies.
- Provide a reusable client-side hook to manage fetching, playback, caching and aborting of TTS audio.

### Description

- Introduced a new hook `useTtsPlayback` at `src/hooks/useTtsPlayback.ts` that handles TTS generation requests, audio playback, caching, aborting pending requests, and exposes `handleTtsClick`, `ttsStates`, and `ttsTextLimit` (constant `TTS_TEXT_LIMIT`).
- Integrated TTS controls into chat messages in `src/pages/ChatPage.tsx` by wiring `useTtsPlayback` and rendering a play/pause/loading button per assistant message with appropriate ARIA attributes and disabled state when text exceeds the limit.
- Integrated TTS controls into feed replies in `src/pages/SyzygyFeedPage.tsx` similarly for AI replies.
- Added styles for the new TTS buttons, spinner and animations to `src/pages/ChatPage.css` and `src/pages/SnacksPage.css` and adjusted the message/footer layout to accommodate the controls.
- The TTS hook uses `TTS_GENERATE_ENDPOINT` to POST `{ text }` and expects a blob audio response, creates an `objectUrl`, and manages lifecycle cleanup (revoking object URLs and aborting on unmount).

### Testing

- No new automated unit tests were added for the TTS feature.
- Ran a project type-check and local build to validate integration of the new hook and UI changes, and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227757f1ac83309fb48c9d15de5d3e)