### PR TITLE
fix: 客厅点名改为下拉抽屉，头像底色统一浅灰 #f6f8fa

### DIFF
--- a/src/pages/LoungePage.css
+++ b/src/pages/LoungePage.css
@@ -283,7 +283,8 @@
   place-items: center;
   font-size: 18px;
   border-radius: 12px;
-  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.55);
+  background: #f6f8fa;
+  border: 1px solid #e8ecf0;
 }
 
 .lounge-message-body {
@@ -337,6 +338,7 @@
 /* ── Composer ─────────────────────────────────── */
 
 .lounge-composer {
+  position: relative;
   display: grid;
   gap: 8px;
   padding: 10px;
@@ -346,22 +348,90 @@
   box-shadow: 0 8px 18px rgba(255, 214, 231, 0.2);
 }
 
-.lounge-mention-row {
-  display: flex;
-  gap: 6px;
-  overflow-x: auto;
-  padding-bottom: 2px;
+/* 点名抽屉：从输入框上方弹出的成员下拉菜单 */
+.lounge-mention-menu {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 10px;
+  z-index: 20;
+  min-width: 200px;
+  max-height: 260px;
+  overflow-y: auto;
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  background: #fff;
+  box-shadow: 0 12px 28px rgba(63, 51, 64, 0.16);
 }
 
-.lounge-mention-chip {
+.lounge-mention-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: #4b3a47;
+  padding: 8px 10px;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.lounge-mention-option:hover {
+  background: #fff0f7;
+}
+
+.lounge-mention-emoji {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  font-size: 14px;
+  border-radius: 9px;
+  background: #f6f8fa;
+  border: 1px solid #e8ecf0;
+}
+
+.lounge-mention-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lounge-mention-dot {
+  width: 8px;
+  height: 8px;
   flex-shrink: 0;
   border-radius: 999px;
-  border: 1px solid;
+}
+
+.lounge-mention-toggle {
+  width: 38px;
+  height: 38px;
+  flex-shrink: 0;
+  border-radius: 12px;
+  border: 1px solid #ffd6e7;
   background: #fff;
-  color: #6b5563;
-  padding: 4px 10px;
-  font-size: 12px;
-  white-space: nowrap;
+  color: #b27f98;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.lounge-mention-toggle--open {
+  background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%);
+  color: #7d5d70;
+}
+
+.lounge-mention-toggle:disabled {
+  opacity: 0.4;
 }
 
 .lounge-input-row {

--- a/src/pages/LoungeRoomPage.tsx
+++ b/src/pages/LoungeRoomPage.tsx
@@ -93,11 +93,13 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
   const [sceneEditorOpen, setSceneEditorOpen] = useState(false)
   const [sceneDraft, setSceneDraft] = useState('')
   const [savingScene, setSavingScene] = useState(false)
+  const [mentionMenuOpen, setMentionMenuOpen] = useState(false)
   const messagesRef = useRef<LoungeMessage[]>([])
   const membersRef = useRef<LoungeMember[]>([])
   const streamControllerRef = useRef<AbortController | null>(null)
   const listEndRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLTextAreaElement | null>(null)
+  const composerRef = useRef<HTMLElement | null>(null)
 
   const memberMap = useMemo(
     () => new Map(members.map((member) => [member.sender, member])),
@@ -194,6 +196,24 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
       streamControllerRef.current?.abort()
     }
   }, [])
+
+  // 点名抽屉点击外部时收起。
+  useEffect(() => {
+    if (!mentionMenuOpen) {
+      return
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null
+      if (target && composerRef.current?.contains(target)) {
+        return
+      }
+      setMentionMenuOpen(false)
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [mentionMenuOpen])
 
   const appendMessage = useCallback((message: LoungeMessage) => {
     // 同步更新 ref：发送后会立即用 messagesRef 构建模型上下文，不能等 React 刷新。
@@ -479,11 +499,7 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
   const renderAvatar = (sender: string) => {
     const member = memberMap.get(sender)
     return (
-      <span
-        className="lounge-avatar"
-        style={{ backgroundColor: member?.color ?? '#cbd5e1' }}
-        aria-hidden="true"
-      >
+      <span className="lounge-avatar" aria-hidden="true">
         {member?.emoji ?? '❔'}
       </span>
     )
@@ -544,23 +560,43 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
         <div ref={listEndRef} />
       </section>
 
-      <footer className="lounge-composer">
-        {members.length > 0 ? (
-          <div className="lounge-mention-row">
+      <footer className="lounge-composer" ref={composerRef}>
+        {mentionMenuOpen && members.length > 0 ? (
+          <div className="lounge-mention-menu" role="menu">
             {members.map((member) => (
               <button
                 key={member.sender}
                 type="button"
-                className="lounge-mention-chip"
-                style={{ borderColor: member.color }}
-                onClick={() => handleInsertMention(member)}
+                role="menuitem"
+                className="lounge-mention-option"
+                onClick={() => {
+                  handleInsertMention(member)
+                  setMentionMenuOpen(false)
+                }}
               >
-                <span aria-hidden="true">{member.emoji}</span> @{member.displayName}
+                <span className="lounge-mention-emoji" aria-hidden="true">{member.emoji}</span>
+                <span className="lounge-mention-name">@{member.displayName}</span>
+                <span
+                  className="lounge-mention-dot"
+                  style={{ backgroundColor: member.color }}
+                  aria-hidden="true"
+                />
               </button>
             ))}
           </div>
         ) : null}
         <div className="lounge-input-row">
+          <button
+            type="button"
+            className={`lounge-mention-toggle ${mentionMenuOpen ? 'lounge-mention-toggle--open' : ''}`}
+            onClick={() => setMentionMenuOpen((prev) => !prev)}
+            disabled={members.length === 0}
+            title="@点名成员"
+            aria-haspopup="menu"
+            aria-expanded={mentionMenuOpen}
+          >
+            @
+          </button>
           <textarea
             ref={inputRef}
             value={draft}


### PR DESCRIPTION
# 客厅 UI 修整（跟进 #410）

## 改动
- **点名 UI 重做**：移除输入框上方的成员 chips 横排（之前在空沙发里会被纵向拉伸成柱子），改为对话框内的下拉抽屉——输入行左侧新增「@」按钮，点击向上弹出成员菜单，选中即插入 `@名字 `，点击菜单外自动收起。
- **头像底色统一浅灰 `#f6f8fa`**：消息头像与菜单里的成员 emoji 都用浅灰底 + 细灰边；成员的注册色（lounge_members.color）保留为菜单项右侧的小色点，不再做头像底色。

仅动 `LoungeRoomPage.tsx` + `LoungePage.css`，数据层与发消息管线零改动。

## 验证
- `npm run build` 通过；`npm run lint` 0 errors（仅存量 warnings）。

https://claude.ai/code/session_018DQiUXSau2gFVbtjqT5WoV

---
_Generated by [Claude Code](https://claude.ai/code/session_018DQiUXSau2gFVbtjqT5WoV)_