### PR TITLE
fix: 客厅@点名浮层锚定输入行上方（修复漂到左上角）

### DIFF
--- a/src/pages/LoungePage.css
+++ b/src/pages/LoungePage.css
@@ -244,13 +244,17 @@
 
 /* ── Chat room ────────────────────────────────── */
 
+/* 错误条等子元素是条件渲染的，固定 grid 行模板会让输入区掉进 1fr 行被拉伸；
+   改用 flex 列布局：消息区独占剩余空间，输入区贴底保持内容高度。 */
 .lounge-room {
-  grid-template-rows: auto auto 1fr auto;
+  display: flex;
+  flex-direction: column;
   height: 100dvh;
   min-height: 0;
 }
 
 .lounge-message-list {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -348,13 +352,20 @@
   box-shadow: 0 8px 18px rgba(255, 214, 231, 0.2);
 }
 
-/* 点名抽屉：从输入框上方弹出的成员下拉菜单 */
+/* 浮层的定位参照：包住点名菜单与输入行，菜单从输入行上沿向上弹出 */
+.lounge-input-anchor {
+  position: relative;
+}
+
+/* 点名抽屉：锚定在输入行正上方的成员下拉菜单 */
 .lounge-mention-menu {
   position: absolute;
   bottom: calc(100% + 8px);
-  left: 10px;
+  left: 0;
   z-index: 20;
   min-width: 200px;
+  max-width: 100%;
+  box-sizing: border-box;
   max-height: 260px;
   overflow-y: auto;
   display: grid;

--- a/src/pages/LoungeRoomPage.tsx
+++ b/src/pages/LoungeRoomPage.tsx
@@ -561,63 +561,65 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
       </section>
 
       <footer className="lounge-composer" ref={composerRef}>
-        {mentionMenuOpen && members.length > 0 ? (
-          <div className="lounge-mention-menu" role="menu">
-            {members.map((member) => (
-              <button
-                key={member.sender}
-                type="button"
-                role="menuitem"
-                className="lounge-mention-option"
-                onClick={() => {
-                  handleInsertMention(member)
-                  setMentionMenuOpen(false)
-                }}
-              >
-                <span className="lounge-mention-emoji" aria-hidden="true">{member.emoji}</span>
-                <span className="lounge-mention-name">@{member.displayName}</span>
-                <span
-                  className="lounge-mention-dot"
-                  style={{ backgroundColor: member.color }}
-                  aria-hidden="true"
-                />
-              </button>
-            ))}
+        <div className="lounge-input-anchor">
+          {mentionMenuOpen && members.length > 0 ? (
+            <div className="lounge-mention-menu" role="menu">
+              {members.map((member) => (
+                <button
+                  key={member.sender}
+                  type="button"
+                  role="menuitem"
+                  className="lounge-mention-option"
+                  onClick={() => {
+                    handleInsertMention(member)
+                    setMentionMenuOpen(false)
+                  }}
+                >
+                  <span className="lounge-mention-emoji" aria-hidden="true">{member.emoji}</span>
+                  <span className="lounge-mention-name">@{member.displayName}</span>
+                  <span
+                    className="lounge-mention-dot"
+                    style={{ backgroundColor: member.color }}
+                    aria-hidden="true"
+                  />
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <div className="lounge-input-row">
+            <button
+              type="button"
+              className={`lounge-mention-toggle ${mentionMenuOpen ? 'lounge-mention-toggle--open' : ''}`}
+              onClick={() => setMentionMenuOpen((prev) => !prev)}
+              disabled={members.length === 0}
+              title="@点名成员"
+              aria-haspopup="menu"
+              aria-expanded={mentionMenuOpen}
+            >
+              @
+            </button>
+            <textarea
+              ref={inputRef}
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
+                  event.preventDefault()
+                  void handleSend()
+                }
+              }}
+              placeholder="在沙发上说点什么…（@成员 可以点名）"
+              rows={2}
+            />
+            <button
+              type="button"
+              className="lounge-send-btn"
+              onClick={() => void handleSend()}
+              disabled={sending || draft.trim().length === 0}
+            >
+              发送
+            </button>
           </div>
-        ) : null}
-        <div className="lounge-input-row">
-          <button
-            type="button"
-            className={`lounge-mention-toggle ${mentionMenuOpen ? 'lounge-mention-toggle--open' : ''}`}
-            onClick={() => setMentionMenuOpen((prev) => !prev)}
-            disabled={members.length === 0}
-            title="@点名成员"
-            aria-haspopup="menu"
-            aria-expanded={mentionMenuOpen}
-          >
-            @
-          </button>
-          <textarea
-            ref={inputRef}
-            value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
-                event.preventDefault()
-                void handleSend()
-              }
-            }}
-            placeholder="在沙发上说点什么…（@成员 可以点名）"
-            rows={2}
-          />
-          <button
-            type="button"
-            className="lounge-send-btn"
-            onClick={() => void handleSend()}
-            disabled={sending || draft.trim().length === 0}
-          >
-            发送
-          </button>
         </div>
       </footer>
 


### PR DESCRIPTION
# 客厅 @点名浮层定位修复（跟进 #411）

## 根因
排查方向 1 命中了一半：浮层的 `position: absolute` 参照没有冒泡到 body，但参照物本身出了问题——

`.lounge-room` 之前用 `grid-template-rows: auto auto 1fr auto` 排（标题/错误条/消息区/输入区）四个子元素，而**错误条是条件渲染的**。没有报错时输入区 footer 掉进 `1fr` 行被拉成大半屏（截图里那块巨大的白色圆角面板就是被拉伸的输入区），浮层虽然锚在输入区容器上沿，但这个容器的上沿已经在页面顶部附近了，于是看起来「漂到左上角遮住标题」。上一版 chips 被纵向拉成柱子也是同一个根因。

## 修复（仅样式/结构，两个文件）
1. **按建议加了专属定位参照**：点名菜单与输入行一起包进 `.lounge-input-anchor`（`position: relative`），菜单 `absolute + bottom: calc(100% + 8px) + left: 0`，从输入行上沿向上弹出、与输入行左对齐；`max-width: 100%` 保证 380px 窄屏不超出。
2. **根因修复**：`.lounge-room` 改为 flex 列布局——消息区 `flex: 1` 独占剩余空间，输入区贴底保持内容高度，错误条有无都不再影响行分配。

## 未动
成员数据来源（lounge_members）、@解析逻辑、消息发送管线均零改动。

## 验证
- `npm run build` 通过；`npm run lint` 0 errors（仅存量 warnings）。

https://claude.ai/code/session_018DQiUXSau2gFVbtjqT5WoV

---
_Generated by [Claude Code](https://claude.ai/code/session_018DQiUXSau2gFVbtjqT5WoV)_