### PR TITLE
feat(lounge): 统一仓鼠客厅 CLI 角色显示名/@名称/头像/映射

### DIFF
--- a/src/constants/loungeRoles.ts
+++ b/src/constants/loungeRoles.ts
@@ -1,0 +1,275 @@
+// 仓鼠客厅角色统一映射表（前端单一事实来源）。
+//
+// 背景：
+//  - lounge_members 表里登记的 sender 是 claude_cli / codex_cli 等「短键」，
+//    @ 菜单与成员名册都来自这张表。
+//  - 本地 CLI Runtime 回写客厅消息时，sender 写成了「显示名」
+//    （如 "Claude Code CLI Syzygy" / "Codex CLI Syzygy"），并不在 lounge_members 里；
+//    真正稳定的标识在 meta.target_role（claude_code_cli_syzygy / codex_cli_syzygy）。
+//    因此这些回复在前端用 sender 查不到成员，头像退化成问号。
+//  - 用户 @ 时写法不一（@Claude CLI / @Claude Code CLI / @Claude CLI Syzygy /
+//    @claude_code_cli_syzygy），需要归一到 Runtime 已识别的 mention sender。
+//
+// 本表把以上写法全部归一到同一角色，统一显示名 / 头像 / 颜色，并把 @ 别名归一到
+// Runtime/监听端已识别的 mention sender（claude_cli / codex_cli）。
+//
+// 约束：只动前端映射，不改 Supabase schema、不改本地 Runtime、不改 Edge Function。
+
+export type LoungeRoleKey =
+  | 'syzygy'
+  | 'claude_cli'
+  | 'codex_cli'
+  | 'syzygy_claude'
+  | 'syzygy_gpt'
+
+export type LoungeRoleDef = {
+  key: LoungeRoleKey
+  /** 完整显示名（消息头 / 成员名册）。 */
+  displayName: string
+  /** 短显示名（紧凑场景）。 */
+  shortName: string
+  /** @ 菜单展示与插入输入框时使用的名字（不含 @）。 */
+  mentionName: string
+  emoji: string
+  color: string
+  /** 写入 lounge_messages.mentions 的 sender —— 必须是 Runtime/监听端已识别的键。 */
+  mentionSender: string
+  /** 可识别为该角色的 message.sender 值（含 Runtime 回写时用的显示名 sender）。 */
+  senderIds: string[]
+  /** 可识别为该角色的 meta.target_role 值。 */
+  targetRoles: string[]
+  /** @ 别名（小写、不含 @），用于把多种写法归一到该角色。 */
+  aliases: string[]
+}
+
+// 颜色沿用现有 lounge_members 配色，保持与历史 UI 一致。
+export const LOUNGE_ROLES: LoungeRoleDef[] = [
+  {
+    key: 'syzygy',
+    displayName: 'Syzygy',
+    shortName: 'Syzygy',
+    mentionName: 'Syzygy',
+    emoji: '💙',
+    color: '#2A9D8F',
+    mentionSender: 'api_syzygy',
+    senderIds: ['api_syzygy'],
+    targetRoles: [],
+    aliases: ['syzygy', 'api_syzygy'],
+  },
+  {
+    key: 'claude_cli',
+    displayName: 'Claude Code CLI Syzygy',
+    shortName: 'Claude CLI',
+    mentionName: 'Claude CLI',
+    emoji: '🦀',
+    color: '#F4A261',
+    mentionSender: 'claude_cli',
+    senderIds: [
+      'claude_cli',
+      'claude_code_cli_syzygy',
+      'Claude Code CLI Syzygy',
+      'Claude CLI',
+      'Claude CLI Syzygy',
+    ],
+    targetRoles: ['claude_code_cli_syzygy'],
+    aliases: [
+      'claude cli',
+      'claude code cli',
+      'claude cli syzygy',
+      'claude code cli syzygy',
+      'claude_code_cli_syzygy',
+      'claude_cli',
+    ],
+  },
+  {
+    key: 'codex_cli',
+    displayName: 'Codex CLI Syzygy',
+    shortName: 'Codex CLI',
+    mentionName: 'Codex CLI',
+    emoji: '🤖',
+    color: '#8AB17D',
+    mentionSender: 'codex_cli',
+    senderIds: ['codex_cli', 'codex_cli_syzygy', 'Codex CLI Syzygy', 'Codex CLI'],
+    targetRoles: ['codex_cli_syzygy'],
+    aliases: ['codex cli', 'codex cli syzygy', 'codex_cli_syzygy', 'codex_cli'],
+  },
+  {
+    key: 'syzygy_claude',
+    displayName: 'Syzygy·Claude',
+    shortName: 'Syzygy·Claude',
+    mentionName: 'Syzygy-Claude',
+    emoji: '🧡',
+    color: '#E76F51',
+    mentionSender: 'client_claude',
+    senderIds: ['client_claude'],
+    targetRoles: [],
+    aliases: ['syzygy-claude', 'syzygy·claude', 'client_claude'],
+  },
+  {
+    key: 'syzygy_gpt',
+    displayName: 'Syzygy·GPT',
+    shortName: 'Syzygy·GPT',
+    mentionName: 'Syzygy-GPT',
+    emoji: '🤍',
+    color: '#264653',
+    mentionSender: 'client_gpt',
+    senderIds: ['client_gpt'],
+    targetRoles: [],
+    aliases: ['syzygy-gpt', 'syzygy·gpt', 'client_gpt'],
+  },
+]
+
+const roleBySenderId = new Map<string, LoungeRoleDef>()
+const roleByTargetRole = new Map<string, LoungeRoleDef>()
+const roleByMentionSender = new Map<string, LoungeRoleDef>()
+for (const role of LOUNGE_ROLES) {
+  roleByMentionSender.set(role.mentionSender, role)
+  for (const senderId of role.senderIds) {
+    roleBySenderId.set(senderId, role)
+    roleBySenderId.set(senderId.toLowerCase(), role)
+  }
+  for (const targetRole of role.targetRoles) {
+    roleByTargetRole.set(targetRole, role)
+    roleByTargetRole.set(targetRole.toLowerCase(), role)
+  }
+}
+
+// 本表已接管的全部 sender（mentionSender + senderIds）。
+// detectLoungeMentions 据此判断某个 DB 成员是否已由本表归一，避免重复 / 冲突。
+export const MAPPED_LOUNGE_SENDERS = new Set<string>(
+  LOUNGE_ROLES.flatMap((role) => [role.mentionSender, ...role.senderIds]),
+)
+
+/** 按 sender（短键或 Runtime 回写的显示名 sender）查角色。 */
+export const findLoungeRoleBySender = (sender: string): LoungeRoleDef | null =>
+  roleBySenderId.get(sender) ??
+  roleBySenderId.get(sender.toLowerCase()) ??
+  roleByMentionSender.get(sender) ??
+  null
+
+export type LoungeMemberView = {
+  displayName: string
+  shortName: string
+  emoji: string
+  color: string
+}
+
+const DEFAULT_VIEW: LoungeMemberView = {
+  displayName: '',
+  shortName: '',
+  // 兜底头像用窝里的仓鼠，绝不出问号。
+  emoji: '🐹',
+  color: '#C9A9BB',
+}
+
+const toView = (role: LoungeRoleDef): LoungeMemberView => ({
+  displayName: role.displayName,
+  shortName: role.shortName,
+  emoji: role.emoji,
+  color: role.color,
+})
+
+type LoungeDbMember = {
+  displayName: string
+  emoji: string
+  color: string
+}
+
+/**
+ * 由 message.sender + meta 解析出展示用的名字 / 头像 / 颜色。
+ * 优先级：meta.target_role（CLI Runtime 回写最稳定）→ sender 命中映射表
+ *        → DB 成员行 → 兜底（用仓鼠头像，不出问号）。
+ */
+export const resolveLoungeMemberView = (
+  message: { sender: string; meta?: Record<string, unknown> | null },
+  dbMember?: LoungeDbMember | null,
+): LoungeMemberView => {
+  const targetRole =
+    typeof message.meta?.target_role === 'string' ? (message.meta.target_role as string) : null
+  if (targetRole) {
+    const role = roleByTargetRole.get(targetRole) ?? roleByTargetRole.get(targetRole.toLowerCase())
+    if (role) {
+      return toView(role)
+    }
+  }
+  const bySender = findLoungeRoleBySender(message.sender)
+  if (bySender) {
+    return toView(bySender)
+  }
+  if (dbMember) {
+    return {
+      displayName: dbMember.displayName,
+      shortName: dbMember.displayName,
+      emoji: dbMember.emoji,
+      color: dbMember.color,
+    }
+  }
+  return { ...DEFAULT_VIEW, displayName: message.sender, shortName: message.sender }
+}
+
+// 名字延续字符：命中 @token 后若紧跟这些字符，说明名字还没结束
+// （例如 @Syzygy 不能命中 @Syzygy-Claude / @Syzygy·GPT）。
+const NAME_CONTINUATION = /[A-Za-z0-9_·-]/
+
+const contentMentionsAlias = (content: string, alias: string): boolean => {
+  if (!alias) {
+    return false
+  }
+  const haystack = content.toLowerCase()
+  const needle = `@${alias.toLowerCase()}`
+  let index = haystack.indexOf(needle)
+  while (index !== -1) {
+    const next = haystack[index + needle.length]
+    if (next === undefined || !NAME_CONTINUATION.test(next)) {
+      return true
+    }
+    index = haystack.indexOf(needle, index + 1)
+  }
+  return false
+}
+
+/**
+ * 把消息内容里的 @ 别名归一为 Runtime 已识别的 mention sender 列表。
+ * members 为 DB 成员，用于兼容本表尚未覆盖的成员（未来新增成员仍可被点名）。
+ */
+export const detectLoungeMentions = (
+  content: string,
+  members: { sender: string; displayName: string }[],
+): string[] => {
+  const senders = new Set<string>()
+  for (const role of LOUNGE_ROLES) {
+    if (role.aliases.some((alias) => contentMentionsAlias(content, alias))) {
+      senders.add(role.mentionSender)
+    }
+  }
+  for (const member of members) {
+    if (MAPPED_LOUNGE_SENDERS.has(member.sender)) {
+      continue
+    }
+    if (
+      contentMentionsAlias(content, member.displayName) ||
+      contentMentionsAlias(content, member.sender)
+    ) {
+      senders.add(member.sender)
+    }
+  }
+  return [...senders]
+}
+
+/**
+ * @ 菜单里某个 DB 成员的展示信息：优先用映射表（统一显示名 / 头像 / 颜色 / @ 名），
+ * 未覆盖的成员退回 DB 原值。返回的 mentionName 即插入输入框 @ 后的文本。
+ */
+export const resolveLoungeMentionEntry = (member: {
+  sender: string
+  displayName: string
+  emoji: string
+  color: string
+}): { mentionName: string; emoji: string; color: string } => {
+  const role = findLoungeRoleBySender(member.sender)
+  return {
+    mentionName: role?.mentionName ?? member.displayName,
+    emoji: role?.emoji ?? member.emoji,
+    color: role?.color ?? member.color,
+  }
+}

--- a/src/pages/LoungeRoomPage.tsx
+++ b/src/pages/LoungeRoomPage.tsx
@@ -13,6 +13,12 @@ import { buildMemoInjectionBlock } from '../utils/memoRetrieval'
 import { isGpt5Auto } from '../utils/modelResolver'
 import { extractLlmUsage, logLlmUsage } from '../utils/llmUsage'
 import { DEFAULT_LOUNGE_SCENE_PROMPT } from '../constants/aiOverlays'
+import {
+  detectLoungeMentions,
+  resolveLoungeMemberView,
+  resolveLoungeMentionEntry,
+  type LoungeMemberView,
+} from '../constants/loungeRoles'
 import type { LoungeMember, LoungeMessage, LoungeSofa } from '../types'
 import './LoungePage.css'
 
@@ -44,33 +50,6 @@ const createLocalId = () =>
 // 流式过程中把 <think>…</think> 段落（含未闭合的尾部）从展示与落库内容中剥掉。
 const stripThinkSegments = (text: string) =>
   text.replace(/<think>[\s\S]*?<\/think>/g, '').replace(/<think>[\s\S]*$/, '')
-
-// @token 命中后要求下一个字符不是名字的延续（如「@Syzygy·GPT」不能算点到「@Syzygy」）。
-const containsMentionToken = (content: string, token: string) => {
-  const needle = `@${token}`
-  let index = content.indexOf(needle)
-  while (index !== -1) {
-    const next = content[index + needle.length]
-    if (next === undefined || !/[A-Za-z0-9_·]/.test(next)) {
-      return true
-    }
-    index = content.indexOf(needle, index + 1)
-  }
-  return false
-}
-
-const detectMentions = (content: string, members: LoungeMember[]): string[] => {
-  const mentions: string[] = []
-  for (const member of members) {
-    if (
-      containsMentionToken(content, member.displayName) ||
-      containsMentionToken(content, member.sender)
-    ) {
-      mentions.push(member.sender)
-    }
-  }
-  return mentions
-}
 
 const formatMessageTime = (value: string) =>
   new Date(value).toLocaleString([], {
@@ -451,8 +430,8 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
     setSending(true)
     setError(null)
     try {
-      // mentions 本期仅解析写入，CLI 唤醒监听属后续任务。
-      const mentions = detectMentions(content, membersRef.current)
+      // 把多种 @ 写法归一为 Runtime 已识别的 mention sender（如 claude_cli / codex_cli）。
+      const mentions = detectLoungeMentions(content, membersRef.current)
       const saved = await addLoungeMessage(sofaId, USER_SENDER, content, mentions)
       appendMessage(saved)
       setDraft('')
@@ -469,10 +448,10 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
     }
   }, [appendMessage, draft, runSyzygyReply, sending, sofaId])
 
-  const handleInsertMention = useCallback((member: LoungeMember) => {
+  const handleInsertMention = useCallback((mentionName: string) => {
     setDraft((prev) => {
       const needsSpace = prev.length > 0 && !prev.endsWith(' ')
-      return `${prev}${needsSpace ? ' ' : ''}@${member.displayName} `
+      return `${prev}${needsSpace ? ' ' : ''}@${mentionName} `
     })
     inputRef.current?.focus()
   }, [])
@@ -503,14 +482,11 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
     [messages, streamingMessage],
   )
 
-  const renderAvatar = (sender: string) => {
-    const member = memberMap.get(sender)
-    return (
-      <span className="lounge-avatar" aria-hidden="true">
-        {member?.emoji ?? '❔'}
-      </span>
-    )
-  }
+  const renderAvatar = (view: LoungeMemberView) => (
+    <span className="lounge-avatar" style={{ borderColor: view.color }} aria-hidden="true">
+      {view.emoji}
+    </span>
+  )
 
   return (
     <div className="lounge-page lounge-room">
@@ -541,18 +517,16 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
         ) : null}
         {renderedMessages.map((message) => {
           const isUser = message.sender === USER_SENDER
-          const member = memberMap.get(message.sender)
+          const view = resolveLoungeMemberView(message, memberMap.get(message.sender) ?? null)
           return (
             <article
               key={message.id}
               className={`lounge-message ${isUser ? 'lounge-message--out' : 'lounge-message--in'}`}
             >
-              {!isUser ? renderAvatar(message.sender) : null}
+              {!isUser ? renderAvatar(view) : null}
               <div className="lounge-message-body">
                 {!isUser ? (
-                  <span className="lounge-message-name">
-                    {member?.displayName ?? message.sender}
-                  </span>
+                  <span className="lounge-message-name">{view.displayName}</span>
                 ) : null}
                 <div className={`lounge-bubble ${message.streaming ? 'lounge-bubble--streaming' : ''}`}>
                   {message.content.length > 0 ? message.content : '…'}
@@ -571,26 +545,29 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
         <div className="lounge-input-anchor">
           {mentionMenuOpen && members.length > 0 ? (
             <div className="lounge-mention-menu" role="menu">
-              {members.map((member) => (
-                <button
-                  key={member.sender}
-                  type="button"
-                  role="menuitem"
-                  className="lounge-mention-option"
-                  onClick={() => {
-                    handleInsertMention(member)
-                    setMentionMenuOpen(false)
-                  }}
-                >
-                  <span className="lounge-mention-emoji" aria-hidden="true">{member.emoji}</span>
-                  <span className="lounge-mention-name">@{member.displayName}</span>
-                  <span
-                    className="lounge-mention-dot"
-                    style={{ backgroundColor: member.color }}
-                    aria-hidden="true"
-                  />
-                </button>
-              ))}
+              {members.map((member) => {
+                const entry = resolveLoungeMentionEntry(member)
+                return (
+                  <button
+                    key={member.sender}
+                    type="button"
+                    role="menuitem"
+                    className="lounge-mention-option"
+                    onClick={() => {
+                      handleInsertMention(entry.mentionName)
+                      setMentionMenuOpen(false)
+                    }}
+                  >
+                    <span className="lounge-mention-emoji" aria-hidden="true">{entry.emoji}</span>
+                    <span className="lounge-mention-name">@{entry.mentionName}</span>
+                    <span
+                      className="lounge-mention-dot"
+                      style={{ backgroundColor: entry.color }}
+                      aria-hidden="true"
+                    />
+                  </button>
+                )
+              })}
             </div>
           ) : null}
           <div className="lounge-input-row">


### PR DESCRIPTION
## 背景（任务 E-3）

仓鼠客厅 @ CLI 角色链路已可用，但前端显示名、@ 名称、头像、颜色与内部 `target_role` 不一致：CLI 回复头像出现 ❔，@ 写法多样无法归一。

## 根因

CLI Runtime 回写客厅消息时 `sender` 写成显示名（`"Claude Code CLI Syzygy"` / `"Codex CLI Syzygy"`，稳定标识在 `meta.target_role`），而这些值并不是 `lounge_members` 的键（`claude_cli` / `codex_cli`）。于是 `memberMap.get(sender)` 返回 `undefined` → 头像退化成 ❔、无颜色。此外缺少统一的角色映射表与 @ 别名归一。

## 改动（仅前端，不动 schema / Runtime / Edge Function / 微信桥）

- **新增 `src/constants/loungeRoles.ts`**：统一映射表 `LOUNGE_ROLES`（显示名 / 短名 / @名 / emoji / 颜色 / mentionSender / senderIds / targetRoles / aliases）+ `resolveLoungeMemberView` / `detectLoungeMentions` / `resolveLoungeMentionEntry`。
- **改 `src/pages/LoungeRoomPage.tsx`**：
  - 回复头像 + 显示名按 `meta.target_role → sender → DB 成员 → 🐹 兜底` 解析，**不再出 ❔**，头像加角色色环；
  - @ 菜单标签/emoji/颜色来自映射表，插入文本为规范 @名（`@Claude CLI` / `@Codex CLI` / `@Syzygy-Claude` / `@Syzygy-GPT`）；
  - 各种 @ 写法归一为 Runtime 已识别的 mention sender（`claude_cli` / `codex_cli`），`@Syzygy-X` 不误命中 `@Syzygy`；旧数据兼容。

## 角色映射表

| 角色 | 显示名 | @ 名 | 头像 | 颜色 | mention sender | target_role |
|---|---|---|---|---|---|---|
| Syzygy | Syzygy | @Syzygy | 💙 | #2A9D8F | api_syzygy | — |
| Claude CLI | Claude Code CLI Syzygy | @Claude CLI | 🦀 | #F4A261 | claude_cli | claude_code_cli_syzygy |
| Codex CLI | Codex CLI Syzygy | @Codex CLI | 🤖 | #8AB17D | codex_cli | codex_cli_syzygy |
| Syzygy·Claude | Syzygy·Claude | @Syzygy-Claude | 🧡 | #E76F51 | client_claude | — |
| Syzygy·GPT | Syzygy·GPT | @Syzygy-GPT | 🤍 | #264653 | client_gpt | — |

## 验证

- `tsc -b` / `eslint` / `vite build` 全绿。
- 用真实 DB 数据跑 24 条断言全通过：@ 菜单显示/插入文本、别名归一、`@Syzygy-Claude` 不误触 `@Syzygy`、CLI 回复显示名+头像（非问号）、旧数据兼容、未知 sender → 🐹。
- ⚠️ 端到端真机回复（`CLAUDE_CLI_DISPLAY_OK` / `CODEX_CLI_DISPLAY_OK` 往返）需 Mac mini Runtime 在线，未在本环境实跑；前端写入的 `mentions` 与历史成功用例一致。

## Runtime alias 说明

前端写入的 `mentions=["claude_cli"]/["codex_cli"]` 与历史能成功唤醒的结构化信号相同，**大概率无需改 Runtime**。唯一风险：若 lounge-listener 对原文做字面匹配而非读 `mentions` 数组，则需在本地 Runtime 别名表补 `@Claude CLI` / `@Codex CLI`（不带 "Syzygy"），前端无需再改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKFQwrJHFFKuM1jBmM6phR)_