### PR TITLE
feat(archive): 新增系统档案页面（Page 3）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ import TimelinePage from './pages/TimelinePage'
 import TodoPage from './pages/TodoPage'
 import HamsterConsolePage from './pages/HamsterConsolePage'
 import AgentCouncilPage from './pages/AgentCouncilPage'
+import ArchivePage from './pages/ArchivePage'
 import WalletPage from './pages/WalletPage'
 import WikiPage from './pages/WikiPage'
 import NovelPage from './pages/NovelPage'
@@ -2228,6 +2229,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <AgentCouncilPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/archive"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <ArchivePage />
             </RequireAuth>
           }
         />

--- a/src/pages/ArchivePage.css
+++ b/src/pages/ArchivePage.css
@@ -1,0 +1,662 @@
+.archive-page {
+  /* default (chuanchuan / pink) theme tokens */
+  --arc-accent: #ffd6e7;
+  --arc-accent-strong: #f5b3d2;
+  --arc-soft: rgba(255, 214, 231, 0.85);
+  --arc-soft-faint: rgba(255, 214, 231, 0.22);
+  --arc-tile: #fff3f8;
+  --arc-kicker: #b27f98;
+  --arc-heading: #68485e;
+  --arc-text: #4f3f4a;
+  --arc-grad-1: rgba(255, 214, 231, 0.34);
+  --arc-grad-2: rgba(255, 239, 246, 0.82);
+  --arc-grad-3: rgba(253, 245, 249, 0.96);
+
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 14px 14px 24px;
+  min-height: 100dvh;
+  flex-shrink: 0;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  color: var(--arc-text);
+  position: relative;
+  isolation: isolate;
+}
+
+.archive-page--syzygy {
+  --arc-accent: #cfe6ff;
+  --arc-accent-strong: #a7cdf5;
+  --arc-soft: rgba(186, 219, 255, 0.9);
+  --arc-soft-faint: rgba(186, 219, 255, 0.24);
+  --arc-tile: #eef6ff;
+  --arc-kicker: #6f88a8;
+  --arc-heading: #3d5675;
+  --arc-text: #3a4658;
+  --arc-grad-1: rgba(186, 219, 255, 0.34);
+  --arc-grad-2: rgba(232, 243, 255, 0.85);
+  --arc-grad-3: rgba(244, 249, 255, 0.96);
+}
+
+.archive-page::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 10% 0%, var(--arc-grad-1), transparent 42%),
+    radial-gradient(circle at 90% 0%, var(--arc-grad-2), transparent 52%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, var(--arc-grad-3) 100%);
+  transition: background 240ms ease;
+}
+
+/* ── Header ───────────────────────────────────── */
+
+.archive-header {
+  position: relative;
+  min-height: 72px;
+  padding: 12px 92px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--arc-soft);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8px 18px var(--arc-soft-faint);
+}
+
+.archive-title-wrap {
+  display: grid;
+  gap: 2px;
+  text-align: center;
+  min-width: 0;
+}
+
+.archive-kicker {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--arc-kicker);
+}
+
+.archive-header .ui-title {
+  margin: 0;
+  color: #5c5c5c;
+}
+
+.archive-back-btn,
+.archive-refresh-btn {
+  position: absolute;
+  top: 14px;
+  border-radius: 999px;
+  border: 1px solid var(--arc-accent);
+  background: #fff;
+  color: var(--arc-heading);
+  padding: 7px 12px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.archive-back-btn { left: 12px; }
+.archive-refresh-btn {
+  right: 12px;
+  background: linear-gradient(180deg, #ffffff 0%, var(--arc-tile) 100%);
+  font-weight: 600;
+}
+.archive-refresh-btn:disabled { opacity: 0.6; }
+
+/* ── Scope switch ─────────────────────────────── */
+
+.archive-scope-switch {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 6px;
+  border: 1px solid var(--arc-soft);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 6px 14px var(--arc-soft-faint);
+}
+
+.archive-scope-switch button {
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 9px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #8a7a84;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.archive-scope-switch button.active {
+  color: var(--arc-heading);
+  border-color: var(--arc-accent-strong);
+  background: linear-gradient(180deg, #ffffff 0%, var(--arc-tile) 100%);
+  box-shadow: 0 4px 10px var(--arc-soft-faint);
+}
+
+/* ── Notice / error / empty ───────────────────── */
+
+.archive-notice,
+.archive-error {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid;
+  background: #fff;
+  font-size: 12px;
+}
+
+.archive-notice {
+  color: #2f7a56;
+  border-color: rgba(126, 211, 167, 0.5);
+}
+
+.archive-error {
+  color: #b13f4d;
+  border-color: rgba(255, 181, 192, 0.7);
+}
+
+.archive-empty {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px dashed var(--arc-soft);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.6);
+  padding: 18px 16px;
+  margin: 0;
+  color: #8f7e88;
+  text-align: center;
+  font-size: 13px;
+}
+
+.archive-page--syzygy .archive-empty {
+  color: #7d8aa0;
+}
+
+/* ── Panels ───────────────────────────────────── */
+
+.archive-panel {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--arc-soft);
+  border-radius: 18px;
+  background: #fff;
+  padding: 14px;
+  box-shadow: 0 10px 20px var(--arc-soft-faint);
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.archive-panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.archive-panel__head h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--arc-heading);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.archive-mini-btn {
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: 1px solid var(--arc-accent);
+  background: linear-gradient(180deg, #ffffff 0%, var(--arc-tile) 100%);
+  color: var(--arc-heading);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.archive-mini-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Tree ─────────────────────────────────────── */
+
+.archive-tree {
+  display: grid;
+  gap: 4px;
+}
+
+.archive-tree__row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.6);
+  min-height: 40px;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.archive-tree__row:hover {
+  background: var(--arc-tile);
+}
+
+.archive-tree__row.active {
+  border-color: var(--arc-accent-strong);
+  background: linear-gradient(180deg, var(--arc-tile) 0%, #ffffff 100%);
+  box-shadow: 0 3px 8px var(--arc-soft-faint);
+}
+
+.archive-tree__caret {
+  flex-shrink: 0;
+  width: 22px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--arc-accent-strong);
+  font-size: 12px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.archive-tree__caret:disabled {
+  cursor: default;
+  color: #cbbcc4;
+}
+
+.archive-tree__name {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  border: none;
+  background: transparent;
+  padding: 8px 4px;
+  cursor: pointer;
+  color: var(--arc-text);
+}
+
+.archive-tree__label {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.archive-tree__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-right: 6px;
+  flex-shrink: 0;
+}
+
+.archive-tree__actions button {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--arc-heading);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.archive-tree__actions button:hover {
+  background: var(--arc-soft-faint);
+}
+
+.archive-tree__actions .archive-tree__delete:hover {
+  background: #ffe8ee;
+}
+
+/* ── Archive list ─────────────────────────────── */
+
+.archive-search {
+  width: 100%;
+  box-sizing: border-box;
+  appearance: none;
+  -webkit-appearance: none;
+  border-radius: 12px;
+  border: 1px solid var(--arc-accent);
+  padding: 9px 12px;
+  font: inherit;
+  color: var(--arc-text);
+  background: #fff;
+}
+
+.archive-search:focus {
+  outline: none;
+  border-color: var(--arc-accent-strong);
+  box-shadow: 0 0 0 2px var(--arc-soft-faint);
+}
+
+.archive-list {
+  display: grid;
+  gap: 8px;
+}
+
+.archive-card {
+  display: grid;
+  gap: 6px;
+  text-align: left;
+  border: 1px solid var(--arc-soft);
+  border-radius: 14px;
+  background: #fff;
+  padding: 10px 12px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px var(--arc-soft-faint);
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.archive-card:hover {
+  background: var(--arc-tile);
+  border-color: var(--arc-accent-strong);
+}
+
+.archive-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.archive-card__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--arc-heading);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.archive-card__excerpt {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #7a6b74;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.archive-page--syzygy .archive-card__excerpt {
+  color: #6c7990;
+}
+
+.archive-card__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 11px;
+  color: #9a8b94;
+}
+
+.archive-card__meta time {
+  margin-left: auto;
+}
+
+.archive-card__chip {
+  border-radius: 999px;
+  border: 1px solid var(--arc-soft);
+  background: var(--arc-tile);
+  padding: 1px 8px;
+  color: var(--arc-heading);
+}
+
+/* ── Importance badge ─────────────────────────── */
+
+.archive-importance {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 2px 9px;
+  font-size: 11px;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+
+.archive-importance--low {
+  color: #6b7280;
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+}
+
+.archive-importance--normal {
+  color: #2f7a56;
+  background: #e8f6ee;
+  border-color: rgba(126, 211, 167, 0.5);
+}
+
+.archive-importance--high {
+  color: #b06a14;
+  background: #fff3e0;
+  border-color: #ffd9a8;
+}
+
+.archive-importance--critical {
+  color: #b13f4d;
+  background: #ffe5ea;
+  border-color: rgba(255, 181, 192, 0.8);
+}
+
+/* ── Modals ───────────────────────────────────── */
+
+.archive-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(70, 56, 73, 0.34);
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  z-index: 60;
+}
+
+.archive-modal {
+  width: min(540px, 100%);
+  max-height: 90dvh;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid var(--arc-soft);
+  border-radius: 20px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 14px 28px rgba(70, 56, 73, 0.24);
+}
+
+.archive-modal--compact {
+  width: min(420px, 100%);
+}
+
+.archive-modal h2 {
+  margin: 0;
+  color: var(--arc-heading);
+  font-size: 18px;
+}
+
+.archive-modal label {
+  display: grid;
+  gap: 5px;
+  font-size: 13px;
+  color: var(--arc-heading);
+  font-weight: 600;
+}
+
+.archive-modal input,
+.archive-modal textarea,
+.archive-modal select {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  box-sizing: border-box;
+  border-radius: 12px;
+  border: 1px solid var(--arc-accent);
+  padding: 10px;
+  font: inherit;
+  font-weight: 400;
+  color: var(--arc-text);
+  background: #fff;
+}
+
+.archive-modal textarea {
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.archive-modal input:focus,
+.archive-modal textarea:focus,
+.archive-modal select:focus {
+  outline: none;
+  border-color: var(--arc-accent-strong);
+  box-shadow: 0 0 0 2px var(--arc-soft-faint);
+}
+
+.archive-modal__readonly {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 12px;
+  font-weight: 400;
+  color: #9a8b94;
+  padding: 2px 2px 0;
+}
+
+.archive-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.archive-modal__actions button {
+  border-radius: 10px;
+  border: 1px solid var(--arc-accent);
+  padding: 8px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.archive-modal__actions .secondary {
+  background: #fff;
+  color: var(--arc-heading);
+}
+
+.archive-modal__actions .danger {
+  background: #ffe8ee;
+  color: #9d3e53;
+  border-color: #ffd0db;
+}
+
+.archive-modal__actions .primary {
+  background: linear-gradient(180deg, #ffffff 0%, var(--arc-tile) 100%);
+  color: var(--arc-heading);
+  border-color: var(--arc-accent-strong);
+}
+
+.archive-modal__actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Tag input ────────────────────────────────── */
+
+.archive-taginput {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  border: 1px solid var(--arc-accent);
+  border-radius: 12px;
+  padding: 7px 8px;
+  background: #fff;
+}
+
+.archive-taginput:focus-within {
+  border-color: var(--arc-accent-strong);
+  box-shadow: 0 0 0 2px var(--arc-soft-faint);
+}
+
+.archive-taginput input {
+  flex: 1;
+  min-width: 110px;
+  border: none !important;
+  padding: 3px 2px !important;
+  box-shadow: none !important;
+  background: transparent !important;
+}
+
+.archive-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  background: var(--arc-tile);
+  border: 1px solid var(--arc-soft);
+  color: var(--arc-heading);
+  padding: 2px 4px 2px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.archive-tag__remove {
+  width: 18px;
+  height: 18px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--arc-heading);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.archive-tag__remove:hover {
+  background: rgba(255, 255, 255, 0.7);
+}
+
+/* ── Responsive ───────────────────────────────── */
+
+@media (max-width: 560px) {
+  .archive-page {
+    padding: 12px;
+  }
+
+  .archive-header {
+    min-height: 72px;
+    padding: 12px 76px;
+  }
+
+  .archive-back-btn,
+  .archive-refresh-btn {
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+}

--- a/src/pages/ArchivePage.tsx
+++ b/src/pages/ArchivePage.tsx
@@ -1,0 +1,829 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react'
+import { useNavigate } from 'react-router-dom'
+import ConfirmDialog from '../components/ConfirmDialog'
+import {
+  createArchive,
+  createArchiveCategory,
+  deleteArchiveCategory,
+  listArchiveCategories,
+  listArchives,
+  renameArchiveCategory,
+  softDeleteArchive,
+  updateArchive,
+} from '../storage/supabaseSync'
+import type { Archive, ArchiveCategory, ArchiveImportance, ArchiveScope } from '../types'
+import './ArchivePage.css'
+
+const SCOPE_META: Record<ArchiveScope, { label: string; emoji: string; kicker: string }> = {
+  chuanchuan: { label: '串串', emoji: '🐹', kicker: 'CHUANCHUAN' },
+  syzygy: { label: 'Syzygy', emoji: '🩵', kicker: 'SYZYGY' },
+}
+
+const IMPORTANCE_ORDER: ArchiveImportance[] = ['low', 'normal', 'high', 'critical']
+const IMPORTANCE_META: Record<ArchiveImportance, { label: string }> = {
+  low: { label: '低' },
+  normal: { label: '普通' },
+  high: { label: '高' },
+  critical: { label: '关键' },
+}
+
+const formatTime = (value: string) => new Date(value).toLocaleString('zh-CN', { hour12: false })
+
+type CategoryFormState =
+  | { mode: 'create'; parentId: string | null; parentName: string | null; name: string }
+  | { mode: 'rename'; categoryId: string; name: string }
+
+type ArchiveEditorState = {
+  mode: 'create' | 'edit'
+  archiveId?: string
+  categoryId: string
+  title: string
+  content: string
+  keywords: string[]
+  aliases: string[]
+  importance: ArchiveImportance
+  source: string
+  updatedAt?: string
+}
+
+type FlatCategory = { category: ArchiveCategory; depth: number }
+
+const flattenCategories = (categories: ArchiveCategory[]): FlatCategory[] => {
+  const childrenMap = new Map<string, ArchiveCategory[]>()
+  categories.forEach((category) => {
+    const key = category.parentId ?? '__root__'
+    const list = childrenMap.get(key) ?? []
+    list.push(category)
+    childrenMap.set(key, list)
+  })
+  const result: FlatCategory[] = []
+  const walk = (parentKey: string, depth: number) => {
+    const children = childrenMap.get(parentKey) ?? []
+    children.forEach((category) => {
+      result.push({ category, depth })
+      walk(category.id, depth + 1)
+    })
+  }
+  walk('__root__', 0)
+  return result
+}
+
+// ── Tag input ────────────────────────────────────────────
+
+type TagInputProps = {
+  values: string[]
+  onChange: (next: string[]) => void
+  placeholder?: string
+}
+
+const TagInput = ({ values, onChange, placeholder }: TagInputProps) => {
+  const [draft, setDraft] = useState('')
+
+  const commit = (raw: string) => {
+    const tokens = raw
+      .split(/[,，]/)
+      .map((token) => token.trim())
+      .filter(Boolean)
+    if (tokens.length === 0) {
+      return
+    }
+    const merged = [...values]
+    tokens.forEach((token) => {
+      if (!merged.includes(token)) {
+        merged.push(token)
+      }
+    })
+    onChange(merged)
+    setDraft('')
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' || event.key === ',' || event.key === '，') {
+      event.preventDefault()
+      commit(draft)
+    } else if (event.key === 'Backspace' && draft.length === 0 && values.length > 0) {
+      onChange(values.slice(0, -1))
+    }
+  }
+
+  return (
+    <div className="archive-taginput">
+      {values.map((tag) => (
+        <span key={tag} className="archive-tag">
+          {tag}
+          <button
+            type="button"
+            className="archive-tag__remove"
+            aria-label={`移除 ${tag}`}
+            onClick={() => onChange(values.filter((item) => item !== tag))}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      <input
+        type="text"
+        value={draft}
+        placeholder={values.length === 0 ? placeholder : ''}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={() => commit(draft)}
+      />
+    </div>
+  )
+}
+
+const ArchivePage = () => {
+  const navigate = useNavigate()
+  const [scope, setScope] = useState<ArchiveScope>('chuanchuan')
+  const [categories, setCategories] = useState<ArchiveCategory[]>([])
+  const [archives, setArchives] = useState<Archive[]>([])
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null)
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
+  const [search, setSearch] = useState('')
+
+  const [loadingCategories, setLoadingCategories] = useState(true)
+  const [loadingArchives, setLoadingArchives] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const [categoryForm, setCategoryForm] = useState<CategoryFormState | null>(null)
+  const [archiveEditor, setArchiveEditor] = useState<ArchiveEditorState | null>(null)
+  const [pendingDeleteCategory, setPendingDeleteCategory] = useState<ArchiveCategory | null>(null)
+  const [pendingDeleteArchive, setPendingDeleteArchive] = useState<Archive | null>(null)
+
+  const flatCategories = useMemo(() => flattenCategories(categories), [categories])
+
+  const refreshCategories = useCallback(async () => {
+    setLoadingCategories(true)
+    try {
+      const data = await listArchiveCategories(scope)
+      setCategories(data)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载档案目录失败', loadError)
+      setError('加载档案目录失败，请稍后重试')
+      setCategories([])
+    } finally {
+      setLoadingCategories(false)
+    }
+  }, [scope])
+
+  useEffect(() => {
+    void refreshCategories()
+  }, [refreshCategories])
+
+  // Pick a valid selected category whenever the category set changes.
+  useEffect(() => {
+    if (categories.length === 0) {
+      setSelectedCategoryId(null)
+      return
+    }
+    setSelectedCategoryId((current) => {
+      if (current && categories.some((category) => category.id === current)) {
+        return current
+      }
+      return flattenCategories(categories)[0]?.category.id ?? null
+    })
+  }, [categories])
+
+  const refreshArchives = useCallback(async (categoryId: string | null) => {
+    if (!categoryId) {
+      setArchives([])
+      return
+    }
+    setLoadingArchives(true)
+    try {
+      const data = await listArchives(categoryId)
+      setArchives(data)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载档案条目失败', loadError)
+      setError('加载档案条目失败，请稍后重试')
+      setArchives([])
+    } finally {
+      setLoadingArchives(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    setSearch('')
+    void refreshArchives(selectedCategoryId)
+  }, [selectedCategoryId, refreshArchives])
+
+  const selectedCategory = useMemo(
+    () => categories.find((category) => category.id === selectedCategoryId) ?? null,
+    [categories, selectedCategoryId],
+  )
+
+  const filteredArchives = useMemo(() => {
+    const keyword = search.trim().toLowerCase()
+    if (!keyword) {
+      return archives
+    }
+    return archives.filter((archive) => {
+      const haystack = [
+        archive.title,
+        archive.content,
+        ...archive.keywords,
+        ...archive.aliases,
+      ]
+        .join('\n')
+        .toLowerCase()
+      return haystack.includes(keyword)
+    })
+  }, [archives, search])
+
+  const childrenMap = useMemo(() => {
+    const map = new Map<string, ArchiveCategory[]>()
+    categories.forEach((category) => {
+      const key = category.parentId ?? '__root__'
+      const list = map.get(key) ?? []
+      list.push(category)
+      map.set(key, list)
+    })
+    return map
+  }, [categories])
+
+  const handleSwitchScope = (next: ArchiveScope) => {
+    if (next === scope) {
+      return
+    }
+    setNotice(null)
+    setError(null)
+    setSelectedCategoryId(null)
+    setCategories([])
+    setArchives([])
+    setScope(next)
+  }
+
+  const toggleCollapse = (categoryId: string) => {
+    setCollapsed((current) => {
+      const next = new Set(current)
+      if (next.has(categoryId)) {
+        next.delete(categoryId)
+      } else {
+        next.add(categoryId)
+      }
+      return next
+    })
+  }
+
+  const nextSortOrder = (parentId: string | null) => {
+    const siblings = childrenMap.get(parentId ?? '__root__') ?? []
+    return siblings.reduce((max, item) => Math.max(max, item.sortOrder), 0) + 10
+  }
+
+  const handleSubmitCategory = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!categoryForm) {
+      return
+    }
+    const name = categoryForm.name.trim()
+    if (!name) {
+      setError('目录名称不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      if (categoryForm.mode === 'create') {
+        const created = await createArchiveCategory({
+          scope,
+          name,
+          parentId: categoryForm.parentId,
+          sortOrder: nextSortOrder(categoryForm.parentId),
+        })
+        setNotice('目录已创建')
+        setError(null)
+        setCategoryForm(null)
+        await refreshCategories()
+        if (categoryForm.parentId) {
+          setCollapsed((current) => {
+            const next = new Set(current)
+            next.delete(categoryForm.parentId as string)
+            return next
+          })
+        }
+        setSelectedCategoryId(created.id)
+      } else {
+        await renameArchiveCategory(categoryForm.categoryId, name)
+        setNotice('目录已重命名')
+        setError(null)
+        setCategoryForm(null)
+        await refreshCategories()
+      }
+    } catch (saveError) {
+      console.warn('保存目录失败', saveError)
+      setError('保存目录失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleConfirmDeleteCategory = async () => {
+    if (!pendingDeleteCategory) {
+      return
+    }
+    const target = pendingDeleteCategory
+    setSaving(true)
+    try {
+      await deleteArchiveCategory(target.id)
+      setNotice('目录已删除')
+      setError(null)
+      setPendingDeleteCategory(null)
+      if (selectedCategoryId === target.id) {
+        setSelectedCategoryId(null)
+      }
+      await refreshCategories()
+    } catch (deleteError) {
+      console.warn('删除目录失败', deleteError)
+      setError('删除目录失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const openCreateArchive = () => {
+    const defaultCategory = selectedCategoryId ?? flatCategories[0]?.category.id ?? ''
+    if (!defaultCategory) {
+      setError('请先创建一个目录')
+      return
+    }
+    setArchiveEditor({
+      mode: 'create',
+      categoryId: defaultCategory,
+      title: '',
+      content: '',
+      keywords: [],
+      aliases: [],
+      importance: 'normal',
+      source: 'manual',
+    })
+  }
+
+  const openEditArchive = (archive: Archive) => {
+    setArchiveEditor({
+      mode: 'edit',
+      archiveId: archive.id,
+      categoryId: archive.categoryId,
+      title: archive.title,
+      content: archive.content,
+      keywords: archive.keywords,
+      aliases: archive.aliases,
+      importance: archive.importance,
+      source: archive.source,
+      updatedAt: archive.updatedAt,
+    })
+  }
+
+  const handleSubmitArchive = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!archiveEditor) {
+      return
+    }
+    const title = archiveEditor.title.trim()
+    if (!archiveEditor.categoryId) {
+      setError('请选择一个目录')
+      return
+    }
+    if (!title) {
+      setError('标题不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      if (archiveEditor.mode === 'create') {
+        await createArchive({
+          categoryId: archiveEditor.categoryId,
+          title,
+          content: archiveEditor.content.trim(),
+          keywords: archiveEditor.keywords,
+          aliases: archiveEditor.aliases,
+          importance: archiveEditor.importance,
+          source: archiveEditor.source || 'manual',
+        })
+        setNotice('档案已创建')
+      } else if (archiveEditor.archiveId) {
+        await updateArchive(archiveEditor.archiveId, {
+          categoryId: archiveEditor.categoryId,
+          title,
+          content: archiveEditor.content.trim(),
+          keywords: archiveEditor.keywords,
+          aliases: archiveEditor.aliases,
+          importance: archiveEditor.importance,
+        })
+        setNotice('档案已更新')
+      }
+      setError(null)
+      const targetCategory = archiveEditor.categoryId
+      setArchiveEditor(null)
+      if (targetCategory !== selectedCategoryId) {
+        setSelectedCategoryId(targetCategory)
+      } else {
+        await refreshArchives(selectedCategoryId)
+      }
+    } catch (saveError) {
+      console.warn('保存档案失败', saveError)
+      setError('保存档案失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleConfirmDeleteArchive = async () => {
+    if (!pendingDeleteArchive) {
+      return
+    }
+    setSaving(true)
+    try {
+      await softDeleteArchive(pendingDeleteArchive.id)
+      setNotice('档案已删除')
+      setError(null)
+      setPendingDeleteArchive(null)
+      setArchiveEditor(null)
+      await refreshArchives(selectedCategoryId)
+    } catch (deleteError) {
+      console.warn('删除档案失败', deleteError)
+      setError('删除档案失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const renderCategoryNode = ({ category, depth }: FlatCategory) => {
+    const children = childrenMap.get(category.id) ?? []
+    const hasChildren = children.length > 0
+    const isCollapsed = collapsed.has(category.id)
+    // Hide rows whose any ancestor is collapsed.
+    let ancestorId = category.parentId
+    while (ancestorId) {
+      if (collapsed.has(ancestorId)) {
+        return null
+      }
+      ancestorId = categories.find((item) => item.id === ancestorId)?.parentId ?? null
+    }
+
+    return (
+      <div
+        key={category.id}
+        className={`archive-tree__row ${selectedCategoryId === category.id ? 'active' : ''}`}
+        style={{ paddingLeft: `${8 + depth * 16}px` }}
+      >
+        <button
+          type="button"
+          className="archive-tree__caret"
+          onClick={() => hasChildren && toggleCollapse(category.id)}
+          aria-label={hasChildren ? (isCollapsed ? '展开' : '收起') : undefined}
+          disabled={!hasChildren}
+        >
+          {hasChildren ? (isCollapsed ? '▸' : '▾') : '·'}
+        </button>
+        <button
+          type="button"
+          className="archive-tree__name"
+          onClick={() => setSelectedCategoryId(category.id)}
+        >
+          <span className="archive-tree__label">{category.name}</span>
+        </button>
+        <div className="archive-tree__actions">
+          <button
+            type="button"
+            title="新增子目录"
+            onClick={() =>
+              setCategoryForm({
+                mode: 'create',
+                parentId: category.id,
+                parentName: category.name,
+                name: '',
+              })
+            }
+          >
+            ＋
+          </button>
+          <button
+            type="button"
+            title="重命名"
+            onClick={() => setCategoryForm({ mode: 'rename', categoryId: category.id, name: category.name })}
+          >
+            ✎
+          </button>
+          <button
+            type="button"
+            title="删除目录"
+            className="archive-tree__delete"
+            onClick={() => setPendingDeleteCategory(category)}
+          >
+            🗑
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const meta = SCOPE_META[scope]
+
+  return (
+    <div className={`archive-page archive-page--${scope}`}>
+      <header className="archive-header">
+        <button type="button" className="ghost archive-back-btn" onClick={() => navigate(-1)}>
+          ← 返回
+        </button>
+        <div className="archive-title-wrap">
+          <p className="archive-kicker">ARCHIVE</p>
+          <h1 className="ui-title">系统档案</h1>
+        </div>
+        <button
+          type="button"
+          className="archive-refresh-btn"
+          onClick={() => void refreshCategories()}
+          disabled={loadingCategories}
+        >
+          刷新
+        </button>
+      </header>
+
+      <div className="archive-scope-switch" role="tablist" aria-label="档案范围">
+        {(Object.keys(SCOPE_META) as ArchiveScope[]).map((value) => (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            aria-selected={scope === value}
+            className={scope === value ? 'active' : ''}
+            onClick={() => handleSwitchScope(value)}
+          >
+            <span aria-hidden="true">{SCOPE_META[value].emoji}</span>
+            {SCOPE_META[value].label}
+          </button>
+        ))}
+      </div>
+
+      {notice ? <p className="archive-notice">{notice}</p> : null}
+      {error ? <p className="archive-error">{error}</p> : null}
+
+      <section className="archive-panel archive-tree-panel" aria-label="目录树">
+        <div className="archive-panel__head">
+          <h2>
+            {meta.emoji} {meta.label}目录
+          </h2>
+          <button
+            type="button"
+            className="archive-mini-btn"
+            onClick={() => setCategoryForm({ mode: 'create', parentId: null, parentName: null, name: '' })}
+          >
+            + 新建目录
+          </button>
+        </div>
+        {loadingCategories ? <p className="archive-empty">加载中…</p> : null}
+        {!loadingCategories && categories.length === 0 ? (
+          <p className="archive-empty">当前范围还没有目录，点击「新建目录」开始整理吧。</p>
+        ) : null}
+        <div className="archive-tree">{flatCategories.map(renderCategoryNode)}</div>
+      </section>
+
+      <section className="archive-panel archive-list-panel" aria-label="档案条目">
+        <div className="archive-panel__head">
+          <h2>{selectedCategory ? `📄 ${selectedCategory.name}` : '档案条目'}</h2>
+          <button
+            type="button"
+            className="archive-mini-btn"
+            onClick={openCreateArchive}
+            disabled={categories.length === 0}
+          >
+            + 新建条目
+          </button>
+        </div>
+
+        {selectedCategory ? (
+          <input
+            className="archive-search"
+            type="search"
+            value={search}
+            placeholder="搜索标题 / 关键词 / 别名 / 正文"
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        ) : null}
+
+        {!selectedCategory ? (
+          <p className="archive-empty">请选择左侧目录查看档案。</p>
+        ) : loadingArchives ? (
+          <p className="archive-empty">加载中…</p>
+        ) : filteredArchives.length === 0 ? (
+          <p className="archive-empty">{search.trim() ? '没有匹配的档案。' : '该目录下还没有档案条目。'}</p>
+        ) : (
+          <div className="archive-list">
+            {filteredArchives.map((archive) => (
+              <button
+                key={archive.id}
+                type="button"
+                className="archive-card"
+                onClick={() => openEditArchive(archive)}
+              >
+                <div className="archive-card__top">
+                  <span className="archive-card__title">{archive.title}</span>
+                  <span className={`archive-importance archive-importance--${archive.importance}`}>
+                    {IMPORTANCE_META[archive.importance].label}
+                  </span>
+                </div>
+                {archive.content ? (
+                  <p className="archive-card__excerpt">{archive.content}</p>
+                ) : null}
+                <div className="archive-card__meta">
+                  {archive.keywords.slice(0, 4).map((keyword) => (
+                    <span key={keyword} className="archive-card__chip">
+                      #{keyword}
+                    </span>
+                  ))}
+                  <time>{formatTime(archive.updatedAt)}</time>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Category create / rename modal ── */}
+      {categoryForm ? (
+        <div className="archive-modal-backdrop" role="dialog" aria-modal="true">
+          <form className="archive-modal archive-modal--compact" onSubmit={handleSubmitCategory}>
+            <h2>
+              {categoryForm.mode === 'create'
+                ? categoryForm.parentName
+                  ? `在「${categoryForm.parentName}」下新增子目录`
+                  : '新建大类目录'
+                : '重命名目录'}
+            </h2>
+            <label>
+              目录名称
+              <input
+                autoFocus
+                type="text"
+                value={categoryForm.name}
+                onChange={(event) => setCategoryForm({ ...categoryForm, name: event.target.value })}
+                placeholder="例如：个人历史"
+              />
+            </label>
+            <div className="archive-modal__actions">
+              <button type="button" className="secondary" onClick={() => setCategoryForm(null)} disabled={saving}>
+                取消
+              </button>
+              <button type="submit" className="primary" disabled={saving}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+
+      {/* ── Archive editor modal ── */}
+      {archiveEditor ? (
+        <div className="archive-modal-backdrop" role="dialog" aria-modal="true">
+          <form className="archive-modal" onSubmit={handleSubmitArchive}>
+            <h2>{archiveEditor.mode === 'create' ? '新建档案' : '编辑档案'}</h2>
+
+            <label>
+              所属目录
+              <select
+                value={archiveEditor.categoryId}
+                onChange={(event) => setArchiveEditor({ ...archiveEditor, categoryId: event.target.value })}
+                required
+              >
+                {flatCategories.map(({ category, depth }) => (
+                  <option key={category.id} value={category.id}>
+                    {`${'　'.repeat(depth)}${category.name}`}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              标题
+              <input
+                type="text"
+                value={archiveEditor.title}
+                onChange={(event) => setArchiveEditor({ ...archiveEditor, title: event.target.value })}
+                placeholder="档案标题"
+                required
+              />
+            </label>
+
+            <label>
+              重要性
+              <select
+                value={archiveEditor.importance}
+                onChange={(event) =>
+                  setArchiveEditor({ ...archiveEditor, importance: event.target.value as ArchiveImportance })
+                }
+              >
+                {IMPORTANCE_ORDER.map((value) => (
+                  <option key={value} value={value}>
+                    {IMPORTANCE_META[value].label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              正文
+              <textarea
+                value={archiveEditor.content}
+                onChange={(event) => setArchiveEditor({ ...archiveEditor, content: event.target.value })}
+                rows={6}
+                placeholder="档案正文内容"
+              />
+            </label>
+
+            <label>
+              关键词
+              <TagInput
+                values={archiveEditor.keywords}
+                onChange={(next) => setArchiveEditor({ ...archiveEditor, keywords: next })}
+                placeholder="输入后回车或逗号添加"
+              />
+            </label>
+
+            <label>
+              别名
+              <TagInput
+                values={archiveEditor.aliases}
+                onChange={(next) => setArchiveEditor({ ...archiveEditor, aliases: next })}
+                placeholder="输入后回车或逗号添加"
+              />
+            </label>
+
+            <div className="archive-modal__readonly">
+              <span>来源：{archiveEditor.source || 'manual'}</span>
+              {archiveEditor.updatedAt ? <span>更新时间：{formatTime(archiveEditor.updatedAt)}</span> : null}
+            </div>
+
+            <div className="archive-modal__actions">
+              <button type="button" className="secondary" onClick={() => setArchiveEditor(null)} disabled={saving}>
+                取消
+              </button>
+              {archiveEditor.mode === 'edit' && archiveEditor.archiveId ? (
+                <button
+                  type="button"
+                  className="danger"
+                  onClick={() => {
+                    const target = archives.find((item) => item.id === archiveEditor.archiveId)
+                    if (target) {
+                      setPendingDeleteArchive(target)
+                    }
+                  }}
+                  disabled={saving}
+                >
+                  删除
+                </button>
+              ) : null}
+              <button type="submit" className="primary" disabled={saving}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={pendingDeleteCategory !== null}
+        title="删除目录"
+        description={
+          pendingDeleteCategory
+            ? `确定要删除目录「${pendingDeleteCategory.name}」吗？其下的子目录和档案都会一并删除，且无法恢复。`
+            : undefined
+        }
+        confirmLabel={saving ? '删除中…' : '删除'}
+        cancelLabel="取消"
+        confirmDisabled={saving}
+        cancelDisabled={saving}
+        onConfirm={() => void handleConfirmDeleteCategory()}
+        onCancel={() => setPendingDeleteCategory(null)}
+      />
+
+      <ConfirmDialog
+        open={pendingDeleteArchive !== null}
+        title="删除档案"
+        description={
+          pendingDeleteArchive
+            ? `确定要删除档案「${pendingDeleteArchive.title}」吗？删除后将不再显示在列表中。`
+            : undefined
+        }
+        confirmLabel={saving ? '删除中…' : '删除'}
+        cancelLabel="取消"
+        confirmDisabled={saving}
+        cancelDisabled={saving}
+        onConfirm={() => void handleConfirmDeleteArchive()}
+        onCancel={() => setPendingDeleteArchive(null)}
+      />
+    </div>
+  )
+}
+
+export default ArchivePage

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -65,7 +65,7 @@ const DEFAULT_ICON_ORDER = [
   "export",
 ];
 const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "todo", "knowledge", "wiki", "novels", "council", "lounge", "hamster-wallet", "hamster-console"];
-const DEFAULT_PAGE3_ICON_ORDER = ["syzygy-feed"];
+const DEFAULT_PAGE3_ICON_ORDER = ["syzygy-feed", "archive"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2", "page3"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -287,6 +287,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "hamster-wallet", defaultEmoji: "💰", label: "仓鼠钱包", route: "/wallet" },
       { id: "hamster-console", defaultEmoji: "🎛️", label: "仓鼠机", route: "/hamster-console" },
       { id: "syzygy-feed", defaultEmoji: "📮", label: "Syzygy Feed", route: "/feed" },
+      { id: "archive", defaultEmoji: "🗂️", label: "系统档案", route: "/archive" },
     ],
     [onOpenChat],
   );
@@ -547,6 +548,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
         DEFAULT_PAGE3_ICON_ORDER,
         {
           "syzygy-feed": defaultAppIconConfigs["syzygy-feed"],
+          archive: defaultAppIconConfigs.archive,
         },
         false,
       ),

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -84,7 +84,7 @@ const DEFAULT_PAGE_LAYOUTS: Record<HomeLayoutPageId, HomePageLayoutState> = {
     appIconConfigs: {},
   },
   page3: {
-    iconOrder: ['syzygy-feed'],
+    iconOrder: ['syzygy-feed', 'archive'],
     widgetOrder: [],
     widgets: [],
     checkinSize: '1x1',

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -1,4 +1,8 @@
 import type {
+  Archive,
+  ArchiveCategory,
+  ArchiveImportance,
+  ArchiveScope,
   BubbleMessage,
   BubbleSession,
   ChatMessage,
@@ -3426,3 +3430,253 @@ export const updateNovelBookMeta = async (bookId:string, updates:{ title?: strin
 export const listNovelChaptersByBookId = async (bookId: string): Promise<NovelChapter[]> => { if (!supabase) return []; const {data,error}=await supabase.from('novel_chapters').select('*').eq('book_id',bookId).order('chapter_number',{ascending:true}); if(error) throw error; return (data??[] as NovelChapterRow[]).map((r)=>mapNovelChapterRow(r as NovelChapterRow)) }
 export const createNovelChapter = async (payload:{ bookId:string; chapterNumber:number; title:string; content:string; directorNote:string; summary:string }): Promise<NovelChapter> => { if (!supabase) throw new Error('Supabase 客户端未配置'); const now=new Date().toISOString(); const {data,error}=await supabase.from('novel_chapters').insert({book_id:payload.bookId,chapter_number:payload.chapterNumber,title:payload.title,content:payload.content,director_note:payload.directorNote,summary:payload.summary,created_at:now,updated_at:now}).select('*').single(); if(error||!data) throw error ?? new Error('创建章节失败'); return mapNovelChapterRow(data as NovelChapterRow) }
 export const updateNovelChapter = async (chapterId:string, updates:{ content?:string; directorNote?:string; summary?:string; status?:'draft'|'published' }): Promise<NovelChapter> => { if (!supabase) throw new Error('Supabase 客户端未配置'); const patch: Record<string, unknown> = {updated_at:new Date().toISOString()}; if(typeof updates.content !== 'undefined') patch.content = updates.content; if(typeof updates.directorNote !== 'undefined') patch.director_note = updates.directorNote; if(typeof updates.summary !== 'undefined') patch.summary = updates.summary; if(typeof updates.status !== 'undefined') patch.status = updates.status; const {data,error}=await supabase.from('novel_chapters').update(patch).eq('id',chapterId).select('*').single(); if(error||!data) throw error ?? new Error('更新章节失败'); return mapNovelChapterRow(data as NovelChapterRow) }
+
+
+// ── System Archive (系统档案) ─────────────────────────────
+
+type ArchiveCategoryRow = {
+  id: string
+  user_id: string
+  parent_id: string | null
+  scope: string
+  name: string
+  sort_order: number | null
+  created_at: string
+  updated_at: string
+}
+
+type ArchiveRow = {
+  id: string
+  user_id: string
+  category_id: string
+  title: string
+  content: string
+  keywords: string[] | null
+  aliases: string[] | null
+  importance: string | null
+  source: string | null
+  is_deleted: boolean | null
+  created_at: string
+  updated_at: string
+}
+
+const ARCHIVE_IMPORTANCE_VALUES: ArchiveImportance[] = ['low', 'normal', 'high', 'critical']
+
+const normalizeArchiveScope = (scope: string): ArchiveScope =>
+  scope === 'syzygy' ? 'syzygy' : 'chuanchuan'
+
+const normalizeArchiveImportance = (importance: string | null): ArchiveImportance =>
+  (ARCHIVE_IMPORTANCE_VALUES as string[]).includes(importance ?? '')
+    ? (importance as ArchiveImportance)
+    : 'normal'
+
+const mapArchiveCategoryRow = (row: ArchiveCategoryRow): ArchiveCategory => ({
+  id: row.id,
+  userId: row.user_id,
+  parentId: row.parent_id,
+  scope: normalizeArchiveScope(row.scope),
+  name: row.name,
+  sortOrder: row.sort_order ?? 0,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const mapArchiveRow = (row: ArchiveRow): Archive => ({
+  id: row.id,
+  userId: row.user_id,
+  categoryId: row.category_id,
+  title: row.title,
+  content: row.content ?? '',
+  keywords: Array.isArray(row.keywords) ? row.keywords : [],
+  aliases: Array.isArray(row.aliases) ? row.aliases : [],
+  importance: normalizeArchiveImportance(row.importance),
+  source: row.source ?? 'manual',
+  isDeleted: row.is_deleted ?? false,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const ARCHIVE_CATEGORY_COLUMNS = 'id,user_id,parent_id,scope,name,sort_order,created_at,updated_at'
+const ARCHIVE_COLUMNS =
+  'id,user_id,category_id,title,content,keywords,aliases,importance,source,is_deleted,created_at,updated_at'
+
+export const listArchiveCategories = async (scope: ArchiveScope): Promise<ArchiveCategory[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('archive_categories')
+    .select(ARCHIVE_CATEGORY_COLUMNS)
+    .eq('user_id', userId)
+    .eq('scope', scope)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapArchiveCategoryRow(row as ArchiveCategoryRow))
+}
+
+export const createArchiveCategory = async (payload: {
+  scope: ArchiveScope
+  name: string
+  parentId: string | null
+  sortOrder?: number
+}): Promise<ArchiveCategory> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('archive_categories')
+    .insert({
+      user_id: userId,
+      scope: payload.scope,
+      name: payload.name,
+      parent_id: payload.parentId,
+      sort_order: payload.sortOrder ?? 0,
+    })
+    .select(ARCHIVE_CATEGORY_COLUMNS)
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('创建目录失败')
+  }
+  return mapArchiveCategoryRow(data as ArchiveCategoryRow)
+}
+
+export const renameArchiveCategory = async (categoryId: string, name: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('archive_categories')
+    .update({ name, updated_at: new Date().toISOString() })
+    .eq('id', categoryId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
+// Hard delete: DB cascades to child categories and their archives.
+export const deleteArchiveCategory = async (categoryId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('archive_categories')
+    .delete()
+    .eq('id', categoryId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}
+
+export const listArchives = async (categoryId: string): Promise<Archive[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('archives')
+    .select(ARCHIVE_COLUMNS)
+    .eq('user_id', userId)
+    .eq('category_id', categoryId)
+    .eq('is_deleted', false)
+    .order('updated_at', { ascending: false })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapArchiveRow(row as ArchiveRow))
+}
+
+export const createArchive = async (payload: {
+  categoryId: string
+  title: string
+  content: string
+  keywords: string[]
+  aliases: string[]
+  importance: ArchiveImportance
+  source?: string
+}): Promise<Archive> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('archives')
+    .insert({
+      user_id: userId,
+      category_id: payload.categoryId,
+      title: payload.title,
+      content: payload.content,
+      keywords: payload.keywords,
+      aliases: payload.aliases,
+      importance: payload.importance,
+      source: payload.source ?? 'manual',
+    })
+    .select(ARCHIVE_COLUMNS)
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('创建档案失败')
+  }
+  return mapArchiveRow(data as ArchiveRow)
+}
+
+export const updateArchive = async (
+  archiveId: string,
+  payload: {
+    categoryId?: string
+    title: string
+    content: string
+    keywords: string[]
+    aliases: string[]
+    importance: ArchiveImportance
+  },
+): Promise<Archive> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const patch: Record<string, unknown> = {
+    title: payload.title,
+    content: payload.content,
+    keywords: payload.keywords,
+    aliases: payload.aliases,
+    importance: payload.importance,
+    updated_at: new Date().toISOString(),
+  }
+  if (typeof payload.categoryId !== 'undefined') {
+    patch.category_id = payload.categoryId
+  }
+  const { data, error } = await supabase
+    .from('archives')
+    .update(patch)
+    .eq('id', archiveId)
+    .eq('user_id', userId)
+    .select(ARCHIVE_COLUMNS)
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('更新档案失败')
+  }
+  return mapArchiveRow(data as ArchiveRow)
+}
+
+export const softDeleteArchive = async (archiveId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase
+    .from('archives')
+    .update({ is_deleted: true, updated_at: new Date().toISOString() })
+    .eq('id', archiveId)
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -486,3 +486,32 @@ export type LoungeMember = {
   emoji: string
   color: string
 }
+
+export type ArchiveScope = 'chuanchuan' | 'syzygy'
+export type ArchiveImportance = 'low' | 'normal' | 'high' | 'critical'
+
+export type ArchiveCategory = {
+  id: string
+  userId: string
+  parentId: string | null
+  scope: ArchiveScope
+  name: string
+  sortOrder: number
+  createdAt: string
+  updatedAt: string
+}
+
+export type Archive = {
+  id: string
+  userId: string
+  categoryId: string
+  title: string
+  content: string
+  keywords: string[]
+  aliases: string[]
+  importance: ArchiveImportance
+  source: string
+  isDeleted: boolean
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
## 概述

在主页 **Page 3** 新增「系统档案」模块，用于管理长期层档案，基于已有的 `archive_categories` / `archives` 两张表。实现前先用 Supabase 核实了线上 schema、种子目录、RLS 策略与外键级联行为，确保字段与权限完全对齐。

## 改动文件

- **新增** `src/pages/ArchivePage.tsx` + `ArchivePage.css` — 系统档案主页面
- `src/storage/supabaseSync.ts` — 档案目录 / 条目的读写函数
- `src/types.ts` — `ArchiveScope / ArchiveImportance / ArchiveCategory / Archive` 类型
- `src/App.tsx` — `/archive` 路由（`RequireAuth` 保护）
- `src/pages/HomePage.tsx` + `src/storage/homeLayout.ts` — Page 3 新增「系统档案」🗂️ 应用图标

## 对照验收标准

| 验收项 | 实现 |
|---|---|
| 串串 / Syzygy 切换 | 顶部分段切换，串串粉色、Syzygy 浅蓝（CSS 变量主题切换），切换只读取对应 scope |
| 默认目录树 | 按 `parent_id` 递归渲染，可展开 / 收起；显示后端种子目录 |
| 新增目录 | 支持新建大类（`parent_id=null`）与子目录；另支持重命名、删除（二次确认） |
| 目录下新增条目 | 新建必须选目录（下拉默认当前目录），importance 下拉 low/normal/high/critical，source 默认 manual |
| 编辑标题 / 正文 / 标签 / 重要性 | 编辑弹窗，keywords / aliases 用标签输入（回车或逗号添加） |
| 删除条目后不再显示 | `is_deleted=true` 软删除，列表只查 `is_deleted=false` |
| 切换目录刷新列表 | 选中目录后按 `updated_at desc` 拉取，并清空搜索框 |
| 搜索 | 前端本地过滤标题 / 关键词 / 别名 / 正文 |

## 权限与安全

- 全程使用当前登录用户的 Supabase session（`requireAuthenticatedUserId()`），insert 显式写入 session 的 `user_id`，满足 RLS 的 `with_check (user_id = auth.uid())`。**未写死 user_id**。
- 已确认 anon 无任何策略 → 无法读取系统档案。
- 删除目录时依赖 DB 外键 `ON DELETE CASCADE` 自动清理子目录与其下档案。

## 暂未做（符合任务说明）

- 不做拖拽排序（`sort_order` 可后续再做）
- 不做日常内容自动升格为系统档案
- 搜索目前为当前目录内的前端过滤，后续可接数据库全文检索

## 校验

- `tsc -b`、针对改动文件的 `eslint`、`vite build` 全部通过（1475 模块成功打包）
- `npm run check` 仅剩的报错位于未改动的 `supabase/functions/hamster-mcp/index.ts`（既有问题，与本 PR 无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXKVXKSGgGfTuXNfy4HfsU)_