### PR TITLE
Remove user_id from Knowledge Library frontend and apply pink UI with Chinese labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1998,7 +1998,7 @@ const App = () => {
           path="/knowledge"
           element={
             <RequireAuth ready={authReady} user={user}>
-              <KnowledgeLibraryPage user={user} />
+              <KnowledgeLibraryPage />
             </RequireAuth>
           }
         />

--- a/src/pages/KnowledgeLibraryPage.css
+++ b/src/pages/KnowledgeLibraryPage.css
@@ -1,31 +1,53 @@
 .knowledge-page {
   min-height: 100vh;
-  background: linear-gradient(135deg, #fff7ed 0%, #fef3c7 40%, #eef2ff 100%);
-  color: #1f2937;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(255, 214, 231, 0.34), transparent 42%),
+    radial-gradient(circle at 90% 0%, rgba(255, 239, 246, 0.82), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.96) 0%, rgba(253, 245, 249, 0.96) 100%);
+  color: #3c3340;
   padding: 20px;
 }
 
 .knowledge-topbar {
   align-items: center;
-  display: flex;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 18px;
+  box-shadow: 0 8px 18px rgba(255, 214, 231, 0.24);
+  display: grid;
   gap: 16px;
-  justify-content: space-between;
+  grid-template-columns: minmax(120px, 1fr) auto minmax(120px, 1fr);
   margin: 0 auto 18px;
   max-width: 1280px;
+  min-height: 72px;
+  padding: 12px;
+}
+
+.knowledge-title-wrap {
+  min-width: 0;
+  text-align: center;
 }
 
 .knowledge-topbar h1 {
+  color: #5c4152;
   font-size: clamp(1.6rem, 4vw, 2.5rem);
   margin: 0;
 }
 
 .knowledge-kicker {
-  color: #b45309;
+  color: #b27f98;
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0.16em;
   margin: 0 0 4px;
-  text-transform: uppercase;
+}
+
+.knowledge-topbar .knowledge-ghost {
+  justify-self: start;
+}
+
+.knowledge-topbar .knowledge-primary {
+  justify-self: end;
 }
 
 .knowledge-shell {
@@ -39,10 +61,10 @@
 .knowledge-main,
 .node-detail,
 .knowledge-modal {
-  background: rgba(255, 255, 255, 0.82);
-  border: 1px solid rgba(251, 191, 36, 0.34);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 214, 231, 0.88);
   border-radius: 24px;
-  box-shadow: 0 20px 50px rgba(146, 64, 14, 0.12);
+  box-shadow: 0 10px 24px rgba(255, 185, 216, 0.2);
   backdrop-filter: blur(18px);
 }
 
@@ -78,20 +100,23 @@
 .edge-title-row button,
 .modal-actions button:not(.knowledge-primary),
 .type-tabs button {
-  background: #fff7ed;
-  color: #92400e;
+  background: #fff7fb;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  color: #7c5a70;
   padding: 8px 12px;
 }
 
 .knowledge-primary {
-  background: linear-gradient(135deg, #f59e0b, #f97316);
-  color: white;
+  background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%);
+  border: 1px solid #ffd6e7;
+  color: #68485e;
   padding: 10px 16px;
 }
 
 .knowledge-notice {
-  background: #fffbeb;
-  color: #92400e;
+  background: #fff1f8;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  color: #8e3866;
   display: block;
   margin: 0 auto 14px;
   max-width: 1280px;
@@ -115,7 +140,7 @@
   background: transparent;
   border: 0;
   border-radius: 14px;
-  color: #374151;
+  color: #4f3f4a;
   cursor: pointer;
   display: flex;
   font-weight: 700;
@@ -127,12 +152,13 @@
 
 .folder-row.active,
 .type-tabs button.active {
-  background: #fef3c7;
-  color: #92400e;
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  color: #59354b;
+  box-shadow: 0 3px 7px rgba(255, 185, 216, 0.38);
 }
 
 .folder-row em {
-  color: #9ca3af;
+  color: #a36f8e;
   font-style: normal;
 }
 
@@ -155,12 +181,13 @@
 }
 
 .folder-create-card {
-  border-top: 1px solid #fde68a;
+  border-top: 1px dashed #f0ccdd;
   margin-top: 12px;
   padding-top: 14px;
 }
 
 .folder-create-card h2 {
+  color: #6d4e63;
   font-size: 1rem;
   margin: 0;
 }
@@ -177,6 +204,10 @@
   gap: 12px;
   justify-content: space-between;
   margin-bottom: 14px;
+}
+
+.knowledge-toolbar span {
+  color: #8f7285;
 }
 
 .type-tabs {
@@ -200,27 +231,29 @@
 
 .node-card,
 .edge-card {
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid #fde68a;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(255, 214, 231, 0.8);
   border-radius: 20px;
   cursor: pointer;
   padding: 14px;
+  box-shadow: 0 8px 14px rgba(255, 214, 231, 0.18);
 }
 
 .node-card.active {
-  border-color: #f59e0b;
-  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.18);
+  border-color: #f8bed9;
+  box-shadow: 0 0 0 3px rgba(255, 185, 216, 0.3);
 }
 
 .node-card h2,
 .detail-head h2 {
+  color: #5c4152;
   margin: 10px 0 6px;
 }
 
 .node-card p,
 .detail-head p,
 .edge-card p {
-  color: #6b7280;
+  color: #6d4e63;
   line-height: 1.55;
   margin: 0 0 10px;
   white-space: pre-wrap;
@@ -244,12 +277,13 @@
 }
 
 .tag-row span {
-  background: #e5e7eb;
-  color: #4b5563;
+  background: #fff1f8;
+  border: 1px solid rgba(255, 214, 231, 0.82);
+  color: #7c5a70;
 }
 
 .node-card time {
-  color: #9ca3af;
+  color: #a36f8e;
   font-size: 0.78rem;
 }
 
@@ -273,6 +307,7 @@
 }
 
 .edge-panel h3 {
+  color: #6d4e63;
   margin-bottom: 8px;
 }
 
@@ -284,7 +319,7 @@
 .edge-peer {
   background: transparent;
   border: 0;
-  color: #2563eb;
+  color: #c45e8d;
   cursor: pointer;
   display: block;
   font-weight: 800;
@@ -294,14 +329,14 @@
 }
 
 .empty-state {
-  color: #9ca3af;
+  color: #8f7285;
   padding: 24px;
   text-align: center;
 }
 
 .knowledge-modal-backdrop {
   align-items: center;
-  background: rgba(15, 23, 42, 0.36);
+  background: rgba(60, 51, 64, 0.36);
   display: flex;
   inset: 0;
   justify-content: center;
@@ -321,11 +356,12 @@
 }
 
 .knowledge-modal h2 {
+  color: #5c4152;
   margin: 0;
 }
 
 .knowledge-modal label {
-  color: #6b7280;
+  color: #6d4e63;
   display: grid;
   font-size: 0.86rem;
   font-weight: 800;
@@ -336,9 +372,9 @@
 .knowledge-page select,
 .knowledge-page textarea {
   background: white;
-  border: 1px solid #fcd34d;
+  border: 1px solid rgba(255, 214, 231, 0.88);
   border-radius: 12px;
-  color: #1f2937;
+  color: #3c3340;
   font: inherit;
   padding: 10px 12px;
 }
@@ -359,7 +395,15 @@
     padding: 12px;
   }
 
-  .knowledge-topbar,
+  .knowledge-topbar {
+    grid-template-columns: 1fr;
+  }
+
+  .knowledge-topbar .knowledge-ghost,
+  .knowledge-topbar .knowledge-primary {
+    justify-self: stretch;
+  }
+
   .knowledge-shell,
   .knowledge-toolbar {
     align-items: stretch;

--- a/src/pages/KnowledgeLibraryPage.tsx
+++ b/src/pages/KnowledgeLibraryPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { User } from '@supabase/supabase-js'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '../supabase/client'
 import type { Database, Json } from '../supabase/types'
@@ -34,13 +33,22 @@ const nodeTypes: NodeType[] = ['concept', 'question', 'insight', 'source', 'quot
 const edgeTypes: EdgeType[] = ['association', 'derivation', 'contradiction', 'application', 'reference', 'question']
 
 const nodeTypeMeta: Record<NodeType, { label: string; color: string }> = {
-  concept: { label: 'Concept', color: '#7c3aed' },
-  question: { label: 'Question', color: '#d97706' },
-  insight: { label: 'Insight', color: '#059669' },
-  source: { label: 'Source', color: '#2563eb' },
-  quote: { label: 'Quote', color: '#db2777' },
-  note: { label: 'Note', color: '#64748b' },
-  application: { label: 'Application', color: '#ea580c' },
+  concept: { label: '概念', color: '#c45e8d' },
+  question: { label: '问题', color: '#d977a3' },
+  insight: { label: '洞见', color: '#a8558f' },
+  source: { label: '资料', color: '#b27f98' },
+  quote: { label: '摘录', color: '#db2777' },
+  note: { label: '笔记', color: '#8f7285' },
+  application: { label: '应用', color: '#e879a6' },
+}
+
+const metadataOptionLabels: Record<string, string> = {
+  open: '待探索',
+  exploring: '探索中',
+  resolved: '已解决',
+  idea: '想法',
+  in_progress: '进行中',
+  done: '已完成',
 }
 
 const edgeTypeLabels: Record<EdgeType, string> = {
@@ -73,7 +81,7 @@ const metadataFields: Record<NodeType, Array<{ key: string; label: string; optio
     { key: 'status', label: '状态', options: ['idea', 'in_progress', 'done'] },
   ],
   source: [
-    { key: 'url', label: 'URL' },
+    { key: 'url', label: '链接' },
     { key: 'author', label: '作者' },
   ],
   quote: [
@@ -107,7 +115,7 @@ const formatTime = (value: string) =>
     minute: '2-digit',
   }).format(new Date(value))
 
-const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
+const KnowledgeLibraryPage = () => {
   const navigate = useNavigate()
   const [folders, setFolders] = useState<FolderRow[]>([])
   const [nodes, setNodes] = useState<NodeRow[]>([])
@@ -208,7 +216,6 @@ const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
   const createFolder = async () => {
     if (!supabase || !folderDraft.name.trim()) return
     const { error } = await supabase.from('knowledge_folders').insert({
-      user_id: user?.id ?? crypto.randomUUID(),
       name: folderDraft.name.trim(),
       icon: folderDraft.icon.trim() || '📁',
       parent_id: folderDraft.parentId || null,
@@ -267,7 +274,7 @@ const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
     }
     const result = editor.id
       ? await supabase.from('learning_nodes').update(payload).eq('id', editor.id)
-      : await supabase.from('learning_nodes').insert({ ...payload, node_type: editor.nodeType, user_id: user?.id ?? crypto.randomUUID() })
+      : await supabase.from('learning_nodes').insert({ ...payload, node_type: editor.nodeType })
     if (result.error) setNotice(result.error.message)
     else {
       setEditor(null)
@@ -302,7 +309,6 @@ const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
           ...edgeDetails,
           target_node_id: edgeEditor.targetNodeId,
           source_node_id: selectedNode.id,
-          user_id: user?.id ?? crypto.randomUUID(),
         })
     if (result.error) setNotice(result.error.message)
     else {
@@ -327,8 +333,8 @@ const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
     <div className="knowledge-page">
       <header className="knowledge-topbar">
         <button type="button" className="knowledge-ghost" onClick={() => navigate(-1)}>← 返回</button>
-        <div>
-          <p className="knowledge-kicker">Knowledge Library</p>
+        <div className="knowledge-title-wrap">
+          <p className="knowledge-kicker">学习知识库</p>
           <h1>仓鼠小窝 · 学习库</h1>
         </div>
         <button type="button" className="knowledge-primary" onClick={openCreateNode}>+ 新建节点</button>
@@ -366,7 +372,7 @@ const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
               </div>
               <section className="folder-create-card">
                 <h2>新建文件夹</h2>
-                <input placeholder="emoji" value={folderDraft.icon} onChange={(event) => setFolderDraft((draft) => ({ ...draft, icon: event.target.value }))} />
+                <input placeholder="图标" value={folderDraft.icon} onChange={(event) => setFolderDraft((draft) => ({ ...draft, icon: event.target.value }))} />
                 <input placeholder="文件夹名称" value={folderDraft.name} onChange={(event) => setFolderDraft((draft) => ({ ...draft, name: event.target.value }))} />
                 <select value={folderDraft.parentId} onChange={(event) => setFolderDraft((draft) => ({ ...draft, parentId: event.target.value }))}>
                   <option value="">无父级</option>
@@ -445,10 +451,10 @@ const KnowledgeLibraryPage = ({ user }: { user: User | null }) => {
             <label>类型<select disabled={Boolean(editor.id)} value={editor.nodeType} onChange={(event) => setEditor((current) => current && ({ ...current, nodeType: event.target.value as NodeType, metadata: {} }))}>{nodeTypes.map((type) => <option key={type} value={type}>{nodeTypeMeta[type].label}</option>)}</select></label>
             <label>标题<input value={editor.title} onChange={(event) => setEditor((current) => current && ({ ...current, title: event.target.value }))} /></label>
             <label>正文<textarea value={editor.content} onChange={(event) => setEditor((current) => current && ({ ...current, content: event.target.value }))} /></label>
-            <label>Tags<input placeholder="逗号分隔" value={editor.tags} onChange={(event) => setEditor((current) => current && ({ ...current, tags: event.target.value }))} /></label>
+            <label>标签<input placeholder="逗号分隔" value={editor.tags} onChange={(event) => setEditor((current) => current && ({ ...current, tags: event.target.value }))} /></label>
             <label>文件夹<select value={editor.folderId} onChange={(event) => setEditor((current) => current && ({ ...current, folderId: event.target.value }))}><option value="">不归档</option>{folderOptions.map(({ folder, depth }) => <option key={folder.id} value={folder.id}>{'—'.repeat(depth)} {folder.name}</option>)}</select></label>
             {metadataFields[editor.nodeType].map((field) => (
-              <label key={field.key}>{field.label}{field.options ? <select value={editor.metadata[field.key] ?? ''} onChange={(event) => setEditor((current) => current && ({ ...current, metadata: { ...current.metadata, [field.key]: event.target.value } }))}><option value="">未选择</option>{field.options.map((option) => <option key={option} value={option}>{option}</option>)}</select> : <input value={editor.metadata[field.key] ?? ''} onChange={(event) => setEditor((current) => current && ({ ...current, metadata: { ...current.metadata, [field.key]: event.target.value } }))} />}</label>
+              <label key={field.key}>{field.label}{field.options ? <select value={editor.metadata[field.key] ?? ''} onChange={(event) => setEditor((current) => current && ({ ...current, metadata: { ...current.metadata, [field.key]: event.target.value } }))}><option value="">未选择</option>{field.options.map((option) => <option key={option} value={option}>{metadataOptionLabels[option] ?? option}</option>)}</select> : <input value={editor.metadata[field.key] ?? ''} onChange={(event) => setEditor((current) => current && ({ ...current, metadata: { ...current.metadata, [field.key]: event.target.value } }))} />}</label>
             ))}
             <div className="modal-actions"><button type="button" className="knowledge-primary" onClick={() => void saveNode()}>保存</button><button type="button" onClick={() => setEditor(null)}>取消</button></div>
           </section>

--- a/src/supabase/types.ts
+++ b/src/supabase/types.ts
@@ -6,7 +6,6 @@ export type Database = {
       knowledge_folders: {
         Row: {
           id: string
-          user_id: string
           parent_id: string | null
           name: string
           icon: string | null
@@ -15,7 +14,6 @@ export type Database = {
         }
         Insert: {
           id?: string
-          user_id: string
           parent_id?: string | null
           name: string
           icon?: string | null
@@ -24,7 +22,6 @@ export type Database = {
         }
         Update: {
           id?: string
-          user_id?: string
           parent_id?: string | null
           name?: string
           icon?: string | null
@@ -44,7 +41,6 @@ export type Database = {
       learning_nodes: {
         Row: {
           id: string
-          user_id: string
           folder_id: string | null
           node_type: 'concept' | 'question' | 'insight' | 'source' | 'quote' | 'note' | 'application'
           title: string
@@ -56,7 +52,6 @@ export type Database = {
         }
         Insert: {
           id?: string
-          user_id: string
           folder_id?: string | null
           node_type: 'concept' | 'question' | 'insight' | 'source' | 'quote' | 'note' | 'application'
           title: string
@@ -68,7 +63,6 @@ export type Database = {
         }
         Update: {
           id?: string
-          user_id?: string
           folder_id?: string | null
           node_type?: 'concept' | 'question' | 'insight' | 'source' | 'quote' | 'note' | 'application'
           title?: string
@@ -91,7 +85,6 @@ export type Database = {
       learning_edges: {
         Row: {
           id: string
-          user_id: string
           source_node_id: string
           target_node_id: string
           edge_type: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
@@ -102,7 +95,6 @@ export type Database = {
         }
         Insert: {
           id?: string
-          user_id: string
           source_node_id: string
           target_node_id: string
           edge_type: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
@@ -113,7 +105,6 @@ export type Database = {
         }
         Update: {
           id?: string
-          user_id?: string
           source_node_id?: string
           target_node_id?: string
           edge_type?: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'


### PR DESCRIPTION
### Motivation
- The three knowledge tables (`knowledge_folders`, `learning_nodes`, `learning_edges`) do not actually include a `user_id` column in the schema, so frontend insert/update logic should stop supplying or filtering by `user_id` to avoid incorrect assumptions and runtime errors. 
- The Knowledge Library UI should match the app's pink-themed style (e.g. Wiki/Memo) and present Chinese labels so the page is visually consistent and localized.

### Description
- Removed the `user` prop from the Knowledge Library page and updated the route to render `<KnowledgeLibraryPage />` without passing `user`. (`src/App.tsx`, `src/pages/KnowledgeLibraryPage.tsx`).
- Eliminated all frontend insert payloads and insert-time defaults that added `user_id` when creating folders, nodes, and edges; also removed `user_id` from the learning node / edge insert logic and folder insert logic in `KnowledgeLibraryPage`. (`src/pages/KnowledgeLibraryPage.tsx`).
- Updated Supabase client typings in `src/supabase/types.ts` to remove `user_id` from the `Row`, `Insert`, and `Update` shapes for `knowledge_folders`, `learning_nodes`, and `learning_edges` so types match the actual database schema.
- Restyled the Knowledge Library UI to a pink theme, centered the title area, and replaced English labels with Chinese equivalents (node type labels, metadata option labels, `Tags` → `标签`, `emoji` → `图标`, `Knowledge Library` → `学习知识库`, etc.). Added mapping for metadata option labels to show human-readable Chinese text in selects. (`src/pages/KnowledgeLibraryPage.css`, `src/pages/KnowledgeLibraryPage.tsx`).

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run lint` and linting completed (the run reported the repository's existing React hook warnings but no new errors caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2665ca7fd48330b1335d6955d2173e)