### PR TITLE
fix(rp): 修复 RP 区在手机/平板上内容被挤压、左右留白过大

### DIFF
--- a/src/pages/RpRoomsPage.css
+++ b/src/pages/RpRoomsPage.css
@@ -5,6 +5,9 @@
 }
 
 .rp-rooms-shell {
+  /* Fill the available width (the page root is a flex column, where `margin: 0 auto`
+     alone would otherwise collapse this to its content width and over-center it). */
+  width: 100%;
   max-width: 760px;
   height: 100%;
   margin: 0 auto;

--- a/src/pages/StoryGroupPage.css
+++ b/src/pages/StoryGroupPage.css
@@ -31,6 +31,9 @@
 }
 
 .story-group-content {
+  /* Fill the available width (the page root is a flex column, where `margin: 0 auto`
+     alone would otherwise collapse this to its content width and over-center it). */
+  width: 100%;
   max-width: 720px;
   margin: 0 auto;
   padding: 16px;


### PR DESCRIPTION
## 问题

RP 区在手机/平板上浏览时内容被挤压在中间，左右两侧留白占比过大（视口越宽越明显）。

## 根因

RP 页面根节点带 `app-shell` 类，是一个 `display:flex; flex-direction:column` 的纵向 flex 容器。内层内容容器只用了 `max-width + margin: 0 auto` 来居中——这是**块级布局**的居中写法。但在 flex 子项上，左右 `margin: auto` 会让它**收缩到内容固有宽度（约 325px）再居中**，而不是先撑满再限宽。于是无论视口多宽，内容都被锁死在 ~325px 并居中，左右留白随视口变宽而膨胀。

用 Playwright 加载真实 CSS 复现：390px 和 600px 视口下内容都固定在 325px 居中，与反馈截图一致。

## 修复

给受影响的两个容器加上 `width: 100%`，使其先撑满可用宽度、仅在超过 max-width 时才在桌面端限宽居中。与房间详情页已有的正确写法 `.rp-dashboard-page { width: min(780px, 100%) }` 保持一致。

- `src/pages/RpRoomsPage.css` → `.rp-rooms-shell`（房间列表页）
- `src/pages/StoryGroupPage.css` → `.story-group-content`（故事组管理页，同样的 bug）

房间详情页 `RpRoomPage` 本身写法正确，无需改动。

## 验证（Playwright 截真实 CSS）

| 视口 | 修复前 | 修复后 |
|------|--------|--------|
| 360 / 390 / 600px | 锁死 ~325px 居中 | 撑满全宽（x=0）|
| 900px（桌面）| — | 限宽 760px 居中（保留桌面体验）|

纯 CSS 改动，不影响逻辑与类型。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCaGiivJJvD11a3RVi2Ds)_