### PR TITLE
feat(timeline,todo): 前端来源标记与待办仪表盘

### DIFF
--- a/src/pages/TimelinePage.css
+++ b/src/pages/TimelinePage.css
@@ -316,12 +316,91 @@
   flex-shrink: 0;
 }
 
+.timeline-card__body {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
 .timeline-card__summary {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
   color: #4f3f4a;
   line-height: 1.45;
+}
+
+.timeline-card__source {
+  justify-self: start;
+  font-size: 11px;
+  font-weight: 600;
+  color: #8a6b7d;
+  background: #fff3f8;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 999px;
+  padding: 2px 9px;
+  line-height: 1.4;
+}
+
+/* ── Source statistics ────────────────────────── */
+
+.timeline-source-stats {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 16px;
+  background: #fff;
+  padding: 12px 14px;
+  display: grid;
+  gap: 8px;
+  box-shadow: 0 6px 14px rgba(255, 214, 231, 0.16);
+}
+
+.timeline-source-stats__title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #76556c;
+}
+
+.timeline-source-stats__empty {
+  font-size: 12px;
+  color: #9c7b8e;
+}
+
+.timeline-source-stats__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.timeline-source-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6a4459;
+  background: #fff5f9;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.timeline-source-chip em {
+  font-style: normal;
+  font-weight: 700;
+  color: #fff;
+  background: #f29cc3;
+  border-radius: 999px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
 }
 
 /* ── Editor modal ─────────────────────────────── */

--- a/src/pages/TimelinePage.tsx
+++ b/src/pages/TimelinePage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import type { TimelineEntry, TimelineRecorder } from '../types'
+import type { TimelineEntry, TimelineRecorder, TimelineSource } from '../types'
 import {
   createTimelineEntry,
   deleteTimelineEntry,
@@ -15,12 +15,44 @@ type TimelineEditorState = {
   eventDate: string
   summary: string
   recorder: TimelineRecorder
+  source: TimelineSource
 }
 
 const RECORDER_META: Record<TimelineRecorder, { emoji: string; label: string }> = {
   chuanchuan: { emoji: '🐹', label: '串串' },
   syzygy: { emoji: '🩵', label: 'Syzygy' },
 }
+
+const DEFAULT_SOURCE: TimelineSource = 'frontend'
+
+// 来源端标签：source 表示写入端，和 recorder（记录者）区分。
+const SOURCE_META: Record<string, { label: string }> = {
+  frontend: { label: '仓鼠窝前端' },
+  wechat_api: { label: '微信' },
+  client_gpt: { label: '客户端 GPT' },
+  client_claude: { label: '客户端 Claude' },
+  codex_cli: { label: 'Codex CLI' },
+  claude_code_cli: { label: 'Claude Code CLI' },
+  system: { label: '系统' },
+  // 历史数据里已存在的旧来源值，保留可读标签。
+  claude: { label: 'Claude' },
+  gpt: { label: 'GPT' },
+  gemini: { label: 'Gemini' },
+  user: { label: '手动' },
+}
+
+// 新建 / 编辑表单可选来源（前端约定的来源端）。
+const SOURCE_OPTIONS: TimelineSource[] = [
+  'frontend',
+  'wechat_api',
+  'client_gpt',
+  'client_claude',
+  'codex_cli',
+  'claude_code_cli',
+  'system',
+]
+
+const getSourceLabel = (source: string) => SOURCE_META[source]?.label ?? source
 
 const getTodayDate = () => {
   const date = new Date()
@@ -54,6 +86,7 @@ const buildEditorState = (entry?: TimelineEntry): TimelineEditorState => ({
   eventDate: entry?.eventDate ?? getTodayDate(),
   summary: entry?.summary ?? '',
   recorder: entry?.recorder ?? 'chuanchuan',
+  source: entry?.source ?? DEFAULT_SOURCE,
 })
 
 const TimelinePage = () => {
@@ -126,6 +159,15 @@ const TimelinePage = () => {
     return Array.from(entriesByDate.entries()).sort((a, b) => b[0].localeCompare(a[0]))
   }, [entriesByDate])
 
+  // 来源统计：本地聚合当前月份各来源端写入数量。
+  const sourceStats = useMemo(() => {
+    const counts = new Map<string, number>()
+    entries.forEach((entry) => {
+      counts.set(entry.source, (counts.get(entry.source) ?? 0) + 1)
+    })
+    return Array.from(counts.entries()).sort((a, b) => b[1] - a[1])
+  }, [entries])
+
   const selectedEntries = useMemo(() => {
     if (!selectedDate) {
       return []
@@ -173,6 +215,7 @@ const TimelinePage = () => {
           eventDate: editor.eventDate,
           summary,
           recorder: editor.recorder,
+          source: editor.source,
         })
         setNotice('时间轴已创建')
       } else if (editor.entryId) {
@@ -180,6 +223,7 @@ const TimelinePage = () => {
           eventDate: editor.eventDate,
           summary,
           recorder: editor.recorder,
+          source: editor.source,
         })
         setNotice('时间轴已更新')
       }
@@ -274,6 +318,22 @@ const TimelinePage = () => {
         </div>
       </section>
 
+      <section className="timeline-source-stats" aria-label="来源统计">
+        <p className="timeline-source-stats__title">本月来源统计</p>
+        {sourceStats.length === 0 ? (
+          <span className="timeline-source-stats__empty">暂无记录</span>
+        ) : (
+          <div className="timeline-source-stats__chips">
+            {sourceStats.map(([source, count]) => (
+              <span key={source} className={`timeline-source-chip timeline-source--${source}`}>
+                {getSourceLabel(source)}
+                <em>{count}</em>
+              </span>
+            ))}
+          </div>
+        )}
+      </section>
+
       {notice ? <p className="timeline-notice">{notice}</p> : null}
       {error ? <p className="timeline-error">{error}</p> : null}
 
@@ -301,7 +361,15 @@ const TimelinePage = () => {
                         <span className="timeline-card__recorder" title={recorderMeta.label}>
                           {recorderMeta.emoji}
                         </span>
-                        <p className="timeline-card__summary">{entry.summary}</p>
+                        <div className="timeline-card__body">
+                          <p className="timeline-card__summary">{entry.summary}</p>
+                          <span
+                            className={`timeline-card__source timeline-source--${entry.source}`}
+                            title={`来源：${getSourceLabel(entry.source)}`}
+                          >
+                            {getSourceLabel(entry.source)}
+                          </span>
+                        </div>
                       </button>
                     )
                   })}
@@ -342,6 +410,23 @@ const TimelinePage = () => {
               >
                 <option value="chuanchuan">{RECORDER_META.chuanchuan.emoji} {RECORDER_META.chuanchuan.label}</option>
                 <option value="syzygy">{RECORDER_META.syzygy.emoji} {RECORDER_META.syzygy.label}</option>
+              </select>
+            </label>
+            <label>
+              来源端
+              <select
+                value={editor.source}
+                onChange={(event) => setEditor({ ...editor, source: event.target.value as TimelineSource })}
+              >
+                {/* 编辑旧记录时，若来源不在标准选项内，补一个当前值方便保留 */}
+                {!SOURCE_OPTIONS.includes(editor.source) ? (
+                  <option value={editor.source}>{getSourceLabel(editor.source)}</option>
+                ) : null}
+                {SOURCE_OPTIONS.map((source) => (
+                  <option key={source} value={source}>
+                    {getSourceLabel(source)}
+                  </option>
+                ))}
               </select>
             </label>
 

--- a/src/pages/TodoPage.css
+++ b/src/pages/TodoPage.css
@@ -338,3 +338,149 @@
   cursor: not-allowed;
   opacity: 0.56;
 }
+
+/* ── View switch (日历 / 仪表盘) ───────────────── */
+
+.todo-view-switch {
+  display: inline-flex;
+  justify-self: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 12px rgba(255, 214, 231, 0.18);
+}
+
+.todo-view-switch__btn {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #8a6b7d;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 7px 16px;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.todo-view-switch__btn.is-active {
+  background: linear-gradient(180deg, #ffdcec 0%, #ffcfe5 100%);
+  color: #5a3448;
+  box-shadow: 0 2px 8px rgba(255, 185, 216, 0.4);
+}
+
+/* ── Status states ────────────────────────────── */
+
+.todo-item__status--in_progress {
+  border-color: #f5b86a;
+  color: #d98a2b;
+  background: #fff6e9;
+}
+
+.todo-item__status--completed {
+  background: linear-gradient(180deg, #ffe3ef 0%, #ffd2e6 100%);
+}
+
+.todo-item--in-progress {
+  border-color: rgba(245, 184, 106, 0.55);
+  background: #fffaf2;
+}
+
+.todo-item__badge {
+  justify-self: start;
+  font-size: 11px;
+  font-weight: 600;
+  color: #8a5a2e;
+  background: #fff3e2;
+  border: 1px solid rgba(245, 184, 106, 0.5);
+  border-radius: 999px;
+  padding: 1px 8px;
+  line-height: 1.5;
+}
+
+.todo-item__meta {
+  color: #98798c;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* ── Dashboard ────────────────────────────────── */
+
+.todo-dashboard {
+  display: grid;
+  gap: 12px;
+}
+
+.todo-dashboard__columns {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.todo-dashboard__col {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  border: 1px solid rgba(255, 214, 231, 0.82);
+  border-radius: 18px;
+  background: linear-gradient(180deg, #fff 0%, #fff8fc 100%);
+  padding: 12px;
+  box-shadow: 0 5px 14px rgba(255, 214, 231, 0.18);
+  min-height: 120px;
+}
+
+.todo-dashboard__col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.todo-dashboard__col-head h3 {
+  margin: 0;
+  font-size: 14px;
+  color: #68485e;
+  padding-left: 8px;
+  border-left: 3px solid #ffd6e7;
+}
+
+.todo-dashboard__count {
+  min-width: 22px;
+  height: 22px;
+  padding: 0 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #fff5f9;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  color: #9a4b72;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.todo-dashboard__list {
+  display: grid;
+  gap: 8px;
+}
+
+.todo-dashboard__empty {
+  margin: 0;
+  border: 1px dashed rgba(255, 214, 231, 0.9);
+  border-radius: 14px;
+  padding: 14px 12px;
+  color: #9c7b8e;
+  background: rgba(255, 255, 255, 0.72);
+  text-align: center;
+  font-size: 12px;
+}
+
+@media (max-width: 560px) {
+  .todo-dashboard__columns {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,19 +1,23 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import type { TodoCategory, TodoCreatedBy, TodoItem } from '../types'
+import type { TodoCategory, TodoCreatedBy, TodoItem, TodoStatus, TodoType } from '../types'
 import {
   createTodoCategory,
   createTodoItem,
   deleteTodoCategory,
   deleteTodoItem,
   listTodoCategoriesByDate,
+  listTodoDashboard,
   listTodosByDate,
   listTodosByMonth,
   updateTodoItem,
   updateTodoItemStatus,
+  type TodoDashboardData,
 } from '../storage/supabaseSync'
 import './TimelinePage.css'
 import './TodoPage.css'
+
+type TodoView = 'calendar' | 'dashboard'
 
 type TodoEditorState = {
   mode: 'create' | 'edit'
@@ -22,6 +26,8 @@ type TodoEditorState = {
   title: string
   notes: string
   createdBy: TodoCreatedBy
+  todoType: TodoType
+  eventDate: string
 }
 
 type CalendarTodoMeta = {
@@ -33,6 +39,31 @@ type CalendarTodoMeta = {
 const CREATED_BY_META: Record<TodoCreatedBy, { emoji: string; label: string }> = {
   串串: { emoji: '🐹', label: '串串' },
   syzygy: { emoji: '💙', label: 'syzygy' },
+}
+
+// 点击状态按钮时的循环顺序：未完成 → 进行中 → 已完成 → 未完成。
+const STATUS_CYCLE: Record<TodoStatus, TodoStatus> = {
+  pending: 'in_progress',
+  in_progress: 'completed',
+  completed: 'pending',
+}
+
+const STATUS_GLYPH: Record<TodoStatus, string> = {
+  pending: '',
+  in_progress: '◐',
+  completed: '✓',
+}
+
+const STATUS_LABEL: Record<TodoStatus, string> = {
+  pending: '未完成',
+  in_progress: '进行中',
+  completed: '已完成',
+}
+
+const STATUS_NOTICE: Record<TodoStatus, string> = {
+  pending: '已恢复为未完成',
+  in_progress: '已标记进行中',
+  completed: '已完成待办',
 }
 
 const toLocalDateKey = (value: Date) => {
@@ -57,6 +88,7 @@ const getMonthRange = (anchorDate: Date) => {
 const TodoPage = () => {
   const navigate = useNavigate()
   const today = useMemo(() => getTodayDate(), [])
+  const [view, setView] = useState<TodoView>('calendar')
   const [monthCursor, setMonthCursor] = useState(() => {
     const now = new Date()
     return new Date(now.getFullYear(), now.getMonth(), 1)
@@ -65,8 +97,10 @@ const TodoPage = () => {
   const [monthTodos, setMonthTodos] = useState<TodoItem[]>([])
   const [categories, setCategories] = useState<TodoCategory[]>([])
   const [dayTodos, setDayTodos] = useState<TodoItem[]>([])
+  const [dashboard, setDashboard] = useState<TodoDashboardData>({ nearTermOpen: [], longTerm: [] })
   const [monthLoading, setMonthLoading] = useState(true)
   const [dayLoading, setDayLoading] = useState(true)
+  const [dashboardLoading, setDashboardLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [categoryName, setCategoryName] = useState('')
   const [showCategoryForm, setShowCategoryForm] = useState(false)
@@ -108,9 +142,23 @@ const TodoPage = () => {
     }
   }, [selectedDate])
 
+  const refreshDashboard = useCallback(async () => {
+    setDashboardLoading(true)
+    try {
+      const data = await listTodoDashboard()
+      setDashboard(data)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载待办仪表盘失败', loadError)
+      setError('加载待办仪表盘失败，请稍后重试')
+    } finally {
+      setDashboardLoading(false)
+    }
+  }, [])
+
   const refreshAll = useCallback(async () => {
-    await Promise.all([refreshMonth(), refreshSelectedDate()])
-  }, [refreshMonth, refreshSelectedDate])
+    await Promise.all([refreshMonth(), refreshSelectedDate(), refreshDashboard()])
+  }, [refreshMonth, refreshSelectedDate, refreshDashboard])
 
   useEffect(() => {
     void refreshMonth()
@@ -119,6 +167,19 @@ const TodoPage = () => {
   useEffect(() => {
     void refreshSelectedDate()
   }, [refreshSelectedDate])
+
+  useEffect(() => {
+    void refreshDashboard()
+  }, [refreshDashboard])
+
+  const dashboardPending = useMemo(
+    () => dashboard.nearTermOpen.filter((todo) => todo.status === 'pending'),
+    [dashboard],
+  )
+  const dashboardInProgress = useMemo(
+    () => dashboard.nearTermOpen.filter((todo) => todo.status === 'in_progress'),
+    [dashboard],
+  )
 
   const todosByDate = useMemo(() => {
     const groups = new Map<string, CalendarTodoMeta>()
@@ -201,7 +262,15 @@ const TodoPage = () => {
   }
 
   const openCreateTodo = (categoryId: string) => {
-    setEditor({ mode: 'create', categoryId, title: '', notes: '', createdBy: '串串' })
+    setEditor({
+      mode: 'create',
+      categoryId,
+      title: '',
+      notes: '',
+      createdBy: '串串',
+      todoType: 'short_term',
+      eventDate: '',
+    })
   }
 
   const openEditTodo = (todo: TodoItem) => {
@@ -212,6 +281,8 @@ const TodoPage = () => {
       title: todo.title,
       notes: todo.notes ?? '',
       createdBy: todo.createdBy,
+      todoType: todo.todoType,
+      eventDate: todo.eventDate ?? '',
     })
   }
 
@@ -226,6 +297,7 @@ const TodoPage = () => {
       setError('待办标题不能为空')
       return
     }
+    const eventDate = editor.todoType === 'long_term' ? editor.eventDate || null : null
     setSaving(true)
     try {
       if (editor.mode === 'create') {
@@ -237,10 +309,18 @@ const TodoPage = () => {
           notes: notes || null,
           createdBy: editor.createdBy,
           sortOrder: categoryTodos.length,
+          todoType: editor.todoType,
+          eventDate,
         })
         setNotice('待办已创建')
       } else if (editor.todoId) {
-        await updateTodoItem(editor.todoId, { title, notes: notes || null, createdBy: editor.createdBy })
+        await updateTodoItem(editor.todoId, {
+          title,
+          notes: notes || null,
+          createdBy: editor.createdBy,
+          todoType: editor.todoType,
+          eventDate,
+        })
         setNotice('待办已更新')
       }
       setEditor(null)
@@ -297,11 +377,12 @@ const TodoPage = () => {
     }
   }
 
-  const handleToggleStatus = async (todo: TodoItem) => {
+  const handleAdvanceStatus = async (todo: TodoItem) => {
+    const nextStatus = STATUS_CYCLE[todo.status]
     setSaving(true)
     try {
-      await updateTodoItemStatus(todo.id, todo.status === 'completed' ? 'pending' : 'completed')
-      setNotice(todo.status === 'completed' ? '已恢复待办' : '已完成待办')
+      await updateTodoItemStatus(todo.id, nextStatus)
+      setNotice(STATUS_NOTICE[nextStatus])
       setError(null)
       await refreshAll()
     } catch (saveError) {
@@ -310,6 +391,38 @@ const TodoPage = () => {
     } finally {
       setSaving(false)
     }
+  }
+
+  const renderDashboardTodo = (todo: TodoItem) => {
+    const creator = CREATED_BY_META[todo.createdBy] ?? CREATED_BY_META.串串
+    const completed = todo.status === 'completed'
+    const inProgress = todo.status === 'in_progress'
+    const meta =
+      todo.todoType === 'long_term'
+        ? `🎯 ${todo.eventDate ?? '未定目标日期'}`
+        : `📅 ${todo.date}`
+    return (
+      <article
+        className={['todo-item', completed && 'todo-item--completed', inProgress && 'todo-item--in-progress'].filter(Boolean).join(' ')}
+        key={todo.id}
+      >
+        <button
+          type="button"
+          className={`todo-item__status todo-item__status--${todo.status}`}
+          onClick={() => handleAdvanceStatus(todo)}
+          aria-label={`当前${STATUS_LABEL[todo.status]}，点击切换为${STATUS_LABEL[STATUS_CYCLE[todo.status]]}`}
+          title={STATUS_LABEL[todo.status]}
+          disabled={saving}
+        >
+          {STATUS_GLYPH[todo.status]}
+        </button>
+        <button type="button" className="todo-item__content" onClick={() => openEditTodo(todo)}>
+          <span className="todo-item__title">{todo.title}</span>
+          <span className="todo-item__meta">{meta}</span>
+        </button>
+        <span className="todo-item__creator" title={creator.label}>{creator.emoji}</span>
+      </article>
+    )
   }
 
   return (
@@ -322,11 +435,35 @@ const TodoPage = () => {
           <p className="timeline-kicker">To do</p>
           <h1 className="ui-title">待办小窝</h1>
         </div>
-        <button type="button" className="timeline-create-btn" onClick={() => setShowCategoryForm(true)}>
-          + 类目
-        </button>
+        {view === 'calendar' ? (
+          <button type="button" className="timeline-create-btn" onClick={() => setShowCategoryForm(true)}>
+            + 类目
+          </button>
+        ) : null}
       </header>
 
+      <div className="todo-view-switch" role="tablist" aria-label="待办视图切换">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === 'calendar'}
+          className={['todo-view-switch__btn', view === 'calendar' && 'is-active'].filter(Boolean).join(' ')}
+          onClick={() => setView('calendar')}
+        >
+          📅 日历
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === 'dashboard'}
+          className={['todo-view-switch__btn', view === 'dashboard' && 'is-active'].filter(Boolean).join(' ')}
+          onClick={() => setView('dashboard')}
+        >
+          📊 仪表盘
+        </button>
+      </div>
+
+      {view === 'calendar' ? (
       <section className="timeline-calendar" aria-label="待办月份日历">
         <div className="timeline-calendar__dot" aria-hidden="true" />
         <div className="timeline-calendar__top">
@@ -372,10 +509,12 @@ const TodoPage = () => {
         </div>
         {monthLoading ? <p className="todo-calendar-loading">月历提示加载中…</p> : null}
       </section>
+      ) : null}
 
       {notice ? <p className="timeline-notice">{notice}</p> : null}
       {error ? <p className="timeline-error">{error}</p> : null}
 
+      {view === 'calendar' ? (
       <section className="timeline-list todo-detail" aria-label="当天待办">
         <div className="todo-detail__top">
           <div>
@@ -440,19 +579,27 @@ const TodoPage = () => {
                       {categoryTodos.map((todo) => {
                         const creator = CREATED_BY_META[todo.createdBy] ?? CREATED_BY_META.串串
                         const completed = todo.status === 'completed'
+                        const inProgress = todo.status === 'in_progress'
                         return (
-                          <article className={['todo-item', completed && 'todo-item--completed'].filter(Boolean).join(' ')} key={todo.id}>
+                          <article
+                            className={['todo-item', completed && 'todo-item--completed', inProgress && 'todo-item--in-progress'].filter(Boolean).join(' ')}
+                            key={todo.id}
+                          >
                             <button
                               type="button"
-                              className="todo-item__status"
-                              onClick={() => handleToggleStatus(todo)}
-                              aria-label={completed ? '恢复为待办' : '标记完成'}
+                              className={`todo-item__status todo-item__status--${todo.status}`}
+                              onClick={() => handleAdvanceStatus(todo)}
+                              aria-label={`当前${STATUS_LABEL[todo.status]}，点击切换为${STATUS_LABEL[STATUS_CYCLE[todo.status]]}`}
+                              title={STATUS_LABEL[todo.status]}
                               disabled={saving}
                             >
-                              {completed ? '✓' : ''}
+                              {STATUS_GLYPH[todo.status]}
                             </button>
                             <button type="button" className="todo-item__content" onClick={() => openEditTodo(todo)}>
                               <span className="todo-item__title">{todo.title}</span>
+                              {todo.todoType === 'long_term' ? (
+                                <span className="todo-item__badge">长期{todo.eventDate ? ` · ${todo.eventDate}` : ''}</span>
+                              ) : null}
                               {todo.notes ? <span className="todo-item__notes">{todo.notes}</span> : null}
                             </button>
                             <div className="todo-item__actions">
@@ -479,6 +626,50 @@ const TodoPage = () => {
           </div>
         ) : null}
       </section>
+      ) : null}
+
+      {view === 'dashboard' ? (
+        <section className="todo-dashboard" aria-label="待办仪表盘">
+          {dashboardLoading ? <p className="tips">加载中…</p> : null}
+          <div className="todo-dashboard__columns">
+            <article className="todo-dashboard__col">
+              <header className="todo-dashboard__col-head">
+                <h3>未完成</h3>
+                <span className="todo-dashboard__count">{dashboardPending.length}</span>
+              </header>
+              {dashboardPending.length === 0 ? (
+                <p className="todo-dashboard__empty">没有未完成的近期待办</p>
+              ) : (
+                <div className="todo-dashboard__list">{dashboardPending.map(renderDashboardTodo)}</div>
+              )}
+            </article>
+
+            <article className="todo-dashboard__col">
+              <header className="todo-dashboard__col-head">
+                <h3>进行中</h3>
+                <span className="todo-dashboard__count">{dashboardInProgress.length}</span>
+              </header>
+              {dashboardInProgress.length === 0 ? (
+                <p className="todo-dashboard__empty">还没有进行中的待办</p>
+              ) : (
+                <div className="todo-dashboard__list">{dashboardInProgress.map(renderDashboardTodo)}</div>
+              )}
+            </article>
+
+            <article className="todo-dashboard__col">
+              <header className="todo-dashboard__col-head">
+                <h3>长期待办</h3>
+                <span className="todo-dashboard__count">{dashboard.longTerm.length}</span>
+              </header>
+              {dashboard.longTerm.length === 0 ? (
+                <p className="todo-dashboard__empty">还没有长期待办</p>
+              ) : (
+                <div className="todo-dashboard__list">{dashboard.longTerm.map(renderDashboardTodo)}</div>
+              )}
+            </article>
+          </div>
+        </section>
+      ) : null}
 
       {editor ? (
         <div className="timeline-editor-backdrop" role="dialog" aria-modal="true">
@@ -512,6 +703,26 @@ const TodoPage = () => {
                 <option value="syzygy">💙 syzygy</option>
               </select>
             </label>
+            <label>
+              待办类型
+              <select
+                value={editor.todoType}
+                onChange={(event) => setEditor({ ...editor, todoType: event.target.value as TodoType })}
+              >
+                <option value="short_term">近期待办</option>
+                <option value="long_term">长期待办</option>
+              </select>
+            </label>
+            {editor.todoType === 'long_term' ? (
+              <label>
+                目标日期
+                <input
+                  type="date"
+                  value={editor.eventDate}
+                  onChange={(event) => setEditor({ ...editor, eventDate: event.target.value })}
+                />
+              </label>
+            ) : null}
             <div className="timeline-editor__actions">
               <button type="button" className="secondary" onClick={() => setEditor(null)} disabled={saving}>
                 取消

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -32,10 +32,12 @@ import type {
   SyzygyReply,
   TimelineEntry,
   TimelineRecorder,
+  TimelineSource,
   TodoCategory,
   TodoCreatedBy,
   TodoItem,
   TodoStatus,
+  TodoType,
   WalletBalance,
   WalletQuest,
   WalletQuestCreator,
@@ -182,6 +184,8 @@ type TodoItemRow = {
   title: string
   notes: string | null
   status: TodoStatus
+  todo_type: TodoType | null
+  event_date: string | null
   created_by: TodoCreatedBy | 'chuan'
   sort_order: number | null
   created_at: string
@@ -496,6 +500,9 @@ const mapTodoItemRow = (row: TodoItemRow): TodoItem => ({
   title: row.title,
   notes: row.notes,
   status: row.status,
+  // 旧数据 todo_type 可能为空，前端统一按 short_term（近期）处理。
+  todoType: row.todo_type === 'long_term' ? 'long_term' : 'short_term',
+  eventDate: row.event_date,
   createdBy: normalizeTodoCreatedBy(row.created_by),
   sortOrder: row.sort_order ?? 0,
   createdAt: row.created_at,
@@ -2613,6 +2620,7 @@ export const createTimelineEntry = async (payload: {
   eventDate: string
   summary: string
   recorder: TimelineRecorder
+  source?: TimelineSource
 }): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
@@ -2623,7 +2631,8 @@ export const createTimelineEntry = async (payload: {
     event_date: payload.eventDate,
     summary: payload.summary,
     recorder: payload.recorder,
-    source: 'user',
+    // 仓鼠窝前端手动写入默认标记来源为 frontend。
+    source: payload.source ?? 'frontend',
   })
   if (error) {
     throw error
@@ -2636,6 +2645,7 @@ export const updateTimelineEntry = async (
     eventDate: string
     summary: string
     recorder: TimelineRecorder
+    source?: TimelineSource
   },
 ): Promise<void> => {
   if (!supabase) {
@@ -2647,6 +2657,7 @@ export const updateTimelineEntry = async (
       event_date: payload.eventDate,
       summary: payload.summary,
       recorder: payload.recorder,
+      ...(payload.source ? { source: payload.source } : {}),
     })
     .eq('id', entryId)
   if (error) {
@@ -2675,7 +2686,7 @@ export const listTodosByMonth = async (
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('todos')
-    .select('id,user_id,category_id,date,title,notes,status,created_by,sort_order,created_at,completed_at')
+    .select('id,user_id,category_id,date,title,notes,status,todo_type,event_date,created_by,sort_order,created_at,completed_at')
     .eq('user_id', userId)
     .gte('date', monthStart)
     .lte('date', monthEnd)
@@ -2713,7 +2724,7 @@ export const listTodosByDate = async (date: string): Promise<TodoItem[]> => {
   const userId = await requireAuthenticatedUserId()
   const { data, error } = await supabase
     .from('todos')
-    .select('id,user_id,category_id,date,title,notes,status,created_by,sort_order,created_at,completed_at')
+    .select('id,user_id,category_id,date,title,notes,status,todo_type,event_date,created_by,sort_order,created_at,completed_at')
     .eq('user_id', userId)
     .eq('date', date)
     .order('sort_order', { ascending: true })
@@ -2722,6 +2733,50 @@ export const listTodosByDate = async (date: string): Promise<TodoItem[]> => {
     throw error
   }
   return (data ?? []).map((row) => mapTodoItemRow(row as TodoItemRow))
+}
+
+export type TodoDashboardData = {
+  // 近期待办（todo_type=short_term 或空），尚未完成的项目，前端再按 status 拆成未完成 / 进行中。
+  nearTermOpen: TodoItem[]
+  // 长期待办（todo_type=long_term），按 event_date 升序，空目标日期排在最后。
+  longTerm: TodoItem[]
+}
+
+export const listTodoDashboard = async (): Promise<TodoDashboardData> => {
+  if (!supabase) {
+    return { nearTermOpen: [], longTerm: [] }
+  }
+  const userId = await requireAuthenticatedUserId()
+  const columns =
+    'id,user_id,category_id,date,title,notes,status,todo_type,event_date,created_by,sort_order,created_at,completed_at'
+  const [nearTermRes, longTermRes] = await Promise.all([
+    supabase
+      .from('todos')
+      .select(columns)
+      .eq('user_id', userId)
+      .neq('status', 'completed')
+      .or('todo_type.eq.short_term,todo_type.is.null')
+      .order('date', { ascending: true })
+      .order('sort_order', { ascending: true })
+      .order('created_at', { ascending: true }),
+    supabase
+      .from('todos')
+      .select(columns)
+      .eq('user_id', userId)
+      .eq('todo_type', 'long_term')
+      .order('event_date', { ascending: true, nullsFirst: false })
+      .order('created_at', { ascending: true }),
+  ])
+  if (nearTermRes.error) {
+    throw nearTermRes.error
+  }
+  if (longTermRes.error) {
+    throw longTermRes.error
+  }
+  return {
+    nearTermOpen: (nearTermRes.data ?? []).map((row) => mapTodoItemRow(row as TodoItemRow)),
+    longTerm: (longTermRes.data ?? []).map((row) => mapTodoItemRow(row as TodoItemRow)),
+  }
 }
 
 export const createTodoCategory = async (payload: {
@@ -2751,11 +2806,14 @@ export const createTodoItem = async (payload: {
   notes: string | null
   createdBy: TodoCreatedBy
   sortOrder: number
+  todoType?: TodoType
+  eventDate?: string | null
 }): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
+  const todoType = payload.todoType ?? 'short_term'
   const { error } = await supabase.from('todos').insert({
     user_id: userId,
     category_id: payload.categoryId,
@@ -2763,6 +2821,9 @@ export const createTodoItem = async (payload: {
     title: payload.title,
     notes: payload.notes,
     status: 'pending',
+    todo_type: todoType,
+    // 仅长期待办保留目标日期，近期待办不写 event_date。
+    event_date: todoType === 'long_term' ? payload.eventDate ?? null : null,
     created_by: payload.createdBy,
     sort_order: payload.sortOrder,
   })
@@ -2773,15 +2834,30 @@ export const createTodoItem = async (payload: {
 
 export const updateTodoItem = async (
   todoId: string,
-  payload: { title: string; notes: string | null; createdBy: TodoCreatedBy },
+  payload: {
+    title: string
+    notes: string | null
+    createdBy: TodoCreatedBy
+    todoType?: TodoType
+    eventDate?: string | null
+  },
 ): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
+  const patch: Record<string, unknown> = {
+    title: payload.title,
+    notes: payload.notes,
+    created_by: payload.createdBy,
+  }
+  if (payload.todoType) {
+    patch.todo_type = payload.todoType
+    patch.event_date = payload.todoType === 'long_term' ? payload.eventDate ?? null : null
+  }
   const { error } = await supabase
     .from('todos')
-    .update({ title: payload.title, notes: payload.notes, created_by: payload.createdBy })
+    .update(patch)
     .eq('id', todoId)
     .eq('user_id', userId)
   if (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,7 +331,8 @@ export type TimelineEntry = {
 }
 
 export type TodoCreatedBy = '串串' | 'syzygy'
-export type TodoStatus = 'pending' | 'completed'
+export type TodoStatus = 'pending' | 'in_progress' | 'completed'
+export type TodoType = 'short_term' | 'long_term'
 
 export type TodoCategory = {
   id: string
@@ -350,6 +351,8 @@ export type TodoItem = {
   title: string
   notes: string | null
   status: TodoStatus
+  todoType: TodoType
+  eventDate: string | null
   createdBy: TodoCreatedBy
   sortOrder: number
   createdAt: string

--- a/supabase/migrations/20260621150000_relax_timeline_source_check.sql
+++ b/supabase/migrations/20260621150000_relax_timeline_source_check.sql
@@ -1,0 +1,26 @@
+-- Allow more granular TIMELINE source values so the frontend (and other writers)
+-- can record which end produced an entry.
+--
+-- 背景：timeline_entries.source 之前的 CHECK 只允许 claude / gpt / gemini / user，
+-- 仓鼠窝前端手动写入需要标记 source=frontend，微信侧 / 客户端 / CLI 也希望各自标记来源。
+-- 这里放宽约束，保留旧值兼容历史数据，并新增前端约定的来源取值。
+-- 表的默认值保持 'claude' 不变（服务端写入方未显式带 source 时沿用旧行为）。
+
+alter table public.timeline_entries
+  drop constraint if exists timeline_entries_source_check;
+
+alter table public.timeline_entries
+  add constraint timeline_entries_source_check
+  check (source = any (array[
+    'claude'::text,
+    'gpt'::text,
+    'gemini'::text,
+    'user'::text,
+    'frontend'::text,
+    'wechat_api'::text,
+    'client_gpt'::text,
+    'client_claude'::text,
+    'codex_cli'::text,
+    'claude_code_cli'::text,
+    'system'::text
+  ]));

--- a/supabase/migrations/20260621151000_add_todo_in_progress_status.sql
+++ b/supabase/migrations/20260621151000_add_todo_in_progress_status.sql
@@ -1,0 +1,13 @@
+-- Add an "in_progress" status for TODO items so the TODO 仪表盘 can split
+-- near-term todos into 未完成 (pending) and 进行中 (in_progress).
+--
+-- 背景：todos.status 之前的 CHECK 只允许 pending / completed，待办仪表盘需要一个
+-- “进行中” 中间态。这里放宽约束，保留旧值兼容历史数据，并新增 in_progress。
+-- 列默认值仍为 'pending'，旧数据不受影响。
+
+alter table public.todos
+  drop constraint if exists todos_status_check;
+
+alter table public.todos
+  add constraint todos_status_check
+  check (status = any (array['pending'::text, 'in_progress'::text, 'completed'::text]));


### PR DESCRIPTION
## 概述

按任务卡完成 TIMELINE / TODO 的前端整理：让 TIMELINE 看得出来源端并提供来源统计，TODO 前端区分近期/长期并新增仪表盘。

实现前核对了线上库真实 schema，发现两处 **CHECK 约束**会阻塞验收目标，需放宽（**不新增表**），已写入迁移并应用到线上库，旧值全部保留以兼容历史数据。

## TIMELINE
- 新建/编辑表单新增「来源端」下拉，默认写入 `source=frontend`（含 `wechat_api` / `client_gpt` / `client_claude` / `codex_cli` / `claude_code_cli` / `system`；编辑旧记录时自动补回其原来源值）
- 列表每条记录展示来源小标签，与 `recorder`（记录者）并存、互不混用
- 新增「本月来源统计」区，前端本地聚合各来源写入数量

## TODO
- 新建/编辑表单新增「待办类型」近期/长期；选长期时显示「目标日期」(`event_date`)
- 状态按钮改为三态循环 未完成 → 进行中 → 已完成，列表区分进行中态
- 新增「📊 仪表盘」视图（与「📅 日历」切换），分三块：**未完成 / 进行中 / 长期待办**；长期按 `event_date` 升序
- 旧数据 `todo_type` 为空统一按 `short_term` 处理，并在仪表盘 near-term 查询用 `todo_type.is.null` 兜底，**不会消失**

## 数据库（不新增表，仅放宽约束）
- `timeline_entries.source` 允许 `frontend/wechat_api/client_gpt/client_claude/codex_cli/claude_code_cli/system`（保留旧值）
- `todos.status` 新增 `in_progress`（保留 `pending/completed`）

迁移文件：
- `supabase/migrations/20260621150000_relax_timeline_source_check.sql`
- `supabase/migrations/20260621151000_add_todo_in_progress_status.sql`

## 验收对照
- [x] 前端新增 TIMELINE 写入 `source=frontend`
- [x] TIMELINE 列表能看到来源标签
- [x] TIMELINE 有来源统计区，可看各来源数量
- [x] TODO 可以选择近期 / 长期
- [x] 长期待办可以填写 `event_date`
- [x] TODO 仪表盘分出未完成、进行中、长期待办
- [x] 旧 TODO 不因 `todo_type` 为空而消失

## 实现说明
「进行中」采用**新增的 `in_progress` 状态**（kanban 常规做法），否则该栏永远为空、无意义；这要求放宽 `todos.status` 约束——属 DB 改动但非新表，符合「不新建数据库表」。若希望「进行中」改用按日期派生而不引入新状态，可再调整。

## 验证
- `tsc -b` 通过、`vite build` 通过、改动文件 `eslint` 干净
- 仅有的 lint error 在 `supabase/functions/hamster-mcp/index.ts`（未触碰，base 分支即存在）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bgqa8jmY3KFEtZMikH7cUi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgqa8jmY3KFEtZMikH7cUi)_