### PR TITLE
Add Syzygy Feed (agent_feed_items) section to Hamster Console

### DIFF
--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -642,3 +642,191 @@
     transform: none;
   }
 }
+
+.hamster-feed-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.hamster-feed-filter {
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.88);
+  color: #8b5f77;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0.42rem 0.7rem;
+}
+
+.hamster-feed-filter.active {
+  background: linear-gradient(135deg, #ff8db8, #ffb3cf);
+  border-color: rgba(255, 141, 184, 0.9);
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(255, 141, 184, 0.22);
+}
+
+.hamster-feed-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.hamster-feed-card {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.78rem;
+  border: 1px solid rgba(255, 214, 231, 0.86);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 248, 251, 0.94));
+  box-shadow: 0 8px 18px rgba(255, 214, 231, 0.2);
+}
+
+.hamster-feed-card.pinned {
+  border-color: rgba(255, 174, 207, 0.95);
+  box-shadow: 0 10px 22px rgba(255, 174, 207, 0.26);
+}
+
+.hamster-feed-card.priority-urgent {
+  border-color: rgba(244, 99, 125, 0.72);
+}
+
+.hamster-feed-card.priority-high {
+  border-color: rgba(255, 172, 96, 0.72);
+}
+
+.hamster-feed-card.archived,
+.hamster-feed-card.expired {
+  opacity: 0.72;
+}
+
+.hamster-feed-card__header {
+  align-items: flex-start;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+}
+
+.hamster-feed-card__title-block {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.hamster-feed-card__title-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.hamster-feed-card__title-row strong {
+  color: #66485d;
+  font-size: 1rem;
+}
+
+.hamster-feed-card__title-block p {
+  color: #826a7b;
+  font-size: 0.88rem;
+  margin: 0;
+}
+
+.hamster-feed-meta-row {
+  align-items: center;
+  color: #9a7a8d;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.78rem;
+  gap: 0.4rem;
+}
+
+.hamster-feed-pill {
+  border: 1px solid rgba(255, 214, 231, 0.78);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: #8a6078;
+  font-size: 0.74rem;
+  font-weight: 700;
+  padding: 0.18rem 0.5rem;
+}
+
+.hamster-feed-pill.pinned,
+.hamster-feed-pill.priority.high {
+  background: #fff2df;
+  border-color: #ffd39a;
+  color: #a65f20;
+}
+
+.hamster-feed-pill.priority.urgent {
+  background: #ffe6ea;
+  border-color: #ff9eb0;
+  color: #b13f4d;
+}
+
+.hamster-feed-pill.priority.low {
+  color: #9f91a0;
+}
+
+.hamster-feed-pill.status.unread {
+  background: #fff0f7;
+  color: #b24f82;
+}
+
+.hamster-feed-pill.status.read {
+  background: #effaf5;
+  border-color: #bfe8d5;
+  color: #327a58;
+}
+
+.hamster-feed-pill.status.archived,
+.hamster-feed-pill.status.expired {
+  background: #f4f1f3;
+  color: #827681;
+}
+
+.hamster-feed-card__body {
+  border-top: 1px dashed rgba(255, 214, 231, 0.9);
+  display: grid;
+  gap: 0.55rem;
+  padding-top: 0.65rem;
+}
+
+.hamster-feed-content {
+  color: #4f3f4a;
+  font-size: 0.92rem;
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+}
+
+.hamster-feed-content p {
+  margin: 0 0 0.55rem;
+  white-space: pre-wrap;
+}
+
+.hamster-feed-content pre,
+.hamster-feed-metadata {
+  background: rgba(255, 246, 250, 0.96);
+  border: 1px solid rgba(255, 214, 231, 0.72);
+  border-radius: 12px;
+  color: #5f4657;
+  font-size: 0.78rem;
+  margin: 0;
+  overflow: auto;
+  padding: 0.7rem;
+}
+
+.hamster-feed-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.hamster-console-accordion__content.expanded {
+  max-height: 6200px;
+}

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { Link } from 'react-router-dom'
+import MarkdownRenderer from '../components/MarkdownRenderer'
 import { supabase } from '../supabase/client'
 import './HamsterConsolePage.css'
 
@@ -142,6 +143,33 @@ type CodexControlRow = {
   created_at: string
 }
 
+type AgentFeedStatus = 'unread' | 'read' | 'archived' | 'expired' | string
+type AgentFeedPriority = 'low' | 'normal' | 'high' | 'urgent' | string
+type AgentFeedItemRow = {
+  id: string
+  user_id: string
+  type: string | null
+  title: string | null
+  summary: string | null
+  content: string | null
+  content_format: 'markdown' | 'plain' | 'json' | string | null
+  priority: AgentFeedPriority | null
+  status: AgentFeedStatus | null
+  source: string | null
+  created_by: string | null
+  visible_from: string | null
+  expires_at: string | null
+  read_at: string | null
+  pinned: boolean | null
+  related_table: string | null
+  related_id: string | null
+  metadata: unknown
+  created_at: string | null
+  updated_at: string | null
+}
+
+type AgentFeedFilter = 'visible' | 'unread' | 'high' | 'read' | 'archived'
+
 type CodexControlViewState = {
   tone: 'green' | 'gray' | 'yellow'
   label: string
@@ -155,6 +183,41 @@ const categoryLabelMap: Record<string, string> = {
   scenario: '场景',
   style: '风格',
 }
+
+const agentFeedTypeLabels: Record<string, string> = {
+  morning_share: '晨间分享',
+  reading_assist: '阅读辅助',
+  daily_card: '每日卡片',
+  system_notice: '系统提示',
+  syzygy_note: 'Syzygy 小纸条',
+  weekly_card: '周回顾',
+  reminder_card: '提醒',
+  print_card: '打印胶囊',
+  dev_log: '开发记录',
+  other: '其他',
+}
+
+const agentFeedPriorityLabels: Record<string, string> = {
+  urgent: '紧急',
+  high: '高优先级',
+  normal: '普通',
+  low: '低优先级',
+}
+
+const agentFeedStatusLabels: Record<string, string> = {
+  unread: '未读',
+  read: '已读',
+  archived: '已归档',
+  expired: '已过期',
+}
+
+const agentFeedPriorityRank: Record<string, number> = { urgent: 4, high: 3, normal: 2, low: 1 }
+
+const isAgentFeedExpired = (item: AgentFeedItemRow, now = Date.now()) => {
+  if (item.status === 'expired') return true
+  return item.expires_at ? new Date(item.expires_at).getTime() <= now : false
+}
+
 
 const formatJson = (value: unknown) => JSON.stringify(value ?? {}, null, 2)
 
@@ -253,6 +316,12 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const [capabilitiesError, setCapabilitiesError] = useState<string | null>(null)
   const [weeklyDigest, setWeeklyDigest] = useState<WeeklyDigestRow | null>(null)
   const [weeklyDigestError, setWeeklyDigestError] = useState<string | null>(null)
+  const [agentFeedItems, setAgentFeedItems] = useState<AgentFeedItemRow[]>([])
+  const [agentFeedError, setAgentFeedError] = useState<string | null>(null)
+  const [agentFeedFilter, setAgentFeedFilter] = useState<AgentFeedFilter>('unread')
+  const [expandedFeedIds, setExpandedFeedIds] = useState<Record<string, boolean>>({})
+  const [expandedFeedMetadataIds, setExpandedFeedMetadataIds] = useState<Record<string, boolean>>({})
+  const [updatingFeedId, setUpdatingFeedId] = useState<string | null>(null)
 
   const activeTemplate = useMemo(
     () => promptTemplates.find((item) => item.id === activeTemplateId) ?? null,
@@ -278,6 +347,17 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const weeklyQueuedCount = printCapsules.filter((item) => item.scheduled_print_week === capsuleWeekFilter && item.status === 'queued').length
   const weeklyPrintedCount = printCapsules.filter((item) => item.scheduled_print_week === capsuleWeekFilter && item.status === 'printed').length
   const snapshotExpired = contextSnapshot?.stale_after ? new Date(contextSnapshot.stale_after).getTime() < nowMs : false
+  const filteredAgentFeedItems = useMemo(() => {
+    const activeItems = agentFeedItems.filter((item) => !isAgentFeedExpired(item, nowMs))
+    const baseItems = agentFeedFilter === 'visible' ? agentFeedItems : agentFeedFilter === 'unread' ? activeItems.filter((item) => (item.status ?? 'unread') === 'unread') : agentFeedFilter === 'high' ? activeItems.filter((item) => ['urgent', 'high'].includes(item.priority ?? 'normal')) : agentFeedItems.filter((item) => item.status === agentFeedFilter)
+    return [...baseItems].sort((left, right) => {
+      const pinnedDelta = Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))
+      if (pinnedDelta) return pinnedDelta
+      const priorityDelta = (agentFeedPriorityRank[right.priority ?? 'normal'] ?? 0) - (agentFeedPriorityRank[left.priority ?? 'normal'] ?? 0)
+      if (priorityDelta) return priorityDelta
+      return new Date(right.created_at ?? 0).getTime() - new Date(left.created_at ?? 0).getTime()
+    })
+  }, [agentFeedFilter, agentFeedItems, nowMs])
 
   const modelOptions = useMemo(() => {
     const merged = new Set<string>(availableModels)
@@ -331,7 +411,7 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     setErrorMessage(null)
 
     const { start: todayStart, end: todayEnd } = getTodayIsoRange()
-    const [channelRes, settingsRes, templateRes, commandsRes, modelRes, codexRes, wechatRes, taskRes, snapshotRes, digestRes, capsuleRes, capabilityRes, weeklyRes] = await Promise.all([
+    const [channelRes, settingsRes, templateRes, commandsRes, modelRes, codexRes, wechatRes, taskRes, snapshotRes, digestRes, capsuleRes, capabilityRes, weeklyRes, feedRes] = await Promise.all([
       supabase
         .from('channel_config')
         .select('user_id, channel_name, active_model')
@@ -375,6 +455,14 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
       supabase.from('print_capsules').select('id, title, type, paper_size, status, trigger_reason, created_at, scheduled_print_week, sort_order, hidden_until_printed, content').order('created_at', { ascending: false }).limit(80),
       supabase.from('capabilities').select('id, name, description, risk_level, enabled, requires_confirmation, output_channel, last_used_at, cooldown_until, usage_count, failure_count').order('name', { ascending: true }),
       supabase.from('weekly_digest').select('id, week_start, week_end, highlights, digest_text').order('week_start', { ascending: false }).limit(1).maybeSingle(),
+      supabase
+        .from('agent_feed_items')
+        .select('id, user_id, type, title, summary, content, content_format, priority, status, source, created_by, visible_from, expires_at, read_at, pinned, related_table, related_id, metadata, created_at, updated_at')
+        .eq('user_id', scopedUserId)
+        .or(`visible_from.is.null,visible_from.lte.${new Date().toISOString()}`)
+        .order('pinned', { ascending: false })
+        .order('created_at', { ascending: false })
+        .limit(80),
     ])
 
     if (channelRes.error || settingsRes.error || templateRes.error || commandsRes.error || modelRes.error || codexRes.error) {
@@ -449,6 +537,8 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     setCapabilitiesError(capabilityRes.error?.message ?? null)
     setWeeklyDigest((weeklyRes.data as WeeklyDigestRow | null) ?? null)
     setWeeklyDigestError(weeklyRes.error?.message ?? null)
+    setAgentFeedItems((feedRes.data ?? []) as AgentFeedItemRow[])
+    setAgentFeedError(feedRes.error?.message ?? null)
 
     setLoading(false)
   }, [scopedUserId])
@@ -662,6 +752,22 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
       current.map((item) => (item.id === activeTemplate.id ? { ...item, content: templateDraft } : item)),
     )
     showToast(`Prompt 已保存：${activeTemplate.name}`)
+  }
+
+
+  const handleUpdateFeedStatus = async (item: AgentFeedItemRow, status: 'read' | 'archived') => {
+    if (!supabase) return
+    setUpdatingFeedId(item.id)
+    setAgentFeedError(null)
+    const patch = status === 'read' ? { status, read_at: new Date().toISOString() } : { status }
+    const { error } = await supabase.from('agent_feed_items').update(patch).eq('id', item.id).eq('user_id', scopedUserId)
+    setUpdatingFeedId(null)
+    if (error) {
+      setAgentFeedError(`状态更新失败，已降级为只读展示：${error.message}`)
+      return
+    }
+    setAgentFeedItems((current) => current.map((feedItem) => (feedItem.id === item.id ? { ...feedItem, ...patch } : feedItem)))
+    showToast(status === 'read' ? '已标记为已读' : '已归档卡片')
   }
 
   const toggleSection = (sectionId: string) => {
@@ -997,6 +1103,64 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
             </button>
             <div className={`hamster-console-accordion__content ${expandedGroups.v3 ? 'expanded' : ''}`}>
               <div className="hamster-console-accordion__inner hamster-console-nested-stack">
+
+          <section className="hamster-console-card glass-card" aria-label="Syzygy Feed">
+            <button className="hamster-console-accordion__header" onClick={() => toggleSection('syzygy-feed')}><h2>Syzygy Feed / 今日卡片</h2><span>{expandedSection === 'syzygy-feed' ? '▼' : '▶'}</span></button>
+            <div className={`hamster-console-accordion__content ${expandedSection === 'syzygy-feed' ? 'expanded' : ''}`}><div className="hamster-console-accordion__inner">
+              <p className="hamster-console-card__hint">读取 agent_feed_items：CLI / Syzygy 生成内容的持久化卡片入口。</p>
+              {agentFeedError ? <p className="hamster-console-alert">当前前端暂时没有权限读取 Syzygy Feed，请检查 Supabase session / RLS。{agentFeedError.includes('状态更新失败') ? `（${agentFeedError}）` : ''}</p> : null}
+              <div className="hamster-feed-filter-row" role="tablist" aria-label="Syzygy Feed 筛选">
+                {[
+                  ['visible', '全部可见'],
+                  ['unread', '未读'],
+                  ['high', '高优先级'],
+                  ['read', '已读'],
+                  ['archived', '已归档'],
+                ].map(([value, label]) => <button key={value} className={`hamster-feed-filter ${agentFeedFilter === value ? 'active' : ''}`} onClick={() => setAgentFeedFilter(value as AgentFeedFilter)}>{label}</button>)}
+              </div>
+              <div className="hamster-feed-list">
+                {filteredAgentFeedItems.map((item) => {
+                  const expanded = Boolean(expandedFeedIds[item.id])
+                  const metadataExpanded = Boolean(expandedFeedMetadataIds[item.id])
+                  const expired = isAgentFeedExpired(item, nowMs)
+                  const status = expired ? 'expired' : (item.status ?? 'unread')
+                  const priority = item.priority ?? 'normal'
+                  return (
+                    <article key={item.id} className={`hamster-feed-card ${status} priority-${priority} ${item.pinned ? 'pinned' : ''}`}>
+                      <button className="hamster-feed-card__header" onClick={() => setExpandedFeedIds((current) => ({ ...current, [item.id]: !expanded }))}>
+                        <div className="hamster-feed-card__title-block">
+                          <div className="hamster-feed-card__title-row"><strong>{item.title ?? '(无标题卡片)'}</strong>{item.pinned ? <span className="hamster-feed-pill pinned">置顶</span> : null}</div>
+                          <p>{item.summary ?? '暂无摘要。'}</p>
+                        </div>
+                        <span>{expanded ? '收起' : '展开'}</span>
+                      </button>
+                      <div className="hamster-feed-meta-row">
+                        <span className="hamster-feed-pill type">{agentFeedTypeLabels[item.type ?? 'other'] ?? item.type ?? '其他'}</span>
+                        <span className={`hamster-feed-pill priority ${priority}`}>{agentFeedPriorityLabels[priority] ?? priority}</span>
+                        <span className={`hamster-feed-pill status ${status}`}>{agentFeedStatusLabels[status] ?? status}</span>
+                        <span>{item.created_by ?? item.source ?? 'unknown'}</span>
+                        <span>{formatDateTime(item.created_at)}</span>
+                        {item.expires_at ? <span>过期：{formatDateTime(item.expires_at)}</span> : null}
+                      </div>
+                      {expanded ? <div className="hamster-feed-card__body">
+                        <div className="hamster-feed-content">
+                          {item.content_format === 'markdown' ? <MarkdownRenderer content={item.content ?? '暂无正文。'} /> : item.content_format === 'json' ? <pre>{item.content ?? '暂无正文。'}</pre> : <p>{item.content ?? '暂无正文。'}</p>}
+                        </div>
+                        {(item.related_table || item.related_id) ? <p className="hamster-console-card__hint">关联记录：{item.related_table ?? '--'} / {item.related_id ?? '--'}</p> : null}
+                        <button className="btn-secondary" onClick={() => setExpandedFeedMetadataIds((current) => ({ ...current, [item.id]: !metadataExpanded }))}>{metadataExpanded ? '收起 metadata' : '查看 metadata'}</button>
+                        {metadataExpanded ? <pre className="hamster-feed-metadata">{formatJson(item.metadata)}</pre> : null}
+                        <div className="hamster-feed-actions">
+                          {(item.status ?? 'unread') === 'unread' && !expired ? <button className="btn-primary" onClick={() => void handleUpdateFeedStatus(item, 'read')} disabled={updatingFeedId === item.id}>{updatingFeedId === item.id ? '更新中...' : '标记已读'}</button> : null}
+                          {item.status !== 'archived' ? <button className="btn-secondary" onClick={() => void handleUpdateFeedStatus(item, 'archived')} disabled={updatingFeedId === item.id}>{updatingFeedId === item.id ? '更新中...' : '归档'}</button> : null}
+                        </div>
+                      </div> : null}
+                    </article>
+                  )
+                })}
+              </div>
+              {!agentFeedError && filteredAgentFeedItems.length === 0 ? <p className="hamster-console-card__hint">{agentFeedFilter === 'unread' && agentFeedItems.some((item) => item.status === 'read') ? '新卡片都读完啦。' : '今天小窝里还没有新卡片。'}</p> : null}
+            </div></div>
+          </section>
 
           <section className="hamster-console-card glass-card" aria-label="执行记录">
             <button className="hamster-console-accordion__header" onClick={() => toggleSection('agent-tasks')}><h2>执行记录</h2><span>{expandedSection === 'agent-tasks' ? '▼' : '▶'}</span></button>


### PR DESCRIPTION
### Motivation
- Provide a front-end MVP for the new `agent_feed_items` table so Syzygy / CLI-generated cards can be surfaced in the V3.0 observability area without changing DB schema or backend flows. 
- Allow users to view, expand, mark read and archive feed cards while gracefully handling RLS/session permission failures.

### Description
- Added a new "Syzygy Feed / 今日卡片" accordion in the Hamster Machine V3.0 observability area that lists `agent_feed_items` and supports expand/collapse, metadata view, related-record display and markdown rendering via `MarkdownRenderer`.
- Introduced TypeScript types for feed rows, labels for `type`/`priority`/`status`, priority ranking and an `isAgentFeedExpired` helper, plus client-side filter and recommended sorting (pinned → priority → created_at).
- Read feed items from Supabase using the existing anon `supabase` client with `user_id = scopedUserId` and `visible_from` filtering, and added UI actions that update entries via `.update()` to set `status='read'` with `read_at` or `status='archived'` (queries include `.eq('id', item.id).eq('user_id', scopedUserId)`).
- Added feed-specific styling and increased accordion expand height; implemented error/empty states and downgrade behavior if updates fail (keeps read-only list and shows error message).
- Files changed: `src/pages/HamsterConsolePage.tsx` and `src/pages/HamsterConsolePage.css`.

### Testing
- Ran `npm run build`, which completed successfully (Vite build produced a large-chunk warning but built artifacts were emitted). 
- Ran `npm run lint`, which finished successfully (existing unrelated warnings remain in other files; no new lint errors introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36319913548330b9d869bf22e98885)