### PR TITLE
revert(wechat): 移除微信侧 Hamster-mcp Feed 调用内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,27 +20,3 @@ Syzygy与串串的仓鼠小家 🐹
 `hamster-mcp` 的鉴权为双通道，任一通过即放行：前端带 Supabase 用户 JWT
 （`Authorization` + `apikey` header）；Claude/GPT 等外部 connector 走 URL query
 密钥 `?key=…`（对应服务端 env `HAMSTER_MCP_KEY`，未配置时该通道关闭）。
-
-## 微信侧 Syzygy Feed 按需读取（Hamster-mcp）
-
-微信侧 Syzygy 接入 Hamster-mcp，可以在需要时按需读取「仓鼠小窝」的 Syzygy Feed，
-而**不是**每轮自动注入。微信侧仍保留最近 3 天 TIMELINE + 最近 3 天 TO DO + 囤囤库
-注入逻辑；Feed 只作为可主动调用的 MCP 能力存在，不影响普通聊天速度。
-
-- **行为规则**写在 `prompt_templates` 的 `wechat_syzygy_feed` 模板里（位置：
-  仓鼠机 → 微信API配置 → Prompt编辑器），随其它 `active` 模板一起拼进系统提示。
-  规则要点：不每轮自动读；只有每天首次主动联系、晨间主动联系 / 随机唤醒，或串串提到
-  「小窝 / Feed / 小纸条 / 周回顾 / 阅读辅助」等语境时才看一眼；没有就不编造；
-  长内容先摘要，要全文再读 detail；`pending_wechat_messages` 是微信提醒发件箱、
-  不是内容来源。该模板由迁移
-  `supabase/migrations/20260621120000_seed_wechat_syzygy_feed_prompt.sql` 幂等播种。
-- **Feed 读取工具**由 `hamster-mcp` 暴露（只读，已部署）：
-  - `get_today_syzygy_feed` —— 今天的 Feed 摘要
-  - `get_syzygy_feed_by_type` —— 按类型（`morning_share` / `syzygy_note` /
-    `reading_assist` / `weekly_card` / `daily_card` …）
-  - `get_recent_syzygy_feed` —— 最近 N 天的摘要
-  - `get_syzygy_feed_detail` —— 按 `id` 读完整正文
-- 微信侧模型需把 `hamster-mcp` 接入为工具源（同上文鉴权方式，外部走 `?key=…`），
-  即可拿到上述 Feed 工具。
-- Feed 内容来自 `agent_feed_items`，完整、稳定的展示处是仓鼠窝首页的 Syzygy Feed
-  （Page 3）。

--- a/supabase/migrations/20260621140000_remove_wechat_syzygy_feed_prompt.sql
+++ b/supabase/migrations/20260621140000_remove_wechat_syzygy_feed_prompt.sql
@@ -1,0 +1,20 @@
+-- Remove the WeChat-side "Syzygy 小窝 Feed（按需查看）" prompt template.
+--
+-- 背景：测试确认当前微信 bot 提供方不支持 MCP / function calling，微信侧无法直接
+-- 调用 Hamster-mcp 读取 Syzygy Feed。因此撤回上一阶段在 prompt_templates 里播种的
+-- wechat_syzygy_feed 模板（见 20260621120000_seed_wechat_syzygy_feed_prompt.sql）。
+-- 后续微信侧改为在本地脚本的上下文构建逻辑里直接注入晨间分享文本，不接 MCP。
+--
+-- 幂等：模板不存在时为 no-op；prompt_templates 表不存在时直接跳过。
+
+do $$
+begin
+  if to_regclass('public.prompt_templates') is null then
+    raise notice 'prompt_templates table not found; skipping wechat_syzygy_feed removal';
+    return;
+  end if;
+
+  delete from public.prompt_templates
+  where user_id = '94dd24be-e136-45bb-836b-6820c09c4292'
+    and name = 'wechat_syzygy_feed';
+end $$;


### PR DESCRIPTION
## 背景

测试确认当前微信 bot 提供方**不支持 MCP / function calling**，微信侧无法直接调用 Hamster-mcp 读取 Syzygy Feed。后续微信侧晨间分享改由**本地脚本的上下文构建逻辑**直接注入文本（不接 MCP）——该本地脚本不在本仓库，故本 PR 不涉及它。

本 PR 撤回上一阶段（#426）在云端引入的微信侧 MCP 调用内容。

## 改动

- **移除 `prompt_templates` 的 `wechat_syzygy_feed` 模板**
  - 新增 append-only 迁移 `supabase/migrations/20260621140000_remove_wechat_syzygy_feed_prompt.sql`，幂等删除该模板（保留 #426 的播种迁移作为历史记录，符合迁移只追加的惯例）。
  - **线上库该行已同步删除**（已验证：用户的 `prompt_templates` 现仅剩 `syzygy_base` / `checkin_day` / `checkin_night` / `cli_reply_style` / `wechat_reply_style`）。
- **README** 移除「微信侧 Syzygy Feed 按需读取（Hamster-mcp）」章节（该能力已不适用，避免留下误导性文档）。

## 未触及

- 本地脚本的上下文构建逻辑（不在本仓库）。
- scheduler、`agent_feed_items` schema、`hamster-mcp` edge function 均未改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196sfFxf42AY2EKqS78xbUh

---
_Generated by [Claude Code](https://claude.ai/code/session_0196sfFxf42AY2EKqS78xbUh)_