### PR TITLE
Use `from_node_id` / `to_node_id` for learning_edges and update UI/types

### DIFF
--- a/src/pages/KnowledgeLibraryPage.tsx
+++ b/src/pages/KnowledgeLibraryPage.tsx
@@ -158,6 +158,11 @@ const formatTime = (value: string) =>
     minute: '2-digit',
   }).format(new Date(value))
 
+const loadLearningEdges = (client: NonNullable<typeof supabase>) => {
+  // learning_edges does not have a user_id column; keep this query unscoped so list and graph views can load edge data.
+  return client.from('learning_edges').select('*').order('created_at', { ascending: false })
+}
+
 const KnowledgeLibraryPage = () => {
   const navigate = useNavigate()
   const [folders, setFolders] = useState<FolderRow[]>([])
@@ -186,10 +191,11 @@ const KnowledgeLibraryPage = () => {
       return
     }
     setLoading(true)
+    const edgeQuery = loadLearningEdges(supabase)
     const [folderResult, nodeResult, edgeResult] = await Promise.all([
       supabase.from('knowledge_folders').select('*').order('created_at', { ascending: true }),
       supabase.from('learning_nodes').select('*').order('created_at', { ascending: false }),
-      supabase.from('learning_edges').select('*').order('created_at', { ascending: false }),
+      edgeQuery,
     ])
     setLoading(false)
     const error = folderResult.error ?? nodeResult.error ?? edgeResult.error
@@ -262,7 +268,7 @@ const KnowledgeLibraryPage = () => {
   )
 
   const selectedNodeEdges = useMemo(
-    () => (selectedNode ? edges.filter((edge) => edge.source_node_id === selectedNode.id || edge.target_node_id === selectedNode.id) : []),
+    () => (selectedNode ? edges.filter((edge) => edge.from_node_id === selectedNode.id || edge.to_node_id === selectedNode.id) : []),
     [edges, selectedNode],
   )
 
@@ -277,14 +283,14 @@ const KnowledgeLibraryPage = () => {
       row: node,
     }))
     const graphLinks: GraphLink[] = edges
-      .filter((edge) => visibleIds.has(edge.source_node_id) && visibleIds.has(edge.target_node_id))
+      .filter((edge) => visibleIds.has(edge.from_node_id) && visibleIds.has(edge.to_node_id))
       .map((edge) => {
-        const source = nodeById.get(edge.source_node_id)
-        const target = nodeById.get(edge.target_node_id)
+        const source = nodeById.get(edge.from_node_id)
+        const target = nodeById.get(edge.to_node_id)
         return {
           id: edge.id,
-          source: edge.source_node_id,
-          target: edge.target_node_id,
+          source: edge.from_node_id,
+          target: edge.to_node_id,
           edgeType: edge.edge_type,
           description: edge.description ?? '无描述',
           strength: edge.strength,
@@ -414,8 +420,8 @@ const KnowledgeLibraryPage = () => {
       ? await supabase.from('learning_edges').update(edgeDetails).eq('id', edgeEditor.id)
       : await supabase.from('learning_edges').insert({
           ...edgeDetails,
-          target_node_id: edgeEditor.targetNodeId,
-          source_node_id: selectedNode.id,
+          to_node_id: edgeEditor.targetNodeId,
+          from_node_id: selectedNode.id,
         })
     if (result.error) setNotice(result.error.message)
     else {
@@ -590,8 +596,8 @@ const KnowledgeLibraryPage = () => {
                     <section className="edge-panel">
                       <div className="edge-title-row"><h3>联想</h3><button type="button" onClick={() => setEdgeEditor({ id: null, targetNodeId: '', edgeType: 'association', description: '', strength: 3 })}>+ 连边</button></div>
                       {selectedNodeEdges.map((edge) => {
-                        const isOutgoing = edge.source_node_id === selectedNode.id
-                        const peer = nodeById.get(isOutgoing ? edge.target_node_id : edge.source_node_id)
+                        const isOutgoing = edge.from_node_id === selectedNode.id
+                        const peer = nodeById.get(isOutgoing ? edge.to_node_id : edge.from_node_id)
                         return (
                           <article key={edge.id} className="edge-card">
                             <button type="button" className="edge-peer" onClick={() => peer && setSelectedNodeId(peer.id)}>{isOutgoing ? '→' : '←'} {peer?.title ?? '未知节点'}</button>

--- a/src/supabase/types.ts
+++ b/src/supabase/types.ts
@@ -85,8 +85,8 @@ export type Database = {
       learning_edges: {
         Row: {
           id: string
-          source_node_id: string
-          target_node_id: string
+          from_node_id: string
+          to_node_id: string
           edge_type: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
           strength: number
           description: string | null
@@ -95,8 +95,8 @@ export type Database = {
         }
         Insert: {
           id?: string
-          source_node_id: string
-          target_node_id: string
+          from_node_id: string
+          to_node_id: string
           edge_type: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
           strength?: number
           description?: string | null
@@ -105,8 +105,8 @@ export type Database = {
         }
         Update: {
           id?: string
-          source_node_id?: string
-          target_node_id?: string
+          from_node_id?: string
+          to_node_id?: string
           edge_type?: 'association' | 'derivation' | 'contradiction' | 'application' | 'reference' | 'question'
           strength?: number
           description?: string | null
@@ -115,15 +115,15 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'learning_edges_source_node_id_fkey'
-            columns: ['source_node_id']
+            foreignKeyName: 'learning_edges_from_node_id_fkey'
+            columns: ['from_node_id']
             isOneToOne: false
             referencedRelation: 'learning_nodes'
             referencedColumns: ['id']
           },
           {
-            foreignKeyName: 'learning_edges_target_node_id_fkey'
-            columns: ['target_node_id']
+            foreignKeyName: 'learning_edges_to_node_id_fkey'
+            columns: ['to_node_id']
             isOneToOne: false
             referencedRelation: 'learning_nodes'
             referencedColumns: ['id']


### PR DESCRIPTION
### Motivation

- Align the codebase with schema changes that replace `source_node_id`/`target_node_id` with `from_node_id`/`to_node_id` on the `learning_edges` table.
- Ensure the knowledge graph UI, edge creation/updating, and type definitions reflect the new column names so graph rendering and edge editing work correctly.

### Description

- Updated the Supabase types in `src/supabase/types.ts` to replace `source_node_id`/`target_node_id` with `from_node_id`/`to_node_id`, and adjusted the related foreign key names.
- Modified `KnowledgeLibraryPage.tsx` to use the new field names everywhere: loading edges, filtering `selectedNodeEdges`, building `graphData` links, computing peer nodes and edge directions, and inserting/updating edges with `from_node_id`/`to_node_id`.
- Added a helper `loadLearningEdges` to query `learning_edges` without scoping by user, as `learning_edges` does not contain a `user_id` column.

### Testing

- Ran TypeScript type check with `tsc` and there were no type errors.
- Built the app with `yarn build` and the build completed successfully.
- Executed the test suite with `yarn test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a267577d6548330b33ef05e81738a06)