### PR TITLE
feat(feed): 将 Syzygy Feed 拆为首页 Page 3 独立入口

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "check": "tsc -b && eslint .",
     "preview": "vite preview",
     "backfill:memory-pilot": "node supabase/scripts/rag-backfill-pilot.mjs"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import './App.css'
 import SettingsPage from './pages/SettingsPage'
 import SnacksPage from './pages/SnacksPage'
 import SyzygyFeedPage from './pages/SyzygyFeedPage'
+import AgentFeedPage from './pages/AgentFeedPage'
 import MemoryVaultPage from './pages/MemoryVaultPage'
 import CheckinPage from './pages/CheckinPage'
 import ExportPage from './pages/ExportPage'
@@ -2203,6 +2204,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <SyzygyFeedPage user={user} snackAiConfig={syzygyAiConfig} />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/feed"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <AgentFeedPage user={user} />
             </RequireAuth>
           }
         />

--- a/src/components/SyzygyFeedEntryCard.css
+++ b/src/components/SyzygyFeedEntryCard.css
@@ -1,0 +1,153 @@
+.syzygy-feed-entry {
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+  display: grid;
+  gap: 12px;
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 22px;
+  padding: 16px;
+  color: #4f3f4a;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(255, 224, 238, 0.7), transparent 46%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(255, 245, 250, 0.96) 100%);
+  box-shadow: 0 10px 24px rgba(255, 196, 222, 0.28);
+  overflow: hidden;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.syzygy-feed-entry:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(255, 188, 217, 0.36);
+}
+
+.syzygy-feed-entry:active {
+  transform: translateY(0);
+}
+
+.syzygy-feed-entry__glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.55) 1.1px, transparent 1.1px);
+  background-size: 18px 18px;
+  opacity: 0.22;
+}
+
+.syzygy-feed-entry__top {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.syzygy-feed-entry__emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  font-size: 22px;
+  background: linear-gradient(180deg, #fff4f9 0%, #ffe6f1 100%);
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  flex-shrink: 0;
+}
+
+.syzygy-feed-entry__heading {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.syzygy-feed-entry__heading strong {
+  font-size: 16px;
+  font-weight: 700;
+  color: #68485e;
+}
+
+.syzygy-feed-entry__heading p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #97778a;
+}
+
+.syzygy-feed-entry__badge {
+  align-self: start;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 7px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(180deg, #ff9ec4 0%, #ff85b3 100%);
+  box-shadow: 0 2px 6px rgba(255, 133, 179, 0.45);
+}
+
+.syzygy-feed-entry__stats {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.syzygy-feed-entry__stat {
+  flex: 1 1 0;
+  min-width: 72px;
+  display: grid;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(255, 214, 231, 0.7);
+}
+
+.syzygy-feed-entry__stat em {
+  font-style: normal;
+  font-size: 18px;
+  font-weight: 700;
+  color: #6a4459;
+}
+
+.syzygy-feed-entry__stat small {
+  font-size: 11px;
+  color: #a48798;
+}
+
+.syzygy-feed-entry__stat.is-high {
+  background: linear-gradient(180deg, #fff0f5 0%, #ffe1ec 100%);
+  border-color: #f7bcd6;
+}
+
+.syzygy-feed-entry__stat.is-high em {
+  color: #c0507d;
+}
+
+.syzygy-feed-entry__stat--time {
+  flex: 2 1 130px;
+}
+
+.syzygy-feed-entry__stat--time em {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.syzygy-feed-entry__hint {
+  position: relative;
+  z-index: 1;
+  font-size: 12px;
+  color: #a48798;
+  padding: 4px 2px;
+}

--- a/src/components/SyzygyFeedEntryCard.tsx
+++ b/src/components/SyzygyFeedEntryCard.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
+import { computeAgentFeedStats, fetchAgentFeedItems, type AgentFeedStats } from '../lib/agentFeed'
+import './SyzygyFeedEntryCard.css'
+
+type SyzygyFeedEntryCardProps = {
+  user: User | null
+}
+
+const formatRelativeUpdated = (iso: string | null) => {
+  if (!iso) {
+    return '还没有新内容'
+  }
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    return '还没有新内容'
+  }
+  const diffMs = Date.now() - date.getTime()
+  const minutes = Math.floor(diffMs / 60000)
+  if (minutes < 1) return '刚刚更新'
+  if (minutes < 60) return `${minutes} 分钟前更新`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} 小时前更新`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days} 天前更新`
+  return `${date.getMonth() + 1}月${date.getDate()}日更新`
+}
+
+const SyzygyFeedEntryCard = ({ user }: SyzygyFeedEntryCardProps) => {
+  const navigate = useNavigate()
+  const [stats, setStats] = useState<AgentFeedStats | null>(null)
+  const [loading, setLoading] = useState<boolean>(() => Boolean(user))
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (!user) {
+      return
+    }
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(false)
+      try {
+        const items = await fetchAgentFeedItems(user.id)
+        if (!cancelled) {
+          setStats(computeAgentFeedStats(items))
+        }
+      } catch (loadError) {
+        console.warn('加载 Syzygy Feed 摘要失败', loadError)
+        if (!cancelled) {
+          setError(true)
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [user])
+
+  const goToFeed = () => navigate('/feed')
+
+  const unread = stats?.unread ?? 0
+  const highPriority = stats?.highPriority ?? 0
+
+  return (
+    <button type="button" className="syzygy-feed-entry" onClick={goToFeed} aria-label="打开 Syzygy Feed">
+      <div className="syzygy-feed-entry__glow" aria-hidden="true" />
+      <div className="syzygy-feed-entry__top">
+        <span className="syzygy-feed-entry__emoji" aria-hidden="true">📮</span>
+        <div className="syzygy-feed-entry__heading">
+          <strong>Syzygy Feed</strong>
+          <p>晨间分享、状态卡、小纸条和周回顾都会放在这里。</p>
+        </div>
+        {unread > 0 ? <span className="syzygy-feed-entry__badge">{unread > 99 ? '99+' : unread}</span> : null}
+      </div>
+
+      <div className="syzygy-feed-entry__stats">
+        {error ? (
+          <span className="syzygy-feed-entry__hint">暂时读不到内容，点开看看。</span>
+        ) : loading ? (
+          <span className="syzygy-feed-entry__hint">正在翻找纸条…</span>
+        ) : (
+          <>
+            <span className="syzygy-feed-entry__stat">
+              <em>{unread}</em>
+              <small>未读</small>
+            </span>
+            <span className={`syzygy-feed-entry__stat ${highPriority > 0 ? 'is-high' : ''}`}>
+              <em>{highPriority}</em>
+              <small>高优先级</small>
+            </span>
+            <span className="syzygy-feed-entry__stat syzygy-feed-entry__stat--time">
+              <em>{formatRelativeUpdated(stats?.lastUpdated ?? null)}</em>
+              <small>最近更新</small>
+            </span>
+          </>
+        )}
+      </div>
+    </button>
+  )
+}
+
+export default SyzygyFeedEntryCard

--- a/src/lib/agentFeed.ts
+++ b/src/lib/agentFeed.ts
@@ -1,0 +1,201 @@
+import { supabase } from '../supabase/client'
+
+// Syzygy Feed 数据层：读取 agent_feed_items（CLI / Syzygy 生成的高频内容卡片）。
+// 仓鼠机里曾内嵌的 Feed 视图被拆出后，首页 Page 3 与独立 Feed 页共用这里的类型与读取逻辑。
+
+export type AgentFeedStatus = 'unread' | 'read' | 'archived' | 'expired' | string
+export type AgentFeedPriority = 'low' | 'normal' | 'high' | 'urgent' | string
+
+export type AgentFeedItem = {
+  id: string
+  user_id: string
+  type: string | null
+  title: string | null
+  summary: string | null
+  content: string | null
+  content_format: 'markdown' | 'plain' | 'json' | string | null
+  priority: AgentFeedPriority | null
+  status: AgentFeedStatus | null
+  source: string | null
+  created_by: string | null
+  visible_from: string | null
+  expires_at: string | null
+  read_at: string | null
+  pinned: boolean | null
+  related_table: string | null
+  related_id: string | null
+  metadata: unknown
+  created_at: string | null
+  updated_at: string | null
+}
+
+export const AGENT_FEED_COLUMNS =
+  'id, user_id, type, title, summary, content, content_format, priority, status, source, created_by, visible_from, expires_at, read_at, pinned, related_table, related_id, metadata, created_at, updated_at'
+
+export const agentFeedTypeLabels: Record<string, string> = {
+  morning_share: '晨间分享',
+  daily_card: '状态卡',
+  syzygy_note: '小纸条',
+  reading_assist: '阅读辅助',
+  weekly_card: '周回顾',
+  reminder_card: '提醒',
+  system_notice: '系统提示',
+  dev_log: '开发记录',
+  print_card: '打印胶囊',
+  other: '其他',
+}
+
+export const agentFeedTypeEmojis: Record<string, string> = {
+  morning_share: '☀️',
+  daily_card: '🗒️',
+  syzygy_note: '📝',
+  reading_assist: '📖',
+  weekly_card: '🗓️',
+  reminder_card: '⏰',
+  system_notice: '🔔',
+  dev_log: '🛠️',
+  print_card: '🖨️',
+  other: '🫧',
+}
+
+export const agentFeedPriorityLabels: Record<string, string> = {
+  urgent: '紧急',
+  high: '高优先级',
+  normal: '普通',
+  low: '低优先级',
+}
+
+export const agentFeedStatusLabels: Record<string, string> = {
+  unread: '未读',
+  read: '已读',
+  archived: '已归档',
+  expired: '已过期',
+}
+
+export const agentFeedPriorityRank: Record<string, number> = { urgent: 4, high: 3, normal: 2, low: 1 }
+
+export const agentFeedTypeOptions = [
+  'morning_share',
+  'daily_card',
+  'syzygy_note',
+  'reading_assist',
+  'weekly_card',
+  'reminder_card',
+  'system_notice',
+  'dev_log',
+] as const
+
+export const typeLabel = (type: string | null) =>
+  agentFeedTypeLabels[type ?? 'other'] ?? type ?? '其他'
+
+export const typeEmoji = (type: string | null) =>
+  agentFeedTypeEmojis[type ?? 'other'] ?? agentFeedTypeEmojis.other
+
+export const isAgentFeedExpired = (item: AgentFeedItem, now = Date.now()) => {
+  if (item.status === 'expired') return true
+  return item.expires_at ? new Date(item.expires_at).getTime() <= now : false
+}
+
+export const resolveAgentFeedStatus = (item: AgentFeedItem, now = Date.now()): AgentFeedStatus =>
+  isAgentFeedExpired(item, now) ? 'expired' : item.status ?? 'unread'
+
+// 排序：置顶 > 未读 > 优先级 > 时间倒序。
+export const sortAgentFeedItems = (items: AgentFeedItem[], now = Date.now()) =>
+  [...items].sort((left, right) => {
+    const pinnedDelta = Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))
+    if (pinnedDelta) return pinnedDelta
+    const leftUnread = resolveAgentFeedStatus(left, now) === 'unread' ? 1 : 0
+    const rightUnread = resolveAgentFeedStatus(right, now) === 'unread' ? 1 : 0
+    if (rightUnread - leftUnread) return rightUnread - leftUnread
+    const priorityDelta =
+      (agentFeedPriorityRank[right.priority ?? 'normal'] ?? 0) -
+      (agentFeedPriorityRank[left.priority ?? 'normal'] ?? 0)
+    if (priorityDelta) return priorityDelta
+    return new Date(right.created_at ?? 0).getTime() - new Date(left.created_at ?? 0).getTime()
+  })
+
+export const fetchAgentFeedItems = async (userId: string): Promise<AgentFeedItem[]> => {
+  if (!supabase) {
+    throw new Error('Supabase 未配置，请检查环境变量。')
+  }
+  const { data, error } = await supabase
+    .from('agent_feed_items')
+    .select(AGENT_FEED_COLUMNS)
+    .eq('user_id', userId)
+    .or(`visible_from.is.null,visible_from.lte.${new Date().toISOString()}`)
+    .order('pinned', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(200)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+  return (data ?? []) as AgentFeedItem[]
+}
+
+export const updateAgentFeedStatus = async (
+  userId: string,
+  itemId: string,
+  status: 'read' | 'archived',
+): Promise<Partial<AgentFeedItem>> => {
+  if (!supabase) {
+    throw new Error('Supabase 未配置，请检查环境变量。')
+  }
+  const patch: Partial<AgentFeedItem> =
+    status === 'read' ? { status, read_at: new Date().toISOString() } : { status }
+  const { error } = await supabase
+    .from('agent_feed_items')
+    .update(patch)
+    .eq('id', itemId)
+    .eq('user_id', userId)
+  if (error) {
+    throw new Error(error.message)
+  }
+  return patch
+}
+
+export type AgentFeedStats = {
+  unread: number
+  highPriority: number
+  lastUpdated: string | null
+}
+
+export const computeAgentFeedStats = (items: AgentFeedItem[], now = Date.now()): AgentFeedStats => {
+  let unread = 0
+  let highPriority = 0
+  let lastUpdated: number | null = null
+
+  items.forEach((item) => {
+    const status = resolveAgentFeedStatus(item, now)
+    if (status === 'unread') {
+      unread += 1
+    }
+    if (status !== 'expired' && status !== 'archived' && ['high', 'urgent'].includes(item.priority ?? 'normal')) {
+      highPriority += 1
+    }
+    const stamp = item.updated_at ?? item.created_at
+    if (stamp) {
+      const time = new Date(stamp).getTime()
+      if (!Number.isNaN(time) && (lastUpdated === null || time > lastUpdated)) {
+        lastUpdated = time
+      }
+    }
+  })
+
+  return {
+    unread,
+    highPriority,
+    lastUpdated: lastUpdated === null ? null : new Date(lastUpdated).toISOString(),
+  }
+}
+
+// 按本地日期（YYYY-MM-DD）归桶，便于日历式浏览。
+export const toLocalDateKey = (value: string | null): string | null => {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/src/pages/AgentFeedPage.css
+++ b/src/pages/AgentFeedPage.css
@@ -1,0 +1,651 @@
+.feed-page {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 14px 14px 24px;
+  min-height: 100dvh;
+  flex-shrink: 0;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  color: #1f2937;
+  position: relative;
+  isolation: isolate;
+}
+
+.feed-page::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(255, 214, 231, 0.34), transparent 42%),
+    radial-gradient(circle at 90% 0%, rgba(255, 239, 246, 0.82), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.96) 0%, rgba(253, 245, 249, 0.96) 100%);
+}
+
+/* ── Header ───────────────────────────────────── */
+
+.feed-page__header {
+  position: relative;
+  min-height: 72px;
+  padding: 12px 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8px 18px rgba(255, 214, 231, 0.24);
+}
+
+.feed-page__title-wrap {
+  display: grid;
+  gap: 2px;
+  text-align: center;
+  min-width: 0;
+}
+
+.feed-page__kicker {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #b27f98;
+}
+
+.feed-page__header .ui-title {
+  margin: 0;
+  color: #5c5c5c;
+}
+
+.feed-page__back,
+.feed-page__today {
+  position: absolute;
+  top: 14px;
+  border-radius: 999px;
+  border: 1px solid #ffd6e7;
+  background: #fff;
+  color: #7d5d70;
+  padding: 7px 12px;
+  font-size: 13px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.feed-page__back { left: 12px; }
+.feed-page__today {
+  right: 12px;
+  background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%);
+  font-weight: 600;
+}
+
+/* ── Hero / overview ──────────────────────────── */
+
+.feed-hero {
+  position: relative;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 20px;
+  padding: 16px;
+  background:
+    radial-gradient(circle at 14% 0%, rgba(255, 224, 238, 0.7), transparent 48%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(255, 245, 250, 0.96) 100%);
+  box-shadow: 0 10px 22px rgba(255, 196, 222, 0.24);
+  overflow: hidden;
+  display: grid;
+  gap: 12px;
+}
+
+.feed-hero__glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.5) 1.1px, transparent 1.1px);
+  background-size: 18px 18px;
+  opacity: 0.2;
+}
+
+.feed-hero__subtitle {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #8a6a7d;
+}
+
+.feed-hero__stats {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.feed-hero__stat {
+  flex: 1 1 0;
+  min-width: 76px;
+  display: grid;
+  gap: 2px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(255, 214, 231, 0.72);
+}
+
+.feed-hero__stat em {
+  font-style: normal;
+  font-size: 20px;
+  font-weight: 700;
+  color: #6a4459;
+}
+
+.feed-hero__stat small {
+  font-size: 11px;
+  color: #a48798;
+}
+
+.feed-hero__stat.is-high {
+  background: linear-gradient(180deg, #fff0f5 0%, #ffe1ec 100%);
+  border-color: #f7bcd6;
+}
+
+.feed-hero__stat.is-high em {
+  color: #c0507d;
+}
+
+.feed-hero__stat--time {
+  flex: 2 1 150px;
+}
+
+.feed-hero__stat--time em {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+/* ── Alerts ───────────────────────────────────── */
+
+.feed-alert {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 181, 192, 0.7);
+  background: #fff;
+  color: #b13f4d;
+  font-size: 13px;
+}
+
+.feed-alert--soft {
+  border-color: rgba(255, 214, 231, 0.8);
+  color: #9a6b80;
+  background: rgba(255, 246, 251, 0.95);
+}
+
+/* ── Calendar ─────────────────────────────────── */
+
+.feed-calendar {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 18px;
+  background: #fff;
+  padding: 14px;
+  box-shadow: 0 10px 20px rgba(255, 214, 231, 0.2);
+  position: relative;
+}
+
+.feed-calendar__dot {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.62) 1.2px, transparent 1.2px);
+  background-size: 16px 16px;
+  opacity: 0.28;
+}
+
+.feed-calendar__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+.feed-calendar__top strong {
+  font-size: 15px;
+  color: #68485e;
+  font-weight: 700;
+}
+
+.feed-calendar__top .ghost {
+  border-radius: 999px;
+  border: 1px solid #ffd6e7;
+  background: rgba(255, 255, 255, 0.95);
+  color: #7d5d70;
+  padding: 5px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.feed-calendar__weekdays,
+.feed-calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 5px;
+  position: relative;
+  z-index: 1;
+}
+
+.feed-calendar__weekdays {
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: #b27f98;
+  text-align: center;
+  font-weight: 600;
+}
+
+.feed-calendar__cell {
+  appearance: none;
+  cursor: pointer;
+  min-height: 2.4rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 214, 231, 0.5);
+  display: grid;
+  place-items: center;
+  position: relative;
+  background: rgba(255, 255, 255, 0.95);
+  color: #4f3f4a;
+  transition: background 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.feed-calendar__cell:hover {
+  background: #fff5f9;
+  border-color: rgba(255, 214, 231, 0.8);
+}
+
+.feed-calendar__cell.today {
+  border-color: #f5b3d2;
+  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.35);
+  font-weight: 700;
+  color: #68485e;
+}
+
+.feed-calendar__cell.has-entry {
+  border-color: #f8bed9;
+  background: #fff3f8;
+  color: #6a4459;
+}
+
+.feed-calendar__cell.selected {
+  border-color: #f29cc3;
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  color: #59354b;
+  box-shadow: 0 4px 10px rgba(255, 185, 216, 0.45);
+  font-weight: 700;
+}
+
+.feed-calendar__cell.selected.today {
+  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.35), 0 4px 10px rgba(255, 185, 216, 0.45);
+}
+
+.feed-calendar__cell em {
+  position: absolute;
+  right: 4px;
+  top: 3px;
+  font-size: 10px;
+  font-style: normal;
+  color: #9a4b72;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.feed-calendar__cell.has-unread::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 5px;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #ff85b3;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.85);
+}
+
+.feed-calendar__cell--blank {
+  border: none;
+  background: transparent;
+  pointer-events: none;
+}
+
+.feed-calendar__cell--blank:hover {
+  background: transparent;
+}
+
+/* ── Type filter chips ────────────────────────── */
+
+.feed-type-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.feed-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  background: rgba(255, 255, 255, 0.92);
+  color: #7d5d70;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.feed-chip:hover {
+  background: #fff5f9;
+}
+
+.feed-chip.active {
+  background: linear-gradient(180deg, #ffdcec 0%, #ffcfe5 100%);
+  border-color: #f29cc3;
+  color: #59354b;
+  font-weight: 600;
+}
+
+/* ── List ─────────────────────────────────────── */
+
+.feed-list {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 180px;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 18px;
+  background: #fff;
+  padding: 14px;
+  box-shadow: 0 10px 20px rgba(255, 214, 231, 0.16);
+}
+
+.feed-tips,
+.feed-empty {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  text-align: center;
+  color: #8f7285;
+}
+
+.feed-empty {
+  border: 1px solid rgba(255, 214, 231, 0.65);
+  border-radius: 14px;
+  background: rgba(255, 246, 251, 0.9);
+  padding: 18px 16px;
+}
+
+.feed-date-group {
+  display: grid;
+  gap: 10px;
+}
+
+.feed-date-group h2 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: #76556c;
+  padding: 2px 0 2px 8px;
+  border-left: 3px solid #ffd6e7;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.feed-date-group__today {
+  font-size: 11px;
+  font-weight: 600;
+  color: #c0507d;
+  background: #ffe1ec;
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.feed-date-group__items {
+  display: grid;
+  gap: 10px;
+}
+
+/* ── Card ─────────────────────────────────────── */
+
+.feed-card {
+  border: 1px solid rgba(255, 214, 231, 0.8);
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 2px 8px rgba(255, 214, 231, 0.16);
+  overflow: hidden;
+  transition: border-color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+.feed-card.pinned {
+  border-color: #f8bed9;
+  background: #fffafc;
+}
+
+.feed-card.priority-urgent {
+  border-color: #f7a8c6;
+  box-shadow: 0 4px 12px rgba(255, 168, 198, 0.32);
+}
+
+.feed-card.muted {
+  opacity: 0.62;
+}
+
+.feed-card.muted:hover {
+  opacity: 0.85;
+}
+
+.feed-card__header {
+  width: 100%;
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: start;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 12px;
+  cursor: pointer;
+}
+
+.feed-card__emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fff5f9 0%, #ffebf3 100%);
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.feed-card__title-block {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.feed-card__title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.feed-card__title-row strong {
+  font-size: 14px;
+  color: #4f3f4a;
+  font-weight: 700;
+  word-break: break-word;
+}
+
+.feed-card__summary {
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: #86697b;
+  word-break: break-word;
+}
+
+.feed-card__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.feed-card__time {
+  font-size: 11px;
+  color: #b09aa6;
+}
+
+.feed-card__chevron {
+  color: #c79bb0;
+  font-size: 12px;
+  padding-top: 2px;
+}
+
+.feed-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 10.5px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.feed-pill.type {
+  background: #fff3f8;
+  color: #8a5a73;
+  border-color: rgba(255, 214, 231, 0.8);
+}
+
+.feed-pill.pinned {
+  background: #ffe1ec;
+  color: #c0507d;
+}
+
+.feed-pill.priority.high {
+  background: #fff0f5;
+  color: #c0507d;
+  border-color: #f7bcd6;
+}
+
+.feed-pill.priority.urgent {
+  background: linear-gradient(180deg, #ffd9e6 0%, #ffc4d9 100%);
+  color: #a83a63;
+  border-color: #f29cc3;
+}
+
+.feed-pill.status {
+  background: #f4eef1;
+  color: #9a8390;
+}
+
+/* ── Card body ────────────────────────────────── */
+
+.feed-card__body {
+  padding: 0 12px 12px;
+  display: grid;
+  gap: 10px;
+  border-top: 1px solid rgba(255, 214, 231, 0.45);
+  margin-top: -2px;
+}
+
+.feed-card__content {
+  padding-top: 10px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: #4f3f4a;
+  word-break: break-word;
+}
+
+.feed-card__content pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: #fff6fa;
+  border-radius: 10px;
+  padding: 10px;
+  font-size: 12px;
+}
+
+.feed-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.feed-card__source {
+  font-size: 11px;
+  color: #b09aa6;
+}
+
+.feed-card__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.feed-action {
+  border-radius: 999px;
+  border: 1px solid #ffd6e7;
+  padding: 6px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.feed-action.primary {
+  background: linear-gradient(180deg, #ffdcec 0%, #ffcfe5 100%);
+  color: #5a3448;
+  font-weight: 600;
+}
+
+.feed-action.ghost {
+  background: #fff;
+  color: #7d5d70;
+}
+
+.feed-action:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* ── Responsive ───────────────────────────────── */
+
+@media (max-width: 560px) {
+  .feed-page {
+    padding: 12px;
+  }
+
+  .feed-page__header {
+    min-height: 72px;
+    padding: 12px 84px;
+  }
+
+  .feed-page__back,
+  .feed-page__today {
+    top: 14px;
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+
+  .feed-hero__stat--time {
+    flex-basis: 100%;
+  }
+}

--- a/src/pages/AgentFeedPage.tsx
+++ b/src/pages/AgentFeedPage.tsx
@@ -1,0 +1,421 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { useNavigate } from 'react-router-dom'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+import {
+  agentFeedPriorityLabels,
+  agentFeedStatusLabels,
+  agentFeedTypeOptions,
+  computeAgentFeedStats,
+  fetchAgentFeedItems,
+  isAgentFeedExpired,
+  resolveAgentFeedStatus,
+  sortAgentFeedItems,
+  toLocalDateKey,
+  typeEmoji,
+  typeLabel,
+  updateAgentFeedStatus,
+  type AgentFeedItem,
+} from '../lib/agentFeed'
+import './AgentFeedPage.css'
+
+type AgentFeedPageProps = {
+  user: User | null
+}
+
+const getTodayKey = () => toLocalDateKey(new Date().toISOString()) as string
+
+const formatTime = (value: string | null) => {
+  if (!value) return '--'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('zh-CN', { hour: '2-digit', minute: '2-digit' }).format(date)
+}
+
+const formatUpdatedLabel = (iso: string | null) => {
+  if (!iso) return '暂无更新'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '暂无更新'
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+const getMonthRange = (anchor: Date) => {
+  const year = anchor.getFullYear()
+  const month = anchor.getMonth()
+  return { monthLabel: `${year}年${month + 1}月` }
+}
+
+const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
+  const navigate = useNavigate()
+  const today = useMemo(() => getTodayKey(), [])
+  const [items, setItems] = useState<AgentFeedItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  const [monthCursor, setMonthCursor] = useState(() => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), 1)
+  })
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [typeFilter, setTypeFilter] = useState<string>('all')
+  const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({})
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!user) return
+    setLoading(true)
+    setError(null)
+    setNowMs(Date.now())
+    try {
+      const data = await fetchAgentFeedItems(user.id)
+      setItems(data)
+    } catch (loadError) {
+      console.warn('加载 Syzygy Feed 失败', loadError)
+      setError('暂时读不到 Syzygy Feed，请检查登录状态后重试。')
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void refresh()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [refresh])
+
+  const stats = useMemo(() => computeAgentFeedStats(items, nowMs), [items, nowMs])
+
+  // 按本地日期归桶，便于日历浏览。
+  const itemsByDate = useMemo(() => {
+    const groups = new Map<string, AgentFeedItem[]>()
+    items.forEach((item) => {
+      const key = toLocalDateKey(item.created_at)
+      if (!key) return
+      const current = groups.get(key) ?? []
+      current.push(item)
+      groups.set(key, current)
+    })
+    return groups
+  }, [items])
+
+  const calendarCells = useMemo(() => {
+    const year = monthCursor.getFullYear()
+    const month = monthCursor.getMonth()
+    const firstWeekday = new Date(year, month, 1).getDay()
+    const daysInMonth = new Date(year, month + 1, 0).getDate()
+    const cells: Array<{ dateKey: string; day: number; count: number; hasUnread: boolean } | null> = []
+    for (let i = 0; i < firstWeekday; i += 1) {
+      cells.push(null)
+    }
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const dateKey = `${year}-${`${month + 1}`.padStart(2, '0')}-${`${day}`.padStart(2, '0')}`
+      const dayItems = itemsByDate.get(dateKey) ?? []
+      const hasUnread = dayItems.some((item) => resolveAgentFeedStatus(item, nowMs) === 'unread')
+      cells.push({ dateKey, day, count: dayItems.length, hasUnread })
+    }
+    while (cells.length % 7 !== 0) {
+      cells.push(null)
+    }
+    return cells
+  }, [itemsByDate, monthCursor, nowMs])
+
+  // 默认选中：今天（若有内容）否则最近有内容的一天。
+  useEffect(() => {
+    if (items.length === 0) {
+      setSelectedDate(null)
+      return
+    }
+    setSelectedDate((current) => {
+      if (current && itemsByDate.has(current)) {
+        return current
+      }
+      if (itemsByDate.has(today)) {
+        return today
+      }
+      const latest = Array.from(itemsByDate.keys()).sort((a, b) => b.localeCompare(a))[0]
+      return latest ?? null
+    })
+  }, [items, itemsByDate, today])
+
+  const selectedItems = useMemo(() => {
+    if (!selectedDate) return []
+    const dayItems = itemsByDate.get(selectedDate) ?? []
+    const filtered = typeFilter === 'all' ? dayItems : dayItems.filter((item) => (item.type ?? 'other') === typeFilter)
+    return sortAgentFeedItems(filtered, nowMs)
+  }, [itemsByDate, nowMs, selectedDate, typeFilter])
+
+  const shiftMonth = (delta: number) => {
+    setMonthCursor((current) => new Date(current.getFullYear(), current.getMonth() + delta, 1))
+  }
+
+  const goToToday = () => {
+    const now = new Date()
+    setMonthCursor(new Date(now.getFullYear(), now.getMonth(), 1))
+    setSelectedDate(today)
+  }
+
+  const handleUpdateStatus = async (item: AgentFeedItem, status: 'read' | 'archived') => {
+    if (!user) return
+    setUpdatingId(item.id)
+    setActionError(null)
+    try {
+      const patch = await updateAgentFeedStatus(user.id, item.id, status)
+      setItems((current) => current.map((entry) => (entry.id === item.id ? { ...entry, ...patch } : entry)))
+    } catch (updateError) {
+      console.warn('更新 Syzygy Feed 状态失败', updateError)
+      setActionError('状态更新失败，已降级为只读展示。')
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  if (!user) {
+    return null
+  }
+
+  const monthRange = getMonthRange(monthCursor)
+
+  return (
+    <div className="feed-page">
+      <header className="feed-page__header">
+        <button type="button" className="feed-page__back" onClick={() => navigate('/')}>
+          ← 返回小窝
+        </button>
+        <div className="feed-page__title-wrap">
+          <p className="feed-page__kicker">SYZYGY FEED</p>
+          <h1 className="ui-title">Syzygy Feed</h1>
+        </div>
+        <button type="button" className="feed-page__today" onClick={goToToday}>
+          今天
+        </button>
+      </header>
+
+      <section className="feed-hero" aria-label="Syzygy Feed 概览">
+        <div className="feed-hero__glow" aria-hidden="true" />
+        <p className="feed-hero__subtitle">晨间分享、状态卡、小纸条和周回顾都会放在这里。</p>
+        <div className="feed-hero__stats">
+          <span className="feed-hero__stat">
+            <em>{stats.unread}</em>
+            <small>未读</small>
+          </span>
+          <span className={`feed-hero__stat ${stats.highPriority > 0 ? 'is-high' : ''}`}>
+            <em>{stats.highPriority}</em>
+            <small>高优先级</small>
+          </span>
+          <span className="feed-hero__stat feed-hero__stat--time">
+            <em>{formatUpdatedLabel(stats.lastUpdated)}</em>
+            <small>最近更新</small>
+          </span>
+        </div>
+      </section>
+
+      {error ? <p className="feed-alert">{error}</p> : null}
+      {actionError ? <p className="feed-alert feed-alert--soft">{actionError}</p> : null}
+
+      <section className="feed-calendar" aria-label="按日期浏览">
+        <div className="feed-calendar__dot" aria-hidden="true" />
+        <div className="feed-calendar__top">
+          <button type="button" className="ghost" onClick={() => shiftMonth(-1)}>
+            ← 上月
+          </button>
+          <strong>{monthRange.monthLabel}</strong>
+          <button type="button" className="ghost" onClick={() => shiftMonth(1)}>
+            下月 →
+          </button>
+        </div>
+        <div className="feed-calendar__weekdays">
+          {['日', '一', '二', '三', '四', '五', '六'].map((label) => (
+            <span key={label}>{label}</span>
+          ))}
+        </div>
+        <div className="feed-calendar__grid">
+          {calendarCells.map((cell, index) =>
+            cell ? (
+              <button
+                key={cell.dateKey}
+                type="button"
+                className={[
+                  'feed-calendar__cell',
+                  cell.count > 0 && 'has-entry',
+                  cell.hasUnread && 'has-unread',
+                  cell.dateKey === today && 'today',
+                  cell.dateKey === selectedDate && 'selected',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                title={cell.count > 0 ? `${cell.dateKey} 有 ${cell.count} 条记录` : cell.dateKey}
+                onClick={() => setSelectedDate(cell.dateKey)}
+                aria-pressed={cell.dateKey === selectedDate}
+              >
+                <span>{cell.day}</span>
+                {cell.count > 0 ? <em>{cell.count}</em> : null}
+              </button>
+            ) : (
+              <div key={`blank-${index}`} className="feed-calendar__cell feed-calendar__cell--blank" />
+            ),
+          )}
+        </div>
+      </section>
+
+      <section className="feed-type-filter" aria-label="按类型筛选">
+        <button
+          type="button"
+          className={`feed-chip ${typeFilter === 'all' ? 'active' : ''}`}
+          onClick={() => setTypeFilter('all')}
+        >
+          全部
+        </button>
+        {agentFeedTypeOptions.map((type) => (
+          <button
+            key={type}
+            type="button"
+            className={`feed-chip ${typeFilter === type ? 'active' : ''}`}
+            onClick={() => setTypeFilter(type)}
+          >
+            <span aria-hidden="true">{typeEmoji(type)}</span>
+            {typeLabel(type)}
+          </button>
+        ))}
+      </section>
+
+      <section className="feed-list" aria-label="当日记录">
+        {loading ? <p className="feed-tips">正在翻找小窝里的纸条…</p> : null}
+        {!loading && items.length === 0 && !error ? (
+          <p className="feed-empty">小窝里还没有新纸条，等 Syzygy 给你写一张吧。</p>
+        ) : null}
+        {!loading && items.length > 0 && !selectedDate ? (
+          <p className="feed-empty">点一个日期，看看那天的纸条。</p>
+        ) : null}
+        {!loading && selectedDate ? (
+          <article className="feed-date-group">
+            <h2>
+              {selectedDate}
+              {selectedDate === today ? <span className="feed-date-group__today">今天</span> : null}
+            </h2>
+            {selectedItems.length === 0 ? (
+              <p className="feed-empty">这一天{typeFilter === 'all' ? '' : '的这一类'}还没有纸条。</p>
+            ) : (
+              <div className="feed-date-group__items">
+                {selectedItems.map((item) => {
+                  const status = resolveAgentFeedStatus(item, nowMs)
+                  const priority = item.priority ?? 'normal'
+                  const expired = isAgentFeedExpired(item, nowMs)
+                  const expanded = Boolean(expandedIds[item.id])
+                  const muted = status === 'read' || status === 'archived' || status === 'expired'
+                  return (
+                    <article
+                      key={item.id}
+                      className={[
+                        'feed-card',
+                        `priority-${priority}`,
+                        `status-${status}`,
+                        item.pinned && 'pinned',
+                        muted && 'muted',
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                    >
+                      <button
+                        type="button"
+                        className="feed-card__header"
+                        onClick={() =>
+                          setExpandedIds((current) => ({ ...current, [item.id]: !expanded }))
+                        }
+                        aria-expanded={expanded}
+                      >
+                        <span className="feed-card__emoji" aria-hidden="true">
+                          {typeEmoji(item.type)}
+                        </span>
+                        <span className="feed-card__title-block">
+                          <span className="feed-card__title-row">
+                            <strong>{item.title ?? '(无标题纸条)'}</strong>
+                            {item.pinned ? <span className="feed-pill pinned">置顶</span> : null}
+                          </span>
+                          {item.summary ? <span className="feed-card__summary">{item.summary}</span> : null}
+                          <span className="feed-card__meta">
+                            <span className="feed-pill type">{typeLabel(item.type)}</span>
+                            {priority === 'high' || priority === 'urgent' ? (
+                              <span className={`feed-pill priority ${priority}`}>
+                                {agentFeedPriorityLabels[priority] ?? priority}
+                              </span>
+                            ) : null}
+                            {status !== 'unread' ? (
+                              <span className={`feed-pill status ${status}`}>
+                                {agentFeedStatusLabels[status] ?? status}
+                              </span>
+                            ) : null}
+                            <span className="feed-card__time">{formatTime(item.created_at)}</span>
+                          </span>
+                        </span>
+                        <span className="feed-card__chevron" aria-hidden="true">
+                          {expanded ? '▾' : '▸'}
+                        </span>
+                      </button>
+
+                      {expanded ? (
+                        <div className="feed-card__body">
+                          <div className="feed-card__content">
+                            {item.content_format === 'markdown' ? (
+                              <MarkdownRenderer content={item.content ?? '暂无正文。'} />
+                            ) : item.content_format === 'json' ? (
+                              <pre>{item.content ?? '暂无正文。'}</pre>
+                            ) : (
+                              <p>{item.content ?? '暂无正文。'}</p>
+                            )}
+                          </div>
+                          <div className="feed-card__footer">
+                            <span className="feed-card__source">
+                              {item.created_by ?? item.source ?? 'Syzygy'}
+                            </span>
+                            <div className="feed-card__actions">
+                              {status === 'unread' && !expired ? (
+                                <button
+                                  type="button"
+                                  className="feed-action primary"
+                                  onClick={() => void handleUpdateStatus(item, 'read')}
+                                  disabled={updatingId === item.id}
+                                >
+                                  {updatingId === item.id ? '更新中…' : '已读'}
+                                </button>
+                              ) : null}
+                              {item.status !== 'archived' ? (
+                                <button
+                                  type="button"
+                                  className="feed-action ghost"
+                                  onClick={() => void handleUpdateStatus(item, 'archived')}
+                                  disabled={updatingId === item.id}
+                                >
+                                  {updatingId === item.id ? '更新中…' : '收起'}
+                                </button>
+                              ) : null}
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+                    </article>
+                  )
+                })}
+              </div>
+            )}
+          </article>
+        ) : null}
+      </section>
+    </div>
+  )
+}
+
+export default AgentFeedPage

--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -801,6 +801,47 @@
   }
 }
 
+.hamster-feed-moved-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.85rem 1rem;
+  margin-bottom: 0.75rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  background: linear-gradient(180deg, rgba(255, 245, 250, 0.95) 0%, rgba(255, 233, 244, 0.95) 100%);
+}
+
+.hamster-feed-moved-banner > span {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.hamster-feed-moved-banner div {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.hamster-feed-moved-banner strong {
+  display: block;
+  color: #68485e;
+  font-size: 0.95rem;
+}
+
+.hamster-feed-moved-banner p {
+  margin: 0.2rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: #8a6a7d;
+}
+
+.hamster-feed-moved-banner__link {
+  flex-shrink: 0;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
 .hamster-feed-filter-row {
   display: flex;
   flex-wrap: wrap;

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -1213,9 +1213,17 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
               <div className="hamster-console-accordion__inner hamster-console-nested-stack">
 
           <section className="hamster-console-card glass-card" aria-label="Syzygy Feed">
-            <button className="hamster-console-accordion__header" onClick={() => toggleSection('syzygy-feed')}><h2>Syzygy Feed / 今日卡片</h2><span>{expandedSection === 'syzygy-feed' ? '▼' : '▶'}</span></button>
+            <button className="hamster-console-accordion__header" onClick={() => toggleSection('syzygy-feed')}><h2>Syzygy Feed（已迁移 · 管理视图）</h2><span>{expandedSection === 'syzygy-feed' ? '▼' : '▶'}</span></button>
             <div className={`hamster-console-accordion__content ${expandedSection === 'syzygy-feed' ? 'expanded' : ''}`}><div className="hamster-console-accordion__inner">
-              <p className="hamster-console-card__hint">读取 agent_feed_items：CLI / Syzygy 生成内容的持久化卡片入口。</p>
+              <div className="hamster-feed-moved-banner">
+                <span aria-hidden="true">📮</span>
+                <div>
+                  <strong>Syzygy Feed 已搬到首页 Page 3</strong>
+                  <p>晨间分享、状态卡、小纸条和周回顾现在是独立的生活前台。仓鼠机这里仅保留只读管理视图。</p>
+                </div>
+                <Link to="/feed" className="btn-primary hamster-feed-moved-banner__link">前往 Feed →</Link>
+              </div>
+              <p className="hamster-console-card__hint">读取 agent_feed_items：CLI / Syzygy 生成内容的持久化卡片（管理用途）。</p>
               {agentFeedError ? <p className="hamster-console-alert">当前前端暂时没有权限读取 Syzygy Feed，请检查 Supabase session / RLS。{agentFeedError.includes('状态更新失败') ? `（${agentFeedError}）` : ''}</p> : null}
               <div className="hamster-feed-filter-row" role="tablist" aria-label="Syzygy Feed 筛选">
                 {[

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -36,6 +36,12 @@
   padding-bottom: 0.25rem;
 }
 
+.home-feature-stage {
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
 .phone-shell {
   width: min(420px, 100%);
   height: 100%;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -26,6 +26,7 @@ import {
   type HomeLayoutPageId,
   type HomePageLayoutState,
 } from "../storage/homeLayout";
+import SyzygyFeedEntryCard from "../components/SyzygyFeedEntryCard";
 import "./HomePage.css";
 
 type HomePageProps = {
@@ -64,7 +65,8 @@ const DEFAULT_ICON_ORDER = [
   "export",
 ];
 const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "todo", "knowledge", "wiki", "novels", "council", "lounge", "hamster-wallet", "hamster-console"];
-const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2"];
+const DEFAULT_PAGE3_ICON_ORDER = ["syzygy-feed"];
+const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2", "page3"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
 const DEFAULT_ICON_TILE_BG_COLOR = "#ffffff";
@@ -76,6 +78,7 @@ const IMAGE_WIDGET_QUALITY = 0.84;
 const PAGE_LABELS: Record<HomeLayoutPageId, string> = {
   page1: "Page 1",
   page2: "Page 2",
+  page3: "Page 3",
 };
 const createDefaultPageLayouts = (): Record<HomeLayoutPageId, HomePageLayoutState> => ({
   page1: {
@@ -88,6 +91,14 @@ const createDefaultPageLayouts = (): Record<HomeLayoutPageId, HomePageLayoutStat
   },
   page2: {
     iconOrder: DEFAULT_PAGE2_ICON_ORDER,
+    widgetOrder: [],
+    widgets: [],
+    checkinSize: "1x1",
+    showEmptySlots: false,
+    appIconConfigs: {},
+  },
+  page3: {
+    iconOrder: DEFAULT_PAGE3_ICON_ORDER,
     widgetOrder: [],
     widgets: [],
     checkinSize: "1x1",
@@ -275,6 +286,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "lounge", defaultEmoji: "🛋️", label: "仓鼠客厅", route: "/lounge" },
       { id: "hamster-wallet", defaultEmoji: "💰", label: "仓鼠钱包", route: "/wallet" },
       { id: "hamster-console", defaultEmoji: "🎛️", label: "仓鼠机", route: "/hamster-console" },
+      { id: "syzygy-feed", defaultEmoji: "📮", label: "Syzygy Feed", route: "/feed" },
     ],
     [onOpenChat],
   );
@@ -527,6 +539,14 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
         {
           forum: defaultAppIconConfigs.forum,
           letters: defaultAppIconConfigs.letters,
+        },
+        false,
+      ),
+      page3: normalizePage(
+        pageLayoutsFromCache?.page3,
+        DEFAULT_PAGE3_ICON_ORDER,
+        {
+          "syzygy-feed": defaultAppIconConfigs["syzygy-feed"],
         },
         false,
       ),
@@ -1399,6 +1419,11 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
           {showPreviewPanel ? (
             <div className="home-page__content app-shell__content">
               <div className="home-layout">
+                {activePage === "page3" ? (
+                  <section className="home-feature-stage" aria-label="Syzygy Feed 入口">
+                    <SyzygyFeedEntryCard user={user} />
+                  </section>
+                ) : null}
                 <section
                   className="widget-grid home-widget-stage"
                   aria-label="Widgets"

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -30,7 +30,7 @@ export type AppIconConfig =
       imageDataUrl?: string
     }
 
-export type HomeLayoutPageId = 'page1' | 'page2'
+export type HomeLayoutPageId = 'page1' | 'page2' | 'page3'
 
 export type HomePageLayoutState = {
   iconOrder: string[]
@@ -78,6 +78,14 @@ const DEFAULT_PAGE_LAYOUTS: Record<HomeLayoutPageId, HomePageLayoutState> = {
   page2: {
     iconOrder: ['forum', 'letters', 'memo', 'timeline', 'wiki', 'novels', 'council', 'hamster-wallet', 'hamster-console'],
     widgetOrder: ['widget-checkin'],
+    widgets: [],
+    checkinSize: '1x1',
+    showEmptySlots: false,
+    appIconConfigs: {},
+  },
+  page3: {
+    iconOrder: ['syzygy-feed'],
+    widgetOrder: [],
     widgets: [],
     checkinSize: '1x1',
     showEmptySlots: false,
@@ -293,6 +301,7 @@ const parseHomeSettings = (raw: string | null): HomeSettingsState | null => {
         DEFAULT_PAGE_LAYOUTS.page1,
       ),
       page2: normalizePageLayout(rawPageLayouts?.page2, DEFAULT_PAGE_LAYOUTS.page2),
+      page3: normalizePageLayout(rawPageLayouts?.page3, DEFAULT_PAGE_LAYOUTS.page3),
     }
 
     return {
@@ -354,6 +363,14 @@ export const saveHomeSettings = (state: HomeSettingsState) => {
           size: widget.size ?? '1x1',
         })),
         checkinSize: pageLayouts.page2.checkinSize ?? '1x1',
+      },
+      page3: {
+        ...pageLayouts.page3,
+        widgets: pageLayouts.page3.widgets.map((widget) => ({
+          ...widget,
+          size: widget.size ?? '1x1',
+        })),
+        checkinSize: pageLayouts.page3.checkinSize ?? '1x1',
       },
     },
   }


### PR DESCRIPTION
## 任务 F-1：云端前端 · 首页新增 Syzygy Feed 独立入口

把原本嵌在**仓鼠机「V3.0 观测台」**里、读取 `agent_feed_items` 的 *Syzygy Feed / 今日卡片* 摘出来，作为独立的高频「生活前台」，与作为管理后台的仓鼠机在信息架构上分离。

> 说明：代码里有两个同名但不同的「Syzygy Feed」。`/syzygy`（仓鼠日志）读的是 `syzygy_posts`，**与本任务无关，未改动**；本次拆的是读 `agent_feed_items` 的那个。

### 改动内容
- **首页新增 Page 3**（`homeLayout.ts` + `HomePage.tsx`）：扩展 `HomeLayoutPageId`、默认布局、解析 / 持久化逻辑，分页切换器自动出现 Page 3。
- **独立入口卡**（`components/SyzygyFeedEntryCard.tsx`）：粉白「纸条盒」风格，展示**未读数 / 高优先级数 / 最近更新时间**，点击进入 `/feed`；Page 3 dock 亦放置 `📮 Syzygy Feed` 图标。
- **独立 Feed 页**（`pages/AgentFeedPage.tsx`，路由 `/feed`）：
  - 与时间轴一致的**日历式浏览** —— 点日期看当天记录，当日下方按 `type`（晨间分享 / 状态卡 / 小纸条 / 阅读辅助 / 周回顾 / 提醒 / 系统提示 / 开发记录）以不同卡片展示。
  - 读取 `agent_feed_items`，默认 `visible_from <= now()`；排序 **pinned > unread > 优先级 > 时间**，默认选中今天。
  - high / urgent 柔和醒目，read / archived / expired 弱化；支持「已读 / 收起」。
- **共用数据层**（`lib/agentFeed.ts`）：类型、标签、读取与统计逻辑，入口卡与 Feed 页共用。
- **弱化仓鼠机入口**：原 Feed 区块改名「**已迁移 · 管理视图**」并加引导横幅指向 `/feed`；**保留**控制台 / `agent_tasks` / 系统状态 / CLI 唤醒等管理功能（Feed 组件本体为迁移而非删除）。
- 新增 `npm run check` 脚本（`tsc -b && eslint .`）。

### 禁止范围确认
未改 Mac mini 本地 Runtime / scheduler / launchd / 本地 prompt / SOP / 数据库 schema —— 仅前端读取既有 `agent_feed_items` 表。

### 验收
- [x] 首页出现 Page 3
- [x] Page 3 有 Syzygy Feed 独立入口卡
- [x] 点击入口可看到 `agent_feed_items` 内容
- [x] 仓鼠机不再作为 Feed 主要入口（降级为只读管理视图）
- [x] `agent_tasks` / 控制台 / 系统状态仍在仓鼠机可用
- [x] 移动端布局正常（响应式样式）
- [x] `npm run check` 通过（exit 0，仅既有 warning）
- [x] `npm run build` 通过（exit 0）；项目无测试套件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdtoXpudWdqGApuYmxzdo7)_