### PR TITLE
Fix daily chat remote message sync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,9 +96,9 @@ const sortSessions = (sessions: ChatSession[]) =>
 const sortMessages = (messages: ChatMessage[]) =>
   [...messages].sort(
     (a, b) =>
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime() ||
       new Date(a.clientCreatedAt ?? a.createdAt).getTime() -
-        new Date(b.clientCreatedAt ?? b.createdAt).getTime() ||
-      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        new Date(b.clientCreatedAt ?? b.createdAt).getTime(),
   )
 
 const selectMostRecentSession = (sessions: ChatSession[]) => {
@@ -250,9 +250,9 @@ const buildRecentExtractionMessages = (
     .filter((message) => message.sessionId === sessionId && message.content.trim().length > 0)
     .sort(
       (a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime() ||
         new Date(a.clientCreatedAt ?? a.createdAt).getTime() -
-          new Date(b.clientCreatedAt ?? b.createdAt).getTime() ||
-        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+          new Date(b.clientCreatedAt ?? b.createdAt).getTime(),
     )
   return scoped.slice(-limit).map((message) => ({ role: message.role, content: message.content }))
 }
@@ -500,6 +500,27 @@ const App = () => {
       setSyncing(false)
     }
   }, [applySnapshot, user])
+
+  const refreshRemoteSessionMessages = useCallback(async (sessionId: string) => {
+    if (!user || !supabase) {
+      return
+    }
+    setSyncing(true)
+    try {
+      const remoteMessages = await fetchRemoteMessages(user.id, sessionId)
+      const nextMessages = mergeMessages(messagesRef.current, remoteMessages)
+      applySnapshot(sessionsRef.current, nextMessages)
+    } catch (error) {
+      console.warn('无法加载 Supabase 会话消息数据', error)
+    } finally {
+      setSyncing(false)
+    }
+  }, [applySnapshot, user])
+
+  const handleActiveSessionChange = useCallback((sessionId: string) => {
+    setActiveChatSessionId(sessionId)
+    void refreshRemoteSessionMessages(sessionId)
+  }, [refreshRemoteSessionMessages])
 
   useEffect(() => {
     if (!supabase) {
@@ -2065,7 +2086,7 @@ const App = () => {
                 defaultReasoning={activeSettings.chatReasoningEnabled}
                 onSelectReasoning={handleSessionReasoningOverrideChange}
                 onArchiveSession={handleSessionArchiveStateChange}
-                onActiveSessionChange={setActiveChatSessionId}
+                onActiveSessionChange={handleActiveSessionChange}
                 user={user}
                 onReturnToGame={isChatOpenedFromGameMode ? handleReturnToGameFromChat : undefined}
                 chatTheme={isChatOpenedFromGameMode ? 'pixel' : 'ios'}
@@ -2416,9 +2437,9 @@ const ChatRoute = ({
       .filter((message) => message.sessionId === sessionId)
       .sort(
         (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime() ||
           new Date(a.clientCreatedAt ?? a.createdAt).getTime() -
-            new Date(b.clientCreatedAt ?? b.createdAt).getTime() ||
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+            new Date(b.clientCreatedAt ?? b.createdAt).getTime(),
       )
   }, [messages, sessionId])
 

--- a/src/storage/chatStorage.ts
+++ b/src/storage/chatStorage.ts
@@ -77,9 +77,9 @@ const sortSessions = (sessions: ChatSession[]) =>
 const sortMessages = (messages: ChatMessage[]) =>
   [...messages].sort(
     (a, b) =>
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime() ||
       new Date(a.clientCreatedAt ?? a.createdAt).getTime() -
-        new Date(b.clientCreatedAt ?? b.createdAt).getTime() ||
-      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        new Date(b.clientCreatedAt ?? b.createdAt).getTime(),
   )
 
 export const loadSnapshot = (): StorageSnapshot => {

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -856,16 +856,23 @@ export const fetchRemoteSessions = async (userId: string): Promise<ChatSession[]
   return (data ?? []).map(mapSessionRow)
 }
 
-export const fetchRemoteMessages = async (userId: string): Promise<ChatMessage[]> => {
+export const fetchRemoteMessages = async (
+  userId: string,
+  sessionId?: string,
+): Promise<ChatMessage[]> => {
   if (!supabase) {
     return []
   }
-  const { data, error } = await supabase
+  let query = supabase
     .from('messages')
     .select('id,session_id,user_id,role,content,created_at,client_id,client_created_at,meta')
     .eq('user_id', userId)
-    .order('client_created_at', { ascending: true })
-    .order('created_at', { ascending: true })
+
+  if (sessionId) {
+    query = query.eq('session_id', sessionId)
+  }
+
+  const { data, error } = await query.order('created_at', { ascending: true })
   if (error) {
     throw error
   }

--- a/supabase/migrations/20260610183000_server_managed_chat_timestamps.sql
+++ b/supabase/migrations/20260610183000_server_managed_chat_timestamps.sql
@@ -3,6 +3,7 @@
 create or replace function public.set_sessions_updated_at_now()
 returns trigger
 language plpgsql
+set search_path = public
 as $$
 begin
   new.updated_at = now();


### PR DESCRIPTION
### Motivation
- Remote messages stopped appearing in opened sessions because the client never fetched per-session `messages` when a window was opened, only `sessions` were refreshed.  
- The merge and sort logic relied on `clientCreatedAt` before `createdAt`, causing inconsistent ordering and causing remote messages to be invisible in some views.  
- The fix must be pull-based only (no Realtime changes) and must preserve local optimistic/pending messages.  
- A minor migration file text fix is required to ensure function definitions include `set search_path = public` while not touching live DB state.  

### Description
- Add optional `sessionId` parameter to `fetchRemoteMessages(userId, sessionId?)` and, when provided, restrict the Supabase query to that `session_id`, ordering by server `created_at`; keep the previous full-user fetch for list-level refreshes (`src/storage/supabaseSync.ts`).  
- Implement `refreshRemoteSessionMessages(sessionId)` in `App.tsx` to fetch and merge remote messages for a single session, and wire `handleActiveSessionChange(sessionId)` to call it when a chat route becomes active, so opening a session pulls its messages (`src/App.tsx`).  
- Change message sorting to use server `createdAt` as the primary key and `clientCreatedAt` as fallback in both runtime and persisted storage (`sortMessages` in `src/App.tsx` and `src/storage/chatStorage.ts`), and keep `mergeMessages` semantics that deduplicate by `id`/`clientId` while preserving local optimistic `pending` messages.  
- Add `set search_path = public` to the `set_sessions_updated_at_now` function definition in the migration file text without running any DB operations (`supabase/migrations/20260610183000_server_managed_chat_timestamps.sql`).  

### Testing
- Ran `npm run build` and the production build completed successfully.  
- Ran `npm run lint` and it exited successfully while preserving existing React Hooks warnings (no new lint errors).  
- Ran `git diff --check` to verify no whitespace/patch issues and the repository diff is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a120c35a883308452b99272b3b53c)