### PR TITLE
前端各聊天模块解析 LLM usage 并写入 llm_usage 表

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ import {
   resolveBubbleChatPrompt,
 } from './constants/aiOverlays'
 import { isGpt5Auto, resolveModelId } from './utils/modelResolver'
+import { extractLlmUsage, logLlmUsage } from './utils/llmUsage'
 import { buildMemoInjectionBlock, buildMemoInjectionFromToggle } from './utils/memoRetrieval'
 import { resolveTimelineFromToggle } from './utils/timelineManualRetrieval'
 import { callMcpTool, listMcpTools, type McpToolCallResult, type McpToolDefinition } from './lib/mcpTools'
@@ -1308,6 +1309,7 @@ const App = () => {
             }
 
             const roundToolCalls: Array<{ id?: string; name: string; argumentsText: string }> = []
+            let roundUsage: Record<string, unknown> | null = null
             flushPending()
             const contentLengthAtRoundStart = assistantContent.length
 
@@ -1319,6 +1321,7 @@ const App = () => {
               if (typeof payload?.model === 'string') {
                 actualModel = payload.model
               }
+              roundUsage = extractLlmUsage(payload)
               const choice = (payload as { choices?: unknown[] })?.choices?.[0] as
                 | Record<string, unknown>
                 | undefined
@@ -1418,6 +1421,8 @@ const App = () => {
                   if (payload?.model) {
                     actualModel = payload.model
                   }
+                  // OpenRouter 在流末尾的 chunk 携带 usage。
+                  roundUsage = extractLlmUsage(payload) ?? roundUsage
                   const deltaToolCalls = (deltaPayload as { tool_calls?: unknown })?.tool_calls
                   if (Array.isArray(deltaToolCalls)) {
                     for (const item of deltaToolCalls) {
@@ -1483,6 +1488,11 @@ const App = () => {
             }
             flushPending()
           }
+
+            logLlmUsage(
+              { module: 'chitchat', conversationId: sessionId, model: actualModel },
+              roundUsage,
+            )
 
             const executableToolCalls = roundToolCalls.filter((call) => call.name)
             if (!includeTools || executableToolCalls.length === 0) {

--- a/src/game/GameModeShell.tsx
+++ b/src/game/GameModeShell.tsx
@@ -24,6 +24,7 @@ import { fetchBubbleMessages } from "../storage/supabaseSync";
 import BubbleChatHistoryModal from "./ui/BubbleChatHistoryModal";
 import { buildMemoInjectionBlock } from "../utils/memoRetrieval";
 import { maybeInjectTimelineContext } from "../utils/timelineAutoInject";
+import { extractLlmUsage, logLlmUsage } from "../utils/llmUsage";
 import "./gameHud.css";
 
 type SharedSnackAiConfig = {
@@ -254,6 +255,14 @@ const GameModeShell = ({
       }
 
       const payload = await response.json();
+      logLlmUsage(
+        {
+          module: 'bubble-chat',
+          conversationId: null,
+          model: typeof payload?.model === 'string' ? payload.model : bubbleChatConfig.model,
+        },
+        extractLlmUsage(payload),
+      );
       const choice = payload?.choices?.[0];
       const message = choice?.message ?? choice ?? {};
       const content = typeof message?.content === 'string' ? message.content : '';

--- a/src/pages/LettersPage.tsx
+++ b/src/pages/LettersPage.tsx
@@ -15,6 +15,7 @@ import { fetchActiveProviderModelConfig } from '../storage/llmProviders'
 import { formatLocalTimestamp } from '../utils/time'
 import './LettersPage.css'
 import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
+import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 
 const PREVIEW_LIMIT = 30
 const LETTER_MEMORY_LIMIT = 20
@@ -261,6 +262,14 @@ const LettersPage = ({
         throw new Error(await response.text())
       }
       const payload = (await response.json()) as Record<string, unknown>
+      logLlmUsage(
+        {
+          module: 'letter',
+          conversationId: null,
+          model: typeof payload.model === 'string' ? payload.model : modelId,
+        },
+        extractLlmUsage(payload),
+      )
       const choice = (payload.choices as Record<string, unknown>[] | undefined)?.[0]
       const message = (choice?.message as Record<string, unknown> | undefined) ?? choice
       const content =

--- a/src/pages/LoungeRoomPage.tsx
+++ b/src/pages/LoungeRoomPage.tsx
@@ -11,6 +11,7 @@ import {
 import { supabase } from '../supabase/client'
 import { buildMemoInjectionBlock } from '../utils/memoRetrieval'
 import { isGpt5Auto } from '../utils/modelResolver'
+import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 import { DEFAULT_LOUNGE_SCENE_PROMPT } from '../constants/aiOverlays'
 import type { LoungeMember, LoungeMessage, LoungeSofa } from '../types'
 import './LoungePage.css'
@@ -281,6 +282,7 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
       streamControllerRef.current = controller
       let assistantContent = ''
       let actualModel = aiConfig.model
+      let usagePayload: Record<string, unknown> | null = null
 
       const updateStreaming = () => {
         setStreamingMessage({
@@ -387,6 +389,8 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
                 if (payload?.model) {
                   actualModel = payload.model
                 }
+                // OpenRouter 在流末尾的 chunk 携带 usage。
+                usagePayload = extractLlmUsage(payload) ?? usagePayload
                 const delta = payload?.choices?.[0]?.delta?.content
                 if (typeof delta === 'string' && delta.length > 0) {
                   assistantContent += delta
@@ -402,6 +406,7 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
           if (typeof payload?.model === 'string') {
             actualModel = payload.model
           }
+          usagePayload = extractLlmUsage(payload)
           const choice = (payload as { choices?: unknown[] })?.choices?.[0] as
             | Record<string, unknown>
             | undefined
@@ -411,6 +416,8 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
           }
           updateStreaming()
         }
+
+        logLlmUsage({ module: 'chitchat', conversationId: null, model: actualModel }, usagePayload)
 
         const finalContent = stripThinkSegments(assistantContent).trim()
         if (finalContent.length > 0) {

--- a/src/pages/NovelPage.tsx
+++ b/src/pages/NovelPage.tsx
@@ -6,6 +6,7 @@ import { supabase } from '../supabase/client'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import type { NovelBook, NovelChapter, NovelCharacterCard, NovelModelConfig } from '../types'
 import { createNovelBook, createNovelChapter, listNovelBooks, listNovelChaptersByBookId, updateNovelBookMeta, updateNovelBookModelConfig, updateNovelChapter } from '../storage/supabaseSync'
+import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 import './NovelPage.css'
 
 const GLOBAL_CONFIG_TITLE = '__global_config__'
@@ -220,6 +221,16 @@ const NovelPage = ({ user }: { user: User | null }) => {
 
     const data = parseResponseJson()
     if (!data) return responseText.trim()
+
+    // 小说模块的请求体未携带 module 参数，写表时用固定标识便于区分。
+    logLlmUsage(
+      {
+        module: 'novel',
+        conversationId: null,
+        model: typeof data.model === 'string' ? data.model : model,
+      },
+      extractLlmUsage(data),
+    )
 
     const choice = Array.isArray(data.choices) ? data.choices[0] : null
     const message = (choice as Record<string, unknown> | null)?.message ?? choice ?? {}

--- a/src/pages/RpRoomPage.tsx
+++ b/src/pages/RpRoomPage.tsx
@@ -8,6 +8,7 @@ import ReasoningPanel from '../components/ReasoningPanel'
 import { useEnabledModels } from '../hooks/useEnabledModels'
 import { stripSpeakerPrefix } from '../utils/rpMessage'
 import { isGpt5Auto } from '../utils/modelResolver'
+import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 import { supabase } from '../supabase/client'
 import {
   createRpMessage,
@@ -446,6 +447,14 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
     const isEventStream = contentType.includes('text/event-stream')
     if (!isEventStream) {
       const openRouterPayload = (await response.json()) as Record<string, unknown>
+      logLlmUsage(
+        {
+          module: 'rp-room',
+          conversationId: payload.conversationId,
+          model: typeof openRouterPayload.model === 'string' ? openRouterPayload.model : payload.modelId,
+        },
+        extractLlmUsage(openRouterPayload),
+      )
       const choice = (openRouterPayload?.choices as unknown[] | undefined)?.[0] as Record<string, unknown> | undefined
       const message = ((choice?.message as Record<string, unknown>) ?? choice ?? {}) as Record<string, unknown>
       const content =
@@ -474,6 +483,7 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
     let finalContent = ''
     let finalReasoning = ''
     let actualModel = payload.modelId
+    let streamUsage: Record<string, unknown> | null = null
     let done = false
 
     while (!done) {
@@ -505,6 +515,8 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
           if (typeof payloadLine.model === 'string') {
             actualModel = payloadLine.model
           }
+          // OpenRouter 在流末尾的 chunk 携带 usage。
+          streamUsage = extractLlmUsage(payloadLine) ?? streamUsage
           const choice = ((payloadLine.choices as unknown[] | undefined)?.[0] as Record<string, unknown> | undefined) ?? {}
           const delta = (choice.delta as Record<string, unknown> | undefined) ?? {}
           const contentDelta = typeof delta.content === 'string' ? delta.content : ''
@@ -526,6 +538,11 @@ const RpRoomPage = ({ user, mode = 'chat', rpReasoningEnabled, rpHighThinkingEna
         }
       }
     }
+
+    logLlmUsage(
+      { module: 'rp-room', conversationId: payload.conversationId, model: actualModel },
+      streamUsage,
+    )
 
     return {
       content: finalContent || '（空回复）',

--- a/src/pages/SnacksPage.tsx
+++ b/src/pages/SnacksPage.tsx
@@ -26,6 +26,7 @@ import {
 } from '../constants/aiOverlays'
 import './SnacksPage.css'
 import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
+import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 
 type SnacksPageProps = {
   user: User | null
@@ -452,6 +453,14 @@ const SnacksPage = ({ user, snackAiConfig, entryMode = 'phone' }: SnacksPageProp
     }
 
     const payload = (await response.json()) as Record<string, unknown>
+    logLlmUsage(
+      {
+        module: 'snack-feed',
+        conversationId: null,
+        model: typeof payload.model === 'string' ? payload.model : snackAiConfig.model,
+      },
+      extractLlmUsage(payload),
+    )
     const choice = (payload?.choices as unknown[] | undefined)?.[0] as
       | Record<string, unknown>
       | undefined

--- a/src/pages/SyzygyFeedPage.tsx
+++ b/src/pages/SyzygyFeedPage.tsx
@@ -28,6 +28,7 @@ import {
 } from '../constants/aiOverlays'
 import './SnacksPage.css'
 import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
+import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 
 type SyzygyFeedPageProps = {
   user: User | null
@@ -589,6 +590,14 @@ const SyzygyFeedPage = ({ user, snackAiConfig, entryMode = 'phone' }: SyzygyFeed
     }
 
     const payload = (await response.json()) as Record<string, unknown>
+    logLlmUsage(
+      {
+        module: 'syzygy-feed',
+        conversationId: null,
+        model: typeof payload.model === 'string' ? payload.model : snackAiConfig.model,
+      },
+      extractLlmUsage(payload),
+    )
     const choice = (payload?.choices as unknown[] | undefined)?.[0] as
       | Record<string, unknown>
       | undefined

--- a/src/pages/forumShared.ts
+++ b/src/pages/forumShared.ts
@@ -4,6 +4,7 @@ import type { MemoryEntry } from '../types'
 import { ensureUserSettings } from '../storage/userSettings'
 import { maybeInjectTimelineContext } from '../utils/timelineAutoInject'
 import { fetchActiveProviderModelConfig } from '../storage/llmProviders'
+import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 
 export const FORUM_AI_SLOTS = [1, 2, 3] as const
 export const FORUM_USER_DISPLAY_NAME = '串串'
@@ -705,6 +706,14 @@ export async function requestForumAiContent({
   }
 
   const payload = (await response.json()) as Record<string, unknown>
+  logLlmUsage(
+    {
+      module: 'forum',
+      conversationId: null,
+      model: typeof payload.model === 'string' ? payload.model : resolvedModel,
+    },
+    extractLlmUsage(payload),
+  )
   if (FORUM_AI_DEBUG) {
     console.info('[Forum AI] openrouter-chat payload', payload)
   }

--- a/src/utils/llmUsage.ts
+++ b/src/utils/llmUsage.ts
@@ -1,0 +1,68 @@
+import { supabase } from '../supabase/client'
+
+export type LlmUsageContext = {
+  module: string | null
+  conversationId?: string | null
+  model?: string | null
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+/**
+ * 从一次 LLM 响应（非流式完整 JSON，或流式的单个 SSE chunk）中取出 usage 对象。
+ * OpenRouter 在流式响应的最后一个 SSE chunk 携带 usage，非流式则在顶层。
+ */
+export const extractLlmUsage = (payload: unknown): Record<string, unknown> | null =>
+  asRecord(asRecord(payload)?.usage)
+
+const toInteger = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : null
+
+const toNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null
+
+/**
+ * 把一轮 LLM 请求的 usage 写入 llm_usage 表。
+ * fire-and-forget：任何失败只打 debug 日志，绝不抛错、绝不阻塞聊天主流程。
+ */
+export const logLlmUsage = (
+  context: LlmUsageContext,
+  usage: Record<string, unknown> | null,
+): void => {
+  try {
+    if (!usage || !supabase) {
+      return
+    }
+    const promptDetails = asRecord(usage.prompt_tokens_details)
+    void supabase
+      .from('llm_usage')
+      .insert({
+        module: context.module ?? null,
+        conversation_id: context.conversationId ?? null,
+        model: context.model ?? null,
+        prompt_tokens: toInteger(usage.prompt_tokens),
+        completion_tokens: toInteger(usage.completion_tokens),
+        total_tokens: toInteger(usage.total_tokens),
+        cached_tokens: toInteger(promptDetails?.cached_tokens) ?? toInteger(usage.cached_tokens),
+        cache_write_tokens:
+          toInteger(promptDetails?.cache_write_tokens) ?? toInteger(usage.cache_write_tokens),
+        cost_usd: toNumber(usage.cost),
+        raw: usage,
+      })
+      .then(
+        ({ error }) => {
+          if (error) {
+            console.debug('[llm-usage] 写入失败（已忽略）', error.message)
+          }
+        },
+        (insertError) => {
+          console.debug('[llm-usage] 写入失败（已忽略）', insertError)
+        },
+      )
+  } catch (error) {
+    console.debug('[llm-usage] 写入失败（已忽略）', error)
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `src/utils/llmUsage.ts`，提供 `extractLlmUsage` + `logLlmUsage` 两个工具函数，fire-and-forget 写入 `llm_usage` 表，失败静默不阻塞聊天主流程。
- `cached_tokens` 优先取 `usage.prompt_tokens_details.cached_tokens`，`cost_usd` 取 `usage.cost`，`raw` 存完整 usage 原对象。
- 覆盖全部 9 处 `openrouter-chat` 调用点（chitchat/bubble-chat/rp-room/forum/letter/snack-feed/syzygy-feed/lounge/novel），流式模式从末尾 SSE chunk 提取 usage，非流式从完整 JSON 提取。
- **未修改 `openrouter-chat` edge function**——OpenRouter 在流式末尾 chunk 默认携带 usage，edge function 原样透传，前端直接解析即可。

## Test plan
- [ ] chitchat 发一条消息，确认 `llm_usage` 表新增一行，module=chitchat，各 token 字段有值
- [ ] rp-room 触发 NPC 回复（流式），确认写入 module=rp-room
- [ ] bubble-chat（游戏模式对话气泡）发送消息，确认写入 module=bubble-chat
- [ ] forum AI 生成回复，确认写入 module=forum
- [ ] snack-feed / syzygy-feed 生成，确认各自 module 正确
- [ ] letter 手动生成来信，确认写入 module=letter
- [ ] novel 页面 AI 生成，确认写入 module=novel
- [ ] 断开网络或模拟 Supabase 插入失败，确认聊天主流程不受影响、console 仅出现 debug 级日志

https://claude.ai/code/session_01GCpivozVdiLXkq35gfrSrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCpivozVdiLXkq35gfrSrn)_