### PR TITLE
Fix daily chat Supabase cross-device sync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -487,11 +487,15 @@ const App = () => {
     }
     setSyncing(true)
     try {
-      const remoteSessions = await fetchRemoteSessions(user.id)
+      const [remoteSessions, remoteMessages] = await Promise.all([
+        fetchRemoteSessions(user.id),
+        fetchRemoteMessages(user.id),
+      ])
       const nextSessions = sortSessions(remoteSessions)
-      applySnapshot(nextSessions, messagesRef.current)
+      const nextMessages = mergeMessages(messagesRef.current, remoteMessages)
+      applySnapshot(nextSessions, nextMessages)
     } catch (error) {
-      console.warn('无法加载 Supabase 会话数据', error)
+      console.warn('无法加载 Supabase 会话/消息数据', error)
     } finally {
       setSyncing(false)
     }
@@ -610,6 +614,45 @@ const App = () => {
     document.addEventListener('visibilitychange', handleVisibilityChange)
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [refreshRemoteSessions, user])
+
+  useEffect(() => {
+    const client = supabase
+    if (!client || !user) {
+      return
+    }
+
+    const channel = client
+      .channel(`daily-chat-sync-${user.id}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'sessions',
+          filter: `user_id=eq.${user.id}`,
+        },
+        () => {
+          void refreshRemoteSessions()
+        },
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'messages',
+          filter: `user_id=eq.${user.id}`,
+        },
+        () => {
+          void refreshRemoteSessions()
+        },
+      )
+      .subscribe()
+
+    return () => {
+      void client.removeChannel(channel)
     }
   }, [refreshRemoteSessions, user])
 


### PR DESCRIPTION
### Motivation
- The daily (bubble) chat was only refreshing `sessions` from Supabase in some refresh paths, so messages created on one device would not always appear on another device when returning to the app or opening the drawer.
- Add realtime listening to ensure the client refreshes when other clients write `sessions` or `messages` for the current user.

### Description
- Update `refreshRemoteSessions` in `src/App.tsx` to fetch both `sessions` and `messages` via `fetchRemoteSessions` and `fetchRemoteMessages`, merge messages with `mergeMessages`, and apply the merged snapshot with `applySnapshot`.
- Add a Supabase Realtime subscription in `src/App.tsx` (`daily-chat-sync-${user.id}`) that listens to `postgres_changes` on the `sessions` and `messages` tables scoped to the current user and triggers `refreshRemoteSessions` on changes.
- Adjust a log message to reflect that both sessions and messages are being loaded when refresh fails.

### Testing
- Ran `npm run build`, which completed successfully and produced the production build.
- Ran `npm run lint`, which completed with existing repository warnings (5 warnings) and no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a292eb0702083309525d3f2614ae025)