### PR TITLE
仓鼠机移除迁移后的重复入口 + 议事厅议题支持删除

### DIFF
--- a/src/pages/AgentCouncilPage.css
+++ b/src/pages/AgentCouncilPage.css
@@ -19,9 +19,14 @@
 .council-error { color:#b13f4d; border-color:rgba(255,181,192,.7); }
 .council-empty { color:#8f7285; border-color:rgba(255,214,231,.65); background:rgba(255,246,251,.9); }
 .topic-list,.message-list,.council-form { display:grid; gap:8px; }
-.topic-item { text-align:left; border:1px solid rgba(255,214,231,.7); border-radius:12px; background:#fff7fb; padding:10px; display:grid; gap:4px; }
+.topic-item { display:flex; align-items:stretch; gap:8px; border:1px solid rgba(255,214,231,.7); border-radius:12px; background:#fff7fb; padding:6px 8px 6px 10px; }
 .topic-item.active { border-color:#f29cc3; background:linear-gradient(180deg,#ffdeec 0%,#ffcfe5 100%); }
-.topic-item span { color:#7d5d70; font-size:12px; }
+.topic-item__select { flex:1; min-width:0; text-align:left; border:none; background:transparent; padding:4px 0; display:grid; gap:4px; font:inherit; color:inherit; cursor:pointer; }
+.topic-item__select strong { word-break:break-word; }
+.topic-item__select span { color:#7d5d70; font-size:12px; }
+.topic-item__delete { align-self:center; flex-shrink:0; border-radius:999px; border:1px solid rgba(255,181,192,.7); background:#fff; color:#b13f4d; padding:5px 11px; font-size:12px; cursor:pointer; }
+.topic-item__delete:hover { background:#ffe8ec; }
+.topic-item__delete:disabled { opacity:.6; cursor:default; }
 .council-form input,.council-form textarea { width:100%; border:1px solid #ffd6e7; border-radius:12px; padding:9px 10px; font:inherit; background:#fff; color:#1f2937; }
 .council-form button { justify-self:end; border-radius:999px; border:1px solid #f3b8d4; background:linear-gradient(180deg,#ffeef6 0%,#ffe1ef 100%); color:#7d5d70; padding:7px 14px; }
 .message-item { border:1px solid rgba(255,214,231,.65); border-radius:12px; padding:10px; background:#fff8fb; }

--- a/src/pages/AgentCouncilPage.tsx
+++ b/src/pages/AgentCouncilPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { createAgentCouncilMessage, listAgentCouncilMessages } from '../storage/supabaseSync'
+import ConfirmDialog from '../components/ConfirmDialog'
+import { createAgentCouncilMessage, deleteAgentCouncilTopic, listAgentCouncilMessages } from '../storage/supabaseSync'
 import type { AgentCouncilMessage, AgentCouncilSpeaker } from '../types'
 import './AgentCouncilPage.css'
 
@@ -24,6 +25,8 @@ const AgentCouncilPage = () => {
   const [newTopic, setNewTopic] = useState('')
   const [newMessage, setNewMessage] = useState('')
   const [replyMessage, setReplyMessage] = useState('')
+  const [pendingDeleteTopic, setPendingDeleteTopic] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -119,6 +122,29 @@ const AgentCouncilPage = () => {
     }
   }
 
+  const handleConfirmDelete = async () => {
+    if (!pendingDeleteTopic) {
+      return
+    }
+    const topic = pendingDeleteTopic
+    setDeleting(true)
+    try {
+      await deleteAgentCouncilTopic(topic)
+      if (activeTopic === topic) {
+        setActiveTopic(null)
+      }
+      setPendingDeleteTopic(null)
+      setNotice('议题已删除')
+      setError(null)
+      await refresh()
+    } catch (deleteError) {
+      console.warn('删除议题失败', deleteError)
+      setError('删除议题失败，请稍后重试')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
   return (
     <div className="council-page">
       <header className="council-header">
@@ -139,15 +165,27 @@ const AgentCouncilPage = () => {
         {!loading && topicSummaries.length === 0 ? <p className="council-empty">暂时还没有议题。</p> : null}
         <div className="topic-list">
           {topicSummaries.map((summary) => (
-            <button
+            <div
               key={summary.topic}
-              type="button"
               className={`topic-item ${activeTopic === summary.topic ? 'active' : ''}`}
-              onClick={() => setActiveTopic(summary.topic)}
             >
-              <strong>{summary.topic}</strong>
-              <span>{SPEAKER_META[summary.latest.speaker].label} · {formatTime(summary.latest.createdAt)}</span>
-            </button>
+              <button
+                type="button"
+                className="topic-item__select"
+                onClick={() => setActiveTopic(summary.topic)}
+              >
+                <strong>{summary.topic}</strong>
+                <span>{SPEAKER_META[summary.latest.speaker].label} · {formatTime(summary.latest.createdAt)}</span>
+              </button>
+              <button
+                type="button"
+                className="topic-item__delete"
+                onClick={() => setPendingDeleteTopic(summary.topic)}
+                aria-label={`删除议题 ${summary.topic}`}
+              >
+                删除
+              </button>
+            </div>
           ))}
         </div>
       </section>
@@ -185,6 +223,18 @@ const AgentCouncilPage = () => {
           <p className="council-empty">请先从上方选择一个议题。</p>
         )}
       </section>
+
+      <ConfirmDialog
+        open={pendingDeleteTopic !== null}
+        title="删除议题"
+        description={pendingDeleteTopic ? `确定要删除议题「${pendingDeleteTopic}」吗？该议题下的全部发言都会一并删除，且无法恢复。` : undefined}
+        confirmLabel={deleting ? '删除中…' : '删除'}
+        cancelLabel="取消"
+        confirmDisabled={deleting}
+        cancelDisabled={deleting}
+        onConfirm={() => void handleConfirmDelete()}
+        onCancel={() => setPendingDeleteTopic(null)}
+      />
     </div>
   )
 }

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { Link } from 'react-router-dom'
-import MarkdownRenderer from '../components/MarkdownRenderer'
 import { supabase } from '../supabase/client'
 import './HamsterConsolePage.css'
 
@@ -128,47 +127,12 @@ type CapabilityRow = {
   failure_count: number | null
 }
 
-type WeeklyDigestRow = {
-  id: string
-  week_start: string | null
-  week_end: string | null
-  highlights: unknown
-  digest_text: string | null
-}
-
 type CodexControlRow = {
   id: string
   action: 'wake' | 'sleep' | string
   status: 'pending' | 'executed' | string
   created_at: string
 }
-
-type AgentFeedStatus = 'unread' | 'read' | 'archived' | 'expired' | string
-type AgentFeedPriority = 'low' | 'normal' | 'high' | 'urgent' | string
-type AgentFeedItemRow = {
-  id: string
-  user_id: string
-  type: string | null
-  title: string | null
-  summary: string | null
-  content: string | null
-  content_format: 'markdown' | 'plain' | 'json' | string | null
-  priority: AgentFeedPriority | null
-  status: AgentFeedStatus | null
-  source: string | null
-  created_by: string | null
-  visible_from: string | null
-  expires_at: string | null
-  read_at: string | null
-  pinned: boolean | null
-  related_table: string | null
-  related_id: string | null
-  metadata: unknown
-  created_at: string | null
-  updated_at: string | null
-}
-
-type AgentFeedFilter = 'visible' | 'unread' | 'high' | 'read' | 'archived'
 
 type CodexControlViewState = {
   tone: 'green' | 'gray' | 'yellow'
@@ -183,41 +147,6 @@ const categoryLabelMap: Record<string, string> = {
   scenario: '场景',
   style: '风格',
 }
-
-const agentFeedTypeLabels: Record<string, string> = {
-  morning_share: '晨间分享',
-  reading_assist: '阅读辅助',
-  daily_card: '每日卡片',
-  system_notice: '系统提示',
-  syzygy_note: 'Syzygy 小纸条',
-  weekly_card: '周回顾',
-  reminder_card: '提醒',
-  print_card: '打印胶囊',
-  dev_log: '开发记录',
-  other: '其他',
-}
-
-const agentFeedPriorityLabels: Record<string, string> = {
-  urgent: '紧急',
-  high: '高优先级',
-  normal: '普通',
-  low: '低优先级',
-}
-
-const agentFeedStatusLabels: Record<string, string> = {
-  unread: '未读',
-  read: '已读',
-  archived: '已归档',
-  expired: '已过期',
-}
-
-const agentFeedPriorityRank: Record<string, number> = { urgent: 4, high: 3, normal: 2, low: 1 }
-
-const isAgentFeedExpired = (item: AgentFeedItemRow, now = Date.now()) => {
-  if (item.status === 'expired') return true
-  return item.expires_at ? new Date(item.expires_at).getTime() <= now : false
-}
-
 
 const formatJson = (value: unknown) => JSON.stringify(value ?? {}, null, 2)
 
@@ -329,15 +258,6 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const [expandedCapsuleId, setExpandedCapsuleId] = useState<string | null>(null)
   const [capabilities, setCapabilities] = useState<CapabilityRow[]>([])
   const [capabilitiesError, setCapabilitiesError] = useState<string | null>(null)
-  const [weeklyDigest, setWeeklyDigest] = useState<WeeklyDigestRow | null>(null)
-  const [weeklyDigestError, setWeeklyDigestError] = useState<string | null>(null)
-  const [agentFeedItems, setAgentFeedItems] = useState<AgentFeedItemRow[]>([])
-  const [agentFeedError, setAgentFeedError] = useState<string | null>(null)
-  const [agentFeedFilter, setAgentFeedFilter] = useState<AgentFeedFilter>('unread')
-  const [expandedFeedIds, setExpandedFeedIds] = useState<Record<string, boolean>>({})
-  const [expandedFeedMetadataIds, setExpandedFeedMetadataIds] = useState<Record<string, boolean>>({})
-  const [updatingFeedId, setUpdatingFeedId] = useState<string | null>(null)
-
   const activeTemplate = useMemo(
     () => promptTemplates.find((item) => item.id === activeTemplateId) ?? null,
     [promptTemplates, activeTemplateId],
@@ -373,17 +293,6 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const weeklyQueuedCount = printCapsules.filter((item) => item.scheduled_print_week === capsuleWeekFilter && item.status === 'queued').length
   const weeklyPrintedCount = printCapsules.filter((item) => item.scheduled_print_week === capsuleWeekFilter && item.status === 'printed').length
   const snapshotExpired = contextSnapshot?.stale_after ? new Date(contextSnapshot.stale_after).getTime() < nowMs : false
-  const filteredAgentFeedItems = useMemo(() => {
-    const activeItems = agentFeedItems.filter((item) => !isAgentFeedExpired(item, nowMs))
-    const baseItems = agentFeedFilter === 'visible' ? agentFeedItems : agentFeedFilter === 'unread' ? activeItems.filter((item) => (item.status ?? 'unread') === 'unread') : agentFeedFilter === 'high' ? activeItems.filter((item) => ['urgent', 'high'].includes(item.priority ?? 'normal')) : agentFeedItems.filter((item) => item.status === agentFeedFilter)
-    return [...baseItems].sort((left, right) => {
-      const pinnedDelta = Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))
-      if (pinnedDelta) return pinnedDelta
-      const priorityDelta = (agentFeedPriorityRank[right.priority ?? 'normal'] ?? 0) - (agentFeedPriorityRank[left.priority ?? 'normal'] ?? 0)
-      if (priorityDelta) return priorityDelta
-      return new Date(right.created_at ?? 0).getTime() - new Date(left.created_at ?? 0).getTime()
-    })
-  }, [agentFeedFilter, agentFeedItems, nowMs])
 
   const modelOptions = useMemo(() => {
     const merged = new Set<string>(availableModels)
@@ -437,7 +346,7 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     setErrorMessage(null)
 
     const { start: todayStart, end: todayEnd } = getTodayIsoRange()
-    const [channelRes, settingsRes, templateRes, commandsRes, modelRes, codexRes, wechatRes, taskRes, snapshotRes, digestRes, capsuleRes, capabilityRes, weeklyRes, feedRes] = await Promise.all([
+    const [channelRes, settingsRes, templateRes, commandsRes, modelRes, codexRes, wechatRes, taskRes, snapshotRes, digestRes, capsuleRes, capabilityRes] = await Promise.all([
       supabase
         .from('channel_config')
         .select('user_id, channel_name, active_model')
@@ -480,15 +389,6 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
       supabase.from('daily_status_digest').select('id, period, summary_text, created_at').gte('created_at', todayStart).lt('created_at', todayEnd),
       supabase.from('print_capsules').select('id, title, type, paper_size, status, trigger_reason, created_at, scheduled_print_week, sort_order, hidden_until_printed, content').order('created_at', { ascending: false }).limit(80),
       supabase.from('capabilities').select('id, name, description, risk_level, enabled, requires_confirmation, output_channel, last_used_at, cooldown_until, usage_count, failure_count').order('name', { ascending: true }),
-      supabase.from('weekly_digest').select('id, week_start, week_end, highlights, digest_text').order('week_start', { ascending: false }).limit(1).maybeSingle(),
-      supabase
-        .from('agent_feed_items')
-        .select('id, user_id, type, title, summary, content, content_format, priority, status, source, created_by, visible_from, expires_at, read_at, pinned, related_table, related_id, metadata, created_at, updated_at')
-        .eq('user_id', scopedUserId)
-        .or(`visible_from.is.null,visible_from.lte.${new Date().toISOString()}`)
-        .order('pinned', { ascending: false })
-        .order('created_at', { ascending: false })
-        .limit(80),
     ])
 
     if (channelRes.error || settingsRes.error || templateRes.error || commandsRes.error || modelRes.error || codexRes.error) {
@@ -561,10 +461,6 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     setPrintCapsulesError(capsuleRes.error?.message ?? null)
     setCapabilities((capabilityRes.data ?? []) as CapabilityRow[])
     setCapabilitiesError(capabilityRes.error?.message ?? null)
-    setWeeklyDigest((weeklyRes.data as WeeklyDigestRow | null) ?? null)
-    setWeeklyDigestError(weeklyRes.error?.message ?? null)
-    setAgentFeedItems((feedRes.data ?? []) as AgentFeedItemRow[])
-    setAgentFeedError(feedRes.error?.message ?? null)
 
     setLoading(false)
   }, [scopedUserId])
@@ -805,22 +701,6 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
       current.map((item) => (item.id === activeTemplate.id ? { ...item, content: templateDraft } : item)),
     )
     showToast(`Prompt 已保存：${activeTemplate.name}`)
-  }
-
-
-  const handleUpdateFeedStatus = async (item: AgentFeedItemRow, status: 'read' | 'archived') => {
-    if (!supabase) return
-    setUpdatingFeedId(item.id)
-    setAgentFeedError(null)
-    const patch = status === 'read' ? { status, read_at: new Date().toISOString() } : { status }
-    const { error } = await supabase.from('agent_feed_items').update(patch).eq('id', item.id).eq('user_id', scopedUserId)
-    setUpdatingFeedId(null)
-    if (error) {
-      setAgentFeedError(`状态更新失败，已降级为只读展示：${error.message}`)
-      return
-    }
-    setAgentFeedItems((current) => current.map((feedItem) => (feedItem.id === item.id ? { ...feedItem, ...patch } : feedItem)))
-    showToast(status === 'read' ? '已标记为已读' : '已归档卡片')
   }
 
   const toggleSection = (sectionId: string) => {
@@ -1206,77 +1086,11 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
 
           <section className="hamster-console-card glass-card hamster-console-group" aria-label="V3.0 观测台">
             <button className="hamster-console-accordion__header" onClick={() => toggleGroup('v3')}>
-              <div><h2>V3.0 观测台</h2><small>执行记录 / 当前状态快照 / 打印胶囊 / 能力 / 周回顾 / 指令</small></div>
+              <div><h2>V3.0 观测台</h2><small>执行记录 / 当前状态快照 / 打印胶囊 / 能力 / 指令</small></div>
               <span>{expandedGroups.v3 ? '▼' : '▶'}</span>
             </button>
             <div className={`hamster-console-accordion__content ${expandedGroups.v3 ? 'expanded' : ''}`}>
               <div className="hamster-console-accordion__inner hamster-console-nested-stack">
-
-          <section className="hamster-console-card glass-card" aria-label="Syzygy Feed">
-            <button className="hamster-console-accordion__header" onClick={() => toggleSection('syzygy-feed')}><h2>Syzygy Feed（已迁移 · 管理视图）</h2><span>{expandedSection === 'syzygy-feed' ? '▼' : '▶'}</span></button>
-            <div className={`hamster-console-accordion__content ${expandedSection === 'syzygy-feed' ? 'expanded' : ''}`}><div className="hamster-console-accordion__inner">
-              <div className="hamster-feed-moved-banner">
-                <span aria-hidden="true">📮</span>
-                <div>
-                  <strong>Syzygy Feed 已搬到首页 Page 3</strong>
-                  <p>晨间分享、状态卡、小纸条和周回顾现在是独立的生活前台。仓鼠机这里仅保留只读管理视图。</p>
-                </div>
-                <Link to="/feed" className="btn-primary hamster-feed-moved-banner__link">前往 Feed →</Link>
-              </div>
-              <p className="hamster-console-card__hint">读取 agent_feed_items：CLI / Syzygy 生成内容的持久化卡片（管理用途）。</p>
-              {agentFeedError ? <p className="hamster-console-alert">当前前端暂时没有权限读取 Syzygy Feed，请检查 Supabase session / RLS。{agentFeedError.includes('状态更新失败') ? `（${agentFeedError}）` : ''}</p> : null}
-              <div className="hamster-feed-filter-row" role="tablist" aria-label="Syzygy Feed 筛选">
-                {[
-                  ['visible', '全部可见'],
-                  ['unread', '未读'],
-                  ['high', '高优先级'],
-                  ['read', '已读'],
-                  ['archived', '已归档'],
-                ].map(([value, label]) => <button key={value} className={`hamster-feed-filter ${agentFeedFilter === value ? 'active' : ''}`} onClick={() => setAgentFeedFilter(value as AgentFeedFilter)}>{label}</button>)}
-              </div>
-              <div className="hamster-feed-list">
-                {filteredAgentFeedItems.map((item) => {
-                  const expanded = Boolean(expandedFeedIds[item.id])
-                  const metadataExpanded = Boolean(expandedFeedMetadataIds[item.id])
-                  const expired = isAgentFeedExpired(item, nowMs)
-                  const status = expired ? 'expired' : (item.status ?? 'unread')
-                  const priority = item.priority ?? 'normal'
-                  return (
-                    <article key={item.id} className={`hamster-feed-card ${status} priority-${priority} ${item.pinned ? 'pinned' : ''}`}>
-                      <button className="hamster-feed-card__header" onClick={() => setExpandedFeedIds((current) => ({ ...current, [item.id]: !expanded }))}>
-                        <div className="hamster-feed-card__title-block">
-                          <div className="hamster-feed-card__title-row"><strong>{item.title ?? '(无标题卡片)'}</strong>{item.pinned ? <span className="hamster-feed-pill pinned">置顶</span> : null}</div>
-                          <p>{item.summary ?? '暂无摘要。'}</p>
-                        </div>
-                        <span>{expanded ? '收起' : '展开'}</span>
-                      </button>
-                      <div className="hamster-feed-meta-row">
-                        <span className="hamster-feed-pill type">{agentFeedTypeLabels[item.type ?? 'other'] ?? item.type ?? '其他'}</span>
-                        <span className={`hamster-feed-pill priority ${priority}`}>{agentFeedPriorityLabels[priority] ?? priority}</span>
-                        <span className={`hamster-feed-pill status ${status}`}>{agentFeedStatusLabels[status] ?? status}</span>
-                        <span>{item.created_by ?? item.source ?? 'unknown'}</span>
-                        <span>{formatDateTime(item.created_at)}</span>
-                        {item.expires_at ? <span>过期：{formatDateTime(item.expires_at)}</span> : null}
-                      </div>
-                      {expanded ? <div className="hamster-feed-card__body">
-                        <div className="hamster-feed-content">
-                          {item.content_format === 'markdown' ? <MarkdownRenderer content={item.content ?? '暂无正文。'} /> : item.content_format === 'json' ? <pre>{item.content ?? '暂无正文。'}</pre> : <p>{item.content ?? '暂无正文。'}</p>}
-                        </div>
-                        {(item.related_table || item.related_id) ? <p className="hamster-console-card__hint">关联记录：{item.related_table ?? '--'} / {item.related_id ?? '--'}</p> : null}
-                        <button className="btn-secondary" onClick={() => setExpandedFeedMetadataIds((current) => ({ ...current, [item.id]: !metadataExpanded }))}>{metadataExpanded ? '收起 metadata' : '查看 metadata'}</button>
-                        {metadataExpanded ? <pre className="hamster-feed-metadata">{formatJson(item.metadata)}</pre> : null}
-                        <div className="hamster-feed-actions">
-                          {(item.status ?? 'unread') === 'unread' && !expired ? <button className="btn-primary" onClick={() => void handleUpdateFeedStatus(item, 'read')} disabled={updatingFeedId === item.id}>{updatingFeedId === item.id ? '更新中...' : '标记已读'}</button> : null}
-                          {item.status !== 'archived' ? <button className="btn-secondary" onClick={() => void handleUpdateFeedStatus(item, 'archived')} disabled={updatingFeedId === item.id}>{updatingFeedId === item.id ? '更新中...' : '归档'}</button> : null}
-                        </div>
-                      </div> : null}
-                    </article>
-                  )
-                })}
-              </div>
-              {!agentFeedError && filteredAgentFeedItems.length === 0 ? <p className="hamster-console-card__hint">{agentFeedFilter === 'unread' && agentFeedItems.some((item) => item.status === 'read') ? '新卡片都读完啦。' : '今天小窝里还没有新卡片。'}</p> : null}
-            </div></div>
-          </section>
 
           <section className="hamster-console-card glass-card" aria-label="执行记录">
             <button className="hamster-console-accordion__header" onClick={() => toggleSection('agent-tasks')}><h2>执行记录</h2><span>{expandedSection === 'agent-tasks' ? '▼' : '▶'}</span></button>
@@ -1313,13 +1127,6 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
             <button className="hamster-console-accordion__header" onClick={() => toggleSection('capabilities')}><h2>能力编排器</h2><span>{expandedSection === 'capabilities' ? '▼' : '▶'}</span></button>
             <div className={`hamster-console-accordion__content ${expandedSection === 'capabilities' ? 'expanded' : ''}`}><div className="hamster-console-accordion__inner">
               {capabilitiesError ? <p className="hamster-console-card__hint">当前前端无权限读取该表：{capabilitiesError}</p> : capabilities.length ? capabilities.map((capability) => <article key={capability.id} className="hamster-mini-card"><strong>{capability.name}</strong><p>{capability.description ?? '暂无说明'}</p><small>{capability.enabled ? '已启用' : '已禁用'} · 风险：{capability.risk_level ?? '--'} · 确认：{capability.requires_confirmation ? '需要' : '不需要'} · 渠道：{capability.output_channel ?? '--'} · 使用/失败：{capability.usage_count ?? 0}/{capability.failure_count ?? 0} · 冷却至：{formatDateTime(capability.cooldown_until)} · 最近使用：{formatDateTime(capability.last_used_at)}</small><em>当前前端无权限修改</em></article>) : <p className="hamster-console-card__hint">暂无能力配置。</p>}
-            </div></div>
-          </section>
-
-          <section className="hamster-console-card glass-card" aria-label="周回顾入口">
-            <button className="hamster-console-accordion__header" onClick={() => toggleSection('weekly-digest')}><h2>周回顾入口</h2><span>{expandedSection === 'weekly-digest' ? '▼' : '▶'}</span></button>
-            <div className={`hamster-console-accordion__content ${expandedSection === 'weekly-digest' ? 'expanded' : ''}`}><div className="hamster-console-accordion__inner">
-              {weeklyDigestError ? <p className="hamster-console-card__hint">当前前端无权限读取该表：{weeklyDigestError}</p> : weeklyDigest ? <div className="hamster-v3-detail"><strong>{weeklyDigest.week_start} → {weeklyDigest.week_end}</strong><pre>{formatJson(weeklyDigest.highlights)}</pre><p>{weeklyDigest.digest_text}</p></div> : <p className="hamster-console-card__hint">还没有生成周回顾。</p>}
             </div></div>
           </section>
 

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -2943,6 +2943,16 @@ export const createAgentCouncilMessage = async (payload: {
   }
 }
 
+export const deleteAgentCouncilTopic = async (topic: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase.from('agent_council').delete().eq('topic', topic)
+  if (error) {
+    throw error
+  }
+}
+
 const assertRpcSuccess = (rpcName: string, payload: unknown) => {
   const result =
     payload && typeof payload === 'object' && 'success' in payload


### PR DESCRIPTION
## 概述

本次包含两项改动。

### 任务一：UI 移除重复入口（V3.0 观测台）
首页 Page 3 的 Syzygy Feed 已经独立呈现「Syzygy Feed」与「周回顾」，仓鼠机面板（`HamsterConsolePage`）中重复的这两个只读视图予以移除：

- 移除 **Syzygy Feed（已迁移 · 管理视图）** 板块
- 移除 **周回顾入口** 板块
- 更新 V3.0 观测台子标题（去掉「周回顾」）

由于项目开启了 `noUnusedLocals`，仅删 JSX 会导致构建失败，因此一并清理了这两个板块**专属**的死代码（相关类型、状态、`loadAll` 中的 `agent_feed_items` / `weekly_digest` 读取查询、`handleUpdateFeedStatus` 等）。

**数据安全性：**
- ✅ 未改动任何 Supabase 数据 —— 只移除前端只读查询与展示
- ✅ 不影响 Page 3 —— `AgentFeedPage` 通过独立的 `lib/agentFeed` 读取 `agent_feed_items`，与仓鼠机页面完全解耦

### 任务二：议事厅议题删除 + 二次确认
`AgentCouncilPage`（议事厅）议题列表：

- 每个议题新增「删除」按钮（重构为容器以避免按钮嵌套）
- 点击删除弹出复用的 `ConfirmDialog` 二次确认弹窗，提示该议题下全部发言将一并删除且无法恢复
- 新增 `deleteAgentCouncilTopic`（`supabaseSync.ts`），按 `topic` 删除该议题全部发言；确认后刷新列表，若删除的是当前选中议题则清空详情
- 已核对 `agent_council` 表 RLS（`ALL / qual=true`），前端 DELETE 被允许

## 验证
- `tsc -b` ✅
- `eslint` ✅
- `npm run build` ✅（仅有与本次改动无关的既有 chunk 体积告警）

## 改动文件
- `src/pages/HamsterConsolePage.tsx`
- `src/pages/AgentCouncilPage.tsx`
- `src/pages/AgentCouncilPage.css`
- `src/storage/supabaseSync.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka81PsjniBEWN3WmdscSwg)_