### PR TITLE
日常聊天上下文优化：工具按钮触发 + Claude prompt caching + 缓存命中埋点

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1232,9 +1232,10 @@ const App = () => {
           streamingControllerRef.current = controller
           setIsStreaming(true)
 
-          // hamster-mcp 工具列表：动态获取（带缓存），失败则本次对话不附带工具。
+          // hamster-mcp 工具列表：仅在用户点亮「工具」按钮时注入（方案 A：单次生效）。
+          // 工具定义有 40+ 条且每轮全量发送、绕过历史压缩，默认不注入可显著降低费用。
           let mcpTools: McpToolDefinition[] | null = null
-          if (!toolsUnsupportedModels.has(effectiveModel)) {
+          if (injectionOptions?.toolsEnabled && !toolsUnsupportedModels.has(effectiveModel)) {
             try {
               mcpTools = await listMcpTools({ accessToken, anonKey }, controller.signal)
             } catch (error) {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -14,6 +14,7 @@ import './ChatPage.css'
 export type ChatInjectionOptions = {
   memoEnabled?: boolean
   timelineEnabled?: boolean
+  toolsEnabled?: boolean
 }
 
 export type ChatPageProps = {
@@ -74,6 +75,7 @@ const ChatPage = ({
   const [draft, setDraft] = useState('')
   const [memoToggle, setMemoToggle] = useState(false)
   const [timelineToggle, setTimelineToggle] = useState(false)
+  const [toolsToggle, setToolsToggle] = useState(false)
   const [openActionsId, setOpenActionsId] = useState<string | null>(null)
   const [actionsMenuPosition, setActionsMenuPosition] = useState<{ top: number; left: number } | null>(null)
   const [openHeaderMenu, setOpenHeaderMenu] = useState(false)
@@ -96,9 +98,11 @@ const ChatPage = ({
     const options: ChatInjectionOptions = {
       memoEnabled: memoToggle,
       timelineEnabled: timelineToggle,
+      toolsEnabled: toolsToggle,
     }
     setMemoToggle(false)
     setTimelineToggle(false)
+    setToolsToggle(false)
     await onSendMessage(trimmed, options)
     setDraft('')
   }
@@ -666,6 +670,14 @@ const ChatPage = ({
             aria-pressed={timelineToggle}
           >
             时间轴
+          </button>
+          <button
+            type="button"
+            className={`injection-toggle${toolsToggle ? ' injection-toggle--active' : ''}`}
+            onClick={() => setToolsToggle((current) => !current)}
+            aria-pressed={toolsToggle}
+          >
+            工具
           </button>
         </div>
         <div className="composer-row">

--- a/src/utils/llmUsage.ts
+++ b/src/utils/llmUsage.ts
@@ -37,6 +37,26 @@ export const logLlmUsage = (
       return
     }
     const promptDetails = asRecord(usage.prompt_tokens_details)
+    // 缓存命中 token：兼容 OpenRouter（cached_tokens / cache_write_tokens）
+    // 与 Anthropic 原生（cache_read_input_tokens / cache_creation_input_tokens）两种命名。
+    const cachedTokens =
+      toInteger(promptDetails?.cached_tokens)
+      ?? toInteger(usage.cached_tokens)
+      ?? toInteger(usage.cache_read_input_tokens)
+    const cacheWriteTokens =
+      toInteger(promptDetails?.cache_write_tokens)
+      ?? toInteger(usage.cache_write_tokens)
+      ?? toInteger(usage.cache_creation_input_tokens)
+    if (cachedTokens || cacheWriteTokens) {
+      // 便于上线后在控制台快速核对 prompt caching 的实际命中情况。
+      console.info('[llm-usage] prompt cache', {
+        module: context.module ?? null,
+        model: context.model ?? null,
+        prompt_tokens: toInteger(usage.prompt_tokens),
+        cached_tokens: cachedTokens,
+        cache_write_tokens: cacheWriteTokens,
+      })
+    }
     void supabase
       .from('llm_usage')
       .insert({
@@ -46,9 +66,8 @@ export const logLlmUsage = (
         prompt_tokens: toInteger(usage.prompt_tokens),
         completion_tokens: toInteger(usage.completion_tokens),
         total_tokens: toInteger(usage.total_tokens),
-        cached_tokens: toInteger(promptDetails?.cached_tokens) ?? toInteger(usage.cached_tokens),
-        cache_write_tokens:
-          toInteger(promptDetails?.cache_write_tokens) ?? toInteger(usage.cache_write_tokens),
+        cached_tokens: cachedTokens,
+        cache_write_tokens: cacheWriteTokens,
         cost_usd: toNumber(usage.cost),
         raw: usage,
       })

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -300,6 +300,9 @@ const buildProviderRequestPayload = (
     if (reasoningPayload) {
       basePayload.reasoning = reasoningPayload
     }
+    // 开启 OpenRouter usage 会计，让流末尾的 chunk 带上缓存命中明细
+    // （cached/cache read/write tokens），便于核对 prompt caching 的实际节省。
+    basePayload.usage = { include: true }
   }
 
   if (tools !== undefined) {

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -313,7 +313,54 @@ const buildProviderRequestPayload = (
     basePayload.system = topLevelSystem
   }
 
+  // Anthropic prompt caching: mark the stable request prefix (tool definitions +
+  // system prompt) with `cache_control` so repeated rounds in a session reuse the
+  // cached tokens at a fraction of the input cost. Only Claude models honor this;
+  // other providers ignore the extra field. Anthropic caches everything up to a
+  // breakpoint, so one breakpoint on the last tool covers the whole tools block,
+  // and one on the system prompt covers the system text.
+  if (isClaudeModel) {
+    applyAnthropicPromptCaching(basePayload)
+  }
+
   return basePayload
+}
+
+const EPHEMERAL_CACHE_CONTROL = { type: 'ephemeral' } as const
+
+const withCacheControlText = (text: string) => [
+  { type: 'text', text, cache_control: EPHEMERAL_CACHE_CONTROL },
+]
+
+const applyAnthropicPromptCaching = (payload: Record<string, unknown>): void => {
+  // 1) Tool definitions: a single breakpoint on the last tool caches the entire
+  //    tools block. Idempotent — re-applying the same marker is harmless.
+  const tools = payload.tools
+  if (Array.isArray(tools) && tools.length > 0) {
+    const lastTool = tools[tools.length - 1]
+    if (lastTool && typeof lastTool === 'object') {
+      ;(lastTool as Record<string, unknown>).cache_control = EPHEMERAL_CACHE_CONTROL
+    }
+  }
+
+  // 2) System prompt, two shapes depending on provider path:
+  //    - top-level `system` string (Anthropic-native / AiHubMix hoist)
+  //    - a `role: "system"` message (OpenRouter pass-through)
+  //    The `typeof … === 'string'` guards keep this safe to call more than once
+  //    (already-wrapped content is an array and is skipped).
+  if (typeof payload.system === 'string' && payload.system.length > 0) {
+    payload.system = withCacheControlText(payload.system)
+    return
+  }
+  const messages = payload.messages
+  if (Array.isArray(messages)) {
+    const systemMessage = messages.find(
+      (message) => (message as Record<string, unknown>)?.role === 'system',
+    ) as Record<string, unknown> | undefined
+    if (systemMessage && typeof systemMessage.content === 'string' && systemMessage.content.length > 0) {
+      systemMessage.content = withCacheControlText(systemMessage.content)
+    }
+  }
 }
 
 const flattenOpenRouterTextParts = (value: unknown): string => {


### PR DESCRIPTION
## 背景

日常聊天区每次请求都无条件注入 40+ 条 MCP 工具定义，且工具定义每轮全量发送、绕过历史压缩，是 API 费用的主要来源。本 PR 从两个方向降本，并补齐用于核对效果的埋点。

## 改动

### 1. 工具注入改为按钮触发（方案 A，单次生效）
- `ChatPage.tsx`：输入区在「备忘录 / 时间轴」旁新增「工具」按钮，同款 toggle 样式，发送后自动复位。`ChatInjectionOptions` 增加 `toolsEnabled`。
- `App.tsx`：工具拉取条件改为 `injectionOptions?.toolsEnabled && !toolsUnsupportedModels...`。不点按钮时 `mcpTools` 为 null，下游工具链路（含工具循环）天然短路，**默认对话不再注入工具定义**。

### 2. Anthropic prompt caching（后端）
- `openrouter-chat/index.ts`：仅对 Claude 模型，在工具定义末尾与 system 提示加 `cache_control: {type:'ephemeral'}` 断点。
- 兼容两条 provider 路径：OpenRouter（`role:"system"` 消息）与 Anthropic-native/AiHubMix（top-level `system` 字符串）。其他厂商忽略该字段；守卫保证可重入幂等。

### 3. 缓存命中埋点
- 开启 OpenRouter usage 会计（`usage.include`），让流末尾 chunk 携带缓存明细。
- `logLlmUsage` 兼容 Anthropic 原生缓存字段名（`cache_read_input_tokens` / `cache_creation_input_tokens`），原先只认 OpenRouter 命名，可能导致 `llm_usage` 专用列为空。
- 命中缓存时打印控制台日志，便于上线后快速核对实际节省。

## 验证
- `tsc -b` 编译通过；改动文件 `eslint` 全部 0 错 0 警。
- 仓库内既有的唯一 lint error 位于 `hamster-mcp/index.ts:210`，为预存问题，不在本 PR 改动范围。
- 未做端到端实跑（未真实发请求核对上游 usage 中的缓存字段）；建议合并后在日常聊天点亮「工具」按钮发一轮多回合工具对话，观察控制台 `[llm-usage] prompt cache` 日志确认命中。

## 注意
- prompt caching 命中需上游（OpenRouter 对 Anthropic 模型）支持透传 `cache_control`；缓存读取按较低费率计费，默认约 5 分钟 TTL。
- Anthropic 对可缓存前缀有最小 token 门槛（约 1024），system 过短时不生效但不报错；40+ 工具定义远超门槛，是收益最大的场景。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A119CURRBmd27eByzWJHth)_