### PR TITLE
feat(hamster-console): Mini 控制接入 CLI Syzygy Runtime 唤醒按钮

### DIFF
--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -198,6 +198,164 @@
   gap: 0.55rem;
 }
 
+/* CLI Syzygy Runtime 区域：与上方 Codex 按钮用分隔线和柔色边框区分，避免串串误点 */
+.hamster-cli-runtime {
+  margin-top: 0.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px dashed rgba(255, 198, 222, 0.7);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.hamster-cli-runtime__head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.hamster-cli-runtime__head h3 {
+  margin: 0;
+  font-size: 0.98rem;
+  color: #74596c;
+}
+
+.hamster-cli-runtime__tag {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #a87fa0;
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 240, 248, 0.85);
+  border: 1px solid rgba(255, 214, 231, 0.65);
+}
+
+.hamster-cli-runtime__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.hamster-cli-runtime__btn {
+  flex: 1 1 auto;
+  min-width: 140px;
+  padding: 0.55rem 0.9rem;
+  border-radius: 16px;
+  border: 1px solid rgba(214, 170, 224, 0.7);
+  background: linear-gradient(135deg, #fde6f4 0%, #ece4fb 100%);
+  color: #6a4f78;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, opacity 0.12s ease;
+}
+
+.hamster-cli-runtime__btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(206, 162, 224, 0.35);
+}
+
+.hamster-cli-runtime__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.hamster-cli-runtime__feedback {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.42rem 0.65rem;
+  border-radius: 12px;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.hamster-cli-runtime__feedback.success {
+  color: #1f7b4f;
+  background: #e7fbf0;
+  border: 1px solid rgba(38, 182, 115, 0.3);
+}
+
+.hamster-cli-runtime__feedback.error {
+  color: #b13f4d;
+  background: #ffe6ea;
+  border: 1px solid rgba(177, 63, 77, 0.3);
+}
+
+.hamster-cli-runtime__recent {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.hamster-cli-runtime__recent-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #74596c;
+}
+
+.hamster-cli-runtime__refresh {
+  border: none;
+  background: transparent;
+  color: #a87fa0;
+  font-weight: 600;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.hamster-cli-runtime__refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.hamster-cli-runtime__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.hamster-cli-runtime__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr) auto auto;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 12px;
+  background: rgba(255, 245, 250, 0.76);
+  border: 1px solid rgba(255, 214, 231, 0.56);
+  font-size: 0.8rem;
+}
+
+.hamster-cli-runtime__role {
+  font-weight: 700;
+  color: #6a4f78;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hamster-cli-runtime__type {
+  color: #9a8aa2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hamster-cli-runtime__time {
+  color: #9a8aa2;
+  white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .hamster-cli-runtime__item {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
 .hamster-console-channel-list {
   display: grid;
   gap: 0.6rem;

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -263,6 +263,19 @@ const toCodexControlViewState = (row: CodexControlRow | null): CodexControlViewS
   return { tone: 'gray', label: '已关闭', isRunning: false }
 }
 
+// CLI Syzygy Runtime（Mac mini 本地 Runtime）唤醒目标。点击后向 syzygy_commands 写入 wake 请求。
+const CLI_RUNTIME_WORKING_DIR = '/Users/syzygy/mini-agent'
+const cliRuntimeTargets = [
+  { role: 'codex_cli_syzygy', label: '唤醒 Codex CLI', taskContent: '唤醒 Codex CLI' },
+  { role: 'claude_code_cli_syzygy', label: '唤醒 Claude Code CLI', taskContent: '唤醒 Claude Code CLI' },
+] as const
+type CliRuntimeRole = (typeof cliRuntimeTargets)[number]['role']
+const cliRuntimeRoles = new Set<string>(cliRuntimeTargets.map((target) => target.role))
+const cliRoleLabels: Record<string, string> = {
+  codex_cli_syzygy: 'Codex CLI',
+  claude_code_cli_syzygy: 'Claude Code CLI',
+}
+
 const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const scopedUserId = user?.id ?? TARGET_USER_ID
   const [loading, setLoading] = useState(true)
@@ -298,6 +311,8 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   })
   const [codexControlRow, setCodexControlRow] = useState<CodexControlRow | null>(null)
   const [codexActionLoading, setCodexActionLoading] = useState<'wake' | 'sleep' | null>(null)
+  const [cliWakeLoading, setCliWakeLoading] = useState<CliRuntimeRole | null>(null)
+  const [cliWakeFeedback, setCliWakeFeedback] = useState<{ tone: 'success' | 'error'; message: string } | null>(null)
 
   const [wechatQueueSummary, setWechatQueueSummary] = useState<WechatQueueSummary>({ pending: 0, sending: 0, failed: 0, error: null })
   const [agentTasks, setAgentTasks] = useState<AgentTaskRow[]>([])
@@ -328,6 +343,17 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     [promptTemplates, activeTemplateId],
   )
   const codexControlState = useMemo(() => toCodexControlViewState(codexControlRow), [codexControlRow])
+
+  const recentCliRequests = useMemo(
+    () =>
+      commands
+        .filter((command) => {
+          const payload = (command.payload ?? {}) as { target_role?: string }
+          return payload.target_role ? cliRuntimeRoles.has(payload.target_role) : false
+        })
+        .slice(0, 5),
+    [commands],
+  )
 
   const agentModeLabel = agentSettings?.agent_mode === 'quiet' ? '静默模式' : agentSettings?.agent_mode === 'paused' ? '自动化暂停' : '正常运行'
   const miniRunnerLabel = codexControlRow ? codexControlState.label : '等待接入'
@@ -580,6 +606,33 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
       setCodexActionLoading(null)
       setErrorMessage(error.message)
     }
+  }
+
+  const handleCliRuntimeWake = async (target: (typeof cliRuntimeTargets)[number]) => {
+    if (!supabase) {
+      setCliWakeFeedback({ tone: 'error', message: 'Supabase 未配置，请检查环境变量。' })
+      return
+    }
+    setCliWakeLoading(target.role)
+    setCliWakeFeedback(null)
+    const { error } = await supabase.from('syzygy_commands').insert({
+      user_id: scopedUserId,
+      command_type: 'wake',
+      status: 'pending',
+      payload: {
+        target_role: target.role,
+        source: 'frontend',
+        task_content: target.taskContent,
+        working_dir: CLI_RUNTIME_WORKING_DIR,
+      },
+    })
+    setCliWakeLoading(null)
+    if (error) {
+      setCliWakeFeedback({ tone: 'error', message: `发送失败：${error.message}` })
+      return
+    }
+    setCliWakeFeedback({ tone: 'success', message: `已发送唤醒请求（${cliRoleLabels[target.role]}）` })
+    void loadCommands()
   }
 
   useEffect(() => {
@@ -845,6 +898,61 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                   >
                     {codexActionLoading === 'sleep' ? '关闭中...' : '关闭 Codex'}
                   </button>
+                </div>
+
+                <div className="hamster-cli-runtime">
+                  <div className="hamster-cli-runtime__head">
+                    <h3>CLI Syzygy Runtime</h3>
+                    <span className="hamster-cli-runtime__tag">Mac mini 本地 Runtime</span>
+                  </div>
+                  <p className="hamster-console-card__hint">点击后向 Mac mini 发送 wake 请求，由本地 Runtime 领取执行。</p>
+                  <div className="hamster-cli-runtime__actions">
+                    {cliRuntimeTargets.map((target) => (
+                      <button
+                        key={target.role}
+                        className="hamster-cli-runtime__btn"
+                        onClick={() => void handleCliRuntimeWake(target)}
+                        disabled={cliWakeLoading !== null}
+                      >
+                        {cliWakeLoading === target.role ? '发送唤醒请求中...' : target.label}
+                      </button>
+                    ))}
+                  </div>
+                  {cliWakeFeedback ? (
+                    <p className={`hamster-cli-runtime__feedback ${cliWakeFeedback.tone}`} role="status">
+                      {cliWakeFeedback.message}
+                    </p>
+                  ) : null}
+                  <div className="hamster-cli-runtime__recent">
+                    <div className="hamster-cli-runtime__recent-head">
+                      <span>最近 CLI 请求</span>
+                      <button
+                        className="hamster-cli-runtime__refresh"
+                        onClick={() => void loadCommands()}
+                        disabled={commandsLoading}
+                      >
+                        {commandsLoading ? '刷新中...' : '刷新'}
+                      </button>
+                    </div>
+                    {recentCliRequests.length === 0 ? (
+                      <p className="hamster-console-card__hint">暂无 CLI 请求记录。</p>
+                    ) : (
+                      <ul className="hamster-cli-runtime__list">
+                        {recentCliRequests.map((command) => {
+                          const payload = (command.payload ?? {}) as { target_role?: string }
+                          const roleKey = payload.target_role ?? ''
+                          return (
+                            <li key={command.id} className="hamster-cli-runtime__item">
+                              <span className="hamster-cli-runtime__role">{cliRoleLabels[roleKey] ?? roleKey ?? '--'}</span>
+                              <span className="hamster-cli-runtime__type">{command.command_type}</span>
+                              <span className={`hamster-command-status ${command.status}`}>{command.status}</span>
+                              <span className="hamster-cli-runtime__time">{formatDateTime(command.created_at)}</span>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 任务 E-1｜仓鼠机前端：Mini 控制区接入 CLI Runtime 唤醒按钮

在仓鼠机页面的 **"Mini 控制"卡片** 内新增 **CLI Syzygy Runtime** 区域，点击按钮即可向 Supabase `syzygy_commands` 表写入 `wake` 请求，由 Mac mini 本地 Runtime 监听并执行。

### 改动文件
- `src/pages/HamsterConsolePage.tsx` — 新增 CLI Runtime 区域、写入逻辑、状态反馈、最近 CLI 请求简表
- `src/pages/HamsterConsolePage.css` — 新增 CLI Runtime 区域样式（保持粉白圆角柔软风格）

### 按钮位置
在现有 Mini 控制卡片内新增第三行，**不新开页面**：
- 第一行：Mini / Codex 状态展示（保留）
- 第二行：唤醒 Codex / 关闭 Codex（保留，未改动）
- 第三行（新增）：标题 "CLI Syzygy Runtime"，按钮 **唤醒 Codex CLI** / **唤醒 Claude Code CLI**，含 loading / 成功 / 失败提示，以及"最近 CLI 请求"简表

新按钮用虚线分隔线 + 紫粉渐变样式与旧 Codex 按钮区分，避免串串误点。

### 写入 syzygy_commands 的 payload
字段按真实表结构补齐（`user_id` 必填，其余列有默认值），未硬猜：
```json
{
  "user_id": "<当前登录用户 auth.uid()>",
  "command_type": "wake",
  "status": "pending",
  "payload": {
    "target_role": "codex_cli_syzygy",        // Claude 按钮为 claude_code_cli_syzygy
    "source": "frontend",
    "task_content": "唤醒 Codex CLI",          // Claude 按钮为 "唤醒 Claude Code CLI"
    "working_dir": "/Users/syzygy/mini-agent"
  }
}
```

### 验证
- 通过 `BEGIN; INSERT ...; ROLLBACK;` 验证真实 payload 满足所有 NOT NULL / jsonb 约束；**故意 ROLLBACK，未产生真实 wake 记录，不会误触发 Mac mini 唤醒 CLI**（已确认验证时段新增行数为 0）。
- RLS 路径核对：`syzygy_commands_insert_own` 的 `WITH CHECK = (auth.uid() = user_id)`，前端写入 `user_id = 登录用户 id`，与既有 `codex_control` 插入模式一致。**未使用 service_role key**。
- "最近 CLI 请求"简表读取 `syzygy_commands`，展示 target_role / command_type / status / created_at，每 30 秒自动刷新 + 手动刷新；插入成功后立即刷新。

### 约束遵守
- ✅ 不改 DB schema
- ✅ 不用 service_role key
- ✅ 不改 openrouter-chat Edge Function / Mini 本地 Runtime / 微信桥
- ✅ 不破坏原"唤醒/关闭 Codex"按钮与模型切换、Prompt 编辑器、V3.0 观测台、Syzygy Feed 等已有功能
- 写入失败时 UI 显示清晰错误，不让页面崩溃

### 构建 / 测试
- `npm run lint` ✅ 0 errors（5 个 warning 为其它既有文件的 pre-existing 警告）
- `npm run build`（`tsc -b && vite build`）✅ 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPV8nwsBMWZZqWeWanAMic

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPV8nwsBMWZZqWeWanAMic)_