### PR TITLE
Revamp Hamster console UI: responsive status cards, grouped accordions, and style polish

### DIFF
--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -1,6 +1,6 @@
 .hamster-console-page {
   min-height: 100%;
-  max-width: 760px;
+  max-width: 920px;
   margin: 0 auto;
   padding: 14px 14px calc(1.5rem + env(safe-area-inset-bottom));
   color: #3f3540;
@@ -393,8 +393,8 @@
 
 .hamster-console-status-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.65rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
 }
 
 .hamster-status-card,
@@ -408,9 +408,13 @@
 
 .hamster-status-card {
   display: grid;
-  gap: 0.24rem;
-  padding: 0.72rem;
+  gap: 0.46rem;
+  padding: 1rem;
+  min-height: 118px;
   min-width: 0;
+  align-content: space-between;
+  position: relative;
+  overflow: hidden;
 }
 
 .hamster-status-card span,
@@ -425,7 +429,7 @@
 
 .hamster-status-card strong {
   color: #68485e;
-  font-size: 0.95rem;
+  font-size: clamp(1.05rem, 2.5vw, 1.32rem);
   line-height: 1.35;
   word-break: break-word;
 }
@@ -486,5 +490,143 @@
   .hamster-console-status-grid,
   .hamster-digest-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+.hamster-console-accordion__header small {
+  display: block;
+  margin-top: 0.18rem;
+  color: #a27d92;
+  font-size: 0.76rem;
+  font-weight: 500;
+}
+
+.hamster-console-accordion__content.expanded {
+  max-height: none;
+  overflow: visible;
+}
+
+.hamster-console-group > .hamster-console-accordion__content > .hamster-console-accordion__inner {
+  padding-top: 0.1rem;
+}
+
+.hamster-console-nested-stack {
+  gap: 0.7rem;
+}
+
+.hamster-console-nested-stack > .hamster-console-card {
+  box-shadow: none;
+  background: rgba(255, 250, 253, 0.72);
+}
+
+.hamster-status-card::after {
+  content: '';
+  position: absolute;
+  inset: auto -24px -30px auto;
+  width: 86px;
+  height: 86px;
+  border-radius: 999px;
+  background: rgba(255, 226, 239, 0.55);
+}
+
+.hamster-status-card__topline {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.hamster-status-card__topline > span:first-child:not(.hamster-console-codex-dot) {
+  color: #8b7284;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.hamster-status-card__icon {
+  margin-left: auto;
+  width: 1.9rem;
+  height: 1.9rem;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 999px;
+  background: #fff4fa;
+  color: #b76f91;
+  border: 1px solid rgba(255, 214, 231, 0.86);
+  font-size: 1rem;
+  z-index: 1;
+}
+
+.hamster-status-card--agent { background: linear-gradient(135deg, rgba(255,255,255,.95), rgba(241,255,248,.86)); }
+.hamster-status-card--runner { background: linear-gradient(135deg, rgba(255,255,255,.95), rgba(244,248,255,.9)); }
+.hamster-status-card--queue { background: linear-gradient(135deg, rgba(255,255,255,.95), rgba(255,248,239,.9)); }
+.hamster-status-card--tasks { background: linear-gradient(135deg, rgba(255,255,255,.95), rgba(255,244,250,.92)); }
+.hamster-status-card.warning { border-color: rgba(236, 98, 119, 0.55); box-shadow: 0 8px 18px rgba(236, 98, 119, 0.14); }
+
+@media (max-width: 520px) {
+  .hamster-console-status-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hamster-status-card {
+    min-height: 108px;
+  }
+}
+
+.hamster-console-page,
+.hamster-console-page *,
+.hamster-console-page *::before,
+.hamster-console-page *::after {
+  box-sizing: border-box;
+}
+
+.hamster-console-page__header {
+  padding-left: clamp(88px, 18vw, 128px);
+  padding-right: clamp(18px, 8vw, 128px);
+  grid-template-columns: minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.hamster-console-page__header h1 {
+  line-height: 1.12;
+}
+
+.hamster-console-page__header > p {
+  width: 100%;
+  max-width: 430px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.35;
+}
+
+.hamster-console-card,
+.hamster-console-accordion,
+.hamster-console-accordion__inner,
+.hamster-console-nested-stack,
+.hamster-console-command-list,
+.hamster-console-channel-list {
+  min-width: 0;
+  width: 100%;
+}
+
+.hamster-console-card,
+.hamster-console-group,
+.hamster-console-nested-stack {
+  overflow: visible;
+}
+
+.hamster-console-accordion__header {
+  min-height: 58px;
+}
+
+@media (max-width: 560px) {
+  .hamster-console-page__header {
+    padding: 12px;
+    padding-top: 48px;
+  }
+
+  .hamster-console-page__back {
+    top: 10px;
+    left: 12px;
+    transform: none;
   }
 }

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -228,6 +228,11 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const [expandedCommandId, setExpandedCommandId] = useState<string | null>(null)
   const [commandsLoading, setCommandsLoading] = useState(false)
   const [expandedSection, setExpandedSection] = useState('mini-control')
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({
+    mini: true,
+    wechat: true,
+    v3: true,
+  })
   const [codexControlRow, setCodexControlRow] = useState<CodexControlRow | null>(null)
   const [codexActionLoading, setCodexActionLoading] = useState<'wake' | 'sleep' | null>(null)
 
@@ -257,6 +262,8 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
 
   const agentModeLabel = agentSettings?.agent_mode === 'quiet' ? '静默模式' : agentSettings?.agent_mode === 'paused' ? '自动化暂停' : '正常运行'
   const miniRunnerLabel = codexControlRow ? codexControlState.label : '等待接入'
+  const agentModeTone = agentSettings?.agent_mode === 'quiet' ? 'yellow' : agentSettings?.agent_mode === 'paused' ? 'gray' : 'green'
+  const wechatQueueHasFailed = wechatQueueSummary.failed > 0
   const todayTaskSummary = useMemo(() => {
     const counts = { completed: 0, failed: 0, running: 0 }
     agentTasks.forEach((task) => {
@@ -661,6 +668,10 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     setExpandedSection((current) => (current === sectionId ? '' : sectionId))
   }
 
+  const toggleGroup = (groupId: 'mini' | 'wechat' | 'v3') => {
+    setExpandedGroups((current) => ({ ...current, [groupId]: !current[groupId] }))
+  }
+
   return (
     <div className="hamster-console-page">
       <header className="hamster-console-page__header">
@@ -679,19 +690,35 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
 
       {!loading ? (
         <>
-          <section className="hamster-console-status-grid" aria-label="V3.0 状态概览">
-            <article className="hamster-status-card"><span>Agent 模式</span><strong>{agentModeLabel}</strong><small>{agentSettings?.agent_mode ?? 'active'}</small></article>
-            <article className="hamster-status-card"><span>Mini Runner</span><strong>{miniRunnerLabel}</strong><small>{codexControlRow ? `最近：${formatDateTime(codexControlRow.created_at)}` : '等待接入'}</small></article>
-            <article className="hamster-status-card"><span>微信消息队列</span><strong>{wechatQueueSummary.error ? '暂无权限读取消息队列' : `${wechatQueueSummary.pending}/${wechatQueueSummary.sending}/${wechatQueueSummary.failed}`}</strong><small>{wechatQueueSummary.error ?? 'pending / sending / failed'}</small></article>
-            <article className="hamster-status-card"><span>今日任务状态</span><strong>{agentTasksError ? '当前前端无权限读取该表' : agentTasks.length ? `${todayTaskSummary.completed} 完成 · ${todayTaskSummary.failed} 失败 · ${todayTaskSummary.running} 运行` : '今日暂无任务'}</strong><small>{agentTasksError ?? 'agent_tasks'}</small></article>
+          <section className="hamster-console-status-grid" aria-label="顶部状态仪表盘">
+            <article className="hamster-status-card hamster-status-card--agent">
+              <div className="hamster-status-card__topline"><span className={`hamster-console-codex-dot ${agentModeTone}`} aria-hidden /><span>Agent 模式</span><span className="hamster-status-card__icon" aria-hidden>●</span></div>
+              <strong>{agentModeLabel}</strong>
+              <small>{agentSettings?.agent_mode ?? 'active'}</small>
+            </article>
+            <article className="hamster-status-card hamster-status-card--runner">
+              <div className="hamster-status-card__topline"><span>Mini Runner</span><span className="hamster-status-card__icon" aria-hidden>⌘</span></div>
+              <strong>{miniRunnerLabel}</strong>
+              <small>{codexControlRow ? `最近：${formatDateTime(codexControlRow.created_at)}` : '等待接入'}</small>
+            </article>
+            <article className={`hamster-status-card hamster-status-card--queue ${wechatQueueHasFailed ? 'warning' : ''}`}>
+              <div className="hamster-status-card__topline"><span>微信消息队列</span><span className="hamster-status-card__icon" aria-hidden>✉</span></div>
+              <strong>{wechatQueueSummary.error ? '暂无权限读取消息队列' : `${wechatQueueSummary.pending} / ${wechatQueueSummary.sending} / ${wechatQueueSummary.failed}`}</strong>
+              <small>{wechatQueueSummary.error ?? 'pending / sending / failed'}</small>
+            </article>
+            <article className="hamster-status-card hamster-status-card--tasks">
+              <div className="hamster-status-card__topline"><span>今日任务状态</span><span className="hamster-status-card__icon" aria-hidden>✓</span></div>
+              <strong>{agentTasksError ? '当前前端无权限读取该表' : agentTasks.length ? `${todayTaskSummary.completed} completed · ${todayTaskSummary.failed} failed` : '今日暂无任务'}</strong>
+              <small>{agentTasksError ?? 'agent_tasks'}</small>
+            </article>
           </section>
           <main className="hamster-console-accordion">
           <section className="hamster-console-card glass-card" aria-label="Mini 控制">
-            <button className="hamster-console-accordion__header" onClick={() => toggleSection('mini-control')}>
+            <button className="hamster-console-accordion__header" onClick={() => toggleGroup('mini')}>
               <h2>Mini 控制</h2>
-              <span>{expandedSection === 'mini-control' ? '▼' : '▶'}</span>
+              <span>{expandedGroups.mini ? '▼' : '▶'}</span>
             </button>
-            <div className={`hamster-console-accordion__content ${expandedSection === 'mini-control' ? 'expanded' : ''}`}>
+            <div className={`hamster-console-accordion__content ${expandedGroups.mini ? 'expanded' : ''}`}>
               <div className="hamster-console-accordion__inner">
                 <div className="hamster-console-codex-status">
                   <span className={`hamster-console-codex-dot ${codexControlState.tone}`} aria-hidden />
@@ -717,6 +744,14 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
             </div>
           </section>
 
+
+          <section className="hamster-console-card glass-card hamster-console-group" aria-label="微信 API 配置">
+            <button className="hamster-console-accordion__header" onClick={() => toggleGroup('wechat')}>
+              <div><h2>微信 API 配置</h2><small>模型 / 主动消息 / 上下文 / Prompt</small></div>
+              <span>{expandedGroups.wechat ? '▼' : '▶'}</span>
+            </button>
+            <div className={`hamster-console-accordion__content ${expandedGroups.wechat ? 'expanded' : ''}`}>
+              <div className="hamster-console-accordion__inner hamster-console-nested-stack">
           <section className="hamster-console-card glass-card" aria-label="模型切换">
             <button className="hamster-console-accordion__header" onClick={() => toggleSection('model-switching')}>
               <h2>模型切换</h2>
@@ -951,6 +986,17 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
               </div>
             </div>
           </section>
+              </div>
+            </div>
+          </section>
+
+          <section className="hamster-console-card glass-card hamster-console-group" aria-label="V3.0 观测台">
+            <button className="hamster-console-accordion__header" onClick={() => toggleGroup('v3')}>
+              <div><h2>V3.0 观测台</h2><small>执行记录 / 当前状态快照 / 打印胶囊 / 能力 / 周回顾 / 指令</small></div>
+              <span>{expandedGroups.v3 ? '▼' : '▶'}</span>
+            </button>
+            <div className={`hamster-console-accordion__content ${expandedGroups.v3 ? 'expanded' : ''}`}>
+              <div className="hamster-console-accordion__inner hamster-console-nested-stack">
 
           <section className="hamster-console-card glass-card" aria-label="执行记录">
             <button className="hamster-console-accordion__header" onClick={() => toggleSection('agent-tasks')}><h2>执行记录</h2><span>{expandedSection === 'agent-tasks' ? '▼' : '▶'}</span></button>
@@ -1037,6 +1083,9 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                   })}
                   {commands.length === 0 ? <p className="hamster-console-card__hint">暂无指令记录。</p> : null}
                 </div>
+              </div>
+            </div>
+          </section>
               </div>
             </div>
           </section>


### PR DESCRIPTION
### Motivation
- Improve the dashboard readability and spacing by enlarging the layout and reorganizing the top status area.  
- Group related controls into persistent, collapsible sections to make the console easier to scan and interact with.  
- Enhance visual cues for status (icons, tones, warning state) and tighten responsive behavior for small screens.

### Description
- Expanded and refactored CSS in `HamsterConsolePage.css` including `max-width` bump, updated grid layouts, new status card visuals, many new utility classes (e.g. `.hamster-status-card__topline`, `.hamster-status-card__icon`, `.hamster-console-nested-stack`) and improved responsive rules.  
- Reworked the top status area markup in `HamsterConsolePage.tsx` to use richer status cards with per-card classes, icons, background accents, and a conditional `warning` state driven by queue failures.  
- Introduced grouped accordion state and behavior by adding `expandedGroups` state and `toggleGroup` handler to control `mini`, `wechat`, and `v3` groups, and wired the UI to use these groups instead of a single `expandedSection` for the top-level panels.  
- Nested existing sections (model switching, templates, agent tasks, snapshot, print capsules, commands) under the new grouped structure and adjusted small copy/formatting for task/capsule summaries and card layout details.

### Testing
- Performed a TypeScript typecheck and app build with `yarn build` which completed successfully.  
- Ran linter with `yarn lint` and unit tests with `yarn test`, both of which succeeded.  
- Verified the changed UI in a local dev server smoke test to confirm accordion toggles and responsive card layouts behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a325893cc808330902c20b18e8d62ac)