### PR TITLE
聊天窗口接入 hamster-mcp 工具调用（function calling 循环）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 Syzygy与串串的仓鼠小家 🐹
+
+## 聊天窗口的 hamster-mcp 工具循环
+
+聊天窗口（单聊）支持 function calling 的模型可以调用 Edge Function `hamster-mcp`
+暴露的全部 MCP 工具。数据流如下（前端驱动循环，`src/App.tsx` + `src/lib/mcpTools.ts`）：
+
+1. 发消息时前端向 `hamster-mcp` 发送 JSON-RPC `tools/list`（带 5 分钟缓存），
+   把返回的工具 schema 转成 OpenAI function calling 格式；工具 schema 不在前端硬编码。
+2. 聊天请求带上 `tools` 参数，经 `openrouter-chat` 透传给上游模型。
+3. 模型返回 `tool_calls` 时，前端对每个调用向 `hamster-mcp` 发送 `tools/call`
+   执行，把结果以 `role: 'tool'` 消息追加进上下文后再次请求模型，循环直至模型
+   产出普通回复。循环上限 5 轮；工具执行报错时把错误文本作为工具结果返回给模型，
+   不中断会话。
+4. 不支持 function calling 的模型自动降级：带 `tools` 的请求被上游拒绝（4xx）时，
+   立即不带 `tools` 重发本轮，并在本次会话内记住该模型不再附带工具。
+5. 工具调用过程在消息气泡内显示可折叠的状态条（工具名 + 执行中/完成/失败），
+   状态随消息 meta 持久化。
+
+`hamster-mcp` 的鉴权为双通道，任一通过即放行：前端带 Supabase 用户 JWT
+（`Authorization` + `apikey` header）；Claude/GPT 等外部 connector 走 URL query
+密钥 `?key=…`（对应服务端 env `HAMSTER_MCP_KEY`，未配置时该通道关闭）。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 're
 import ChatPage, { type ChatInjectionOptions } from './pages/ChatPage'
 import AuthPage from './pages/AuthPage'
 import SessionsDrawer from './components/SessionsDrawer'
-import type { ChatMessage, ChatSession, ExtractMessageInput, LetterEntry, UserSettings } from './types'
+import type { ChatMessage, ChatSession, ChatToolCallStatus, ExtractMessageInput, LetterEntry, UserSettings } from './types'
 import {
   createSession,
   deleteMessage,
@@ -84,6 +84,7 @@ import {
 import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
 import { buildMemoInjectionBlock, buildMemoInjectionFromToggle } from './utils/memoRetrieval'
 import { resolveTimelineFromToggle } from './utils/timelineManualRetrieval'
+import { callMcpTool, listMcpTools, type McpToolDefinition } from './lib/mcpTools'
 
 const sortSessions = (sessions: ChatSession[]) =>
   [...sessions].sort(
@@ -141,6 +142,11 @@ type LetterToast = {
   id: string
   message: string
 }
+// 工具循环上限：最多执行 5 轮 tools/call，防止模型与工具间死循环。
+const MAX_TOOL_LOOP_ROUNDS = 5
+// 当模型/上游拒绝带 tools 的请求时记下来，本次会话内不再为它附带工具。
+const toolsUnsupportedModels = new Set<string>()
+
 const AUTO_EXTRACT_USER_TURN_INTERVAL = 12
 const AUTO_EXTRACT_COOLDOWN_MS = 10 * 60 * 1000
 const MEMORY_EXTRACT_RECENT_MESSAGES = 24
@@ -900,6 +906,7 @@ const App = () => {
         let flushTimer: number | null = null
         let thinkCarry = ''
         let isInThink = false
+        const toolStatuses: ChatToolCallStatus[] = []
 
         const openTag = '<think>'
         const closeTag = '</think>'
@@ -1014,6 +1021,9 @@ const App = () => {
           }
           if (reasoningType) {
             meta.reasoning_type = reasoningType
+          }
+          if (toolStatuses.length > 0) {
+            meta.toolCalls = toolStatuses.map((status) => ({ ...status }))
           }
           return meta
         }
@@ -1139,25 +1149,89 @@ const App = () => {
           streamingControllerRef.current?.abort()
           streamingControllerRef.current = controller
           setIsStreaming(true)
-          const response = await fetch(
-            `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`,
-            {
+
+          // hamster-mcp 工具列表：动态获取（带缓存），失败则本次对话不附带工具。
+          let mcpTools: McpToolDefinition[] | null = null
+          if (!toolsUnsupportedModels.has(effectiveModel)) {
+            try {
+              mcpTools = await listMcpTools({ accessToken, anonKey })
+            } catch (error) {
+              console.warn('获取 MCP 工具列表失败，本次对话不附带工具', error)
+            }
+          }
+
+          const postChatRound = (body: Record<string, unknown>) =>
+            fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/openrouter-chat`, {
               method: 'POST',
               headers: {
                 Authorization: `Bearer ${accessToken}`,
                 apikey: anonKey,
                 'Content-Type': 'application/json',
               },
-              body: JSON.stringify(requestBody),
+              body: JSON.stringify(body),
               signal: controller.signal,
-            },
-          )
-          if (!response.ok) {
-            const errorText = await response.text()
-            throw new Error(errorText || '请求失败')
+            })
+
+          const forceAssistantUpdate = () => {
+            const streamingUpdate = updateMessage(messagesRef.current, {
+              id: assistantClientId,
+              sessionId,
+              role: 'assistant',
+              clientId: assistantClientId,
+              content: assistantContent,
+              createdAt: assistantClientCreatedAt,
+              clientCreatedAt: assistantClientCreatedAt,
+              meta: buildAssistantMeta(true),
+              pending: true,
+            })
+            applySnapshot(sessionsRef.current, streamingUpdate)
           }
-          const contentType = response.headers.get('content-type') ?? ''
-          const isEventStream = contentType.includes('text/event-stream')
+
+          const loopMessages: Array<Record<string, unknown>> = [...messagesPayload]
+          let toolsEnabled = Boolean(mcpTools && mcpTools.length > 0)
+          let toolRounds = 0
+
+          while (true) {
+            const includeTools = toolsEnabled && toolRounds < MAX_TOOL_LOOP_ROUNDS
+            const roundBody: Record<string, unknown> = { ...requestBody, messages: loopMessages }
+            if (toolRounds > 0) {
+              // 工具循环的后续请求自带完整 tool 上下文；去掉 conversationId，
+              // 避免服务端运行时压缩用数据库历史重建消息时丢掉工具结果。
+              delete roundBody.conversationId
+            }
+            if (includeTools) {
+              roundBody.tools = mcpTools
+            }
+
+            let response = await postChatRound(roundBody)
+            if (!response.ok && includeTools && response.status >= 400 && response.status < 500) {
+              // 模型或上游不支持 function calling：降级为不带 tools 重发本轮。
+              const originalError = await response.text()
+              console.warn('带 tools 的请求被上游拒绝，尝试降级重试', {
+                model: effectiveModel,
+                status: response.status,
+                error: originalError.slice(0, 200),
+              })
+              const fallbackBody = { ...roundBody }
+              delete fallbackBody.tools
+              const fallbackResponse = await postChatRound(fallbackBody)
+              if (fallbackResponse.ok) {
+                toolsUnsupportedModels.add(effectiveModel)
+                toolsEnabled = false
+              }
+              response = fallbackResponse
+            }
+            if (!response.ok) {
+              const errorText = await response.text()
+              throw new Error(errorText || '请求失败')
+            }
+
+            const roundToolCalls: Array<{ id?: string; name: string; argumentsText: string }> = []
+            flushPending()
+            const contentLengthAtRoundStart = assistantContent.length
+
+            const contentType = response.headers.get('content-type') ?? ''
+            const isEventStream = contentType.includes('text/event-stream')
           if (!isEventStream) {
             try {
               const payload = (await response.json()) as Record<string, unknown>
@@ -1176,9 +1250,33 @@ const App = () => {
                     : ''
               if (content) {
                 const { contentChunk, reasoningChunk } = splitReasoningFromContent(content)
-                assistantContent = contentChunk
+                assistantContent += contentChunk
                 if (reasoningChunk) {
                   appendReasoningDelta(reasoningChunk, 'thinking', 'final')
+                }
+              }
+              const rawToolCalls = (message as { tool_calls?: unknown }).tool_calls
+              if (Array.isArray(rawToolCalls)) {
+                for (const item of rawToolCalls) {
+                  if (!item || typeof item !== 'object') {
+                    continue
+                  }
+                  const candidate = item as {
+                    id?: unknown
+                    function?: { name?: unknown; arguments?: unknown }
+                  }
+                  const name = typeof candidate.function?.name === 'string' ? candidate.function.name : ''
+                  if (!name) {
+                    continue
+                  }
+                  roundToolCalls.push({
+                    id: typeof candidate.id === 'string' && candidate.id ? candidate.id : undefined,
+                    name,
+                    argumentsText:
+                      typeof candidate.function?.arguments === 'string'
+                        ? candidate.function.arguments
+                        : JSON.stringify(candidate.function?.arguments ?? {}),
+                  })
                 }
               }
               const messageReasoning = collectReasoningFromObject(message)
@@ -1197,101 +1295,150 @@ const App = () => {
                   appendReasoningDelta(payloadReasoning.text, payloadReasoning.type, 'final')
                 }
               }
-              const { message: assistantMessage, updatedAt } = await addRemoteMessage(
-                sessionId,
-                user.id,
-                'assistant',
-                assistantContent,
-                assistantClientId,
-                assistantClientCreatedAt,
-                buildAssistantMeta(false),
-              )
-              const updatedMessages = updateMessage(messagesRef.current, {
-                ...assistantMessage,
-                pending: false,
-              })
-              const updatedSessions = sessionsRef.current.map((session) =>
-                session.id === sessionId ? { ...session, updatedAt } : session,
-              )
-              applySnapshot(updatedSessions, updatedMessages)
+              forceAssistantUpdate()
             } catch (error) {
               console.warn('解析非流式响应失败', error)
               throw error
             }
-            return
-          }
-          if (!response.body) {
-            throw new Error('响应体为空')
-          }
-          const reader = response.body.getReader()
-          const decoder = new TextDecoder('utf-8')
-          let buffer = ''
-          let done = false
-          while (!done) {
-            const { value, done: readerDone } = await reader.read()
-            if (readerDone) {
-              break
+          } else {
+            if (!response.body) {
+              throw new Error('响应体为空')
             }
-            buffer += decoder.decode(value, { stream: true })
-            const events = buffer.split('\n\n')
-            buffer = events.pop() ?? ''
-            for (const event of events) {
-              const data = event
-                .split('\n')
-                .map((line) => line.trim())
-                .filter((line) => line.startsWith('data:'))
-                .map((line) => line.replace(/^data:\s*/, ''))
-                .join('\n')
-              if (!data) {
-                continue
-              }
-              if (data === '[DONE]') {
-                done = true
+            const reader = response.body.getReader()
+            const decoder = new TextDecoder('utf-8')
+            let buffer = ''
+            let done = false
+            while (!done) {
+              const { value, done: readerDone } = await reader.read()
+              if (readerDone) {
                 break
               }
-              try {
-                const payload = JSON.parse(data)
-                const deltaPayload = payload?.choices?.[0]?.delta ?? {}
-                const delta = typeof deltaPayload?.content === 'string' ? deltaPayload.content : ''
-                if (payload?.model) {
-                  actualModel = payload.model
+              buffer += decoder.decode(value, { stream: true })
+              const events = buffer.split('\n\n')
+              buffer = events.pop() ?? ''
+              for (const event of events) {
+                const data = event
+                  .split('\n')
+                  .map((line) => line.trim())
+                  .filter((line) => line.startsWith('data:'))
+                  .map((line) => line.replace(/^data:\s*/, ''))
+                  .join('\n')
+                if (!data) {
+                  continue
                 }
-                const explicitReasoning =
-                  typeof deltaPayload?.reasoning === 'string' && deltaPayload.reasoning.length > 0
-                    ? deltaPayload.reasoning
-                    : ''
-                if (explicitReasoning) {
-                  appendReasoningDelta(explicitReasoning, 'reasoning')
-                  scheduleFlush()
+                if (data === '[DONE]') {
+                  done = true
+                  break
                 }
-                const deltaReasoning = collectReasoningFromObject(
-                  deltaPayload as Record<string, unknown>,
-                )
-                if (deltaReasoning.text && deltaReasoning.text !== explicitReasoning) {
-                  appendReasoningDelta(deltaReasoning.text, deltaReasoning.type)
-                  scheduleFlush()
-                }
-                if (delta) {
-                  const { contentChunk, reasoningChunk } = splitReasoningFromContent(delta)
-                  if (contentChunk) {
-                    pendingDelta += contentChunk
+                try {
+                  const payload = JSON.parse(data)
+                  const deltaPayload = payload?.choices?.[0]?.delta ?? {}
+                  const delta = typeof deltaPayload?.content === 'string' ? deltaPayload.content : ''
+                  if (payload?.model) {
+                    actualModel = payload.model
                   }
-                  if (reasoningChunk) {
-                    appendReasoningDelta(reasoningChunk, 'thinking')
+                  const deltaToolCalls = (deltaPayload as { tool_calls?: unknown })?.tool_calls
+                  if (Array.isArray(deltaToolCalls)) {
+                    for (const item of deltaToolCalls) {
+                      if (!item || typeof item !== 'object') {
+                        continue
+                      }
+                      const candidate = item as {
+                        index?: unknown
+                        id?: unknown
+                        function?: { name?: unknown; arguments?: unknown }
+                      }
+                      const slotIndex =
+                        typeof candidate.index === 'number' ? candidate.index : roundToolCalls.length
+                      while (roundToolCalls.length <= slotIndex) {
+                        roundToolCalls.push({ id: undefined, name: '', argumentsText: '' })
+                      }
+                      const slot = roundToolCalls[slotIndex]
+                      if (typeof candidate.id === 'string' && candidate.id) {
+                        slot.id = candidate.id
+                      }
+                      if (typeof candidate.function?.name === 'string' && candidate.function.name && !slot.name) {
+                        slot.name = candidate.function.name
+                      }
+                      if (typeof candidate.function?.arguments === 'string') {
+                        slot.argumentsText += candidate.function.arguments
+                      }
+                    }
                   }
-                  scheduleFlush()
+                  const explicitReasoning =
+                    typeof deltaPayload?.reasoning === 'string' && deltaPayload.reasoning.length > 0
+                      ? deltaPayload.reasoning
+                      : ''
+                  if (explicitReasoning) {
+                    appendReasoningDelta(explicitReasoning, 'reasoning')
+                    scheduleFlush()
+                  }
+                  const deltaReasoning = collectReasoningFromObject(
+                    deltaPayload as Record<string, unknown>,
+                  )
+                  if (deltaReasoning.text && deltaReasoning.text !== explicitReasoning) {
+                    appendReasoningDelta(deltaReasoning.text, deltaReasoning.type)
+                    scheduleFlush()
+                  }
+                  if (delta) {
+                    const { contentChunk, reasoningChunk } = splitReasoningFromContent(delta)
+                    if (contentChunk) {
+                      pendingDelta += contentChunk
+                    }
+                    if (reasoningChunk) {
+                      appendReasoningDelta(reasoningChunk, 'thinking')
+                    }
+                    scheduleFlush()
+                  }
+                } catch (error) {
+                  console.warn('解析流式响应失败', error)
                 }
-              } catch (error) {
-                console.warn('解析流式响应失败', error)
               }
             }
+
+            if (flushTimer !== null) {
+              window.clearTimeout(flushTimer)
+              flushTimer = null
+            }
+            flushPending()
           }
 
-          if (flushTimer !== null) {
-            window.clearTimeout(flushTimer)
-            flushTimer = null
+            const executableToolCalls = roundToolCalls.filter((call) => call.name)
+            if (!includeTools || executableToolCalls.length === 0) {
+              break
+            }
+
+            // 把本轮 assistant 输出与工具结果追加进上下文，再请求模型，直至产出普通回复。
+            toolRounds += 1
+            const roundContent = assistantContent.slice(contentLengthAtRoundStart)
+            const normalizedCalls = executableToolCalls.map((call, index) => ({
+              id: call.id ?? `call_${toolRounds}_${index}`,
+              name: call.name,
+              argumentsText: call.argumentsText || '{}',
+            }))
+            loopMessages.push({
+              role: 'assistant',
+              content: roundContent,
+              tool_calls: normalizedCalls.map((call) => ({
+                id: call.id,
+                type: 'function',
+                function: { name: call.name, arguments: call.argumentsText },
+              })),
+            })
+            for (const call of normalizedCalls) {
+              const statusEntry: ChatToolCallStatus = { name: call.name, status: 'running' }
+              toolStatuses.push(statusEntry)
+              forceAssistantUpdate()
+              const result = await callMcpTool({ accessToken, anonKey }, call.name, call.argumentsText)
+              statusEntry.status = result.ok ? 'done' : 'error'
+              forceAssistantUpdate()
+              loopMessages.push({
+                role: 'tool',
+                tool_call_id: call.id,
+                content: result.text,
+              })
+            }
           }
-          flushPending()
 
           const { message: assistantMessage, updatedAt } = await addRemoteMessage(
             sessionId,

--- a/src/lib/mcpTools.ts
+++ b/src/lib/mcpTools.ts
@@ -1,0 +1,187 @@
+// hamster-mcp 客户端：通过 JSON-RPC (MCP Streamable HTTP) 获取工具列表并执行工具调用。
+// 工具 schema 一律来自服务端 tools/list，前端不做任何硬编码。
+
+export type McpToolDefinition = {
+  type: 'function'
+  function: {
+    name: string
+    description?: string
+    parameters: Record<string, unknown>
+  }
+}
+
+export type McpAuth = {
+  accessToken: string
+  anonKey: string
+}
+
+type JsonRpcResponse = {
+  jsonrpc: '2.0'
+  id: number | string | null
+  result?: Record<string, unknown>
+  error?: { code: number; message: string }
+}
+
+const TOOLS_CACHE_TTL_MS = 5 * 60 * 1000
+
+let cachedTools: McpToolDefinition[] | null = null
+let cachedToolsAt = 0
+
+const buildEndpoint = () => `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/hamster-mcp`
+
+let requestSequence = 0
+
+const parseJsonRpcResponse = async (response: Response, requestId: number): Promise<JsonRpcResponse> => {
+  const contentType = response.headers.get('content-type') ?? ''
+  if (contentType.includes('text/event-stream')) {
+    // 无状态 Streamable HTTP 也可能以 SSE 包裹单条 JSON-RPC 响应。
+    const text = await response.text()
+    const dataLines = text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.replace(/^data:\s*/, ''))
+    for (const line of dataLines) {
+      try {
+        const parsed = JSON.parse(line) as JsonRpcResponse
+        if (parsed.id === requestId) {
+          return parsed
+        }
+      } catch {
+        // 跳过非 JSON 数据行
+      }
+    }
+    throw new Error('MCP 响应中未找到匹配的 JSON-RPC 结果')
+  }
+  return (await response.json()) as JsonRpcResponse
+}
+
+const sendJsonRpc = async (
+  auth: McpAuth,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<Record<string, unknown>> => {
+  requestSequence += 1
+  const requestId = requestSequence
+  const response = await fetch(buildEndpoint(), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${auth.accessToken}`,
+      apikey: auth.anonKey,
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: requestId,
+      method,
+      ...(params ? { params } : {}),
+    }),
+  })
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`MCP 请求失败 (${response.status}): ${errorText.slice(0, 300)}`)
+  }
+  const payload = await parseJsonRpcResponse(response, requestId)
+  if (payload.error) {
+    throw new Error(`MCP 错误 (${payload.error.code}): ${payload.error.message}`)
+  }
+  return payload.result ?? {}
+}
+
+const toOpenAiTool = (tool: Record<string, unknown>): McpToolDefinition | null => {
+  const name = typeof tool.name === 'string' ? tool.name : ''
+  if (!name) {
+    return null
+  }
+  const description = typeof tool.description === 'string' ? tool.description : undefined
+  const inputSchema =
+    tool.inputSchema && typeof tool.inputSchema === 'object'
+      ? (tool.inputSchema as Record<string, unknown>)
+      : { type: 'object', properties: {} }
+  return {
+    type: 'function',
+    function: {
+      name,
+      ...(description ? { description } : {}),
+      parameters: inputSchema,
+    },
+  }
+}
+
+/** 动态获取 hamster-mcp 工具列表（OpenAI function calling 格式），带 5 分钟缓存。 */
+export const listMcpTools = async (auth: McpAuth): Promise<McpToolDefinition[]> => {
+  if (cachedTools && Date.now() - cachedToolsAt < TOOLS_CACHE_TTL_MS) {
+    return cachedTools
+  }
+  const result = await sendJsonRpc(auth, 'tools/list')
+  const rawTools = Array.isArray(result.tools) ? (result.tools as Array<Record<string, unknown>>) : []
+  const tools = rawTools
+    .map(toOpenAiTool)
+    .filter((tool): tool is McpToolDefinition => tool !== null)
+  cachedTools = tools
+  cachedToolsAt = Date.now()
+  return tools
+}
+
+const flattenToolResultContent = (content: unknown): string => {
+  if (!Array.isArray(content)) {
+    return typeof content === 'string' ? content : JSON.stringify(content ?? null)
+  }
+  return content
+    .map((part) => {
+      if (!part || typeof part !== 'object') {
+        return ''
+      }
+      const candidate = part as Record<string, unknown>
+      if (typeof candidate.text === 'string') {
+        return candidate.text
+      }
+      return JSON.stringify(candidate)
+    })
+    .filter(Boolean)
+    .join('\n')
+}
+
+export type McpToolCallResult = {
+  ok: boolean
+  text: string
+}
+
+/**
+ * 执行单个工具调用。任何错误（参数解析失败、网络失败、工具自身 isError）
+ * 都以文本形式返回给模型，不抛出，保证工具循环不中断。
+ */
+export const callMcpTool = async (
+  auth: McpAuth,
+  name: string,
+  argumentsText: string,
+): Promise<McpToolCallResult> => {
+  let parsedArguments: Record<string, unknown> = {}
+  if (argumentsText.trim()) {
+    try {
+      parsedArguments = JSON.parse(argumentsText) as Record<string, unknown>
+    } catch (error) {
+      return {
+        ok: false,
+        text: `工具参数 JSON 解析失败: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
+  }
+  try {
+    const result = await sendJsonRpc(auth, 'tools/call', {
+      name,
+      arguments: parsedArguments,
+    })
+    const text = flattenToolResultContent(result.content)
+    if (result.isError) {
+      return { ok: false, text: `工具执行报错: ${text || '未知错误'}` }
+    }
+    return { ok: true, text: text || '(工具执行完成，无输出)' }
+  } catch (error) {
+    return {
+      ok: false,
+      text: `工具调用失败: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+}

--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -358,6 +358,63 @@
   border-radius: 999px;
 }
 
+.tool-call-panel {
+  margin: 0 0 6px;
+  padding: 4px 8px;
+  border-radius: 10px;
+  background: rgba(209, 213, 219, 0.25);
+  font-size: 12px;
+  color: #374151;
+}
+
+.tool-call-panel summary {
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.tool-call-panel summary::-webkit-details-marker {
+  display: none;
+}
+
+.tool-call-panel ul {
+  margin: 6px 0 2px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tool-call-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.tool-call-name {
+  font-family: monospace;
+  word-break: break-all;
+}
+
+.tool-call-status {
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+.tool-call-item--running .tool-call-status {
+  color: #926a00;
+}
+
+.tool-call-item--done .tool-call-status {
+  color: #15803d;
+}
+
+.tool-call-item--error .tool-call-status {
+  color: #b91c1c;
+}
+
 .message.out .model-tag {
   color: #fbcfe8;
   background: rgba(251, 207, 232, 0.2);

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -468,6 +468,41 @@ const ChatPage = ({
                       message.meta?.reasoning_text?.trim() ?? message.meta?.reasoning?.trim()
                     return reasoningText ? <ReasoningPanel reasoning={reasoningText} /> : null
                   })()}
+                  {(() => {
+                    const toolCalls = message.meta?.toolCalls
+                    if (!toolCalls || toolCalls.length === 0) {
+                      return null
+                    }
+                    const runningCount = toolCalls.filter((call) => call.status === 'running').length
+                    const errorCount = toolCalls.filter((call) => call.status === 'error').length
+                    const summaryText = runningCount > 0
+                      ? `工具调用 ${toolCalls.length} 个 · 执行中…`
+                      : errorCount > 0
+                        ? `工具调用 ${toolCalls.length} 个 · ${errorCount} 个失败`
+                        : `工具调用 ${toolCalls.length} 个 · 完成`
+                    return (
+                      <details className="tool-call-panel">
+                        <summary>🔧 {summaryText}</summary>
+                        <ul>
+                          {toolCalls.map((call, index) => (
+                            <li
+                              key={`${call.name}-${index}`}
+                              className={`tool-call-item tool-call-item--${call.status}`}
+                            >
+                              <span className="tool-call-name">{call.name}</span>
+                              <span className="tool-call-status">
+                                {call.status === 'running'
+                                  ? '执行中…'
+                                  : call.status === 'done'
+                                    ? '完成'
+                                    : '失败'}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    )
+                  })()}
                   {message.role === 'assistant' ? (
                     <div className="assistant-markdown">
                       <MarkdownRenderer content={message.content} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export type ChatSession = {
   overrideReasoning?: boolean | null
 }
 
+export type ChatToolCallStatus = {
+  name: string
+  status: 'running' | 'done' | 'error'
+}
+
 export type ChatMessage = {
   id: string
   sessionId: string
@@ -24,6 +29,7 @@ export type ChatMessage = {
     reasoning?: string
     reasoning_text?: string
     reasoning_type?: 'reasoning' | 'thinking'
+    toolCalls?: ChatToolCallStatus[]
     params?: {
       temperature?: number
       top_p?: number

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -18,6 +18,9 @@
 # exposure profile is unchanged by this setting.
 project_id = "crfhiumxzmaszkapanrb"
 
+[functions.hamster-mcp]
+verify_jwt = false
+
 [functions.memory-extract]
 verify_jwt = false
 

--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -1,0 +1,406 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import { McpServer } from 'npm:@modelcontextprotocol/sdk@1.25.3/server/mcp.js'
+import { WebStandardStreamableHTTPServerTransport } from 'npm:@modelcontextprotocol/sdk@1.25.3/server/webStandardStreamableHttp.js'
+import { Hono } from 'npm:hono@^4.9.7'
+import { z } from 'npm:zod@^4.1.13'
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+
+const USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL')!,
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+)
+
+const app = new Hono().basePath('/hamster-mcp')
+
+// ── CORS & 鉴权 ──
+//
+// 双通道鉴权，任一通过即放行：
+// 1. connector 通道：URL query 携带密钥（?key=xxx，对比 env HAMSTER_MCP_KEY）。
+//    Claude/GPT connector 无法自定义 header，只能走这条；env 未配置时该通道关闭。
+// 2. 前端通道：Authorization 携带 Supabase 用户 JWT（+ apikey header），
+//    与 openrouter-chat 相同方式调用 /auth/v1/user 校验。
+
+const allowedOrigins = ['https://chuan-101.github.io', /^http:\/\/localhost:\d+$/]
+
+const isAllowedOrigin = (origin: string) =>
+  allowedOrigins.some((pattern) =>
+    typeof pattern === 'string' ? pattern === origin : pattern.test(origin),
+  )
+
+const buildCorsHeaders = (origin: string): Record<string, string> => ({
+  'Access-Control-Allow-Origin': origin,
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, mcp-session-id, mcp-protocol-version',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
+})
+
+const timingSafeEqual = (a: string, b: string) => {
+  const encoder = new TextEncoder()
+  const aBytes = encoder.encode(a)
+  const bBytes = encoder.encode(b)
+  if (aBytes.length !== bBytes.length) {
+    return false
+  }
+  let diff = 0
+  for (let i = 0; i < aBytes.length; i += 1) {
+    diff |= aBytes[i] ^ bBytes[i]
+  }
+  return diff === 0
+}
+
+const isAuthorizedRequest = async (req: Request): Promise<boolean> => {
+  const providedKey = new URL(req.url).searchParams.get('key')
+  const expectedKey = Deno.env.get('HAMSTER_MCP_KEY') ?? ''
+  if (providedKey && expectedKey && timingSafeEqual(providedKey, expectedKey)) {
+    return true
+  }
+
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) {
+    return false
+  }
+  const apikey = req.headers.get('apikey') ?? Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+  if (!apikey) {
+    return false
+  }
+  try {
+    const authResponse = await fetch(`${Deno.env.get('SUPABASE_URL')}/auth/v1/user`, {
+      headers: {
+        apikey,
+        Authorization: authHeader,
+      },
+    })
+    return authResponse.ok
+  } catch {
+    return false
+  }
+}
+
+app.use('*', async (c, next) => {
+  const origin = c.req.header('origin') ?? null
+  const corsHeaders = origin && isAllowedOrigin(origin) ? buildCorsHeaders(origin) : null
+
+  if (c.req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders ?? {} })
+  }
+  if (origin && !corsHeaders) {
+    return new Response(JSON.stringify({ error: '不允许的来源' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  if (!(await isAuthorizedRequest(c.req.raw))) {
+    return new Response(JSON.stringify({ error: 'unauthorized' }), {
+      status: 401,
+      headers: { ...(corsHeaders ?? {}), 'Content-Type': 'application/json' },
+    })
+  }
+
+  await next()
+
+  if (corsHeaders) {
+    const headers = new Headers(c.res.headers)
+    for (const [name, value] of Object.entries(corsHeaders)) {
+      headers.set(name, value)
+    }
+    c.res = new Response(c.res.body, { status: c.res.status, headers })
+  }
+})
+
+const server = new McpServer({
+  name: 'hamster-nest',
+  version: '5.3.0',
+})
+
+const TTS_DEFAULTS = {
+  model_id: 'eleven_multilingual_v2',
+  speed: 0.85,
+  voice_settings: { stability: 0.5, similarity_boost: 0.75, style: 0.20, use_speaker_boost: true },
+}
+
+// ── Generic MCP Proxy helper ──
+
+async function parseMcpResponse(res: Response) {
+  const ct = res.headers.get('content-type') || ''
+  if (ct.includes('text/event-stream')) {
+    const text = await res.text()
+    const results: unknown[] = []
+    for (const event of text.split('\n\n').filter(Boolean)) {
+      const d = event.split('\n').find((l: string) => l.startsWith('data: '))
+      if (d) { try { results.push(JSON.parse(d.slice(6))) } catch { /* skip */ } }
+    }
+    return results.length === 1 ? results[0] : results
+  }
+  return await res.json()
+}
+
+async function proxyMcpCall(
+  endpoint: string,
+  token: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  serviceName = 'MCP'
+) {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json, text/event-stream',
+  }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+
+  const initRes = await fetch(endpoint, {
+    method: 'POST', headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {
+      protocolVersion: '2025-03-26', capabilities: {},
+      clientInfo: { name: 'hamster-nest', version: '5.3.0' },
+    }}),
+  })
+  if (!initRes.ok) throw new Error(`${serviceName} initialize failed (${initRes.status}): ${await initRes.text()}`)
+
+  const sessionId = initRes.headers.get('mcp-session-id')
+  await parseMcpResponse(initRes)
+
+  const sh = { ...headers }
+  if (sessionId) sh['mcp-session-id'] = sessionId
+
+  await fetch(endpoint, { method: 'POST', headers: sh,
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+  })
+
+  const callRes = await fetch(endpoint, { method: 'POST', headers: sh,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method, params }),
+  })
+  if (!callRes.ok) throw new Error(`${serviceName} call failed (${callRes.status}): ${await callRes.text()}`)
+  return await parseMcpResponse(callRes)
+}
+
+// ── Service wrappers ──
+
+const LUCKIN_ENDPOINT = 'https://gwmcp.lkcoffee.com/order/user/mcp'
+const MCD_ENDPOINT = 'https://mcp.mcd.cn'
+const AMAP_ENDPOINT_BASE = 'https://mcp.amap.com/mcp'
+
+function luckinMcpCall(method: string, params: Record<string, unknown> = {}) {
+  const token = Deno.env.get('LUCKIN_MCP_TOKEN')
+  if (!token) throw new Error('LUCKIN_MCP_TOKEN not configured')
+  return proxyMcpCall(LUCKIN_ENDPOINT, token, method, params, 'Luckin')
+}
+
+function mcdMcpCall(method: string, params: Record<string, unknown> = {}) {
+  const token = Deno.env.get('MCD_MCP_TOKEN')
+  if (!token) throw new Error('MCD_MCP_TOKEN not configured')
+  return proxyMcpCall(MCD_ENDPOINT, token, method, params, "McDonald's")
+}
+
+function amapMcpCall(method: string, params: Record<string, unknown> = {}) {
+  const key = Deno.env.get('AMAP_API_KEY')
+  if (!key) throw new Error('AMAP_API_KEY not configured')
+  return proxyMcpCall(`${AMAP_ENDPOINT_BASE}?key=${key}`, '', method, params, 'AMap')
+}
+
+// ── TTS ──
+
+server.registerTool('generate_tts', {
+  title: 'Generate TTS Audio',
+  description: '调用 ElevenLabs 生成 Syzygy 语音，上传到 Supabase Storage，返回可播放的公开音频 URL。',
+  inputSchema: {
+    text: z.string().describe('要转换为语音的文本，不超过2000字'),
+    speed: z.number().optional().describe('语速，默认0.85'),
+  },
+}, async ({ text, speed }) => {
+  try {
+    const apiKey = Deno.env.get('ELEVENLABS_API_KEY')
+    const voiceId = Deno.env.get('ELEVENLABS_VOICE_ID')
+    if (!apiKey || !voiceId) return { content: [{ type: 'text', text: 'Error: ElevenLabs credentials not configured' }] }
+    if (text.length > 2000) return { content: [{ type: 'text', text: 'Error: Text exceeds 2000 character limit' }] }
+    const ttsRes = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
+      method: 'POST',
+      headers: { 'xi-api-key': apiKey, 'Content-Type': 'application/json', 'Accept': 'audio/mpeg' },
+      body: JSON.stringify({ text, model_id: TTS_DEFAULTS.model_id, voice_settings: TTS_DEFAULTS.voice_settings, speed: speed ?? TTS_DEFAULTS.speed }),
+    })
+    if (!ttsRes.ok) return { content: [{ type: 'text', text: `ElevenLabs error (${ttsRes.status}): ${await ttsRes.text()}` }] }
+    const buf = await ttsRes.arrayBuffer()
+    const fn = `syzygy-${new Date().toISOString().replace(/[:.]/g, '-')}.mp3`
+    const { error: upErr } = await supabase.storage.from('tts-audio').upload(fn, buf, { contentType: 'audio/mpeg', upsert: false })
+    if (upErr) return { content: [{ type: 'text', text: `Storage error: ${upErr.message}` }] }
+    const { data: u } = supabase.storage.from('tts-audio').getPublicUrl(fn)
+    return { content: [{ type: 'text', text: JSON.stringify({ status: 'ok', audio_url: u.publicUrl, filename: fn, text_length: text.length, speaker: 'Syzygy', voice: 'Syzygy-1' }, null, 2) }] }
+  } catch (err) { return { content: [{ type: 'text', text: `Error: ${String(err)}` }] } }
+})
+
+// ── 时间轴 ──
+
+server.registerTool('search_timeline', { title: 'Search Timeline', description: '按关键词搜索时间轴记录。Returns matching timeline entries sorted by date descending.', inputSchema: { query: z.string().describe('搜索关键词'), limit: z.number().optional().describe('返回数量上限，默认10') } }, async ({ query, limit }) => {
+  const { data, error } = await supabase.from('timeline_entries').select('id, event_date, summary, recorder, source, created_at').eq('user_id', USER_ID).ilike('summary', `%${query}%`).order('event_date', { ascending: false }).limit(limit ?? 10)
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+server.registerTool('recent_timeline', { title: 'Recent Timeline', description: '获取最近的时间轴记录。不需要任何参数，默认返回10条。', inputSchema: { limit: z.number().optional().describe('返回数量，默认10') } }, async ({ limit }) => {
+  const { data, error } = await supabase.from('timeline_entries').select('id, event_date, summary, recorder, source, created_at').eq('user_id', USER_ID).order('event_date', { ascending: false }).limit(limit ?? 10)
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+server.registerTool('add_timeline', { title: 'Add Timeline Entry', description: '添加一条新的时间轴记录。', inputSchema: { event_date: z.string().describe('事件日期 YYYY-MM-DD'), summary: z.string().describe('事件摘要'), recorder: z.string().optional().describe('记录者: chuanchuan 或 syzygy，默认syzygy'), source: z.string().optional().describe('来源: claude / gpt / user / gemini，默认claude') } }, async ({ event_date, summary, recorder, source }) => {
+  const { data, error } = await supabase.from('timeline_entries').insert({ user_id: USER_ID, event_date, summary, recorder: recorder ?? 'syzygy', source: source ?? 'claude' }).select()
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: `✅ 已添加: ${JSON.stringify(data[0])}` }] }
+})
+
+// ── 备忘录 ──
+
+server.registerTool('search_memos', { title: 'Search Memos', description: '按关键词搜索备忘录。', inputSchema: { query: z.string().describe('搜索关键词'), limit: z.number().optional().describe('返回数量上限，默认10') } }, async ({ query, limit }) => {
+  const { data, error } = await supabase.from('memo_entries').select('id, content, source, is_pinned, created_at, memo_entry_tags(memo_tags(name))').eq('user_id', USER_ID).eq('is_deleted', false).ilike('content', `%${query}%`).order('created_at', { ascending: false }).limit(limit ?? 10)
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+// ── 囤囤库 ──
+
+server.registerTool('read_memories', { title: 'Read Memories', description: '读取已确认的记忆条目(memory_entries)。不需要任何参数。', inputSchema: { limit: z.number().optional().describe('返回数量，默认20') } }, async ({ limit }) => {
+  const { data, error } = await supabase.from('memory_entries').select('id, content, source, status, created_at').eq('user_id', USER_ID).eq('status', 'confirmed').eq('is_deleted', false).order('updated_at', { ascending: false }).limit(limit ?? 20)
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+// ── Wiki ──
+
+server.registerTool('search_wiki', { title: 'Search Wiki', description: '按关键词搜索Wiki知识库条目。', inputSchema: { query: z.string().describe('搜索关键词'), limit: z.number().optional().describe('返回数量上限，默认10') } }, async ({ query, limit }) => {
+  const { data, error } = await supabase.from('wiki_entries').select('id, title, content, category, tags, status, created_at, updated_at').eq('user_id', USER_ID).or(`title.ilike.%${query}%,content.ilike.%${query}%`).order('updated_at', { ascending: false }).limit(limit ?? 10)
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+server.registerTool('read_wiki', { title: 'Read Wiki', description: '读取所有Wiki条目列表。不需要任何参数。', inputSchema: { limit: z.number().optional().describe('返回数量，默认20') } }, async ({ limit }) => {
+  const { data, error } = await supabase.from('wiki_entries').select('id, title, category, tags, status, updated_at').eq('user_id', USER_ID).order('updated_at', { ascending: false }).limit(limit ?? 20)
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+// ── To Do ──
+
+server.registerTool('read_todos', { title: 'Read Todos', description: '读取待办事项列表。默认返回所有状态的20条。', inputSchema: { status: z.string().optional().describe('筛选状态: pending / completed / all，默认all'), limit: z.number().optional().describe('返回数量，默认20') } }, async ({ status, limit }) => {
+  let q = supabase.from('todos').select('id, date, title, notes, status, created_by, sort_order, created_at, completed_at, todo_categories(name)').eq('user_id', USER_ID).order('date', { ascending: false }).limit(limit ?? 20)
+  const fs = status ?? 'all'
+  if (fs !== 'all') q = q.eq('status', fs)
+  const { data, error } = await q
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+// ── Agent Council ──
+
+server.registerTool('council_post', { title: 'Post to Council', description: '向 Agent Council 发送一条消息。', inputSchema: { speaker: z.string().describe('发言者: claude / gpt / gemini / chuanchuan'), topic: z.string().describe('话题'), message: z.string().describe('消息内容') } }, async ({ speaker, topic, message }) => {
+  const { error } = await supabase.from('agent_council').insert({ speaker, topic, message }).select()
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: `✅ Council 消息已发送: ${topic}` }] }
+})
+
+server.registerTool('council_read', { title: 'Read Council', description: '阅读 Agent Council 的最近消息。', inputSchema: { limit: z.number().optional().describe('返回数量，默认10') } }, async ({ limit }) => {
+  const { data, error } = await supabase.from('agent_council').select('*').order('created_at', { ascending: false }).limit(limit ?? 10)
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+// ── 学习库 ──
+
+server.registerTool('list_folders', { title: 'List Knowledge Folders', description: '列出所有学习库文件夹。', inputSchema: {} }, async () => {
+  const { data, error } = await supabase.from('knowledge_folders').select('id, name, description, icon, parent_id, sort_order, created_at').order('sort_order', { ascending: true })
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+server.registerTool('add_folder', { title: 'Add Knowledge Folder', description: '创建新的学习库文件夹。', inputSchema: { name: z.string().describe('文件夹名称'), description: z.string().optional().describe('描述'), icon: z.string().optional().describe('emoji'), parent_id: z.string().optional().describe('父文件夹ID') } }, async ({ name, description, icon, parent_id }) => {
+  const row: Record<string, unknown> = { name }
+  if (description) row.description = description
+  if (icon) row.icon = icon
+  if (parent_id) row.parent_id = parent_id
+  const { data, error } = await supabase.from('knowledge_folders').insert(row).select()
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: `✅ 文件夹已创建: ${JSON.stringify(data[0])}` }] }
+})
+
+server.registerTool('add_node', { title: 'Add Learning Node', description: '创建学习节点。', inputSchema: { node_type: z.string().describe('类型: concept/question/insight/source/quote/note/application'), title: z.string().describe('标题'), content: z.string().optional().describe('内容'), folder_id: z.string().optional().describe('文件夹ID'), tags: z.array(z.string()).optional().describe('标签'), metadata: z.record(z.unknown()).optional().describe('专属字段') } }, async ({ node_type, title, content, folder_id, tags, metadata }) => {
+  const row: Record<string, unknown> = { node_type, title }
+  if (content) row.content = content
+  if (folder_id) row.folder_id = folder_id
+  if (tags) row.tags = tags
+  if (metadata) row.metadata = metadata
+  const { data, error } = await supabase.from('learning_nodes').insert(row).select()
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: `✅ 节点已创建: ${JSON.stringify(data[0])}` }] }
+})
+
+server.registerTool('search_nodes', { title: 'Search Learning Nodes', description: '搜索学习节点。', inputSchema: { query: z.string().describe('关键词'), node_type: z.string().optional().describe('类型筛选'), folder_id: z.string().optional().describe('文件夹筛选'), limit: z.number().optional().describe('数量上限，默认10') } }, async ({ query, node_type, folder_id, limit }) => {
+  let q = supabase.from('learning_nodes').select('id, node_type, title, content, tags, metadata, folder_id, created_at').or(`title.ilike.%${query}%,content.ilike.%${query}%`).order('updated_at', { ascending: false }).limit(limit ?? 10)
+  if (node_type) q = q.eq('node_type', node_type)
+  if (folder_id) q = q.eq('folder_id', folder_id)
+  const { data, error } = await q
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] }
+})
+
+server.registerTool('add_edge', { title: 'Add Learning Edge', description: '创建联想边。', inputSchema: { from_node_id: z.string().describe('起始节点ID'), to_node_id: z.string().describe('目标节点ID'), edge_type: z.string().describe('边类型: association/derivation/contradiction/application/reference/question'), description: z.string().optional().describe('描述'), strength: z.number().optional().describe('强度 1-5') } }, async ({ from_node_id, to_node_id, edge_type, description, strength }) => {
+  const row: Record<string, unknown> = { from_node_id, to_node_id, edge_type }
+  if (description) row.description = description
+  if (strength) row.strength = strength
+  const { data, error } = await supabase.from('learning_edges').insert(row).select()
+  if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }] }
+  return { content: [{ type: 'text', text: `✅ 联想边已创建: ${JSON.stringify(data[0])}` }] }
+})
+
+server.registerTool('get_node_edges', { title: 'Get Node Edges', description: '获取节点的所有联想边。', inputSchema: { node_id: z.string().describe('节点ID') } }, async ({ node_id }) => {
+  const { data: out, error: oE } = await supabase.from('learning_edges').select('id, from_node_id, to_node_id, edge_type, description, strength, created_at').eq('from_node_id', node_id)
+  if (oE) return { content: [{ type: 'text', text: `Error: ${oE.message}` }] }
+  const { data: inc, error: iE } = await supabase.from('learning_edges').select('id, from_node_id, to_node_id, edge_type, description, strength, created_at').eq('to_node_id', node_id)
+  if (iE) return { content: [{ type: 'text', text: `Error: ${iE.message}` }] }
+  return { content: [{ type: 'text', text: JSON.stringify({ outgoing: out, incoming: inc }, null, 2) }] }
+})
+
+// ── 瑞幸咖啡 ──
+
+server.registerTool('luckin_list_tools', { title: 'List Luckin Coffee Tools', description: '列出瑞幸咖啡 MCP 提供的所有可用工具。不需要任何参数。', inputSchema: {} }, async () => {
+  try { return { content: [{ type: 'text', text: JSON.stringify(await luckinMcpCall('tools/list'), null, 2) }] } }
+  catch (err) { return { content: [{ type: 'text', text: `Error: ${String(err)}` }] } }
+})
+
+server.registerTool('luckin_call', { title: 'Call Luckin Coffee Tool', description: '调用瑞幸咖啡 MCP 的具体工具。先用 luckin_list_tools 查看可用工具列表。', inputSchema: { tool_name: z.string().describe('工具名称'), arguments: z.record(z.unknown()).optional().describe('参数') } }, async ({ tool_name, arguments: args }) => {
+  try { return { content: [{ type: 'text', text: JSON.stringify(await luckinMcpCall('tools/call', { name: tool_name, arguments: args ?? {} }), null, 2) }] } }
+  catch (err) { return { content: [{ type: 'text', text: `Error: ${String(err)}` }] } }
+})
+
+// ── 麦当劳 ──
+
+server.registerTool('mcd_list_tools', { title: "List McDonald's Tools", description: '列出麦当劳 MCP 提供的所有可用工具。不需要任何参数。', inputSchema: {} }, async () => {
+  try { return { content: [{ type: 'text', text: JSON.stringify(await mcdMcpCall('tools/list'), null, 2) }] } }
+  catch (err) { return { content: [{ type: 'text', text: `Error: ${String(err)}` }] } }
+})
+
+server.registerTool('mcd_call', { title: "Call McDonald's Tool", description: '调用麦当劳 MCP 的具体工具。先用 mcd_list_tools 查看可用工具列表。', inputSchema: { tool_name: z.string().describe('工具名称'), arguments: z.record(z.unknown()).optional().describe('参数') } }, async ({ tool_name, arguments: args }) => {
+  try { return { content: [{ type: 'text', text: JSON.stringify(await mcdMcpCall('tools/call', { name: tool_name, arguments: args ?? {} }), null, 2) }] } }
+  catch (err) { return { content: [{ type: 'text', text: `Error: ${String(err)}` }] } }
+})
+
+// ── 高德地图 ──
+
+server.registerTool('amap_list_tools', { title: 'List AMap Tools', description: '列出高德地图 MCP 提供的所有可用工具（地理编码、天气、路径规划、周边搜索、打车、导航等）。不需要任何参数。', inputSchema: {} }, async () => {
+  try { return { content: [{ type: 'text', text: JSON.stringify(await amapMcpCall('tools/list'), null, 2) }] } }
+  catch (err) { return { content: [{ type: 'text', text: `Error: ${String(err)}` }] } }
+})
+
+server.registerTool('amap_call', { title: 'Call AMap Tool', description: '调用高德地图 MCP 的具体工具。先用 amap_list_tools 查看可用工具列表。', inputSchema: { tool_name: z.string().describe('工具名称'), arguments: z.record(z.unknown()).optional().describe('参数') } }, async ({ tool_name, arguments: args }) => {
+  try { return { content: [{ type: 'text', text: JSON.stringify(await amapMcpCall('tools/call', { name: tool_name, arguments: args ?? {} }), null, 2) }] } }
+  catch (err) { return { content: [{ type: 'text', text: `Error: ${String(err)}` }] } }
+})
+
+// ── MCP Transport ──
+app.all('*', async (c) => {
+  const transport = new WebStandardStreamableHTTPServerTransport()
+  await server.connect(transport)
+  return transport.handleRequest(c.req.raw)
+})
+
+Deno.serve(app.fetch)

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -2,8 +2,10 @@ import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 type OpenAiMessage = {
-  role: 'user' | 'assistant' | 'system'
+  role: 'user' | 'assistant' | 'system' | 'tool'
   content: string
+  tool_calls?: unknown
+  tool_call_id?: string
 }
 
 type OpenRouterPayload = {
@@ -15,6 +17,8 @@ type OpenRouterPayload = {
   top_p?: number
   max_tokens?: number
   reasoning?: boolean | Record<string, unknown>
+  tools?: unknown[]
+  tool_choice?: unknown
   stream?: boolean
   module?: 'snack-feed' | 'syzygy-feed' | 'bubble-chat' | 'rp-room' | string
   rpKeepRecentMessages?: number
@@ -148,6 +152,8 @@ type BuildProviderRequestOptions = {
   top_p: number | undefined
   max_tokens: number | undefined
   reasoning: OpenRouterPayload['reasoning']
+  tools?: unknown[]
+  tool_choice?: unknown
   stream: boolean
 }
 
@@ -220,7 +226,7 @@ const buildProviderRequestPayload = (
   provider: RuntimeProviderConfig,
   options: BuildProviderRequestOptions,
 ): Record<string, unknown> => {
-  const { resolvedModelId, messages, temperature, top_p, max_tokens, reasoning, stream } = options
+  const { resolvedModelId, messages, temperature, top_p, max_tokens, reasoning, tools, tool_choice, stream } = options
   const normalizedProviderName = normalizeProviderName(provider.provider)
   const isOpenRouter = normalizedProviderName === 'openrouter'
   const isAiHubMix = normalizedProviderName === 'aihubmix'
@@ -247,7 +253,7 @@ const buildProviderRequestPayload = (
       .map((message) => message.content)
       .filter((content) => content.length > 0)
     outgoingMessages = messages.filter(
-      (message) => message.role === 'user' || message.role === 'assistant',
+      (message) => message.role === 'user' || message.role === 'assistant' || message.role === 'tool',
     )
     if (systemContents.length > 0) {
       topLevelSystem = systemContents.join('\n')
@@ -294,6 +300,13 @@ const buildProviderRequestPayload = (
     if (reasoningPayload) {
       basePayload.reasoning = reasoningPayload
     }
+  }
+
+  if (tools !== undefined) {
+    basePayload.tools = tools
+  }
+  if (tool_choice !== undefined) {
+    basePayload.tool_choice = tool_choice
   }
 
   if (topLevelSystem !== null) {
@@ -1177,7 +1190,7 @@ serve(async (req) => {
     })
   }
 
-  const { temperature, top_p, max_tokens, reasoning } = payload
+  const { temperature, top_p, max_tokens, reasoning, tools, tool_choice } = payload
   const stream = payload.stream ?? true
   const isForumModule = payload.module === 'forum'
   if (isForumModule) {
@@ -1252,6 +1265,8 @@ serve(async (req) => {
           top_p,
           max_tokens,
           reasoning,
+          tools,
+          tool_choice,
           stream,
         }),
       ),


### PR DESCRIPTION
# ⚠️ 合并即破坏现有 connector 接入 — 请先读这里

**合并部署后，旧的 hamster-mcp connector URL（无密钥）会立即失效（返回 401）。** 需要你做两件事：

1. 在 Supabase 项目（crfhiumxzmaszkapanrb）的 Edge Functions Secrets 中新增 `HAMSTER_MCP_KEY`（任意强随机字符串）。未配置前 connector 通道保持关闭。
2. 把 **Claude 与 GPT 两端** 的 connector 地址更新为：
   `https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/hamster-mcp?key=<HAMSTER_MCP_KEY>`

---

## 改动内容（3 个 commit，按审查顺序）

### 1️⃣ openrouter-chat 最小增量（红线已单独批准，独立 commit 便于回滚）
仅两件事：透传请求体中的 `tools` / `tool_choice` 到上游；消息放行 `role:'tool'` 及 assistant 的 `tool_calls` / `tool_call_id` 字段（含 Claude system-hoisting 分支，原先会把 tool 消息整条过滤掉）。**不带 `tools` 的请求行为与现状完全一致。** +19/-4 行。

### 2️⃣ hamster-mcp 加固 + 纳入仓库
原先部署在仓库外（手动部署），现 vendor 进 `supabase/functions/hamster-mcp/`，合并后由现有 CI（`deploy-edge-functions.yml`，deploy all）自动部署。工具注册与 MCP transport 未动，新增：

- **CORS**：允许 `chuan-101.github.io` 与 `localhost`，处理 OPTIONS 预检（原先无 CORS，浏览器无法调用）
- **双通道鉴权**（原先完全无鉴权，service-role 权限对公网裸奔）：
  - 前端通道：`Authorization` 带 Supabase 用户 JWT + `apikey` header，与 openrouter-chat 同方式校验 `/auth/v1/user`
  - connector 通道：URL query `?key=` 比对 env `HAMSTER_MCP_KEY`（timing-safe 比较；connector 无法自定义 header 所以走 query）
  - 任一通过即放行；均不通过返回 401；非白名单 Origin 返回 403
- `config.toml` 增加 `[functions.hamster-mcp] verify_jwt = false`（与其他函数一致，网关层 JWT 校验对 ES256 token 不可用，函数内自行校验）
- 顺手修复 vendored 代码中一处 lint error（`council_post` 未使用的 `data` 解构，行为不变）

### 3️⃣ 前端工具循环（聊天窗口 / chitchat 模块）
- `src/lib/mcpTools.ts`：hamster-mcp JSON-RPC 客户端 — `tools/list`（5 分钟缓存，转 OpenAI function calling 格式，**schema 不硬编码**）与 `tools/call`（一切错误以文本返回给模型，不中断会话）
- `App.tsx` sendMessage：请求附带 `tools`；同时支持流式（SSE `delta.tool_calls` 按 index 累积）与非流式（`message.tool_calls`）解析；模型返回 tool_calls 时逐个执行，结果以 `role:'tool'` 追加上下文后再次请求，**循环上限 5 轮**；循环后续请求去掉 `conversationId`，避免服务端运行时压缩用数据库历史重建消息时丢掉工具结果
- **优雅降级**：带 `tools` 的请求被上游 4xx 拒绝时，立即不带 `tools` 重发本轮；成功则本次会话内记住该模型不支持，不再附带工具
- UI：assistant 气泡内可折叠工具状态条（🔧 工具名 + 执行中/完成/失败），样式对齐现有气泡，状态随消息 meta 持久化
- README 增加工具循环数据流说明

## 验证
- `tsc -b`、`eslint .`（0 error）、`vite build` 全部通过
- 两个 Edge Function 经 ESLint 完整解析无错误（本环境网络策略拦截 jsr.io，无法跑 `deno check`，hamster-mcp 改动仅为标准 Hono 中间件 + Web API）
- 未触碰任何 Supabase 表结构与其他 Edge Function；第三方 token（瑞幸/麦当劳/高德）均保留在服务端 env

## 部署顺序建议
先在 Supabase 配好 `HAMSTER_MCP_KEY` → 合并本 PR（CI 自动部署三处）→ 更新两端 connector URL。

https://claude.ai/code/session_01WETi2ZpWjYsbPEPmF4tG9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01WETi2ZpWjYsbPEPmF4tG9U)_