### PR TITLE
feat(wechat): 微信侧接入 Hamster-mcp，按需读取 Syzygy Feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,27 @@ Syzygy与串串的仓鼠小家 🐹
 `hamster-mcp` 的鉴权为双通道，任一通过即放行：前端带 Supabase 用户 JWT
 （`Authorization` + `apikey` header）；Claude/GPT 等外部 connector 走 URL query
 密钥 `?key=…`（对应服务端 env `HAMSTER_MCP_KEY`，未配置时该通道关闭）。
+
+## 微信侧 Syzygy Feed 按需读取（Hamster-mcp）
+
+微信侧 Syzygy 接入 Hamster-mcp，可以在需要时按需读取「仓鼠小窝」的 Syzygy Feed，
+而**不是**每轮自动注入。微信侧仍保留最近 3 天 TIMELINE + 最近 3 天 TO DO + 囤囤库
+注入逻辑；Feed 只作为可主动调用的 MCP 能力存在，不影响普通聊天速度。
+
+- **行为规则**写在 `prompt_templates` 的 `wechat_syzygy_feed` 模板里（位置：
+  仓鼠机 → 微信API配置 → Prompt编辑器），随其它 `active` 模板一起拼进系统提示。
+  规则要点：不每轮自动读；只有每天首次主动联系、晨间主动联系 / 随机唤醒，或串串提到
+  「小窝 / Feed / 小纸条 / 周回顾 / 阅读辅助」等语境时才看一眼；没有就不编造；
+  长内容先摘要，要全文再读 detail；`pending_wechat_messages` 是微信提醒发件箱、
+  不是内容来源。该模板由迁移
+  `supabase/migrations/20260621120000_seed_wechat_syzygy_feed_prompt.sql` 幂等播种。
+- **Feed 读取工具**由 `hamster-mcp` 暴露（只读，已部署）：
+  - `get_today_syzygy_feed` —— 今天的 Feed 摘要
+  - `get_syzygy_feed_by_type` —— 按类型（`morning_share` / `syzygy_note` /
+    `reading_assist` / `weekly_card` / `daily_card` …）
+  - `get_recent_syzygy_feed` —— 最近 N 天的摘要
+  - `get_syzygy_feed_detail` —— 按 `id` 读完整正文
+- 微信侧模型需把 `hamster-mcp` 接入为工具源（同上文鉴权方式，外部走 `?key=…`），
+  即可拿到上述 Feed 工具。
+- Feed 内容来自 `agent_feed_items`，完整、稳定的展示处是仓鼠窝首页的 Syzygy Feed
+  （Page 3）。

--- a/supabase/migrations/20260621120000_seed_wechat_syzygy_feed_prompt.sql
+++ b/supabase/migrations/20260621120000_seed_wechat_syzygy_feed_prompt.sql
@@ -1,0 +1,56 @@
+-- Seed the WeChat-side "Syzygy 小窝 Feed（按需查看）" prompt template.
+--
+-- 这条 prompt 引导 Syzygy 在需要时通过 Hamster-mcp 按需读取 agent_feed_items
+-- (get_today_syzygy_feed / get_syzygy_feed_by_type / get_recent_syzygy_feed /
+-- get_syzygy_feed_detail)，而不是每轮自动把 Feed 注入上下文。
+-- 放置位置：仓鼠机 → 微信API配置 → Prompt编辑器（prompt_templates，category=style）。
+-- 微信侧仍保留最近 3 天 TIMELINE + 最近 3 天 TO DO + 囤囤库注入，本条只是新增一个
+-- 可主动调用的能力层，按用户配置「拼接所有 active 模板」的方式参与系统提示。
+--
+-- 幂等：重复执行会刷新内容。prompt_templates 表由仓库外的环境创建，
+-- 因此当表不存在时本迁移直接跳过，避免在全新库上失败。
+
+do $$
+begin
+  if to_regclass('public.prompt_templates') is null then
+    raise notice 'prompt_templates table not found; skipping wechat_syzygy_feed seed';
+    return;
+  end if;
+
+  insert into public.prompt_templates (user_id, name, category, content, version, active)
+  values (
+    '94dd24be-e136-45bb-836b-6820c09c4292',
+    'wechat_syzygy_feed',
+    'style',
+    $prompt$# Syzygy 小窝 Feed（按需查看，别每轮自动读）
+
+你接入了 Hamster-mcp，可以在需要时查看「仓鼠小窝」的 Syzygy Feed —— 那是你和各端自己生成、沉淀下来的卡片：晨间分享(morning_share)、小纸条(syzygy_note)、阅读辅助(reading_assist)、每日卡片(daily_card)、周回顾(weekly_card) 等。你这边已经常驻注入了最近 3 天的 TIMELINE、最近 3 天的 TO DO 和囤囤库，所以 Feed 不用每轮都翻，它只是一个你可以主动调用的能力，别让它拖慢普通聊天。
+
+## 什么时候看一眼
+- 每天第一次主动联系串串时，可以先瞄一眼今天的 Feed。
+- 晨间主动联系、随机唤醒、日常关心这类时刻，语境合适就看。
+- 串串提到「小窝 / Feed / 今天 / 早上 / 小纸条 / 阅读辅助 / 周回顾」之类时，主动去查。
+- 其余普通闲聊不用查；同一段对话里看过一次就够了，别反复翻。
+
+## 用哪个工具
+- get_today_syzygy_feed：今天的 Feed 摘要列表（默认就够用）。
+- get_syzygy_feed_by_type：按类型看，比如 morning_share / syzygy_note / reading_assist / weekly_card / daily_card。
+- get_recent_syzygy_feed：回看最近几天。
+- get_syzygy_feed_detail：串串想看某条全文时，再用它按 id 读详情。
+
+## 怎么提、怎么说
+- 今天若真有 morning_share / syzygy_note / reading_assist / daily_card 这类内容，可以自然带一句，比如「我看了眼小窝，今天有张卡片放在那儿」，再顺着聊。
+- 别机械播报数据库字段（id、status、created_at 这些不用念）。
+- 读到长内容先给摘要，别整段刷屏；串串要看全文时再用 detail 读出来。
+- 今天没有新 Feed 就自然略过，或说「今天小窝里还没有新卡片」——绝不编造内容。
+- pending_wechat_messages 只是微信提醒的发件箱，不是内容来源，别拿它当 Feed 读。
+- Feed 的完整稳定展示处是仓鼠窝首页的 Syzygy Feed，你读到的是同一批 agent_feed_items。$prompt$,
+    1,
+    true
+  )
+  on conflict (user_id, name, version) do update
+  set content = excluded.content,
+      category = excluded.category,
+      active = excluded.active,
+      updated_at = now();
+end $$;


### PR DESCRIPTION
## 目标

让微信侧 Syzygy 接入 Hamster-mcp，在需要时**按需**读取「仓鼠小窝」的 Syzygy Feed，而**不是**每轮自动注入。微信侧仍保留最近 3 天 TIMELINE + 最近 3 天 TO DO + 囤囤库全量注入；Feed 只作为可主动调用的 MCP 能力存在，不影响普通聊天速度。

## 改动

- **新增 prompt 模板 `wechat_syzygy_feed`**（`prompt_templates`，`category=style`，`active`，目标用户 `94dd24be…`）。
  - 位置：仓鼠机 → 微信API配置 → Prompt编辑器；随其它 `active` 模板一起拼进微信侧系统提示。
  - 规则要点（覆盖任务卡 9 条）：不每轮自动读；只在每天首次主动联系 / 晨间主动联系 / 随机唤醒，或串串提到「小窝 · Feed · 小纸条 · 周回顾 · 阅读辅助」等语境时看一眼；没有就不编造；不机械播报数据库字段；长内容先摘要、要全文再读 detail；`pending_wechat_messages` 是微信提醒发件箱、不是内容来源。
  - 通过幂等迁移 `supabase/migrations/20260621120000_seed_wechat_syzygy_feed_prompt.sql` 播种（表不存在时自动跳过）。该模板**已写入线上库**。
- **README** 新增「微信侧 Syzygy Feed 按需读取」章节，记录流程与所用只读工具。

## Feed 读取工具（已部署，未改动 edge function）

`hamster-mcp` 已暴露以下只读工具，本次未改动也未重新部署：

- `get_today_syzygy_feed` — 今天的 Feed 摘要
- `get_syzygy_feed_by_type` — 按类型（`morning_share` / `syzygy_note` / `reading_assist` / `weekly_card` / `daily_card` …）
- `get_recent_syzygy_feed` — 最近 N 天摘要
- `get_syzygy_feed_detail` — 按 `id` 读全文

## 验证

- `get_today_syzygy_feed` → 正常返回今天卡片（周回顾 + 晨间分享），**只给摘要、不含全文/归档/过期**。✓
- `get_syzygy_feed_by_type(syzygy_note)` → `[]`（今天没有），印证「没有就不编造」。✓

## 范围与约束

- ✅ 保留原有最近 3 天 TIMELINE + 最近 3 天 TO DO + 囤囤库注入逻辑。
- ✅ 未改 scheduler、未改 `agent_feed_items` schema、未新增自动注入 Context Builder。
- ✅ Feed 查询为按需调用，不影响普通聊天速度。

## 注意

1. 本 PR 依赖「微信 bot 拼接所有 `active` 模板」这一前提。若 bot 实际按固定名字选 style 模板（如只取 `wechat_reply_style`），需改为把规则并入 `wechat_reply_style`。
2. 仓库中的 `supabase/functions/hamster-mcp/index.ts` 仍落后于线上 v26（缺 Feed/阅读工具）。本 PR **故意未同步/重新部署**，因为线上已正常服务这些工具，从过期源码部署反而会抹掉它们。是否需要单独同步可后续决定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196sfFxf42AY2EKqS78xbUh

---
_Generated by [Claude Code](https://claude.ai/code/session_0196sfFxf42AY2EKqS78xbUh)_