### PR TITLE
重构 RP 区（跑跑滚轮区）UI：杂志风浅粉玻璃改造

### DIFF
--- a/src/pages/RpRoomPage.css
+++ b/src/pages/RpRoomPage.css
@@ -18,7 +18,10 @@
   height: 100dvh;
   display: flex;
   flex-direction: column;
-  background: var(--page-bg);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(255, 214, 231, 0.32), transparent 42%),
+    radial-gradient(circle at 88% 2%, rgba(255, 239, 246, 0.7), transparent 50%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.98) 0%, rgba(253, 245, 249, 0.98) 60%, rgba(248, 246, 250, 0.98) 100%);
   isolation: isolate;
 }
 
@@ -28,8 +31,9 @@
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  background-image: radial-gradient(circle, rgba(107, 114, 128, 0.08) 1.15px, transparent 1.2px);
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 196, 222, 0.42) 1.2px, transparent 1.3px);
   background-size: 18px 18px;
+  opacity: 0.7;
 }
 
 .rp-room-dashboard-page > * {
@@ -49,11 +53,20 @@
 }
 
 .rp-room-header-dashboard {
-  background: var(--accent);
-  background-image: none;
-  color: var(--text-main);
-  border-bottom: 1px solid var(--glass-border);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  background: linear-gradient(180deg, #fff 0%, #fff4f9 100%);
+  background-image: linear-gradient(180deg, #fff 0%, #fff4f9 100%);
+  color: #5c4152;
+  border-bottom: 1px dashed rgba(207, 147, 173, 0.5);
+  box-shadow: 0 6px 18px rgba(255, 185, 216, 0.16);
+}
+
+.rp-room-header-dashboard h1 {
+  color: #5c4152;
+  font-weight: 800;
+}
+
+.rp-room-header-dashboard .ghost {
+  color: #7d5d70;
 }
 
 .rp-room-header h1 {
@@ -172,89 +185,154 @@
   width: min(780px, 100%);
   min-height: 100%;
   margin: 0 auto;
-  padding: 14px;
+  padding: 14px 14px 24px;
   overflow: visible;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
-.rp-dashboard-page h2 {
-  margin: 0;
-  font-size: 15px;
+/* "仪表盘" page heading — magazine masthead */
+.rp-dashboard-page > h2.ui-title {
+  margin: 2px 0 0;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #c98aa6;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.rp-dashboard-page > h2.ui-title::after {
+  content: '';
+  flex: 1;
+  height: 0;
+  border-top: 1px dashed rgba(207, 147, 173, 0.5);
 }
 
 .rp-dashboard-section {
-  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.68);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.06);
-  padding: 12px;
+  position: relative;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 10px 22px rgba(255, 214, 231, 0.2);
+  padding: 16px 16px 18px;
   display: flex;
   flex-direction: column;
+  gap: 10px;
+}
+
+/* gray dashed divider element sitting in the gap between cards */
+.rp-dashboard-section + .rp-dashboard-section::before {
+  content: '';
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  top: -9px;
+  border-top: 1px dashed rgba(148, 163, 184, 0.55);
+}
+
+/* small pink accent dot before each card title */
+.rp-dashboard-section h3 {
+  margin: 0;
+  font-size: 15px;
+  color: #5c4152;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
   gap: 8px;
 }
 
-.rp-dashboard-section h3 {
-  margin: 0;
-  font-size: 14px;
+.rp-dashboard-section h3::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #ffb7d4, #ff9dc4);
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.45);
+  flex-shrink: 0;
 }
 
 .rp-dashboard-section label {
   font-size: 12px;
-  color: #334155;
+  color: #6a6473;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
 }
 
 .rp-dashboard-section input,
 .rp-dashboard-section textarea,
 .rp-dashboard-section select {
-  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
+  border: 1px solid #e4dbe8;
   border-radius: 12px;
-  padding: 8px 10px;
+  padding: 9px 11px;
   font-size: 13px;
-  background: rgba(255, 255, 255, 0.76);
-  color: var(--text-main);
+  background: #fff;
+  color: #3f3749;
+  font-family: inherit;
+}
+
+.rp-dashboard-section input::placeholder,
+.rp-dashboard-section textarea::placeholder {
+  color: #c9a9b8;
 }
 
 .rp-dashboard-section input:focus,
 .rp-dashboard-section textarea:focus,
 .rp-dashboard-section select:focus {
   outline: none;
-  border-color: color-mix(in srgb, var(--accent) 62%, #fda4af 38%);
-  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.3);
+  border-color: #f8bad4;
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.4);
 }
 
 .rp-dashboard-helper {
   margin: 0;
   font-size: 12px;
-  color: #64748b;
+  color: #a07a8e;
 }
 
 .rp-dashboard-page button.primary,
 .rp-dashboard-page .rp-npc-form-actions .primary {
-  border: none;
-  background: var(--accent);
-  color: var(--text-main);
+  border: 1px solid #f8bed9;
+  background: linear-gradient(180deg, #ffeef6 0%, #ffd9ea 100%);
+  color: #59354b;
   border-radius: 999px;
-  padding: 9px 14px;
+  padding: 10px 16px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-  box-shadow: 0 6px 14px rgba(249, 168, 212, 0.34);
+  box-shadow: 0 6px 14px rgba(255, 185, 216, 0.4);
+  transition: transform 110ms ease, box-shadow 120ms ease;
+}
+
+.rp-dashboard-page button.primary:hover:not(:disabled),
+.rp-dashboard-page .rp-npc-form-actions .primary:hover:not(:disabled) {
+  box-shadow: 0 8px 18px rgba(255, 185, 216, 0.55);
+  transform: translateY(-1px);
+}
+
+.rp-dashboard-page button.primary:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .rp-dashboard-page button.ghost,
 .rp-dashboard-page .rp-model-empty-hint .ghost {
-  border: 1px solid color-mix(in srgb, var(--glass-border) 70%, #d1d5db 30%);
-  background: rgba(255, 255, 255, 0.74);
-  color: #334155;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  background: #fff;
+  color: #7d5d70;
   border-radius: 999px;
-  padding: 6px 10px;
+  padding: 6px 12px;
   font-size: 12px;
   cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.rp-dashboard-page button.ghost:hover {
+  background: #fff1f8;
+  border-color: #f7bdd8;
 }
 
 .rp-room-card {
@@ -285,19 +363,20 @@
 }
 
 .rp-npc-item {
-  border: 1px solid color-mix(in srgb, var(--glass-border) 72%, #d1d5db 28%);
-  border-radius: 12px;
-  padding: 10px;
-  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid rgba(241, 228, 235, 0.95);
+  border-radius: 14px;
+  padding: 12px;
+  background: linear-gradient(180deg, #fff 0%, #fffaff 100%);
   display: flex;
   justify-content: space-between;
   gap: 10px;
 }
 
 .rp-npc-name {
-  margin: 0;
+  margin: 0 0 2px;
   font-size: 14px;
   font-weight: 700;
+  color: #5c4152;
 }
 
 .rp-npc-actions {

--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -5,20 +5,20 @@
 }
 
 .rp-rooms-shell {
-  max-width: 1080px;
+  max-width: 760px;
   height: 100%;
   margin: 0 auto;
-  padding: 12px 16px 16px;
+  padding: 14px 16px 16px;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 18px;
+  gap: 14px;
 }
 
 .rp-rooms-top {
   z-index: 12;
   display: grid;
-  gap: 24px;
-  padding-top: 4px;
+  gap: 14px;
+  padding-top: 2px;
 }
 
 .rp-rooms-top.app-shell__header {
@@ -38,62 +38,81 @@
   background: transparent;
 }
 
+/* Page backdrop: soft pink wash echoing the Wiki / Novel areas */
 .rp-rooms-page::before {
   content: '';
   position: absolute;
   inset: 0;
-  z-index: -1;
+  z-index: -2;
   background:
-    radial-gradient(circle at 16% 8%, rgba(253, 208, 223, 0.4), transparent 44%),
-    radial-gradient(circle at 84% 12%, rgba(209, 213, 219, 0.34), transparent 46%),
-    linear-gradient(160deg, #fdf8fb 0%, #f4f4f6 54%, #f8f6fa 100%);
+    radial-gradient(circle at 12% 0%, rgba(255, 214, 231, 0.4), transparent 44%),
+    radial-gradient(circle at 88% 4%, rgba(255, 239, 246, 0.85), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.97) 0%, rgba(253, 245, 249, 0.97) 54%, rgba(248, 246, 250, 0.97) 100%);
 }
 
+/* Pink polka-dot texture overlay */
 .rp-rooms-page::after {
   content: '';
   position: absolute;
   inset: 0;
   pointer-events: none;
   z-index: -1;
-  background-image: radial-gradient(circle, rgba(107, 114, 128, 0.1) 1.1px, transparent 1.2px);
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 196, 222, 0.5) 1.2px, transparent 1.3px);
   background-size: 18px 18px;
-  opacity: 0.34;
+  opacity: 0.55;
 }
 
-.rp-rooms-header,
-.rp-create-card,
-.rp-list-card {
-  padding: 14px;
-  border-radius: 22px;
+/* Shared magazine kicker label */
+.rp-kicker {
+  margin: 0 0 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #c98aa6;
 }
 
+/* ---- Header ---- */
 .rp-rooms-header {
   position: relative;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
-  padding: 16px 18px;
-  border: none;
-  border-bottom: 1px dashed #ffd6e7;
-  background: rgba(255, 255, 255, 0.6);
-  box-shadow: 0 14px 30px rgba(148, 163, 184, 0.15);
-  backdrop-filter: blur(14px);
+  padding: 18px 20px;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 20px;
+  background: #fff;
+  box-shadow: 0 10px 22px rgba(255, 214, 231, 0.22);
 }
 
-.rp-rooms-header h1,
-.rp-room-tile h3 {
+/* thin pink accent bar on the left edge */
+.rp-rooms-header::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 16px;
+  bottom: 16px;
+  width: 4px;
+  border-radius: 0 4px 4px 0;
+  background: linear-gradient(180deg, #ffb7d4, #ff9dc4);
+}
+
+.rp-rooms-heading {
+  min-width: 0;
+}
+
+.rp-rooms-header h1 {
   margin: 0;
-}
-
-.rp-rooms-header p {
-  margin: 6px 0 0;
-  color: #8c8c8c;
-}
-
-.rp-rooms-header .ui-title {
-  color: #5c5c5c;
+  font-size: 22px;
+  color: #5c4152;
   font-weight: 800;
+}
+
+.rp-rooms-subtitle {
+  margin: 6px 0 0;
+  color: #a07a8e;
+  font-size: 13px;
 }
 
 .rp-header-actions {
@@ -104,20 +123,20 @@
 }
 
 .rp-back-btn {
-  border: 1px solid rgba(255, 214, 231, 0.9);
+  border: 1px solid #ffd6e7;
   border-radius: 999px;
   padding: 7px 14px;
-  background: rgba(255, 255, 255, 0.68);
-  color: #5c5c5c;
+  background: #fff;
+  color: #7d5d70;
+  font-size: 13px;
   font-weight: 600;
-  box-shadow: 0 8px 18px rgba(92, 92, 92, 0.1);
-  backdrop-filter: blur(8px);
   cursor: pointer;
-  transition: box-shadow 140ms ease, transform 140ms ease;
+  transition: box-shadow 140ms ease, transform 140ms ease, background 140ms ease;
 }
 
 .rp-back-btn:hover {
-  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.4), 0 10px 20px rgba(92, 92, 92, 0.14);
+  background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%);
+  box-shadow: 0 6px 14px rgba(255, 185, 216, 0.34);
   transform: translateY(-1px);
 }
 
@@ -125,88 +144,90 @@
   transform: translateY(1px);
 }
 
-.rp-create-row {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 8px;
-}
-
+/* ---- Create card ---- */
 .rp-create-card {
   position: relative;
-  overflow: visible;
-  background-color: #ffffff;
-  background-image:
-    linear-gradient(rgba(231, 231, 231, 0.35) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(231, 231, 231, 0.35) 1px, transparent 1px);
-  background-size: 18px 18px;
-  border: 1px solid #ffd6e7;
-  box-shadow: 0 14px 30px rgba(92, 92, 92, 0.1);
+  overflow: hidden;
+  padding: 16px 18px 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  background: #fff;
+  box-shadow: 0 10px 22px rgba(255, 214, 231, 0.2);
 }
 
-.rp-create-card::before {
+/* faint dotted texture inside the create card */
+.rp-create-card::after {
   content: '';
   position: absolute;
-  top: -11px;
-  left: 16px;
-  width: 66px;
-  height: 20px;
-  border-radius: 4px;
-  background: linear-gradient(120deg, rgba(255, 214, 231, 0.7), rgba(255, 214, 231, 0.45));
-  box-shadow: 0 4px 8px rgba(92, 92, 92, 0.12);
-  transform: rotate(-7deg);
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.45) 1.1px, transparent 1.2px);
+  background-size: 16px 16px;
+  opacity: 0.4;
+}
+
+.rp-create-card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .rp-create-card .ui-title {
-  color: #5c5c5c;
-  margin-bottom: 14px;
+  margin: 0 0 12px;
+  color: #5c4152;
+  font-size: 16px;
+}
+
+.rp-create-kicker {
+  color: #cf93ad;
+}
+
+.rp-create-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
 }
 
 .rp-create-row input,
 .rp-rename-row input {
-  border: 1px solid var(--glass-border);
+  border: 1px solid rgba(255, 214, 231, 0.88);
   border-radius: 12px;
   padding: 10px 12px;
-  background: rgba(255, 255, 255, 0.74);
-}
-
-.rp-create-row input {
-  border: 0;
-  border-bottom: 2px solid #f0f0f0;
-  border-radius: 0;
-  background: rgba(255, 255, 255, 0.9);
-  color: #5c5c5c;
-  padding-left: 2px;
+  background: #fff;
+  color: #5c4152;
+  font: inherit;
 }
 
 .rp-create-row input::placeholder {
-  color: #a8a8a8;
+  color: #c9a9b8;
 }
 
-.rp-create-row input:focus {
+.rp-create-row input:focus,
+.rp-rename-row input:focus {
   outline: none;
-  border-bottom-color: #ffd6e7;
-  box-shadow: 0 6px 10px -8px rgba(255, 214, 231, 0.9);
+  border-color: #f8bad4;
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.4);
 }
 
 .rp-create-btn {
-  border: 1px solid #ffd6e7;
+  border: 1px solid #f8bed9;
   border-radius: 999px;
-  background: #ffd6e7;
-  color: #5c5c5c;
+  background: linear-gradient(180deg, #ffeef6 0%, #ffd9ea 100%);
+  color: #59354b;
   font-weight: 700;
-  padding: 10px 16px;
+  padding: 10px 18px;
   cursor: pointer;
-  box-shadow: 0 10px 18px rgba(255, 214, 231, 0.45);
+  box-shadow: 0 6px 14px rgba(255, 185, 216, 0.4);
   transition: transform 110ms ease, box-shadow 120ms ease;
 }
 
 .rp-create-btn:hover:not(:disabled) {
-  box-shadow: 0 12px 20px rgba(255, 214, 231, 0.55);
+  box-shadow: 0 8px 18px rgba(255, 185, 216, 0.55);
+  transform: translateY(-1px);
 }
 
 .rp-create-btn:active:not(:disabled) {
-  transform: translateY(2px) scale(0.99);
-  box-shadow: 0 4px 10px rgba(255, 214, 231, 0.45);
+  transform: translateY(1px) scale(0.99);
+  box-shadow: 0 4px 10px rgba(255, 185, 216, 0.4);
 }
 
 .rp-create-btn:disabled {
@@ -214,55 +235,110 @@
   cursor: wait;
 }
 
+/* ---- List card ---- */
+.rp-list-card {
+  padding: 16px 16px 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  background: #fff;
+  box-shadow: 0 10px 22px rgba(255, 214, 231, 0.18);
+}
+
 .rp-list-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 10px;
+  padding-bottom: 12px;
+  border-bottom: 1px dashed rgba(207, 147, 173, 0.45);
 }
 
 .rp-tabs {
   display: inline-flex;
-  border: 1px solid var(--glass-border);
+  border: 1px solid rgba(255, 214, 231, 0.85);
   border-radius: 999px;
   padding: 3px;
-  background: rgba(255, 255, 255, 0.5);
+  background: #fff7fb;
 }
 
 .rp-tabs button {
   border: 0;
   background: transparent;
-  color: var(--text-main);
+  color: #8a6a7c;
   border-radius: 999px;
-  padding: 5px 12px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
+  transition: background 140ms ease, color 140ms ease, box-shadow 140ms ease;
 }
 
 .rp-tabs button.active {
-  background: rgba(255, 255, 255, 0.88);
-  box-shadow: var(--shadow-soft);
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  color: #59354b;
+  box-shadow: 0 3px 7px rgba(255, 185, 216, 0.38);
 }
 
+.rp-list-card .ghost {
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 999px;
+  background: #fff;
+  color: #7d5d70;
+  padding: 6px 13px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.rp-list-card .ghost:hover:not(:disabled) {
+  background: #fff1f8;
+  border-color: #f7bdd8;
+}
+
+.rp-list-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.rp-list-title-row .ui-title {
+  margin: 0;
+  font-size: 15px;
+  color: #5c4152;
+}
+
+.rp-room-count {
+  font-size: 12px;
+  color: #b88aa0;
+  font-weight: 600;
+}
+
+/* ---- Room tiles: light-pink iOS glass ---- */
 .rp-room-grid {
   list-style: none;
-  margin: 10px 0 0;
+  margin: 12px 0 0;
   padding: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 13px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
 }
 
 .rp-room-tile {
   position: relative;
   width: 100%;
-  border-radius: 20px;
-  padding: 12px;
+  border-radius: 18px;
+  padding: 14px;
   min-height: 0;
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.14);
-  overflow: visible;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 240, 247, 0.86) 100%);
+  box-shadow: 0 8px 18px rgba(255, 185, 216, 0.2);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  overflow: hidden;
   display: grid;
   grid-template-rows: auto auto auto;
   gap: 10px;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
 }
 
 .rp-room-tile::before {
@@ -270,135 +346,105 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
   pointer-events: none;
+}
+
+.rp-room-tile:hover {
+  transform: translateY(-2px);
+  border-color: #f7bdd8;
+  box-shadow: 0 12px 24px rgba(255, 185, 216, 0.34);
 }
 
 .rp-room-tile-top {
   position: relative;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+}
+
+.rp-tile-tag {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  color: #c46a93;
+  background: rgba(255, 214, 231, 0.55);
+  border: 1px solid rgba(248, 190, 217, 0.7);
+  border-radius: 999px;
+  padding: 2px 9px;
 }
 
 .rp-tile-icon-btn {
   width: 28px;
   height: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(248, 190, 217, 0.6);
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.42);
-  color: #1f2937;
+  background: rgba(255, 255, 255, 0.7);
+  color: #9a7388;
   cursor: pointer;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.rp-tile-icon-btn:hover {
+  background: #fff;
+  color: #5c4152;
 }
 
 .rp-actions-popover {
   position: fixed;
-  border: 1px solid rgba(229, 231, 235, 0.95);
+  border: 1px solid rgba(255, 214, 231, 0.95);
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: var(--shadow-soft);
+  background: #fff;
+  box-shadow: 0 12px 26px rgba(194, 130, 160, 0.26);
   z-index: 4;
-}
-
-.rp-color-popover {
-  position: fixed;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 6px;
-  width: 196px;
-  padding: 8px;
-  border: 1px solid rgba(229, 231, 235, 0.95);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: var(--shadow-soft);
-}
-
-.rp-color-popover-portal {
-  z-index: var(--z-popover);
-}
-
-.rp-actions-popover-portal {
-  z-index: var(--z-popover);
-}
-
-.rp-color-swatch {
-  border: 1px solid rgba(17, 24, 39, 0.1);
-  border-radius: 8px;
-  width: 100%;
-  aspect-ratio: 1;
-  cursor: pointer;
-}
-
-.rp-color-custom {
-  grid-column: 1 / -1;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  margin-top: 2px;
-  padding-top: 6px;
-  border-top: 1px solid rgba(209, 213, 219, 0.8);
-  font-size: 12px;
-  color: var(--text-subtle);
-}
-
-.rp-color-custom input[type='color'] {
-  width: 34px;
-  height: 30px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  border-radius: 10px;
-  background: transparent;
-  padding: 0;
-  cursor: pointer;
-}
-
-.rp-color-custom span {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  color: #374151;
-}
-
-
-.rp-color-close-btn {
-  grid-column: 1 / -1;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.9);
-  padding: 6px 8px;
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.rp-actions-popover {
   display: grid;
   gap: 4px;
   min-width: 120px;
   padding: 6px;
 }
 
+.rp-actions-popover-portal {
+  z-index: var(--z-popover);
+}
+
 .rp-actions-popover button {
   border: none;
   border-radius: 8px;
-  padding: 6px 10px;
+  padding: 7px 10px;
   background: transparent;
   text-align: left;
+  color: #5c4152;
+  font-size: 13px;
   cursor: pointer;
+}
+
+.rp-actions-popover button:hover {
+  background: #fff1f8;
 }
 
 .rp-actions-popover .danger {
   color: #b91c1c;
 }
 
+.rp-actions-popover .danger:hover {
+  background: #fdecec;
+}
+
 .rp-room-tile-content {
+  position: relative;
   min-height: 0;
   min-width: 0;
   display: grid;
   align-content: start;
   gap: 5px;
-  color: rgba(17, 24, 39, 0.92);
+  color: #5c4152;
 }
 
 .rp-room-tile h3 {
+  margin: 0;
   font-size: 15px;
   line-height: 1.35;
+  color: #5c4152;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -408,28 +454,29 @@
 .rp-room-meta {
   margin: 0;
   font-size: 12px;
-  color: rgba(31, 41, 55, 0.72);
+  color: #a07a8e;
 }
 
 .rp-enter-btn {
+  position: relative;
   width: 100%;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  background: rgba(255, 255, 255, 0.26);
-  color: #111827;
-  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.16);
-  backdrop-filter: blur(6px);
+  border: 1px solid #f8bed9;
+  background: linear-gradient(180deg, #ffeef6 0%, #ffd9ea 100%);
+  color: #59354b;
+  font-weight: 700;
+  box-shadow: 0 5px 12px rgba(255, 185, 216, 0.36);
 }
 
 .rp-enter-btn:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.32);
+  box-shadow: 0 8px 16px rgba(255, 185, 216, 0.5);
 }
 
 .rp-enter-btn:active:not(:disabled) {
   transform: translateY(1px);
-  background: rgba(255, 255, 255, 0.36);
 }
 
+/* ---- Rename inline form ---- */
 .rp-rename-row {
   display: grid;
   gap: 6px;
@@ -442,32 +489,43 @@
 }
 
 .rp-rename-actions > button {
-  flex: 1 1 120px;
+  flex: 1 1 100px;
 }
 
 .rp-rooms-page .tips {
-  color: var(--text-subtle);
-  margin: 0;
+  color: #a07a8e;
+  margin: 8px 0 0;
 }
 
 .rp-rooms-page .error {
   color: #b91c1c;
-  margin: 0;
+  margin: 8px 0 0;
 }
 
 @media (max-width: 680px) {
   .rp-rooms-shell {
-    padding: 8px 10px 12px;
-    gap: 10px;
+    padding: 10px 12px 12px;
+    gap: 12px;
   }
 
   .rp-rooms-top {
-    gap: 10px;
+    gap: 12px;
   }
 
-  .rp-rooms-header,
+  .rp-rooms-header {
+    flex-direction: column;
+  }
+
+  .rp-header-actions {
+    width: 100%;
+  }
+
+  .rp-header-actions .rp-back-btn {
+    flex: 1;
+    text-align: center;
+  }
+
   .rp-create-row {
-    display: grid;
     grid-template-columns: 1fr;
   }
 
@@ -475,20 +533,10 @@
     grid-template-columns: minmax(0, 1fr);
     gap: 11px;
   }
-
-  .rp-room-tile {
-    min-height: 0;
-    border-radius: 18px;
-  }
 }
 
-
 @media (max-width: 560px) {
-  .rp-rooms-page::before {
-    background: linear-gradient(180deg, #fdf8fb 0%, #f4f4f6 100%);
-  }
-
   .rp-rooms-page::after {
-    opacity: 0.16;
+    opacity: 0.32;
   }
 }

--- a/src/pages/RpRoomsPage.tsx
+++ b/src/pages/RpRoomsPage.tsx
@@ -10,7 +10,6 @@ import {
   fetchRpSessions,
   renameRpSession,
   updateRpSessionArchiveState,
-  updateRpSessionTileColor,
 } from '../storage/supabaseSync'
 import type { RpSession } from '../types'
 import './RpRoomsPage.css'
@@ -29,29 +28,10 @@ type DeleteAction = {
   sessionId: string
 }
 
-const TILE_COLOR_PALETTE = [
-  '#F88FA4', '#F9A49A', '#F6B58A', '#F4C39A',
-  '#F3C2CC', '#E9BEDA', '#DAB9F2', '#C7C0F6',
-  '#BFD0F8', '#B7DEE8', '#BFD9C8', '#CFD4DF',
-  '#B8BECF', '#D9CED8', '#A4A9B8', '#8A90A1',
-]
-
-const COLOR_POPOVER_WIDTH = 196
-const COLOR_POPOVER_HEIGHT = 214
-const COLOR_POPOVER_GAP = 8
+const ACTIONS_POPOVER_GAP = 8
 const ACTIONS_POPOVER_WIDTH = 140
 const ACTIONS_POPOVER_HEIGHT = 124
 const VIEWPORT_MARGIN = 8
-const TILE_COLOR_DEBOUNCE_MS = 320
-
-const resolveRoomTileColor = (room: RpSession) => {
-  const color = room.tileColor?.trim()
-  if (color && /^#[0-9a-fA-F]{6}$/.test(color)) {
-    return color
-  }
-  const hash = Array.from(room.id).reduce((acc, char) => acc + char.charCodeAt(0), 0)
-  return TILE_COLOR_PALETTE[hash % TILE_COLOR_PALETTE.length]
-}
 
 const formatRoomTime = (session: RpSession) => {
   const timestamp = session.updatedAt ?? session.createdAt
@@ -62,15 +42,6 @@ const formatRoomTime = (session: RpSession) => {
     minute: '2-digit',
   })
 }
-
-const normalizeHexColor = (value: string) => {
-  const trimmed = value.trim()
-  if (!/^#[0-9a-fA-F]{6}$/.test(trimmed)) {
-    return null
-  }
-  return trimmed.toUpperCase()
-}
-
 
 const isAbortError = (error: unknown) => (
   error instanceof DOMException && error.name === 'AbortError'
@@ -94,16 +65,10 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
   const [deletingRoomId, setDeletingRoomId] = useState<string | null>(null)
   const [roomMessageCounts, setRoomMessageCounts] = useState<Record<string, number>>({})
   const [countsLoading, setCountsLoading] = useState(false)
-  const [openPaletteRoomId, setOpenPaletteRoomId] = useState<string | null>(null)
   const [openActionsRoomId, setOpenActionsRoomId] = useState<string | null>(null)
-  const [palettePosition, setPalettePosition] = useState<{ top: number; left: number } | null>(null)
   const [actionsPosition, setActionsPosition] = useState<{ top: number; left: number } | null>(null)
-  const paletteTriggerRefs = useRef<Record<string, HTMLButtonElement | null>>({})
   const actionsTriggerRefs = useRef<Record<string, HTMLButtonElement | null>>({})
-  const palettePopoverRef = useRef<HTMLDivElement | null>(null)
   const actionsPopoverRef = useRef<HTMLDivElement | null>(null)
-  const pendingTileColorTimeoutsRef = useRef<Record<string, number>>({})
-  const tileColorRequestControllersRef = useRef<Record<string, AbortController>>({})
 
   const isArchivedView = tab === 'archived'
   const isMutating = Boolean(savingRoomId || deletingRoomId || updatingArchive)
@@ -171,92 +136,21 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
   }, [rooms, user])
 
   useEffect(() => {
-    return () => {
-      Object.values(pendingTileColorTimeoutsRef.current).forEach((timerId) => {
-        window.clearTimeout(timerId)
-      })
-      pendingTileColorTimeoutsRef.current = {}
-
-      Object.values(tileColorRequestControllersRef.current).forEach((controller) => {
-        controller.abort()
-      })
-      tileColorRequestControllersRef.current = {}
-    }
-  }, [])
-
-  useEffect(() => {
     const closeMenus = (event: PointerEvent) => {
       const target = event.target as Node | null
       if (!target) {
         return
       }
 
-      if (palettePopoverRef.current?.contains(target)) {
-        return
-      }
       if (actionsPopoverRef.current?.contains(target)) {
         return
       }
 
-      setOpenPaletteRoomId(null)
       setOpenActionsRoomId(null)
     }
     document.addEventListener('pointerdown', closeMenus)
     return () => document.removeEventListener('pointerdown', closeMenus)
   }, [])
-
-  useEffect(() => {
-    if (!openPaletteRoomId) {
-      setPalettePosition(null)
-      return
-    }
-
-    let frameId: number | null = null
-
-    const updatePalettePosition = () => {
-      frameId = null
-      const trigger = paletteTriggerRefs.current[openPaletteRoomId]
-      if (!trigger) {
-        setPalettePosition(null)
-        return
-      }
-
-      const triggerRect = trigger.getBoundingClientRect()
-      const viewportWidth = window.innerWidth
-      const viewportHeight = window.innerHeight
-
-      let left = triggerRect.right - COLOR_POPOVER_WIDTH
-      left = Math.max(VIEWPORT_MARGIN, Math.min(left, viewportWidth - COLOR_POPOVER_WIDTH - VIEWPORT_MARGIN))
-
-      let top = triggerRect.bottom + COLOR_POPOVER_GAP
-      const wouldOverflowBottom = top + COLOR_POPOVER_HEIGHT > viewportHeight - VIEWPORT_MARGIN
-      if (wouldOverflowBottom) {
-        top = triggerRect.top - COLOR_POPOVER_HEIGHT - COLOR_POPOVER_GAP
-      }
-      top = Math.max(VIEWPORT_MARGIN, Math.min(top, viewportHeight - COLOR_POPOVER_HEIGHT - VIEWPORT_MARGIN))
-
-      setPalettePosition({ top, left })
-    }
-
-    const scheduleUpdatePalettePosition = () => {
-      if (frameId !== null) {
-        return
-      }
-      frameId = window.requestAnimationFrame(updatePalettePosition)
-    }
-
-    updatePalettePosition()
-    window.addEventListener('resize', scheduleUpdatePalettePosition)
-    window.addEventListener('scroll', scheduleUpdatePalettePosition, true)
-
-    return () => {
-      window.removeEventListener('resize', scheduleUpdatePalettePosition)
-      window.removeEventListener('scroll', scheduleUpdatePalettePosition, true)
-      if (frameId !== null) {
-        window.cancelAnimationFrame(frameId)
-      }
-    }
-  }, [openPaletteRoomId])
 
   useEffect(() => {
     if (!openActionsRoomId) {
@@ -281,10 +175,10 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
       let left = triggerRect.right - ACTIONS_POPOVER_WIDTH
       left = Math.max(VIEWPORT_MARGIN, Math.min(left, viewportWidth - ACTIONS_POPOVER_WIDTH - VIEWPORT_MARGIN))
 
-      let top = triggerRect.bottom + COLOR_POPOVER_GAP
+      let top = triggerRect.bottom + ACTIONS_POPOVER_GAP
       const wouldOverflowBottom = top + ACTIONS_POPOVER_HEIGHT > viewportHeight - VIEWPORT_MARGIN
       if (wouldOverflowBottom) {
-        top = triggerRect.top - ACTIONS_POPOVER_HEIGHT - COLOR_POPOVER_GAP
+        top = triggerRect.top - ACTIONS_POPOVER_HEIGHT - ACTIONS_POPOVER_GAP
       }
       top = Math.max(VIEWPORT_MARGIN, Math.min(top, viewportHeight - ACTIONS_POPOVER_HEIGHT - VIEWPORT_MARGIN))
 
@@ -330,49 +224,6 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
     } finally {
       setCreating(false)
     }
-  }
-
-  const handleTileColorSelect = (roomId: string, color: string) => {
-    const normalizedColor = normalizeHexColor(color)
-    if (!normalizedColor) {
-      return
-    }
-
-    setRooms((current) => current.map((room) => (room.id === roomId ? { ...room, tileColor: normalizedColor } : room)))
-
-    const existingTimeoutId = pendingTileColorTimeoutsRef.current[roomId]
-    if (typeof existingTimeoutId !== 'undefined') {
-      window.clearTimeout(existingTimeoutId)
-      delete pendingTileColorTimeoutsRef.current[roomId]
-    }
-
-    const existingController = tileColorRequestControllersRef.current[roomId]
-    if (existingController) {
-      existingController.abort()
-      delete tileColorRequestControllersRef.current[roomId]
-    }
-
-    pendingTileColorTimeoutsRef.current[roomId] = window.setTimeout(() => {
-      const controller = new AbortController()
-      tileColorRequestControllersRef.current[roomId] = controller
-      delete pendingTileColorTimeoutsRef.current[roomId]
-
-      void (async () => {
-        try {
-          await updateRpSessionTileColor(roomId, normalizedColor, controller.signal)
-        } catch (updateError) {
-          if (isAbortError(updateError)) {
-            return
-          }
-          console.warn('更新 RP 房间颜色失败', updateError)
-          setNotice('颜色已本地更新，云端保存失败。')
-        } finally {
-          if (tileColorRequestControllersRef.current[roomId] === controller) {
-            delete tileColorRequestControllersRef.current[roomId]
-          }
-        }
-      })()
-    }, TILE_COLOR_DEBOUNCE_MS)
   }
 
   const handleToggleArchive = async () => {
@@ -461,22 +312,16 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
   }
 
   const tabTitle = useMemo(() => (isArchivedView ? '已归档房间' : '活跃房间'), [isArchivedView])
-  const activePaletteColor = useMemo(() => {
-    if (!openPaletteRoomId) {
-      return '#F88FA4'
-    }
-    const room = rooms.find((item) => item.id === openPaletteRoomId)
-    return room ? resolveRoomTileColor(room).toUpperCase() : '#F88FA4'
-  }, [openPaletteRoomId, rooms])
 
   return (
     <div className="rp-rooms-page app-shell">
       <div className="rp-rooms-shell">
         <section className="rp-rooms-top app-shell__header">
           <header className="rp-rooms-header">
-            <div>
+            <div className="rp-rooms-heading">
+              <p className="rp-kicker">ROLEPLAY · 滚轮放映厅</p>
               <h1 className="ui-title">跑跑滚轮区 🎡🐹</h1>
-              <p>管理 RP 房间，给每段剧情留好场记与分镜。</p>
+              <p className="rp-rooms-subtitle">管理 RP 房间，给每段剧情留好场记与分镜。</p>
             </div>
             <div className="rp-header-actions">
               <button type="button" className="rp-back-btn" onClick={() => navigate('/rp/story-groups')}>
@@ -489,7 +334,8 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
           </header>
 
           <section className="rp-create-card">
-            <h2 className="ui-title">新建房间</h2>
+            <p className="rp-kicker rp-create-kicker">NEW ROOM · 新建房间</p>
+            <h2 className="ui-title">开一间新房间</h2>
             <div className="rp-create-row">
               <input
                 value={newTitle}
@@ -531,7 +377,12 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
             {notice ? <p className="tips">{notice}</p> : null}
             {error ? <p className="error">{error}</p> : null}
 
-            <h2 className="ui-title">{tabTitle}</h2>
+            <div className="rp-list-title-row">
+              <h2 className="ui-title">{tabTitle}</h2>
+              {!loading && rooms.length > 0 ? (
+                <span className="rp-room-count">{rooms.length} 间</span>
+              ) : null}
+            </div>
             {loading ? <p className="tips">加载中…</p> : null}
             {!loading && rooms.length === 0 ? (
               <p className="tips">{isArchivedView ? '还没有归档房间。' : '还没有房间，先新建一个吧。'}</p>
@@ -543,31 +394,14 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
                 const isSaving = savingRoomId === room.id
                 const isDeleting = deletingRoomId === room.id
                 const isBusy = isMutating || isSaving || isDeleting
-                const tileColor = resolveRoomTileColor(room)
 
                 return (
                   <li
                     key={room.id}
                     className="rp-room-tile"
-                    style={{ backgroundColor: tileColor }}
                   >
                     <div className="rp-room-tile-top">
-                      <button
-                        type="button"
-                        className="rp-tile-icon-btn"
-                        aria-label="更改房间颜色"
-                        ref={(element) => {
-                          paletteTriggerRefs.current[room.id] = element
-                        }}
-                        onClick={(event) => {
-                          event.stopPropagation()
-                          setOpenActionsRoomId(null)
-                          setOpenPaletteRoomId((current) => (current === room.id ? null : room.id))
-                        }}
-                      >
-                        🎨
-                      </button>
-
+                      <span className="rp-tile-tag">RP</span>
                       <button
                         type="button"
                         className="rp-tile-icon-btn"
@@ -577,7 +411,6 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
                         }}
                         onClick={(event) => {
                           event.stopPropagation()
-                          setOpenPaletteRoomId(null)
                           setOpenActionsRoomId((current) => (current === room.id ? null : room.id))
                         }}
                       >
@@ -624,46 +457,6 @@ const RpRoomsPage = ({ user }: RpRoomsPageProps) => {
           </section>
         </section>
       </div>
-
-      {openPaletteRoomId && palettePosition
-        ? createPortal(
-            <div
-              className="rp-color-popover rp-color-popover-portal"
-              role="menu"
-              style={{ top: palettePosition.top, left: palettePosition.left }}
-              ref={palettePopoverRef}
-              onPointerDownCapture={(event) => event.stopPropagation()}
-              onClick={(event) => event.stopPropagation()}
-            >
-              {TILE_COLOR_PALETTE.map((color) => (
-                <button
-                  key={color}
-                  type="button"
-                  className="rp-color-swatch"
-                  style={{ backgroundColor: color }}
-                  onClick={() => void handleTileColorSelect(openPaletteRoomId, color)}
-                  aria-label={`使用颜色 ${color}`}
-                />
-              ))}
-              <label className="rp-color-custom" htmlFor="rp-custom-tile-color">
-                自定义
-                <input
-                  id="rp-custom-tile-color"
-                  type="color"
-                  value={activePaletteColor}
-                  onInput={(event) => void handleTileColorSelect(openPaletteRoomId, event.currentTarget.value)}
-                  onChange={(event) => void handleTileColorSelect(openPaletteRoomId, event.target.value)}
-                  aria-label="选择自定义颜色"
-                />
-                <span>{activePaletteColor}</span>
-              </label>
-              <button type="button" className="rp-color-close-btn" onClick={() => setOpenPaletteRoomId(null)}>
-                完成
-              </button>
-            </div>,
-            document.body,
-          )
-        : null}
 
       {openActionsRoomId && actionsPosition
         ? createPortal(


### PR DESCRIPTION
## 概述

仅改动 UI/样式，不动任何交互逻辑与 API 调用逻辑。参考 Wiki 区、小说区的设计语言，对跑跑滚轮区（RP 区）做了一次整体的杂志风重排。

## 变更内容

### 1. 去掉房间卡片选色功能
- 移除 🎨 调色按钮、颜色弹窗，以及整套调色状态/逻辑（`TILE_COLOR_PALETTE`、`handleTileColorSelect`、防抖定时器与请求控制器等）
- 房间卡片统一为**浅粉 iOS 玻璃风**（半透明白粉渐变 + 毛玻璃模糊 + 柔和粉色阴影）
- 改名 / 归档 / 删除 / 进入等原有交互全部保留；数据层 `tileColor` 字段与 `updateRpSessionTileColor` API 未删除，只是不再被 UI 调用

### 2. 参考 Wiki / 小说区排版
- 760px 居中栏、白底粉描边卡片、软粉阴影、圆角 18–20px，与 Wiki/Novel 一致
- 房间列表改为**两列玻璃卡片网格**

### 3. 杂志风高级元素
- 粉色波点纹理（页面背景 + 新建卡内部）
- 大写英文 kicker 标签（`ROLEPLAY · 滚轮放映厅`、`NEW ROOM · 新建房间`）
- 标题左侧粉色竖条、卡片虚线分隔、卡片角标 `RP` 徽章
- 整体粉色调，辅以白色 / 浅灰

### 4. 仪表盘卡片精致化
- "仪表盘"做成杂志刊头 + 横向虚线
- 每张设置卡标题前加粉色光晕圆点，字体 / 底色更柔和
- **卡片之间加灰色虚线分隔**，输入框换粉描边，按钮统一为粉色渐变胶囊

## 验证
- `npm run build` 通过
- ESLint 通过
- 使用 Chromium 实际渲染两个页面确认视觉效果

## 改动文件
- `src/pages/RpRoomsPage.tsx`
- `src/pages/RpRoomsPage.css`
- `src/pages/RpRoomPage.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgidBzunQQqVhZMtrCXujC)_