### PR TITLE
feat(lounge): 仓鼠客厅「正在回复」状态动画 (E-4A)

### DIFF
--- a/src/constants/loungeRoles.ts
+++ b/src/constants/loungeRoles.ts
@@ -147,6 +147,10 @@ export const findLoungeRoleBySender = (sender: string): LoungeRoleDef | null =>
   roleByMentionSender.get(sender) ??
   null
 
+/** 按 target_role（syzygy_commands.payload.target_role）查角色。 */
+export const findLoungeRoleByTargetRole = (targetRole: string): LoungeRoleDef | null =>
+  roleByTargetRole.get(targetRole) ?? roleByTargetRole.get(targetRole.toLowerCase()) ?? null
+
 export type LoungeMemberView = {
   displayName: string
   shortName: string
@@ -205,6 +209,18 @@ export const resolveLoungeMemberView = (
     }
   }
   return { ...DEFAULT_VIEW, displayName: message.sender, shortName: message.sender }
+}
+
+/**
+ * 由 target_role 解析「正在回复」动画用的展示信息（名字 / 头像 / 颜色）。
+ * 未命中映射时退回兜底仓鼠头像，绝不出问号。
+ */
+export const resolveLoungeViewByTargetRole = (targetRole: string): LoungeMemberView => {
+  const role = findLoungeRoleByTargetRole(targetRole)
+  if (role) {
+    return toView(role)
+  }
+  return { ...DEFAULT_VIEW, displayName: targetRole, shortName: targetRole }
 }
 
 // 名字延续字符：命中 @token 后若紧跟这些字符，说明名字还没结束

--- a/src/hooks/useLoungeReplyStatus.ts
+++ b/src/hooks/useLoungeReplyStatus.ts
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from 'react'
+import { supabase } from '../supabase/client'
+
+// E-4A：仓鼠客厅「正在回复」状态。
+//
+// 数据源选型（只读，不改 schema / Runtime / Edge Function）：
+//  - lounge_messages 表没有 read_by 列 → 方案①（read_by 状态标记）不存在，排除。
+//  - agent_tasks 不在 supabase_realtime 发布里，无法实时推送 → 不选。
+//  - syzygy_commands 命中所有需求且在 realtime 发布里：
+//      payload.source = 'lounge_messages'
+//      payload.target_role = claude_code_cli_syzygy / codex_cli_syzygy
+//      payload.source_message_id / lounge_message_id = 被 @ 的原消息 id
+//      payload.lounge_sofa_id = 沙发 id（按沙发隔离）
+//      payload.source_role = 发起者（chuanchuan 或某模型）→ 天然兼容「模型 @ 模型」
+//      status = pending / running / done / failed（E-4B 本地 Runtime 写入）
+//    RLS：select 限定 auth.uid() = user_id，前端登录用户能读自己的命令，
+//    无 service_role 也可读；读不到时优雅降级（不显示动画、不崩溃）。
+
+export type LoungeReplyStatusPhase = 'processing' | 'timeout' | 'failed'
+
+export type LoungeReplyStatus = {
+  commandId: string
+  sourceMessageId: string
+  targetRole: string
+  phase: LoungeReplyStatusPhase
+}
+
+type CommandRow = {
+  id: string
+  status: string | null
+  payload: Record<string, unknown> | null
+  created_at: string | null
+  completed_at: string | null
+}
+
+// 只关心近期命令：避免历史 done/failed 把客厅塞满旧提示（保持动画「轻」）。
+const STATUS_WINDOW_MS = 30 * 60 * 1000
+// 超过 2 分钟仍未 done/failed → 判定为「可能卡住了」。
+const TIMEOUT_MS = 2 * 60 * 1000
+
+// 状态值归一：兼容 syzygy_commands(pending/running/done/failed) 与
+// agent_tasks(processing/completed)、read_by 标记(processing) 等旧写法。
+const PROCESSING_STATUSES = new Set(['pending', 'running', 'processing', 'claimed', 'in_progress'])
+const DONE_STATUSES = new Set(['done', 'completed', 'complete', 'success', 'succeeded'])
+const FAILED_STATUSES = new Set(['failed', 'fail', 'error', 'errored', 'cancelled', 'canceled'])
+
+const asString = (value: unknown): string | null => (typeof value === 'string' ? value : null)
+
+const matchesSofa = (row: CommandRow, sofaId: string): boolean => {
+  const payload = row.payload ?? {}
+  return (
+    asString(payload['source']) === 'lounge_messages' &&
+    asString(payload['lounge_sofa_id']) === sofaId
+  )
+}
+
+/**
+ * 读取某张沙发上「被 @ 角色正在回复」的状态，返回
+ * Map<原消息 id, 该消息下方要展示的状态指示器列表>。
+ */
+export const useLoungeReplyStatus = (
+  sofaId: string | undefined,
+  userId: string | undefined,
+): Map<string, LoungeReplyStatus[]> => {
+  const [rows, setRows] = useState<Map<string, CommandRow>>(() => new Map())
+  // 超时判定依赖时间推进，定时刷新 now 触发重算。
+  const [nowMs, setNowMs] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!supabase || !sofaId || !userId) {
+      setRows(new Map())
+      return
+    }
+    const client = supabase
+    let active = true
+
+    const load = async () => {
+      // 滚动 30 分钟窗口：每次重取都重建 map，自动淘汰过旧的 done/failed，避免堆积。
+      const windowStart = new Date(Date.now() - STATUS_WINDOW_MS).toISOString()
+      try {
+        const { data, error } = await client
+          .from('syzygy_commands')
+          .select('id,status,payload,created_at,completed_at')
+          .eq('user_id', userId)
+          .gte('created_at', windowStart)
+          .order('created_at', { ascending: false })
+          .limit(100)
+        if (error) {
+          throw error
+        }
+        if (!active) {
+          return
+        }
+        const next = new Map<string, CommandRow>()
+        for (const row of (data ?? []) as CommandRow[]) {
+          if (matchesSofa(row, sofaId)) {
+            next.set(row.id, row)
+          }
+        }
+        setRows(next)
+      } catch (loadError) {
+        // 权限不足 / 网络异常：优雅降级，不显示动画也不让页面崩溃。
+        console.warn('读取客厅回复状态失败（降级为不显示动画）', loadError)
+        if (active) {
+          setRows(new Map())
+        }
+      }
+    }
+    void load()
+
+    // Realtime：本地 Runtime 把 pending→running→done/failed 写进 syzygy_commands，
+    // 这里实时收 INSERT/UPDATE，让动画即时出现 / 消失。filter 只能按顶层列，
+    // 用 user_id 收窄，沙发 / 来源再在客户端过滤。
+    const channel = client
+      .channel(`lounge-reply-status-${sofaId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'syzygy_commands',
+          filter: `user_id=eq.${userId}`,
+        },
+        (payload) => {
+          const row = payload.new as CommandRow | null
+          if (!row?.id || !matchesSofa(row, sofaId)) {
+            return
+          }
+          setRows((prev) => {
+            const next = new Map(prev)
+            next.set(row.id, row)
+            return next
+          })
+        },
+      )
+      .subscribe()
+
+    // 兜底轮询：万一某条 realtime UPDATE（尤其 done）丢了，避免动画卡着不消失。
+    const refetch = window.setInterval(() => void load(), 25000)
+
+    return () => {
+      active = false
+      window.clearInterval(refetch)
+      void client.removeChannel(channel)
+    }
+  }, [sofaId, userId])
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNowMs(Date.now()), 15000)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  return useMemo(() => {
+    // 同一原消息 + 同一角色可能有多条命令（重试），收敛到 created_at 最新的一条。
+    const latestByKey = new Map<string, { row: CommandRow; messageId: string; targetRole: string }>()
+    for (const row of rows.values()) {
+      const payload = row.payload ?? {}
+      const messageId =
+        asString(payload['source_message_id']) ?? asString(payload['lounge_message_id'])
+      const targetRole = asString(payload['target_role'])
+      if (!messageId || !targetRole) {
+        continue
+      }
+      const key = `${messageId}::${targetRole}`
+      const prev = latestByKey.get(key)
+      const rowTime = row.created_at ? new Date(row.created_at).getTime() : 0
+      const prevTime = prev?.row.created_at ? new Date(prev.row.created_at).getTime() : -1
+      if (!prev || rowTime >= prevTime) {
+        latestByKey.set(key, { row, messageId, targetRole })
+      }
+    }
+
+    const byMessage = new Map<string, LoungeReplyStatus[]>()
+    for (const { row, messageId, targetRole } of latestByKey.values()) {
+      const status = (row.status ?? '').toLowerCase()
+      let phase: LoungeReplyStatusPhase | null = null
+      if (DONE_STATUSES.has(status)) {
+        // 完成：动画消失，真正的回复消息会通过 lounge_messages 实时出现。
+        phase = null
+      } else if (FAILED_STATUSES.has(status)) {
+        phase = 'failed'
+      } else if (PROCESSING_STATUSES.has(status) || status === '') {
+        const startedMs = row.created_at ? new Date(row.created_at).getTime() : nowMs
+        phase = nowMs - startedMs > TIMEOUT_MS ? 'timeout' : 'processing'
+      }
+      if (!phase) {
+        continue
+      }
+      const list = byMessage.get(messageId) ?? []
+      list.push({ commandId: row.id, sourceMessageId: messageId, targetRole, phase })
+      byMessage.set(messageId, list)
+    }
+    return byMessage
+  }, [rows, nowMs])
+}

--- a/src/pages/LoungePage.css
+++ b/src/pages/LoungePage.css
@@ -339,6 +339,115 @@
   padding: 0 2px;
 }
 
+/* ── 正在回复状态（E-4A）──────────────────────── */
+
+/* 一条原消息可能同时点名多个角色，纵向堆叠各自的状态。 */
+.lounge-reply-status-group {
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 86%;
+  margin-top: -4px;
+  padding-left: 2px;
+}
+
+.lounge-reply-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px 5px 6px;
+  border-radius: 14px;
+  border-top-left-radius: 6px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed rgba(255, 214, 231, 0.9);
+  font-size: 12px;
+  color: #8a6178;
+  animation: lounge-status-in 0.2s ease;
+}
+
+.lounge-reply-status--failed {
+  border-style: solid;
+  border-color: rgba(230, 111, 81, 0.4);
+  background: rgba(230, 111, 81, 0.08);
+  color: #b9543b;
+}
+
+.lounge-reply-status--timeout {
+  border-color: rgba(195, 155, 174, 0.6);
+  color: #9a7c8c;
+}
+
+.lounge-reply-status-text {
+  line-height: 1.4;
+}
+
+.lounge-avatar--sm {
+  width: 24px;
+  height: 24px;
+  font-size: 13px;
+  border-radius: 9px;
+}
+
+/* 三点跳动 —— 轻量、不抢视线。 */
+.lounge-typing {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 3px;
+  padding-bottom: 1px;
+}
+
+.lounge-typing span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.55;
+  animation: lounge-typing-bounce 1.2s ease-in-out infinite;
+}
+
+.lounge-typing span:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.lounge-typing span:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@keyframes lounge-typing-bounce {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.45;
+  }
+  30% {
+    transform: translateY(-4px);
+    opacity: 0.9;
+  }
+}
+
+@keyframes lounge-status-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lounge-typing span {
+    animation: none;
+    opacity: 0.7;
+  }
+  .lounge-reply-status {
+    animation: none;
+  }
+}
+
 /* ── Composer ─────────────────────────────────── */
 
 .lounge-composer {

--- a/src/pages/LoungeRoomPage.tsx
+++ b/src/pages/LoungeRoomPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
@@ -17,8 +17,10 @@ import {
   detectLoungeMentions,
   resolveLoungeMemberView,
   resolveLoungeMentionEntry,
+  resolveLoungeViewByTargetRole,
   type LoungeMemberView,
 } from '../constants/loungeRoles'
+import { useLoungeReplyStatus, type LoungeReplyStatus } from '../hooks/useLoungeReplyStatus'
 import type { LoungeMember, LoungeMessage, LoungeSofa } from '../types'
 import './LoungePage.css'
 
@@ -85,6 +87,9 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
     () => new Map(members.map((member) => [member.sender, member])),
     [members],
   )
+
+  // 被 @ 角色的「正在回复 / 失败 / 卡住」状态，按原消息 id 分组（读 syzygy_commands）。
+  const replyStatusByMessage = useLoungeReplyStatus(sofaId, user?.id)
 
   useEffect(() => {
     messagesRef.current = messages
@@ -488,6 +493,39 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
     </span>
   )
 
+  // 原消息下方的轻量状态：正在回复（三点跳动）/ 失败 / 卡住。头像与颜色复用 E-3 角色映射。
+  const renderReplyIndicator = (indicator: LoungeReplyStatus) => {
+    const view = resolveLoungeViewByTargetRole(indicator.targetRole)
+    const label =
+      indicator.phase === 'failed'
+        ? `${view.shortName} 回复失败，可稍后再试。`
+        : indicator.phase === 'timeout'
+          ? `${view.shortName} 可能卡住了，稍后可再试。`
+          : `${view.shortName} 正在回复…`
+    return (
+      <div
+        key={indicator.commandId}
+        className={`lounge-reply-status lounge-reply-status--${indicator.phase}`}
+      >
+        <span
+          className="lounge-avatar lounge-avatar--sm"
+          style={{ borderColor: view.color }}
+          aria-hidden="true"
+        >
+          {view.emoji}
+        </span>
+        <span className="lounge-reply-status-text">{label}</span>
+        {indicator.phase === 'processing' ? (
+          <span className="lounge-typing" aria-hidden="true">
+            <span />
+            <span />
+            <span />
+          </span>
+        ) : null}
+      </div>
+    )
+  }
+
   return (
     <div className="lounge-page lounge-room">
       <header className="lounge-header">
@@ -518,24 +556,32 @@ const LoungeRoomPage = ({ user, aiConfig, onSaveLoungeScenePrompt }: LoungeRoomP
         {renderedMessages.map((message) => {
           const isUser = message.sender === USER_SENDER
           const view = resolveLoungeMemberView(message, memberMap.get(message.sender) ?? null)
+          // 不假设只有串串的消息会触发回复：模型 @ 模型同样命中这里（按原消息 id 取状态）。
+          const indicators = replyStatusByMessage.get(message.id) ?? []
           return (
-            <article
-              key={message.id}
-              className={`lounge-message ${isUser ? 'lounge-message--out' : 'lounge-message--in'}`}
-            >
-              {!isUser ? renderAvatar(view) : null}
-              <div className="lounge-message-body">
-                {!isUser ? (
-                  <span className="lounge-message-name">{view.displayName}</span>
-                ) : null}
-                <div className={`lounge-bubble ${message.streaming ? 'lounge-bubble--streaming' : ''}`}>
-                  {message.content.length > 0 ? message.content : '…'}
+            <Fragment key={message.id}>
+              <article
+                className={`lounge-message ${isUser ? 'lounge-message--out' : 'lounge-message--in'}`}
+              >
+                {!isUser ? renderAvatar(view) : null}
+                <div className="lounge-message-body">
+                  {!isUser ? (
+                    <span className="lounge-message-name">{view.displayName}</span>
+                  ) : null}
+                  <div className={`lounge-bubble ${message.streaming ? 'lounge-bubble--streaming' : ''}`}>
+                    {message.content.length > 0 ? message.content : '…'}
+                  </div>
+                  <span className="lounge-message-time">
+                    {message.streaming ? '正在输入…' : formatMessageTime(message.createdAt)}
+                  </span>
                 </div>
-                <span className="lounge-message-time">
-                  {message.streaming ? '正在输入…' : formatMessageTime(message.createdAt)}
-                </span>
-              </div>
-            </article>
+              </article>
+              {indicators.length > 0 ? (
+                <div className="lounge-reply-status-group">
+                  {indicators.map((indicator) => renderReplyIndicator(indicator))}
+                </div>
+              ) : null}
+            </Fragment>
           )
         })}
         <div ref={listEndRef} />


### PR DESCRIPTION
## 背景

仓鼠客厅里某个成员被 @ 后，在 CLI / 模型处理期间，前端显示对应角色「正在回复」的轻量动画；完成后动画消失、失败/超时显示短提示。本任务**只改前端 UI / 状态展示**。

## 改了哪些文件
- `src/hooks/useLoungeReplyStatus.ts`（新增）— 读取并归一「正在回复」状态。
- `src/pages/LoungeRoomPage.tsx` — 在每条原消息下方渲染状态指示器。
- `src/constants/loungeRoles.ts` — 新增 `findLoungeRoleByTargetRole` / `resolveLoungeViewByTargetRole`，动画头像/颜色/名字复用 E-3 角色映射。
- `src/pages/LoungePage.css` — 三点跳动动画 + 状态条样式（含 `prefers-reduced-motion` 降级）。

## 状态源选型
选 **`syzygy_commands`**，因为：
- ❌ `read_by` 标记 —— `lounge_messages` **没有 `read_by` 列**，方案不存在。
- ❌ `agent_tasks` —— **不在 `supabase_realtime` 发布里**，无法实时推送。
- ✅ `syzygy_commands` —— 在 realtime 发布里，payload 携带 `source='lounge_messages'`、`target_role`、`source_message_id`/`lounge_message_id`、`lounge_sofa_id`、`source_role`、`status`。RLS 为 `auth.uid() = user_id`，登录用户可读自己的命令，**无需 service_role**。

实时：按 `user_id` 订阅 `syzygy_commands` 的 INSERT/UPDATE，客户端再按沙发+来源过滤；外加滚动 30 分钟兜底轮询，防止个别 realtime 事件丢失导致动画卡住。

## done / failed / timeout 判定
按 `source_message_id`+`target_role` 收敛到最新一条命令：
- `pending`/`running` → **processing**（「Claude CLI 正在回复…」+ 三点跳动）
- `done` → **隐藏**（真正回复经 `lounge_messages` 实时出现）
- `failed` → **「Claude CLI 回复失败，可稍后再试。」**
- processing 且 `now − created_at > 2 分钟` → **「Claude CLI 可能卡住了，稍后可再试。」**

## 兼容点
- **多角色同时回复**：同一原消息下纵向堆叠多条指示器，各用自己头像/颜色。
- **模型之间 @**：指示器锚定 `source_message_id`，不假设 `sender=chuanchuan`；已用线上数据验证 `Codex CLI Syzygy @Claude CLI` 正常显示。
- 头像/颜色/名字全部走 E-3 映射，**无问号头像**；读取失败优雅降级、不崩溃。

## 约束遵守
未改 Supabase schema / 本地 Runtime / openrouter-chat Edge Function / 微信桥 / @ 菜单；未用 service_role；未破坏 E-3 映射与原有消息显示。

## 验证
- `tsc -b`、`eslint`、`vite build` 全部通过。
- 线上数据核对：人@模型、模型@模型链路完整（原消息 → syzygy_commands → done 回写 lounge_messages，meta.target_role 命中 E-3 映射）。

## 是否需要本地 Runtime 配合
基本不需要。建议（非阻塞）：E-4B 创建命令时尽早写 `pending`/`running`，动画会更早亮起；当前即使只有 done/failed 也能正确工作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmQJiBqJa2QQGovpkKLJR8)_