### PR TITLE
将输入区注入开关收进 "+" 弹出菜单

### DIFF
--- a/src/pages/ChatPage.css
+++ b/src/pages/ChatPage.css
@@ -653,43 +653,114 @@
   color: var(--text-subtle);
 }
 
-.injection-toggles {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.injection-toggle {
+.injection-trigger {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 14px;
-  min-height: 28px;
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
   border-radius: 999px;
   border: 1px solid var(--glass-border);
   background: var(--glass-bg);
-  font-size: 12px;
-  font-weight: 600;
   color: var(--text-subtle);
   cursor: pointer;
-  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
   user-select: none;
 }
 
-.injection-toggle:hover {
+.injection-trigger:hover {
   background: rgba(255, 255, 255, 0.35);
   color: var(--text-main);
 }
 
-.injection-toggle--active {
-  background: color-mix(in srgb, var(--accent) 38%, #ffffff 62%);
-  border-color: color-mix(in srgb, var(--accent-strong) 45%, var(--glass-border) 55%);
-  color: var(--text-main);
-  box-shadow: 0 2px 8px rgba(249, 168, 212, 0.22);
+.injection-trigger__icon {
+  font-size: 22px;
+  line-height: 1;
+  font-weight: 400;
+  transition: transform 200ms ease;
 }
 
-.injection-toggle--active:hover {
-  background: color-mix(in srgb, var(--accent) 48%, #ffffff 52%);
+.injection-trigger--open {
+  background: rgba(255, 255, 255, 0.4);
+  color: var(--text-main);
+}
+
+.injection-trigger--open .injection-trigger__icon {
+  transform: rotate(45deg);
+}
+
+.injection-trigger--active {
+  border-color: color-mix(in srgb, var(--accent-strong) 45%, var(--glass-border) 55%);
+  color: var(--text-main);
+}
+
+.injection-trigger__badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-strong) 70%, #f472b6 30%);
+  color: #ffffff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+  box-shadow: 0 1px 4px rgba(249, 168, 212, 0.4);
+}
+
+.injection-menu {
+  position: fixed;
+  z-index: 1500;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 132px;
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(229, 231, 235, 0.9);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(12px);
+}
+
+.injection-menu__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-main);
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.injection-menu__item:hover {
+  background: #f3f4f6;
+}
+
+.injection-menu__item--active {
+  background: color-mix(in srgb, var(--accent) 30%, #ffffff 70%);
+  color: var(--text-main);
+}
+
+.injection-menu__item--active:hover {
+  background: color-mix(in srgb, var(--accent) 40%, #ffffff 60%);
+}
+
+.injection-menu__check {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent-strong);
 }
 
 .composer-row {
@@ -754,10 +825,13 @@
     padding: 0 10px;
   }
 
-  .injection-toggle {
-    min-height: 26px;
-    padding: 3px 12px;
-    font-size: 12px;
+  .injection-trigger {
+    width: 38px;
+    height: 38px;
+  }
+
+  .injection-trigger__icon {
+    font-size: 20px;
   }
 
   .chip-value {
@@ -1118,31 +1192,49 @@
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
 }
 
-.chat-page--pixel .injection-toggle {
+.chat-page--pixel .injection-trigger {
   border: 2px solid var(--pixel-border);
   background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
   color: var(--pixel-subtle);
+  border-radius: 12px;
   box-shadow:
     inset 0 1px 0 #fffdf9,
     inset 0 -2px 0 rgba(134, 130, 125, 0.4);
 }
 
-.chat-page--pixel .injection-toggle:hover {
+.chat-page--pixel .injection-trigger:hover,
+.chat-page--pixel .injection-trigger--open {
   background: linear-gradient(180deg, #fffbf5 0%, #f6d7d4 100%);
   color: var(--pixel-text);
 }
 
-.chat-page--pixel .injection-toggle--active {
-  background: linear-gradient(180deg, #f6d7d4 0%, #efc2bc 100%);
+.chat-page--pixel .injection-trigger--active {
   border-color: #86827d;
   color: var(--pixel-text);
-  box-shadow:
-    inset 0 1px 0 #fffdf9,
-    inset 0 -2px 0 rgba(134, 130, 125, 0.4);
 }
 
-.chat-page--pixel .injection-toggle--active:hover {
-  background: linear-gradient(180deg, #efc2bc 0%, #e8b0a8 100%);
+.chat-page--pixel .injection-menu {
+  background: linear-gradient(180deg, #fffbf5 0%, #fdf4e8 100%);
+  border: 3px solid var(--pixel-border);
+  border-radius: 12px;
+  box-shadow:
+    inset 0 0 0 2px #fffdf9,
+    inset 0 0 0 6px rgba(246, 215, 212, 0.18),
+    inset 0 -6px 0 rgba(134, 130, 125, 0.22),
+    0 12px 22px rgba(90, 85, 81, 0.14);
+}
+
+.chat-page--pixel .injection-menu__item {
+  color: var(--pixel-text);
+  font-weight: 700;
+}
+
+.chat-page--pixel .injection-menu__item:hover {
+  background: rgba(246, 215, 212, 0.5);
+}
+
+.chat-page--pixel .injection-menu__item--active {
+  background: linear-gradient(180deg, #f6d7d4 0%, #efc2bc 100%);
 }
 
 .chat-page--pixel .composer-toggle input {

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -80,6 +80,8 @@ const ChatPage = ({
   const [actionsMenuPosition, setActionsMenuPosition] = useState<{ top: number; left: number } | null>(null)
   const [openHeaderMenu, setOpenHeaderMenu] = useState(false)
   const [headerMenuPosition, setHeaderMenuPosition] = useState({ top: 0, right: 0 })
+  const [openInjectionMenu, setOpenInjectionMenu] = useState(false)
+  const [injectionMenuPosition, setInjectionMenuPosition] = useState({ bottom: 0, left: 0 })
   const [pendingDelete, setPendingDelete] = useState<ChatMessage | null>(null)
   const [letters, setLetters] = useState<LetterEntry[]>([])
   const bottomRef = useRef<HTMLDivElement | null>(null)
@@ -87,6 +89,8 @@ const ChatPage = ({
   const actionTriggerRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const headerMenuRef = useRef<HTMLDivElement | null>(null)
   const headerMenuButtonRef = useRef<HTMLButtonElement | null>(null)
+  const injectionMenuRef = useRef<HTMLDivElement | null>(null)
+  const injectionButtonRef = useRef<HTMLButtonElement | null>(null)
   const { handleTtsClick, ttsStates, ttsTextLimit } = useTtsPlayback()
   const navigate = useNavigate()
 
@@ -138,6 +142,19 @@ const ChatPage = ({
   const actionsLabel = useMemo(() => {
     return openActionsId ? '关闭操作菜单' : '打开操作菜单'
   }, [openActionsId])
+
+  const injectionOptions = [
+    { key: 'memo', label: '备忘录', active: memoToggle, toggle: () => setMemoToggle((current) => !current) },
+    { key: 'timeline', label: '时间轴', active: timelineToggle, toggle: () => setTimelineToggle((current) => !current) },
+    { key: 'tools', label: '工具', active: toolsToggle, toggle: () => setToolsToggle((current) => !current) },
+  ] as const
+
+  const activeInjectionCount = injectionOptions.filter((option) => option.active).length
+
+  const handleInjectionSelect = (toggle: () => void) => {
+    toggle()
+    setOpenInjectionMenu(false)
+  }
 
   const sessionOverride = session.overrideModel?.trim() || null
   const selectedModel = sessionOverride ?? defaultModel
@@ -318,6 +335,42 @@ const ChatPage = ({
       document.removeEventListener('click', handleClick)
     }
   }, [openHeaderMenu])
+
+  useEffect(() => {
+    if (!openInjectionMenu) {
+      return
+    }
+
+    const updateInjectionMenuPosition = () => {
+      const triggerRect = injectionButtonRef.current?.getBoundingClientRect()
+      if (!triggerRect) {
+        return
+      }
+      setInjectionMenuPosition({
+        bottom: Math.max(window.innerHeight - triggerRect.top + POPOVER_GAP, VIEWPORT_MARGIN),
+        left: Math.max(triggerRect.left, VIEWPORT_MARGIN),
+      })
+    }
+
+    updateInjectionMenuPosition()
+    window.addEventListener('resize', updateInjectionMenuPosition)
+    window.addEventListener('scroll', updateInjectionMenuPosition, true)
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (injectionButtonRef.current?.contains(target) || injectionMenuRef.current?.contains(target)) {
+        return
+      }
+      setOpenInjectionMenu(false)
+    }
+    document.addEventListener('click', handleClick)
+
+    return () => {
+      window.removeEventListener('resize', updateInjectionMenuPosition)
+      window.removeEventListener('scroll', updateInjectionMenuPosition, true)
+      document.removeEventListener('click', handleClick)
+    }
+  }, [openInjectionMenu])
 
   return (
     <div
@@ -654,33 +707,30 @@ const ChatPage = ({
           当前模型：{selectedModel}
           {hasOverride ? '（会话覆盖）' : '（默认）'}
         </span>
-        <div className="injection-toggles">
-          <button
-            type="button"
-            className={`injection-toggle${memoToggle ? ' injection-toggle--active' : ''}`}
-            onClick={() => setMemoToggle((current) => !current)}
-            aria-pressed={memoToggle}
-          >
-            备忘录
-          </button>
-          <button
-            type="button"
-            className={`injection-toggle${timelineToggle ? ' injection-toggle--active' : ''}`}
-            onClick={() => setTimelineToggle((current) => !current)}
-            aria-pressed={timelineToggle}
-          >
-            时间轴
-          </button>
-          <button
-            type="button"
-            className={`injection-toggle${toolsToggle ? ' injection-toggle--active' : ''}`}
-            onClick={() => setToolsToggle((current) => !current)}
-            aria-pressed={toolsToggle}
-          >
-            工具
-          </button>
-        </div>
         <div className="composer-row">
+          <button
+            ref={injectionButtonRef}
+            type="button"
+            className={`injection-trigger${openInjectionMenu ? ' injection-trigger--open' : ''}${
+              activeInjectionCount > 0 ? ' injection-trigger--active' : ''
+            }`}
+            aria-label="更多选项"
+            aria-haspopup="menu"
+            aria-expanded={openInjectionMenu}
+            onClick={(event) => {
+              event.stopPropagation()
+              setOpenInjectionMenu((current) => !current)
+            }}
+          >
+            <span className="injection-trigger__icon" aria-hidden="true">
+              +
+            </span>
+            {activeInjectionCount > 0 ? (
+              <span className="injection-trigger__badge" aria-hidden="true">
+                {activeInjectionCount}
+              </span>
+            ) : null}
+          </button>
           <textarea
             className="textarea-glass"
             placeholder="输入你的消息"
@@ -702,6 +752,35 @@ const ChatPage = ({
           </button>
         </div>
       </form>
+      {openInjectionMenu
+        ? createPortal(
+            <div
+              className="injection-menu"
+              role="menu"
+              ref={injectionMenuRef}
+              style={{ bottom: `${injectionMenuPosition.bottom}px`, left: `${injectionMenuPosition.left}px` }}
+            >
+              {injectionOptions.map((option) => (
+                <button
+                  key={option.key}
+                  type="button"
+                  role="menuitemcheckbox"
+                  aria-checked={option.active}
+                  className={`injection-menu__item${option.active ? ' injection-menu__item--active' : ''}`}
+                  onClick={() => handleInjectionSelect(option.toggle)}
+                >
+                  <span className="injection-menu__label">{option.label}</span>
+                  {option.active ? (
+                    <span className="injection-menu__check" aria-hidden="true">
+                      ✓
+                    </span>
+                  ) : null}
+                </button>
+              ))}
+            </div>,
+            document.body,
+          )
+        : null}
       <ConfirmDialog
         open={pendingDelete !== null}
         title="删除这条消息？"


### PR DESCRIPTION
## 背景

日常聊天输入区原本把「备忘录 / 时间轴 / 工具」三个注入开关平铺在输入框上方，比较占空间。本次将其收进输入区左侧的一个 "+" 弹出菜单。

## 改动

**之前：** 三个按钮平铺在输入框上方。

**现在：** 输入区左侧一个 "+" 圆形图标按钮，点击展开小弹出菜单。

### 交互
- 点 "+" 展开 / 收起菜单，图标旋转 45°（视觉上变成 "×"）
- 在菜单中选某一项 → 触发对应 toggle → 自动关闭菜单
- 再点 "+" 或点击菜单外部 → 关闭
- 已激活的选项在菜单里显示 ✓ 高亮
- "+" 按钮右上角小徽标显示当前激活的注入数量，收起菜单也能看到状态

### 实现要点
- **只改 UI 入口，逻辑零改动**：`memoToggle` / `timelineToggle` / `toolsToggle` 状态与 `submitDraft` 发送逻辑完全保持原样
- 弹出菜单用 `createPortal` 渲染到 `body`，向上展开贴着输入区，复用页面里「聊天操作」「消息操作」菜单的同款定位模式，避免被容器裁剪
- iOS 与像素（pixel）两套主题都补了对应样式，移动端做了尺寸适配

## 验证
- `tsc` 类型检查通过
- `eslint` 无报错
- `npm run build` 构建成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQd2TMuGHCmW9YhEYJ5Awe)_