### PR TITLE
Fix knowledge graph canvas bounds, constrain nodes and tune force simulation

### DIFF
--- a/src/pages/KnowledgeLibraryPage.css
+++ b/src/pages/KnowledgeLibraryPage.css
@@ -455,18 +455,24 @@
 }
 
 .graph-canvas {
-  border: 1px solid rgba(255, 214, 231, 0.86);
-  border-radius: 22px;
-  min-height: 560px;
-  overflow: hidden;
-  position: relative;
   background:
     radial-gradient(circle at 16% 12%, rgba(251, 207, 231, 0.34), transparent 30%),
     linear-gradient(180deg, rgba(255, 250, 253, 0.92), rgba(255, 247, 251, 0.92));
+  border: 1px solid rgba(255, 214, 231, 0.86);
+  border-radius: 22px;
+  contain: layout paint;
+  height: clamp(420px, 62vh, 640px);
+  overflow: hidden;
+  position: relative;
+  width: 100%;
 }
 
 .graph-canvas canvas {
   display: block;
+  height: 100% !important;
+  max-height: 100%;
+  max-width: 100%;
+  width: 100% !important;
 }
 
 .graph-legend {

--- a/src/pages/KnowledgeLibraryPage.tsx
+++ b/src/pages/KnowledgeLibraryPage.tsx
@@ -89,6 +89,20 @@ const edgeTypeMeta: Record<EdgeType, { color: string; dash: number[] | null }> =
   question: { color: '#74a85f', dash: [4, 4] },
 }
 
+const graphDefaultSize = { width: 760, height: 560 }
+const graphMinSize = { width: 320, height: 420 }
+const graphNodeBoundaryPadding = 76
+const graphCenterStrength = 0.42
+const graphChargeStrength = -32
+const graphAlphaDecay = 0.06
+const graphVelocityDecay = 0.55
+
+type TunableForce = {
+  strength?: (value: number) => unknown
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value))
+
 const createEmptyEditor = (folderId: string | null): NodeEditor => ({
   id: null,
   nodeType: 'concept',
@@ -164,7 +178,7 @@ const KnowledgeLibraryPage = () => {
   const [nodeSearch, setNodeSearch] = useState('')
   const graphRef = useRef<ForceGraphMethods<NodeObject<GraphNode>, LinkObject<GraphNode, GraphLink>> | undefined>(undefined)
   const graphWrapRef = useRef<HTMLDivElement | null>(null)
-  const [graphSize, setGraphSize] = useState({ width: 760, height: 560 })
+  const [graphSize, setGraphSize] = useState(graphDefaultSize)
 
   const loadAll = useCallback(async () => {
     if (!supabase) {
@@ -198,7 +212,10 @@ const KnowledgeLibraryPage = () => {
     if (!element) return undefined
     const resize = () => {
       const rect = element.getBoundingClientRect()
-      setGraphSize({ width: Math.max(320, rect.width), height: Math.max(420, rect.height) })
+      setGraphSize({
+        width: Math.max(graphMinSize.width, Math.round(rect.width)),
+        height: Math.max(graphMinSize.height, Math.round(rect.height)),
+      })
     }
     resize()
     const observer = new ResizeObserver(resize)
@@ -276,6 +293,17 @@ const KnowledgeLibraryPage = () => {
       })
     return { nodes: graphNodes, links: graphLinks }
   }, [edges, filteredNodes, nodeById])
+
+  useEffect(() => {
+    if (viewMode !== 'graph') return
+    const graph = graphRef.current
+    if (!graph) return
+    const centerForce = graph.d3Force('center') as TunableForce | undefined
+    const chargeForce = graph.d3Force('charge') as TunableForce | undefined
+    centerForce?.strength?.(graphCenterStrength)
+    chargeForce?.strength?.(graphChargeStrength)
+    graph.d3ReheatSimulation()
+  }, [graphData.links.length, graphData.nodes.length, viewMode])
 
   const childFolderCount = useMemo(() => {
     const count = new Map<string, number>()
@@ -402,6 +430,28 @@ const KnowledgeLibraryPage = () => {
     if (error) setNotice(error.message)
     else await loadAll()
   }
+
+  const constrainGraphNode = useCallback((node: NodeObject<GraphNode>) => {
+    const xLimit = Math.max(0, graphSize.width / 2 - graphNodeBoundaryPadding)
+    const yLimit = Math.max(0, graphSize.height / 2 - graphNodeBoundaryPadding)
+    const x = typeof node.x === 'number' ? clamp(node.x, -xLimit, xLimit) : 0
+    const y = typeof node.y === 'number' ? clamp(node.y, -yLimit, yLimit) : 0
+
+    if (node.x !== x) {
+      node.x = x
+      node.vx = 0
+    }
+    if (node.y !== y) {
+      node.y = y
+      node.vy = 0
+    }
+    if (typeof node.fx === 'number') node.fx = clamp(node.fx, -xLimit, xLimit)
+    if (typeof node.fy === 'number') node.fy = clamp(node.fy, -yLimit, yLimit)
+  }, [graphSize.height, graphSize.width])
+
+  const constrainGraphNodes = useCallback(() => {
+    graphData.nodes.forEach(constrainGraphNode)
+  }, [constrainGraphNode, graphData.nodes])
 
   const drawGraphNode = useCallback((node: NodeObject<GraphNode>, context: CanvasRenderingContext2D, globalScale: number) => {
     const label = node.title
@@ -580,9 +630,15 @@ const KnowledgeLibraryPage = () => {
                     linkDirectionalArrowLength={4}
                     linkDirectionalArrowRelPos={0.96}
                     linkHoverPrecision={8}
+                    d3AlphaDecay={graphAlphaDecay}
+                    d3VelocityDecay={graphVelocityDecay}
+                    cooldownTime={3600}
+                    onEngineTick={constrainGraphNodes}
                     minZoom={0.25}
                     maxZoom={4}
                     enableNodeDrag
+                    onNodeDrag={constrainGraphNode}
+                    onNodeDragEnd={constrainGraphNode}
                     onNodeClick={(node) => { setSelectedNodeId(node.id); openEditNode(node.row) }}
                   />
                 ) : (


### PR DESCRIPTION
### Motivation
- Prevent the force-graph canvas from growing indefinitely as node positions drift and keep the visual area stable.
- Ensure nodes cannot be dragged or simulated outside the visible canvas area by adding boundary constraints.
- Make the force simulation converge faster and more stably by increasing center pull and reducing node repulsion, and by accelerating cooling.

### Description
- Constrain the canvas layout with CSS by giving `.graph-canvas` a bounded responsive height, `contain: layout paint`, and forcing the internal `canvas` to match container dimensions, to stop the canvas expanding with node coordinates (modified `src/pages/KnowledgeLibraryPage.css`).
- Add tunable constants for graph sizing and forces (`graphDefaultSize`, `graphMinSize`, `graphCenterStrength`, `graphChargeStrength`, `graphAlphaDecay`, `graphVelocityDecay`) and a small `clamp` helper to centralize parameters (added to `src/pages/KnowledgeLibraryPage.tsx`).
- Update `ResizeObserver` to compute `graphSize` from the container rect with minimum sizes, and apply new `d3Force('center')` / `d3Force('charge')` strengths then call `d3ReheatSimulation()` so force changes take effect when graph data/view changes (in `KnowledgeLibraryPage.tsx`).
- Add node boundary logic: `constrainGraphNode` and `constrainGraphNodes` to clamp `x/y` and `fx/fy` (zeroing velocities when clamped), wire these into `ForceGraph2D` via `onEngineTick`, `onNodeDrag`, and `onNodeDragEnd`, and enable faster cooling with `d3AlphaDecay`, `d3VelocityDecay`, and `cooldownTime` props (in `KnowledgeLibraryPage.tsx`).

### Testing
- Ran the production build with `npm run build`, which completed successfully.
- Ran the static checks with `npm run lint`, which exited successfully; lint output contains 5 existing React hook warnings in unrelated files but no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2672a1ca048330b5437949e7a06c82)