### PR TITLE
Add Knowledge Library frontend, Supabase types and Phase‑1 RLS migration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ import AgentCouncilPage from './pages/AgentCouncilPage'
 import WalletPage from './pages/WalletPage'
 import WikiPage from './pages/WikiPage'
 import NovelPage from './pages/NovelPage'
+import KnowledgeLibraryPage from './pages/KnowledgeLibraryPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1990,6 +1991,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <WikiPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/knowledge"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <KnowledgeLibraryPage user={user} />
             </RequireAuth>
           }
         />

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -329,7 +329,8 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   }
 
   useEffect(() => {
-    void loadAll()
+    const handle = window.setTimeout(() => void loadAll(), 0)
+    return () => window.clearTimeout(handle)
   }, [loadAll])
 
   useEffect(() => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ const DEFAULT_ICON_ORDER = [
   "settings",
   "export",
 ];
-const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "todo", "wiki", "novels", "council", "hamster-wallet", "hamster-console"];
+const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "todo", "knowledge", "wiki", "novels", "council", "hamster-wallet", "hamster-console"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -268,6 +268,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "memo", defaultEmoji: "📝", label: "备忘录", route: "/memo" },
       { id: "timeline", defaultEmoji: "🗓️", label: "时间轴", route: "/timeline" },
       { id: "todo", defaultEmoji: "🌷", label: "To do", route: "/todo" },
+      { id: "knowledge", defaultEmoji: "🪺", label: "学习库", route: "/knowledge" },
       { id: "wiki", defaultEmoji: "📚", label: "Wiki", route: "/wiki" },
       { id: "novels", defaultEmoji: "📖", label: "小说", route: "/novels" },
       { id: "council", defaultEmoji: "🏛️", label: "议事厅", route: "/council" },

--- a/src/pages/KnowledgeLibraryPage.css
+++ b/src/pages/KnowledgeLibraryPage.css
@@ -1,0 +1,381 @@
+.knowledge-page {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #fff7ed 0%, #fef3c7 40%, #eef2ff 100%);
+  color: #1f2937;
+  padding: 20px;
+}
+
+.knowledge-topbar {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin: 0 auto 18px;
+  max-width: 1280px;
+}
+
+.knowledge-topbar h1 {
+  font-size: clamp(1.6rem, 4vw, 2.5rem);
+  margin: 0;
+}
+
+.knowledge-kicker {
+  color: #b45309;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+
+.knowledge-shell {
+  display: flex;
+  gap: 16px;
+  margin: 0 auto;
+  max-width: 1280px;
+}
+
+.knowledge-sidebar,
+.knowledge-main,
+.node-detail,
+.knowledge-modal {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(251, 191, 36, 0.34);
+  border-radius: 24px;
+  box-shadow: 0 20px 50px rgba(146, 64, 14, 0.12);
+  backdrop-filter: blur(18px);
+}
+
+.knowledge-sidebar {
+  flex: 0 0 300px;
+  padding: 14px;
+  transition: flex-basis 0.2s ease;
+}
+
+.knowledge-sidebar.collapsed {
+  flex-basis: 72px;
+}
+
+.drawer-toggle,
+.knowledge-ghost,
+.knowledge-primary,
+.folder-actions button,
+.detail-actions button,
+.edge-title-row button,
+.modal-actions button,
+.type-tabs button,
+.knowledge-notice {
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.drawer-toggle,
+.knowledge-ghost,
+.folder-actions button,
+.detail-actions button,
+.edge-title-row button,
+.modal-actions button:not(.knowledge-primary),
+.type-tabs button {
+  background: #fff7ed;
+  color: #92400e;
+  padding: 8px 12px;
+}
+
+.knowledge-primary {
+  background: linear-gradient(135deg, #f59e0b, #f97316);
+  color: white;
+  padding: 10px 16px;
+}
+
+.knowledge-notice {
+  background: #fffbeb;
+  color: #92400e;
+  display: block;
+  margin: 0 auto 14px;
+  max-width: 1280px;
+  padding: 12px 16px;
+  text-align: left;
+  width: 100%;
+}
+
+.folder-list {
+  display: grid;
+  gap: 4px;
+  margin: 12px 0;
+}
+
+.folder-item {
+  border-radius: 16px;
+}
+
+.folder-row {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 14px;
+  color: #374151;
+  cursor: pointer;
+  display: flex;
+  font-weight: 700;
+  justify-content: space-between;
+  padding: 10px 12px;
+  text-align: left;
+  width: 100%;
+}
+
+.folder-row.active,
+.type-tabs button.active {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.folder-row em {
+  color: #9ca3af;
+  font-style: normal;
+}
+
+.folder-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  margin: 4px 0 8px;
+}
+
+.folder-actions button {
+  font-size: 0.72rem;
+  padding: 4px 8px;
+}
+
+.folder-edit-row,
+.folder-create-card {
+  display: grid;
+  gap: 8px;
+}
+
+.folder-create-card {
+  border-top: 1px solid #fde68a;
+  margin-top: 12px;
+  padding-top: 14px;
+}
+
+.folder-create-card h2 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.knowledge-main {
+  flex: 1;
+  min-width: 0;
+  padding: 18px;
+}
+
+.knowledge-toolbar {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.type-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.node-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) 360px;
+}
+
+.node-list {
+  align-content: start;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+}
+
+.node-card,
+.edge-card {
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid #fde68a;
+  border-radius: 20px;
+  cursor: pointer;
+  padding: 14px;
+}
+
+.node-card.active {
+  border-color: #f59e0b;
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.18);
+}
+
+.node-card h2,
+.detail-head h2 {
+  margin: 10px 0 6px;
+}
+
+.node-card p,
+.detail-head p,
+.edge-card p {
+  color: #6b7280;
+  line-height: 1.55;
+  margin: 0 0 10px;
+  white-space: pre-wrap;
+}
+
+.type-badge,
+.tag-row span {
+  border-radius: 999px;
+  color: white;
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 800;
+  padding: 4px 8px;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.tag-row span {
+  background: #e5e7eb;
+  color: #4b5563;
+}
+
+.node-card time {
+  color: #9ca3af;
+  font-size: 0.78rem;
+}
+
+.node-detail {
+  align-self: start;
+  max-height: calc(100vh - 150px);
+  overflow: auto;
+  padding: 16px;
+}
+
+.detail-actions,
+.edge-title-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.edge-title-row {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.edge-panel h3 {
+  margin-bottom: 8px;
+}
+
+.edge-card {
+  cursor: default;
+  margin-bottom: 10px;
+}
+
+.edge-peer {
+  background: transparent;
+  border: 0;
+  color: #2563eb;
+  cursor: pointer;
+  display: block;
+  font-weight: 800;
+  margin-bottom: 6px;
+  padding: 0;
+  text-align: left;
+}
+
+.empty-state {
+  color: #9ca3af;
+  padding: 24px;
+  text-align: center;
+}
+
+.knowledge-modal-backdrop {
+  align-items: center;
+  background: rgba(15, 23, 42, 0.36);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 20px;
+  position: fixed;
+  z-index: 20;
+}
+
+.knowledge-modal {
+  display: grid;
+  gap: 12px;
+  max-height: 90vh;
+  max-width: 560px;
+  overflow: auto;
+  padding: 20px;
+  width: min(560px, 100%);
+}
+
+.knowledge-modal h2 {
+  margin: 0;
+}
+
+.knowledge-modal label {
+  color: #6b7280;
+  display: grid;
+  font-size: 0.86rem;
+  font-weight: 800;
+  gap: 6px;
+}
+
+.knowledge-page input,
+.knowledge-page select,
+.knowledge-page textarea {
+  background: white;
+  border: 1px solid #fcd34d;
+  border-radius: 12px;
+  color: #1f2937;
+  font: inherit;
+  padding: 10px 12px;
+}
+
+.knowledge-page textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+@media (max-width: 900px) {
+  .knowledge-page {
+    padding: 12px;
+  }
+
+  .knowledge-topbar,
+  .knowledge-shell,
+  .knowledge-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .knowledge-sidebar,
+  .knowledge-sidebar.collapsed {
+    flex-basis: auto;
+  }
+
+  .node-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .node-detail {
+    max-height: none;
+  }
+}

--- a/src/pages/KnowledgeLibraryPage.tsx
+++ b/src/pages/KnowledgeLibraryPage.tsx
@@ -1,0 +1,475 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from '../supabase/client'
+import type { Database, Json } from '../supabase/types'
+import './KnowledgeLibraryPage.css'
+
+type FolderRow = Database['public']['Tables']['knowledge_folders']['Row']
+type NodeRow = Database['public']['Tables']['learning_nodes']['Row']
+type EdgeRow = Database['public']['Tables']['learning_edges']['Row']
+type NodeType = NodeRow['node_type']
+type EdgeType = EdgeRow['edge_type']
+type Metadata = Record<string, string>
+
+type NodeEditor = {
+  id: string | null
+  nodeType: NodeType
+  title: string
+  content: string
+  tags: string
+  folderId: string
+  metadata: Metadata
+}
+
+type EdgeEditor = {
+  id: string | null
+  targetNodeId: string
+  edgeType: EdgeType
+  description: string
+  strength: number
+}
+
+const nodeTypes: NodeType[] = ['concept', 'question', 'insight', 'source', 'quote', 'note', 'application']
+const edgeTypes: EdgeType[] = ['association', 'derivation', 'contradiction', 'application', 'reference', 'question']
+
+const nodeTypeMeta: Record<NodeType, { label: string; color: string }> = {
+  concept: { label: 'Concept', color: '#7c3aed' },
+  question: { label: 'Question', color: '#d97706' },
+  insight: { label: 'Insight', color: '#059669' },
+  source: { label: 'Source', color: '#2563eb' },
+  quote: { label: 'Quote', color: '#db2777' },
+  note: { label: 'Note', color: '#64748b' },
+  application: { label: 'Application', color: '#ea580c' },
+}
+
+const edgeTypeLabels: Record<EdgeType, string> = {
+  association: '关联',
+  derivation: '推导',
+  contradiction: '矛盾',
+  application: '应用',
+  reference: '引用',
+  question: '提问',
+}
+
+const createEmptyEditor = (folderId: string | null): NodeEditor => ({
+  id: null,
+  nodeType: 'concept',
+  title: '',
+  content: '',
+  tags: '',
+  folderId: folderId ?? '',
+  metadata: {},
+})
+
+const metadataFields: Record<NodeType, Array<{ key: string; label: string; options?: string[] }>> = {
+  concept: [{ key: 'source', label: '来源' }],
+  question: [
+    { key: 'status', label: '状态', options: ['open', 'exploring', 'resolved'] },
+    { key: 'answer', label: '答案' },
+  ],
+  application: [
+    { key: 'project', label: '项目名' },
+    { key: 'status', label: '状态', options: ['idea', 'in_progress', 'done'] },
+  ],
+  source: [
+    { key: 'url', label: 'URL' },
+    { key: 'author', label: '作者' },
+  ],
+  quote: [
+    { key: 'origin', label: '出处' },
+    { key: 'page', label: '页码' },
+  ],
+  insight: [],
+  note: [],
+}
+
+const asMetadata = (value: Json): Metadata => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [key, typeof item === 'string' ? item : String(item ?? '')]),
+  )
+}
+
+const parseTags = (value: string) =>
+  value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+
+const formatTime = (value: string) =>
+  new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value))
+
+const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
+  const navigate = useNavigate()
+  const [folders, setFolders] = useState<FolderRow[]>([])
+  const [nodes, setNodes] = useState<NodeRow[]>([])
+  const [edges, setEdges] = useState<EdgeRow[]>([])
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+  const [nodeTypeFilter, setNodeTypeFilter] = useState<'all' | NodeType>('all')
+  const [drawerOpen, setDrawerOpen] = useState(true)
+  const [loading, setLoading] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [folderDraft, setFolderDraft] = useState({ name: '', icon: '📁', parentId: '' })
+  const [editingFolderId, setEditingFolderId] = useState<string | null>(null)
+  const [editingFolderName, setEditingFolderName] = useState('')
+  const [editor, setEditor] = useState<NodeEditor | null>(null)
+  const [edgeEditor, setEdgeEditor] = useState<EdgeEditor | null>(null)
+  const [nodeSearch, setNodeSearch] = useState('')
+
+  const loadAll = useCallback(async () => {
+    if (!supabase) {
+      setNotice('Supabase 环境变量未配置，无法读取学习库。')
+      return
+    }
+    setLoading(true)
+    const [folderResult, nodeResult, edgeResult] = await Promise.all([
+      supabase.from('knowledge_folders').select('*').order('created_at', { ascending: true }),
+      supabase.from('learning_nodes').select('*').order('created_at', { ascending: false }),
+      supabase.from('learning_edges').select('*').order('created_at', { ascending: false }),
+    ])
+    setLoading(false)
+    const error = folderResult.error ?? nodeResult.error ?? edgeResult.error
+    if (error) {
+      setNotice(error.message)
+      return
+    }
+    setFolders(folderResult.data ?? [])
+    setNodes(nodeResult.data ?? [])
+    setEdges(edgeResult.data ?? [])
+  }, [])
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => void loadAll(), 0)
+    return () => window.clearTimeout(handle)
+  }, [loadAll])
+
+  const folderOptions = useMemo(() => {
+    const byParent = new Map<string | null, FolderRow[]>()
+    folders.forEach((folder) => {
+      const key = folder.parent_id ?? null
+      byParent.set(key, [...(byParent.get(key) ?? []), folder])
+    })
+    const result: Array<{ folder: FolderRow; depth: number }> = []
+    const walk = (parentId: string | null, depth: number) => {
+      ;(byParent.get(parentId) ?? []).forEach((folder) => {
+        result.push({ folder, depth })
+        walk(folder.id, depth + 1)
+      })
+    }
+    walk(null, 0)
+    return result
+  }, [folders])
+
+  const selectedNode = useMemo(
+    () => nodes.find((node) => node.id === selectedNodeId) ?? null,
+    [nodes, selectedNodeId],
+  )
+
+  const filteredNodes = useMemo(
+    () =>
+      nodes.filter((node) => {
+        const folderMatches = selectedFolderId ? node.folder_id === selectedFolderId : true
+        const typeMatches = nodeTypeFilter === 'all' ? true : node.node_type === nodeTypeFilter
+        return folderMatches && typeMatches
+      }),
+    [nodes, nodeTypeFilter, selectedFolderId],
+  )
+
+  const selectedNodeEdges = useMemo(
+    () => (selectedNode ? edges.filter((edge) => edge.source_node_id === selectedNode.id || edge.target_node_id === selectedNode.id) : []),
+    [edges, selectedNode],
+  )
+
+  const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes])
+  const childFolderCount = useMemo(() => {
+    const count = new Map<string, number>()
+    folders.forEach((folder) => {
+      if (folder.parent_id) count.set(folder.parent_id, (count.get(folder.parent_id) ?? 0) + 1)
+    })
+    return count
+  }, [folders])
+  const folderNodeCount = useMemo(() => {
+    const count = new Map<string, number>()
+    nodes.forEach((node) => {
+      if (node.folder_id) count.set(node.folder_id, (count.get(node.folder_id) ?? 0) + 1)
+    })
+    return count
+  }, [nodes])
+
+  const createFolder = async () => {
+    if (!supabase || !folderDraft.name.trim()) return
+    const { error } = await supabase.from('knowledge_folders').insert({
+      user_id: user?.id ?? crypto.randomUUID(),
+      name: folderDraft.name.trim(),
+      icon: folderDraft.icon.trim() || '📁',
+      parent_id: folderDraft.parentId || null,
+    })
+    if (error) setNotice(error.message)
+    else {
+      setFolderDraft({ name: '', icon: '📁', parentId: '' })
+      await loadAll()
+    }
+  }
+
+  const saveFolderName = async (folderId: string) => {
+    if (!supabase || !editingFolderName.trim()) return
+    const { error } = await supabase.from('knowledge_folders').update({ name: editingFolderName.trim() }).eq('id', folderId)
+    if (error) setNotice(error.message)
+    else {
+      setEditingFolderId(null)
+      await loadAll()
+    }
+  }
+
+  const deleteFolder = async (folderId: string) => {
+    if (!supabase) return
+    if ((childFolderCount.get(folderId) ?? 0) > 0 || (folderNodeCount.get(folderId) ?? 0) > 0) {
+      setNotice('只能删除空文件夹：请先移走子文件夹和节点。')
+      return
+    }
+    const { error } = await supabase.from('knowledge_folders').delete().eq('id', folderId)
+    if (error) setNotice(error.message)
+    else await loadAll()
+  }
+
+  const openCreateNode = () => setEditor(createEmptyEditor(selectedFolderId))
+  const openEditNode = (node: NodeRow) =>
+    setEditor({
+      id: node.id,
+      nodeType: node.node_type,
+      title: node.title,
+      content: node.content ?? '',
+      tags: node.tags.join(', '),
+      folderId: node.folder_id ?? '',
+      metadata: asMetadata(node.metadata),
+    })
+
+  const saveNode = async () => {
+    if (!supabase || !editor || !editor.title.trim()) return
+    const metadata = Object.fromEntries(
+      metadataFields[editor.nodeType].map(({ key }) => [key, editor.metadata[key] ?? '']).filter(([, value]) => String(value).trim()),
+    )
+    const payload = {
+      title: editor.title.trim(),
+      content: editor.content.trim() || null,
+      tags: parseTags(editor.tags),
+      folder_id: editor.folderId || null,
+      metadata,
+    }
+    const result = editor.id
+      ? await supabase.from('learning_nodes').update(payload).eq('id', editor.id)
+      : await supabase.from('learning_nodes').insert({ ...payload, node_type: editor.nodeType, user_id: user?.id ?? crypto.randomUUID() })
+    if (result.error) setNotice(result.error.message)
+    else {
+      setEditor(null)
+      await loadAll()
+    }
+  }
+
+  const deleteNode = async (nodeId: string) => {
+    if (!supabase) return
+    const { error } = await supabase.from('learning_nodes').delete().eq('id', nodeId)
+    if (error) setNotice(error.message)
+    else {
+      setSelectedNodeId(null)
+      await loadAll()
+    }
+  }
+
+  const saveEdge = async () => {
+    if (!supabase || !selectedNode || !edgeEditor || !edgeEditor.targetNodeId) return
+    if (edgeEditor.targetNodeId === selectedNode.id) {
+      setNotice('不允许建立自连边。')
+      return
+    }
+    const edgeDetails = {
+      edge_type: edgeEditor.edgeType,
+      description: edgeEditor.description.trim() || null,
+      strength: edgeEditor.strength,
+    }
+    const result = edgeEditor.id
+      ? await supabase.from('learning_edges').update(edgeDetails).eq('id', edgeEditor.id)
+      : await supabase.from('learning_edges').insert({
+          ...edgeDetails,
+          target_node_id: edgeEditor.targetNodeId,
+          source_node_id: selectedNode.id,
+          user_id: user?.id ?? crypto.randomUUID(),
+        })
+    if (result.error) setNotice(result.error.message)
+    else {
+      setEdgeEditor(null)
+      await loadAll()
+    }
+  }
+
+  const deleteEdge = async (edgeId: string) => {
+    if (!supabase) return
+    const { error } = await supabase.from('learning_edges').delete().eq('id', edgeId)
+    if (error) setNotice(error.message)
+    else await loadAll()
+  }
+
+  const searchedTargetNodes = useMemo(() => {
+    const query = nodeSearch.trim().toLowerCase()
+    return nodes.filter((node) => node.id !== selectedNode?.id && (!query || node.title.toLowerCase().includes(query))).slice(0, 30)
+  }, [nodeSearch, nodes, selectedNode])
+
+  return (
+    <div className="knowledge-page">
+      <header className="knowledge-topbar">
+        <button type="button" className="knowledge-ghost" onClick={() => navigate(-1)}>← 返回</button>
+        <div>
+          <p className="knowledge-kicker">Knowledge Library</p>
+          <h1>仓鼠小窝 · 学习库</h1>
+        </div>
+        <button type="button" className="knowledge-primary" onClick={openCreateNode}>+ 新建节点</button>
+      </header>
+
+      {notice ? <button type="button" className="knowledge-notice" onClick={() => setNotice(null)}>{notice}</button> : null}
+
+      <div className="knowledge-shell">
+        <aside className={drawerOpen ? 'knowledge-sidebar' : 'knowledge-sidebar collapsed'}>
+          <button type="button" className="drawer-toggle" onClick={() => setDrawerOpen((open) => !open)}>{drawerOpen ? '收起' : '展开'}</button>
+          {drawerOpen ? (
+            <>
+              <button type="button" className={selectedFolderId === null ? 'folder-row active' : 'folder-row'} onClick={() => setSelectedFolderId(null)}>
+                <span>🌐 全部</span><em>{nodes.length}</em>
+              </button>
+              <div className="folder-list">
+                {folderOptions.map(({ folder, depth }) => (
+                  <div key={folder.id} className="folder-item" style={{ paddingLeft: 10 + depth * 18 }}>
+                    {editingFolderId === folder.id ? (
+                      <div className="folder-edit-row">
+                        <input value={editingFolderName} onChange={(event) => setEditingFolderName(event.target.value)} />
+                        <button type="button" onClick={() => void saveFolderName(folder.id)}>保存</button>
+                      </div>
+                    ) : (
+                      <button type="button" className={selectedFolderId === folder.id ? 'folder-row active' : 'folder-row'} onClick={() => setSelectedFolderId(folder.id)}>
+                        <span>{folder.icon ?? '📁'} {folder.name}</span><em>{folderNodeCount.get(folder.id) ?? 0}</em>
+                      </button>
+                    )}
+                    <div className="folder-actions">
+                      <button type="button" onClick={() => { setEditingFolderId(folder.id); setEditingFolderName(folder.name) }}>编辑</button>
+                      <button type="button" onClick={() => void deleteFolder(folder.id)}>删除</button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <section className="folder-create-card">
+                <h2>新建文件夹</h2>
+                <input placeholder="emoji" value={folderDraft.icon} onChange={(event) => setFolderDraft((draft) => ({ ...draft, icon: event.target.value }))} />
+                <input placeholder="文件夹名称" value={folderDraft.name} onChange={(event) => setFolderDraft((draft) => ({ ...draft, name: event.target.value }))} />
+                <select value={folderDraft.parentId} onChange={(event) => setFolderDraft((draft) => ({ ...draft, parentId: event.target.value }))}>
+                  <option value="">无父级</option>
+                  {folderOptions.map(({ folder, depth }) => <option key={folder.id} value={folder.id}>{'—'.repeat(depth)} {folder.name}</option>)}
+                </select>
+                <button type="button" className="knowledge-primary" onClick={() => void createFolder()}>创建</button>
+              </section>
+            </>
+          ) : null}
+        </aside>
+
+        <main className="knowledge-main">
+          <div className="knowledge-toolbar">
+            <div className="type-tabs">
+              <button type="button" className={nodeTypeFilter === 'all' ? 'active' : ''} onClick={() => setNodeTypeFilter('all')}>全部</button>
+              {nodeTypes.map((type) => <button key={type} type="button" className={nodeTypeFilter === type ? 'active' : ''} onClick={() => setNodeTypeFilter(type)}>{nodeTypeMeta[type].label}</button>)}
+            </div>
+            <span>{loading ? '加载中…' : `${filteredNodes.length} 个节点`}</span>
+          </div>
+
+          <section className="node-grid">
+            <div className="node-list">
+              {filteredNodes.map((node) => (
+                <article key={node.id} className={selectedNodeId === node.id ? 'node-card active' : 'node-card'} onClick={() => setSelectedNodeId(node.id)}>
+                  <span className="type-badge" style={{ background: nodeTypeMeta[node.node_type].color }}>{nodeTypeMeta[node.node_type].label}</span>
+                  <h2>{node.title}</h2>
+                  <p>{node.content || '暂无正文'}</p>
+                  <div className="tag-row">{node.tags.map((tag) => <span key={tag}>#{tag}</span>)}</div>
+                  <time>{formatTime(node.created_at)}</time>
+                </article>
+              ))}
+              {!loading && filteredNodes.length === 0 ? <p className="empty-state">暂无节点，点击右上角新建。</p> : null}
+            </div>
+
+            <aside className="node-detail">
+              {selectedNode ? (
+                <>
+                  <div className="detail-head">
+                    <span className="type-badge" style={{ background: nodeTypeMeta[selectedNode.node_type].color }}>{nodeTypeMeta[selectedNode.node_type].label}</span>
+                    <h2>{selectedNode.title}</h2>
+                    <p>{selectedNode.content}</p>
+                    <div className="detail-actions">
+                      <button type="button" onClick={() => openEditNode(selectedNode)}>编辑</button>
+                      <button type="button" onClick={() => void deleteNode(selectedNode.id)}>删除</button>
+                    </div>
+                  </div>
+                  <section className="edge-panel">
+                    <div className="edge-title-row"><h3>联想</h3><button type="button" onClick={() => setEdgeEditor({ id: null, targetNodeId: '', edgeType: 'association', description: '', strength: 3 })}>+ 连边</button></div>
+                    {selectedNodeEdges.map((edge) => {
+                      const isOutgoing = edge.source_node_id === selectedNode.id
+                      const peer = nodeById.get(isOutgoing ? edge.target_node_id : edge.source_node_id)
+                      return (
+                        <article key={edge.id} className="edge-card">
+                          <button type="button" className="edge-peer" onClick={() => peer && setSelectedNodeId(peer.id)}>{isOutgoing ? '→' : '←'} {peer?.title ?? '未知节点'}</button>
+                          <span>{edgeTypeLabels[edge.edge_type]} · 强度 {edge.strength}/5</span>
+                          <p>{edge.description || '无描述'}</p>
+                          <div className="detail-actions">
+                            <button type="button" onClick={() => peer && setEdgeEditor({ id: edge.id, targetNodeId: peer.id, edgeType: edge.edge_type, description: edge.description ?? '', strength: edge.strength })}>编辑</button>
+                            <button type="button" onClick={() => void deleteEdge(edge.id)}>删除</button>
+                          </div>
+                        </article>
+                      )
+                    })}
+                  </section>
+                </>
+              ) : <p className="empty-state">选择一个节点查看详情和联想。</p>}
+            </aside>
+          </section>
+        </main>
+      </div>
+
+      {editor ? (
+        <div className="knowledge-modal-backdrop">
+          <section className="knowledge-modal">
+            <h2>{editor.id ? '编辑节点' : '新建节点'}</h2>
+            <label>类型<select disabled={Boolean(editor.id)} value={editor.nodeType} onChange={(event) => setEditor((current) => current && ({ ...current, nodeType: event.target.value as NodeType, metadata: {} }))}>{nodeTypes.map((type) => <option key={type} value={type}>{nodeTypeMeta[type].label}</option>)}</select></label>
+            <label>标题<input value={editor.title} onChange={(event) => setEditor((current) => current && ({ ...current, title: event.target.value }))} /></label>
+            <label>正文<textarea value={editor.content} onChange={(event) => setEditor((current) => current && ({ ...current, content: event.target.value }))} /></label>
+            <label>Tags<input placeholder="逗号分隔" value={editor.tags} onChange={(event) => setEditor((current) => current && ({ ...current, tags: event.target.value }))} /></label>
+            <label>文件夹<select value={editor.folderId} onChange={(event) => setEditor((current) => current && ({ ...current, folderId: event.target.value }))}><option value="">不归档</option>{folderOptions.map(({ folder, depth }) => <option key={folder.id} value={folder.id}>{'—'.repeat(depth)} {folder.name}</option>)}</select></label>
+            {metadataFields[editor.nodeType].map((field) => (
+              <label key={field.key}>{field.label}{field.options ? <select value={editor.metadata[field.key] ?? ''} onChange={(event) => setEditor((current) => current && ({ ...current, metadata: { ...current.metadata, [field.key]: event.target.value } }))}><option value="">未选择</option>{field.options.map((option) => <option key={option} value={option}>{option}</option>)}</select> : <input value={editor.metadata[field.key] ?? ''} onChange={(event) => setEditor((current) => current && ({ ...current, metadata: { ...current.metadata, [field.key]: event.target.value } }))} />}</label>
+            ))}
+            <div className="modal-actions"><button type="button" className="knowledge-primary" onClick={() => void saveNode()}>保存</button><button type="button" onClick={() => setEditor(null)}>取消</button></div>
+          </section>
+        </div>
+      ) : null}
+
+      {edgeEditor && selectedNode ? (
+        <div className="knowledge-modal-backdrop">
+          <section className="knowledge-modal">
+            <h2>{edgeEditor.id ? '编辑连边' : '新建连边'}</h2>
+            <label>搜索节点<input value={nodeSearch} onChange={(event) => setNodeSearch(event.target.value)} placeholder="输入标题筛选" /></label>
+            <label>目标节点<select disabled={Boolean(edgeEditor.id)} value={edgeEditor.targetNodeId} onChange={(event) => setEdgeEditor((current) => current && ({ ...current, targetNodeId: event.target.value }))}><option value="">选择节点</option>{searchedTargetNodes.map((node) => <option key={node.id} value={node.id}>{node.title}</option>)}</select></label>
+            <label>类型<select value={edgeEditor.edgeType} onChange={(event) => setEdgeEditor((current) => current && ({ ...current, edgeType: event.target.value as EdgeType }))}>{edgeTypes.map((type) => <option key={type} value={type}>{edgeTypeLabels[type]}</option>)}</select></label>
+            <label>描述<textarea value={edgeEditor.description} onChange={(event) => setEdgeEditor((current) => current && ({ ...current, description: event.target.value }))} /></label>
+            <label>强度 {edgeEditor.strength}<input type="range" min="1" max="5" value={edgeEditor.strength} onChange={(event) => setEdgeEditor((current) => current && ({ ...current, strength: Number(event.target.value) }))} /></label>
+            <div className="modal-actions"><button type="button" className="knowledge-primary" onClick={() => void saveEdge()}>保存</button><button type="button" onClick={() => setEdgeEditor(null)}>取消</button></div>
+          </section>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default KnowledgeLibraryPage

--- a/src/supabase/types.ts
+++ b/src/supabase/types.ts
@@ -1,0 +1,148 @@
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      knowledge_folders: {
+        Row: {
+          id: string
+          user_id: string
+          parent_id: string | null
+          name: string
+          icon: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          parent_id?: string | null
+          name: string
+          icon?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          parent_id?: string | null
+          name?: string
+          icon?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'knowledge_folders_parent_id_fkey'
+            columns: ['parent_id']
+            isOneToOne: false
+            referencedRelation: 'knowledge_folders'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      learning_nodes: {
+        Row: {
+          id: string
+          user_id: string
+          folder_id: string | null
+          node_type: 'concept' | 'question' | 'insight' | 'source' | 'quote' | 'note' | 'application'
+          title: string
+          content: string | null
+          tags: string[]
+          metadata: Json
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          folder_id?: string | null
+          node_type: 'concept' | 'question' | 'insight' | 'source' | 'quote' | 'note' | 'application'
+          title: string
+          content?: string | null
+          tags?: string[]
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          folder_id?: string | null
+          node_type?: 'concept' | 'question' | 'insight' | 'source' | 'quote' | 'note' | 'application'
+          title?: string
+          content?: string | null
+          tags?: string[]
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'learning_nodes_folder_id_fkey'
+            columns: ['folder_id']
+            isOneToOne: false
+            referencedRelation: 'knowledge_folders'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      learning_edges: {
+        Row: {
+          id: string
+          user_id: string
+          source_node_id: string
+          target_node_id: string
+          edge_type: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
+          strength: number
+          description: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          source_node_id: string
+          target_node_id: string
+          edge_type: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
+          strength?: number
+          description?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          source_node_id?: string
+          target_node_id?: string
+          edge_type?: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
+          strength?: number
+          description?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'learning_edges_source_node_id_fkey'
+            columns: ['source_node_id']
+            isOneToOne: false
+            referencedRelation: 'learning_nodes'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'learning_edges_target_node_id_fkey'
+            columns: ['target_node_id']
+            isOneToOne: false
+            referencedRelation: 'learning_nodes'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+    }
+    Views: Record<string, never>
+    Functions: Record<string, never>
+    Enums: Record<string, never>
+    CompositeTypes: Record<string, never>
+  }
+}

--- a/supabase/migrations/20260608120000_add_knowledge_library_policies.sql
+++ b/supabase/migrations/20260608120000_add_knowledge_library_policies.sql
@@ -1,0 +1,70 @@
+-- Knowledge Library: permissive Phase 1 RLS policies for anon/authenticated clients.
+-- Tables may already exist in the hosted Supabase project; create missing local tables for type-safe development.
+CREATE TABLE IF NOT EXISTS knowledge_folders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  parent_id uuid REFERENCES knowledge_folders(id) ON DELETE RESTRICT,
+  name text NOT NULL,
+  icon text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS learning_nodes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  folder_id uuid REFERENCES knowledge_folders(id) ON DELETE SET NULL,
+  node_type text NOT NULL CHECK (node_type IN ('concept', 'question', 'insight', 'source', 'quote', 'note', 'application')),
+  title text NOT NULL,
+  content text,
+  tags text[] NOT NULL DEFAULT '{}',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS learning_edges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  source_node_id uuid NOT NULL REFERENCES learning_nodes(id) ON DELETE CASCADE,
+  target_node_id uuid NOT NULL REFERENCES learning_nodes(id) ON DELETE CASCADE,
+  edge_type text NOT NULL CHECK (edge_type IN ('association', 'derivation', 'contradiction', 'application', 'reference', 'question')),
+  strength integer NOT NULL DEFAULT 3 CHECK (strength BETWEEN 1 AND 5),
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT no_self_loop CHECK (source_node_id <> target_node_id)
+);
+
+ALTER TABLE knowledge_folders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE learning_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE learning_edges ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Knowledge folders anon authenticated CRUD" ON knowledge_folders;
+CREATE POLICY "Knowledge folders anon authenticated CRUD"
+  ON knowledge_folders
+  FOR ALL
+  TO anon, authenticated
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Learning nodes anon authenticated CRUD" ON learning_nodes;
+CREATE POLICY "Learning nodes anon authenticated CRUD"
+  ON learning_nodes
+  FOR ALL
+  TO anon, authenticated
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Learning edges anon authenticated CRUD" ON learning_edges;
+CREATE POLICY "Learning edges anon authenticated CRUD"
+  ON learning_edges
+  FOR ALL
+  TO anon, authenticated
+  USING (true)
+  WITH CHECK (true);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_folders_parent ON knowledge_folders (parent_id);
+CREATE INDEX IF NOT EXISTS idx_learning_nodes_folder_type_created ON learning_nodes (folder_id, node_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_learning_edges_source ON learning_edges (source_node_id);
+CREATE INDEX IF NOT EXISTS idx_learning_edges_target ON learning_edges (target_node_id);


### PR DESCRIPTION
### Motivation
- Provide a Phase‑1, usable Knowledge Library UI for creating and organizing learning content backed by Supabase tables. 
- Ship local type-safe Supabase table definitions so the frontend can call the new tables with TypeScript types.
- Allow quick trial usage by enabling permissive RLS policies for anon/authenticated reads/writes during Phase 1.
- Integrate the page into the app shell and Home Page so users can access the feature from the main UI.

### Description
- Added a new `KnowledgeLibraryPage` component and stylesheet implementing a folders drawer, nested folder display, folder create/edit/delete (delete requires empty), node list with type filter, node editor modal with dynamic metadata fields per `node_type`, and a node detail panel with edge (联想) management (create/edit/delete, strength slider, description, target search, peer navigation, and self-loop prevention). (`src/pages/KnowledgeLibraryPage.tsx`, `src/pages/KnowledgeLibraryPage.css`).
- Added typed Supabase table types for the new tables with `Database` typings exported for client use. (`src/supabase/types.ts`).
- Added a Phase‑1 migration that creates `knowledge_folders`, `learning_nodes`, and `learning_edges` tables, indexes, constraints (including `no_self_loop`), and permissive RLS policies for `anon` and `authenticated`. (`supabase/migrations/20260608120000_add_knowledge_library_policies.sql`).
- Wired the new route and UI into the app by adding a `/knowledge` route and a Page‑2 home icon entry for “学习库”, and adjusted a small React effect in `HamsterConsolePage` to avoid synchronous setState-in-effect lint warnings. (`src/App.tsx`, `src/pages/HomePage.tsx`, `src/pages/HamsterConsolePage.tsx`).

### Testing
- Built the production bundle with `npm run build` which completed successfully (Vite build produced assets, with a chunk size warning only). 
- Ran lint with `npm run lint` and resolved the blocking hook rule; final lint run completed with existing non-blocking warnings in unrelated files. 
- Manual smoke checks in the dev flow verified the new `/knowledge` route loads and the page UI renders (folders, node list, modals, and edge dialogs) when Supabase env is configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265ef9c0c88330a6d3ea6033889b3c)