### PR TITLE
Add knowledge library graph view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "phaser": "^3.90.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-force-graph-2d": "^1.29.1",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
         "remark-gfm": "^4.0.1"
@@ -1451,6 +1452,12 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1896,6 +1903,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1986,6 +2002,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2061,6 +2087,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2206,6 +2244,222 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2634,6 +2888,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.4",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.4.tgz",
+      "integrity": "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2808,11 +3102,29 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -2900,11 +3212,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2967,6 +3287,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3007,6 +3339,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3022,6 +3360,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -3941,6 +4291,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4107,6 +4466,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4115,6 +4484,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/property-information": {
@@ -4156,6 +4536,44 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-markdown": {
@@ -4476,6 +4894,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "phaser": "^3.90.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
     "remark-gfm": "^4.0.1"

--- a/src/pages/KnowledgeLibraryPage.css
+++ b/src/pages/KnowledgeLibraryPage.css
@@ -423,3 +423,88 @@
     max-height: none;
   }
 }
+
+.view-switch {
+  background: #fff7fb;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 999px;
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+}
+
+.view-switch button {
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  color: #7c5a70;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 8px 14px;
+}
+
+.view-switch button.active {
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  box-shadow: 0 3px 7px rgba(255, 185, 216, 0.34);
+  color: #59354b;
+}
+
+.graph-panel {
+  display: grid;
+  gap: 10px;
+}
+
+.graph-canvas {
+  border: 1px solid rgba(255, 214, 231, 0.86);
+  border-radius: 22px;
+  min-height: 560px;
+  overflow: hidden;
+  position: relative;
+  background:
+    radial-gradient(circle at 16% 12%, rgba(251, 207, 231, 0.34), transparent 30%),
+    linear-gradient(180deg, rgba(255, 250, 253, 0.92), rgba(255, 247, 251, 0.92));
+}
+
+.graph-canvas canvas {
+  display: block;
+}
+
+.graph-legend {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(255, 214, 231, 0.86);
+  border-radius: 16px;
+  bottom: 12px;
+  box-shadow: 0 8px 18px rgba(255, 185, 216, 0.2);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  left: 12px;
+  max-width: calc(100% - 24px);
+  padding: 10px 12px;
+  position: absolute;
+}
+
+.graph-legend span {
+  align-items: center;
+  color: #6d4e63;
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 800;
+  gap: 5px;
+}
+
+.graph-legend i {
+  border: 2px solid rgba(255, 255, 255, 0.95);
+  border-radius: 999px;
+  display: inline-block;
+  height: 12px;
+  width: 12px;
+}
+
+.graph-hint {
+  color: #8f7285;
+  font-size: 0.86rem;
+  font-weight: 700;
+  text-align: right;
+}

--- a/src/pages/KnowledgeLibraryPage.tsx
+++ b/src/pages/KnowledgeLibraryPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ForceGraph2D, { type ForceGraphMethods, type LinkObject, type NodeObject } from 'react-force-graph-2d'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '../supabase/client'
 import type { Database, Json } from '../supabase/types'
@@ -10,6 +11,25 @@ type EdgeRow = Database['public']['Tables']['learning_edges']['Row']
 type NodeType = NodeRow['node_type']
 type EdgeType = EdgeRow['edge_type']
 type Metadata = Record<string, string>
+type ViewMode = 'list' | 'graph'
+
+type GraphNode = {
+  id: string
+  title: string
+  nodeType: NodeType
+  folderId: string | null
+  row: NodeRow
+}
+
+type GraphLink = {
+  id: string
+  source: string
+  target: string
+  edgeType: EdgeType
+  description: string
+  strength: number
+  isCrossFolder: boolean
+}
 
 type NodeEditor = {
   id: string | null
@@ -33,13 +53,13 @@ const nodeTypes: NodeType[] = ['concept', 'question', 'insight', 'source', 'quot
 const edgeTypes: EdgeType[] = ['association', 'derivation', 'contradiction', 'application', 'reference', 'question']
 
 const nodeTypeMeta: Record<NodeType, { label: string; color: string }> = {
-  concept: { label: '概念', color: '#c45e8d' },
-  question: { label: '问题', color: '#d977a3' },
-  insight: { label: '洞见', color: '#a8558f' },
-  source: { label: '资料', color: '#b27f98' },
-  quote: { label: '摘录', color: '#db2777' },
-  note: { label: '笔记', color: '#8f7285' },
-  application: { label: '应用', color: '#e879a6' },
+  concept: { label: '概念', color: '#ef7b9e' },
+  question: { label: '问题', color: '#a6cf93' },
+  insight: { label: '洞见', color: '#fbcfe7' },
+  source: { label: '资料', color: '#f2b880' },
+  quote: { label: '摘录', color: '#9ca3af' },
+  note: { label: '笔记', color: '#6b7280' },
+  application: { label: '应用', color: '#89c4c6' },
 }
 
 const metadataOptionLabels: Record<string, string> = {
@@ -58,6 +78,15 @@ const edgeTypeLabels: Record<EdgeType, string> = {
   application: '应用',
   reference: '引用',
   question: '提问',
+}
+
+const edgeTypeMeta: Record<EdgeType, { color: string; dash: number[] | null }> = {
+  association: { color: '#d86f94', dash: null },
+  derivation: { color: '#8b5cf6', dash: [8, 5] },
+  reference: { color: '#0f9ca3', dash: [2, 5] },
+  contradiction: { color: '#ef4444', dash: [10, 4, 2, 4] },
+  application: { color: '#2f9fa3', dash: null },
+  question: { color: '#74a85f', dash: [4, 4] },
 }
 
 const createEmptyEditor = (folderId: string | null): NodeEditor => ({
@@ -123,6 +152,7 @@ const KnowledgeLibraryPage = () => {
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null)
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [nodeTypeFilter, setNodeTypeFilter] = useState<'all' | NodeType>('all')
+  const [viewMode, setViewMode] = useState<ViewMode>('list')
   const [drawerOpen, setDrawerOpen] = useState(true)
   const [loading, setLoading] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
@@ -132,6 +162,9 @@ const KnowledgeLibraryPage = () => {
   const [editor, setEditor] = useState<NodeEditor | null>(null)
   const [edgeEditor, setEdgeEditor] = useState<EdgeEditor | null>(null)
   const [nodeSearch, setNodeSearch] = useState('')
+  const graphRef = useRef<ForceGraphMethods<NodeObject<GraphNode>, LinkObject<GraphNode, GraphLink>> | undefined>(undefined)
+  const graphWrapRef = useRef<HTMLDivElement | null>(null)
+  const [graphSize, setGraphSize] = useState({ width: 760, height: 560 })
 
   const loadAll = useCallback(async () => {
     if (!supabase) {
@@ -159,6 +192,25 @@ const KnowledgeLibraryPage = () => {
     const handle = window.setTimeout(() => void loadAll(), 0)
     return () => window.clearTimeout(handle)
   }, [loadAll])
+
+  useEffect(() => {
+    const element = graphWrapRef.current
+    if (!element) return undefined
+    const resize = () => {
+      const rect = element.getBoundingClientRect()
+      setGraphSize({ width: Math.max(320, rect.width), height: Math.max(420, rect.height) })
+    }
+    resize()
+    const observer = new ResizeObserver(resize)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [viewMode])
+
+  useEffect(() => {
+    if (viewMode !== 'graph') return
+    const handle = window.setTimeout(() => graphRef.current?.zoomToFit(500, 48), 120)
+    return () => window.clearTimeout(handle)
+  }, [viewMode, selectedFolderId, nodeTypeFilter, nodes.length, edges.length])
 
   const folderOptions = useMemo(() => {
     const byParent = new Map<string | null, FolderRow[]>()
@@ -198,6 +250,33 @@ const KnowledgeLibraryPage = () => {
   )
 
   const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes])
+  const graphData = useMemo(() => {
+    const visibleIds = new Set(filteredNodes.map((node) => node.id))
+    const graphNodes: GraphNode[] = filteredNodes.map((node) => ({
+      id: node.id,
+      title: node.title,
+      nodeType: node.node_type,
+      folderId: node.folder_id,
+      row: node,
+    }))
+    const graphLinks: GraphLink[] = edges
+      .filter((edge) => visibleIds.has(edge.source_node_id) && visibleIds.has(edge.target_node_id))
+      .map((edge) => {
+        const source = nodeById.get(edge.source_node_id)
+        const target = nodeById.get(edge.target_node_id)
+        return {
+          id: edge.id,
+          source: edge.source_node_id,
+          target: edge.target_node_id,
+          edgeType: edge.edge_type,
+          description: edge.description ?? '无描述',
+          strength: edge.strength,
+          isCrossFolder: Boolean(source && target && source.folder_id !== target.folder_id),
+        }
+      })
+    return { nodes: graphNodes, links: graphLinks }
+  }, [edges, filteredNodes, nodeById])
+
   const childFolderCount = useMemo(() => {
     const count = new Map<string, number>()
     folders.forEach((folder) => {
@@ -324,6 +403,40 @@ const KnowledgeLibraryPage = () => {
     else await loadAll()
   }
 
+  const drawGraphNode = useCallback((node: NodeObject<GraphNode>, context: CanvasRenderingContext2D, globalScale: number) => {
+    const label = node.title
+    const radius = 7 + Math.min(6, Math.max(0, label.length / 8))
+    const x = node.x ?? 0
+    const y = node.y ?? 0
+    context.beginPath()
+    context.arc(x, y, radius, 0, 2 * Math.PI, false)
+    context.fillStyle = nodeTypeMeta[node.nodeType].color
+    context.fill()
+    context.lineWidth = selectedNodeId === node.id ? 3 / globalScale : 1.5 / globalScale
+    context.strokeStyle = selectedNodeId === node.id ? '#7c2d52' : 'rgba(255,255,255,0.92)'
+    context.stroke()
+
+    const fontSize = Math.max(11 / globalScale, 4)
+    context.font = `700 ${fontSize}px sans-serif`
+    context.textAlign = 'center'
+    context.textBaseline = 'top'
+    const textWidth = context.measureText(label).width
+    const padding = 3 / globalScale
+    context.fillStyle = 'rgba(255, 255, 255, 0.86)'
+    context.fillRect(x - textWidth / 2 - padding, y + radius + 2 / globalScale, textWidth + padding * 2, fontSize + padding * 2)
+    context.fillStyle = '#4f3f4a'
+    context.fillText(label, x, y + radius + 4 / globalScale)
+  }, [selectedNodeId])
+
+  const paintGraphNodePointer = useCallback((node: NodeObject<GraphNode>, color: string, context: CanvasRenderingContext2D) => {
+    const label = node.title
+    const radius = 10 + Math.min(10, Math.max(0, label.length / 7))
+    context.fillStyle = color
+    context.beginPath()
+    context.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI, false)
+    context.fill()
+  }, [])
+
   const searchedTargetNodes = useMemo(() => {
     const query = nodeSearch.trim().toLowerCase()
     return nodes.filter((node) => node.id !== selectedNode?.id && (!query || node.title.toLowerCase().includes(query))).slice(0, 30)
@@ -390,57 +503,98 @@ const KnowledgeLibraryPage = () => {
               <button type="button" className={nodeTypeFilter === 'all' ? 'active' : ''} onClick={() => setNodeTypeFilter('all')}>全部</button>
               {nodeTypes.map((type) => <button key={type} type="button" className={nodeTypeFilter === type ? 'active' : ''} onClick={() => setNodeTypeFilter(type)}>{nodeTypeMeta[type].label}</button>)}
             </div>
-            <span>{loading ? '加载中…' : `${filteredNodes.length} 个节点`}</span>
+            <div className="view-switch" aria-label="学习库视图切换">
+              <button type="button" className={viewMode === 'list' ? 'active' : ''} onClick={() => setViewMode('list')}>列表</button>
+              <button type="button" className={viewMode === 'graph' ? 'active' : ''} onClick={() => setViewMode('graph')}>图谱</button>
+            </div>
+            <span>{loading ? '加载中…' : `${filteredNodes.length} 个节点 · ${graphData.links.length} 条边`}</span>
           </div>
 
-          <section className="node-grid">
-            <div className="node-list">
-              {filteredNodes.map((node) => (
-                <article key={node.id} className={selectedNodeId === node.id ? 'node-card active' : 'node-card'} onClick={() => setSelectedNodeId(node.id)}>
-                  <span className="type-badge" style={{ background: nodeTypeMeta[node.node_type].color }}>{nodeTypeMeta[node.node_type].label}</span>
-                  <h2>{node.title}</h2>
-                  <p>{node.content || '暂无正文'}</p>
-                  <div className="tag-row">{node.tags.map((tag) => <span key={tag}>#{tag}</span>)}</div>
-                  <time>{formatTime(node.created_at)}</time>
-                </article>
-              ))}
-              {!loading && filteredNodes.length === 0 ? <p className="empty-state">暂无节点，点击右上角新建。</p> : null}
-            </div>
+          {viewMode === 'list' ? (
+            <section className="node-grid">
+              <div className="node-list">
+                {filteredNodes.map((node) => (
+                  <article key={node.id} className={selectedNodeId === node.id ? 'node-card active' : 'node-card'} onClick={() => setSelectedNodeId(node.id)}>
+                    <span className="type-badge" style={{ background: nodeTypeMeta[node.node_type].color }}>{nodeTypeMeta[node.node_type].label}</span>
+                    <h2>{node.title}</h2>
+                    <p>{node.content || '暂无正文'}</p>
+                    <div className="tag-row">{node.tags.map((tag) => <span key={tag}>#{tag}</span>)}</div>
+                    <time>{formatTime(node.created_at)}</time>
+                  </article>
+                ))}
+                {!loading && filteredNodes.length === 0 ? <p className="empty-state">暂无节点，点击右上角新建。</p> : null}
+              </div>
 
-            <aside className="node-detail">
-              {selectedNode ? (
-                <>
-                  <div className="detail-head">
-                    <span className="type-badge" style={{ background: nodeTypeMeta[selectedNode.node_type].color }}>{nodeTypeMeta[selectedNode.node_type].label}</span>
-                    <h2>{selectedNode.title}</h2>
-                    <p>{selectedNode.content}</p>
-                    <div className="detail-actions">
-                      <button type="button" onClick={() => openEditNode(selectedNode)}>编辑</button>
-                      <button type="button" onClick={() => void deleteNode(selectedNode.id)}>删除</button>
+              <aside className="node-detail">
+                {selectedNode ? (
+                  <>
+                    <div className="detail-head">
+                      <span className="type-badge" style={{ background: nodeTypeMeta[selectedNode.node_type].color }}>{nodeTypeMeta[selectedNode.node_type].label}</span>
+                      <h2>{selectedNode.title}</h2>
+                      <p>{selectedNode.content}</p>
+                      <div className="detail-actions">
+                        <button type="button" onClick={() => openEditNode(selectedNode)}>编辑</button>
+                        <button type="button" onClick={() => void deleteNode(selectedNode.id)}>删除</button>
+                      </div>
                     </div>
-                  </div>
-                  <section className="edge-panel">
-                    <div className="edge-title-row"><h3>联想</h3><button type="button" onClick={() => setEdgeEditor({ id: null, targetNodeId: '', edgeType: 'association', description: '', strength: 3 })}>+ 连边</button></div>
-                    {selectedNodeEdges.map((edge) => {
-                      const isOutgoing = edge.source_node_id === selectedNode.id
-                      const peer = nodeById.get(isOutgoing ? edge.target_node_id : edge.source_node_id)
-                      return (
-                        <article key={edge.id} className="edge-card">
-                          <button type="button" className="edge-peer" onClick={() => peer && setSelectedNodeId(peer.id)}>{isOutgoing ? '→' : '←'} {peer?.title ?? '未知节点'}</button>
-                          <span>{edgeTypeLabels[edge.edge_type]} · 强度 {edge.strength}/5</span>
-                          <p>{edge.description || '无描述'}</p>
-                          <div className="detail-actions">
-                            <button type="button" onClick={() => peer && setEdgeEditor({ id: edge.id, targetNodeId: peer.id, edgeType: edge.edge_type, description: edge.description ?? '', strength: edge.strength })}>编辑</button>
-                            <button type="button" onClick={() => void deleteEdge(edge.id)}>删除</button>
-                          </div>
-                        </article>
-                      )
-                    })}
-                  </section>
-                </>
-              ) : <p className="empty-state">选择一个节点查看详情和联想。</p>}
-            </aside>
-          </section>
+                    <section className="edge-panel">
+                      <div className="edge-title-row"><h3>联想</h3><button type="button" onClick={() => setEdgeEditor({ id: null, targetNodeId: '', edgeType: 'association', description: '', strength: 3 })}>+ 连边</button></div>
+                      {selectedNodeEdges.map((edge) => {
+                        const isOutgoing = edge.source_node_id === selectedNode.id
+                        const peer = nodeById.get(isOutgoing ? edge.target_node_id : edge.source_node_id)
+                        return (
+                          <article key={edge.id} className="edge-card">
+                            <button type="button" className="edge-peer" onClick={() => peer && setSelectedNodeId(peer.id)}>{isOutgoing ? '→' : '←'} {peer?.title ?? '未知节点'}</button>
+                            <span>{edgeTypeLabels[edge.edge_type]} · 强度 {edge.strength}/5</span>
+                            <p>{edge.description || '无描述'}</p>
+                            <div className="detail-actions">
+                              <button type="button" onClick={() => peer && setEdgeEditor({ id: edge.id, targetNodeId: peer.id, edgeType: edge.edge_type, description: edge.description ?? '', strength: edge.strength })}>编辑</button>
+                              <button type="button" onClick={() => void deleteEdge(edge.id)}>删除</button>
+                            </div>
+                          </article>
+                        )
+                      })}
+                    </section>
+                  </>
+                ) : <p className="empty-state">选择一个节点查看详情和联想。</p>}
+              </aside>
+            </section>
+          ) : (
+            <section className="graph-panel">
+              <div className="graph-canvas" ref={graphWrapRef}>
+                {graphData.nodes.length > 0 ? (
+                  <ForceGraph2D
+                    ref={graphRef}
+                    graphData={graphData}
+                    width={graphSize.width}
+                    height={graphSize.height}
+                    backgroundColor="rgba(255, 250, 253, 0.72)"
+                    nodeId="id"
+                    nodeLabel={(node) => `${node.title} · ${nodeTypeMeta[node.nodeType].label}`}
+                    nodeCanvasObject={drawGraphNode}
+                    nodePointerAreaPaint={paintGraphNodePointer}
+                    linkLabel={(link) => `${edgeTypeLabels[link.edgeType]}：${link.description || '无描述'}`}
+                    linkColor={(link) => link.isCrossFolder ? `${edgeTypeMeta[link.edgeType].color}66` : edgeTypeMeta[link.edgeType].color}
+                    linkLineDash={(link) => edgeTypeMeta[link.edgeType].dash}
+                    linkWidth={(link) => Math.max(1, link.strength * 0.55)}
+                    linkDirectionalArrowLength={4}
+                    linkDirectionalArrowRelPos={0.96}
+                    linkHoverPrecision={8}
+                    minZoom={0.25}
+                    maxZoom={4}
+                    enableNodeDrag
+                    onNodeClick={(node) => { setSelectedNodeId(node.id); openEditNode(node.row) }}
+                  />
+                ) : (
+                  <p className="empty-state">当前筛选下暂无可展示节点。</p>
+                )}
+                <div className="graph-legend">
+                  {nodeTypes.map((type) => <span key={type}><i style={{ background: nodeTypeMeta[type].color }} />{nodeTypeMeta[type].label}</span>)}
+                </div>
+              </div>
+              <div className="graph-hint">滚轮缩放 · 拖拽画布平移 · 拖拽节点调整布局 · 悬停连边查看描述</div>
+            </section>
+          )}
         </main>
       </div>
 


### PR DESCRIPTION
### Motivation
- Provide a visual graph view for the learning library so users can inspect relationships between nodes beyond the list view. 
- Color and style nodes/edges by `node_type` / `edge_type` to make topology and semantics immediately visible. 
- Keep folder filtering and the existing node editor workflow intact so users can filter and edit from either view.

### Description
- Added `react-force-graph-2d` dependency and related lockfile updates; wired the package in `package.json` and installed it. 
- Implemented a new `graph` mode in `src/pages/KnowledgeLibraryPage.tsx` with a `列表/图谱` view switch, and derived `graphData` from the existing `nodes`, `edges`, and folder/type filters. 
- Rendered nodes with custom canvas drawing and labels and styled links by `edge_type` (solid/dashed/dotted + color); cross-folder edges are rendered semi-transparent. Clicking a node opens the existing editor modal. 
- Added responsive sizing, auto `zoomToFit`, pan/zoom/drag interactions, and CSS in `src/pages/KnowledgeLibraryPage.css` for the toggle, canvas, legend, and hints.

### Testing
- Ran `npm run lint`; lint completed and returned existing repository warnings only. 
- Ran `npm run build`; production build succeeded (bundle size warnings only). 
- Installed `react-force-graph-2d` locally and verified the app builds and the new graph view code compiles without TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266b5121c083308830d1baa8bf5410)