### PR TITLE
mcpTools:AbortSignal.any 缺失时降级桥接(跟进 #408 Codex 评审)

### DIFF
--- a/src/lib/mcpTools.ts
+++ b/src/lib/mcpTools.ts
@@ -32,6 +32,24 @@ const buildEndpoint = () => `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/h
 
 let requestSequence = 0
 
+// AbortSignal.any 在较旧浏览器（如 Safari < 17.4）中不存在，缺失时手动桥接两个信号，
+// 避免 fetch 前抛 TypeError 导致工具被静默禁用。
+const combineSignals = (signal: AbortSignal, timeoutSignal: AbortSignal): AbortSignal => {
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([signal, timeoutSignal])
+  }
+  if (signal.aborted) {
+    return signal
+  }
+  if (timeoutSignal.aborted) {
+    return timeoutSignal
+  }
+  const controller = new AbortController()
+  signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true })
+  timeoutSignal.addEventListener('abort', () => controller.abort(timeoutSignal.reason), { once: true })
+  return controller.signal
+}
+
 const parseJsonRpcResponse = async (response: Response, requestId: number): Promise<JsonRpcResponse> => {
   const contentType = response.headers.get('content-type') ?? ''
   if (contentType.includes('text/event-stream')) {
@@ -80,7 +98,7 @@ const sendJsonRpc = async (
       method,
       ...(params ? { params } : {}),
     }),
-    signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+    signal: signal ? combineSignals(signal, timeoutSignal) : timeoutSignal,
   })
   if (!response.ok) {
     const errorText = await response.text()


### PR DESCRIPTION
跟进 #408 的 Codex 评审建议(P2):`AbortSignal.any` 在较旧浏览器(如 Safari < 17.4)中不存在,此时每个带调用方 signal 的 MCP 请求会在 fetch 发起前直接抛 `TypeError`——聊天路径现在总是传 `controller.signal`,等于这些浏览器上 `tools/list` 静默失败、工具被悄悄禁用,缓存的 `tools/call` 全部报"调用失败"。

## 改动

`src/lib/mcpTools.ts` 新增 `combineSignals` 辅助函数:

- `AbortSignal.any` 可用时照常使用
- 缺失时手动桥接:任一信号已中止则直接返回该信号,否则新建 `AbortController`,在两个信号的 `abort` 事件上以原 `reason` 转发中止(保留 `TimeoutError` 与用户中止的区分,超时文案逻辑不受影响)

仅 1 个文件,+19/−1 行,行为在支持 `AbortSignal.any` 的浏览器上完全不变。

## 验证

- `npm run lint`:0 错误(5 条存量 hooks 警告不变)
- `npm run build`(tsc -b + vite):通过

https://claude.ai/code/session_01DYFmuGR5TLNJDSVnkUJDeg

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYFmuGR5TLNJDSVnkUJDeg)_