### PR TITLE
Fix chat timestamp sync source

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2402,6 +2402,7 @@ const ChatRoute = ({
 }) => {
   const { sessionId } = useParams()
   const navigate = useNavigate()
+  const [pendingCreatedSessionId, setPendingCreatedSessionId] = useState<string | null>(null)
 
   const activeSession = sessions.find((session) => session.id === sessionId)
 
@@ -2423,6 +2424,7 @@ const ChatRoute = ({
 
   const handleCreateSession = useCallback(async () => {
     const newSession = await onCreateSession()
+    setPendingCreatedSessionId(newSession.id)
     navigate(`/chat/${newSession.id}`)
     onCloseDrawer()
   }, [navigate, onCloseDrawer, onCreateSession])
@@ -2457,13 +2459,17 @@ const ChatRoute = ({
   )
 
   useEffect(() => {
-    if (!activeSession && sessions.length > 0) {
-      const targetSession = selectMostRecentSession(sessions)
-      if (targetSession) {
-        navigate(`/chat/${targetSession.id}`, { replace: true })
-      }
+    if (activeSession || sessions.length === 0) {
+      return
     }
-  }, [activeSession, navigate, sessions])
+    if (sessionId && sessionId === pendingCreatedSessionId) {
+      return
+    }
+    const targetSession = selectMostRecentSession(sessions)
+    if (targetSession) {
+      navigate(`/chat/${targetSession.id}`, { replace: true })
+    }
+  }, [activeSession, navigate, pendingCreatedSessionId, sessionId, sessions])
 
   useEffect(() => {
     if (activeSession || syncing || !sessionsReady || sessions.length > 0) {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -879,14 +879,11 @@ export const createRemoteSession = async (
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
-  const now = new Date().toISOString()
   const { data, error } = await supabase
     .from('sessions')
     .insert({
       user_id: userId,
       title,
-      created_at: now,
-      updated_at: now,
     })
     .select('id,user_id,title,created_at,updated_at,override_model,override_reasoning,is_archived,archived_at')
     .single()
@@ -1352,10 +1349,9 @@ export const renameRemoteSession = async (
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
-  const now = new Date().toISOString()
   const { data, error } = await supabase
     .from('sessions')
-    .update({ title, updated_at: now })
+    .update({ title })
     .eq('id', sessionId)
     .select('id,user_id,title,created_at,updated_at,override_model,override_reasoning,is_archived,archived_at')
     .single()
@@ -1372,10 +1368,9 @@ export const updateRemoteSessionOverride = async (
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
-  const now = new Date().toISOString()
   const { data, error } = await supabase
     .from('sessions')
-    .update({ override_model: overrideModel, updated_at: now })
+    .update({ override_model: overrideModel })
     .eq('id', sessionId)
     .select('id,user_id,title,created_at,updated_at,override_model,override_reasoning,is_archived,archived_at')
     .single()
@@ -1392,10 +1387,9 @@ export const updateRemoteSessionReasoningOverride = async (
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
-  const now = new Date().toISOString()
   const { data, error } = await supabase
     .from('sessions')
-    .update({ override_reasoning: overrideReasoning, updated_at: now })
+    .update({ override_reasoning: overrideReasoning })
     .eq('id', sessionId)
     .select('id,user_id,title,created_at,updated_at,override_model,override_reasoning,is_archived,archived_at')
     .single()
@@ -1463,7 +1457,6 @@ export const addRemoteMessage = async (
     throw new Error('Supabase 客户端未配置')
   }
   const safeMeta = meta ?? {}
-  const now = new Date().toISOString()
   const { data, error } = await supabase
     .from('messages')
     .insert({
@@ -1471,7 +1464,6 @@ export const addRemoteMessage = async (
       user_id: userId,
       role,
       content,
-      created_at: now,
       client_id: clientId,
       client_created_at: clientCreatedAt,
       meta: safeMeta,
@@ -1481,15 +1473,16 @@ export const addRemoteMessage = async (
   if (error || !data) {
     throw error ?? new Error('发送消息失败')
   }
-  const { error: sessionError } = await supabase
+  const { data: sessionData, error: sessionError } = await supabase
     .from('sessions')
-    .update({ updated_at: now })
+    .select('updated_at')
     .eq('id', sessionId)
-  if (sessionError) {
-    throw sessionError
+    .single()
+  if (sessionError || !sessionData) {
+    throw sessionError ?? new Error('刷新会话时间失败')
   }
   const message = mapMessageRow(data as MessageRow)
-  return { message, updatedAt: now }
+  return { message, updatedAt: (sessionData as Pick<SessionRow, 'updated_at'>).updated_at }
 }
 
 export const deleteRemoteMessage = async (messageId: string) => {

--- a/supabase/migrations/20260610183000_server_managed_chat_timestamps.sql
+++ b/supabase/migrations/20260610183000_server_managed_chat_timestamps.sql
@@ -1,0 +1,44 @@
+-- Keep daily chat timestamps server-owned so client timezone math cannot poison sync cursors.
+
+create or replace function public.set_sessions_updated_at_now()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_sessions_updated_at_now on public.sessions;
+create trigger set_sessions_updated_at_now
+before update on public.sessions
+for each row
+execute function public.set_sessions_updated_at_now();
+
+create or replace function public.touch_session_updated_at_from_messages()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  target_session_id uuid;
+begin
+  target_session_id = coalesce(new.session_id, old.session_id);
+
+  if target_session_id is not null then
+    update public.sessions
+    set updated_at = now()
+    where id = target_session_id;
+  end if;
+
+  return coalesce(new, old);
+end;
+$$;
+
+drop trigger if exists touch_session_updated_at_after_messages on public.messages;
+create trigger touch_session_updated_at_after_messages
+after insert or update or delete on public.messages
+for each row
+execute function public.touch_session_updated_at_from_messages();


### PR DESCRIPTION
### Motivation

- 客厅 PR 引入的前端自行构造/写入 `created_at`/`updated_at` 导致落库时间包含时区算术（出现未来时间戳），进而破坏增量拉取游标，表现为“不同步”。
- 需要把会话/消息的时间戳交回数据库由 `DEFAULT now()` / 服务端时间源管理，同时避免新建会话时路由/本地状态竞态导致消息落入旧会话。

### Description

- 移除客户端在日常聊天相关写入中带入的时间字段，改为让数据库生成时间：修改 `src/storage/supabaseSync.ts` 中的会话/消息创建与会话更新逻辑，删除 `created_at` / `updated_at` 的前端赋值并保留 `client_created_at` 用于本地排序与乐观更新。 (`src/storage/supabaseSync.ts`)
- 在消息插入后不再用客户端时间去更新会话，而是从数据行中读取并返回 `sessions.updated_at`，避免客户端时间污染同步游标。 (`src/storage/supabaseSync.ts`)
- 新增数据库 migration，添加触发器使 `sessions.updated_at` 由服务端管理并在 `messages` 插入/更新/删除时触发 touch：`supabase/migrations/20260610183000_server_managed_chat_timestamps.sql`（包含 `set_sessions_updated_at_now` 和 `touch_session_updated_at_from_messages`）。
- 修复路由/新会话竞态：在 `src/App.tsx` 中引入 `pendingCreatedSessionId`，在新建会话后标记并在自动跳转逻辑中避免把刚创建（但尚未同步到本地列表）的 session 覆盖回最近旧会话，防止发送时 composer 仍指向旧会话。 (`src/App.tsx`)

### Testing

- 执行 `npm run lint`，通过（仓库里已有的若干 React hook warning 仍存在，但无新增 error）。
- 执行 `npm run build`（`tsc -b && vite build`），构建成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2985e9fdf8833082148140d207b490)