### PR TITLE
feat(feed): 新增本月概览板块

### DIFF
--- a/src/components/MonthlyOverview.tsx
+++ b/src/components/MonthlyOverview.tsx
@@ -1,0 +1,55 @@
+import type { MonthlyOverviewContent } from '../lib/agentFeed'
+
+type MonthlyOverviewProps = {
+  data: MonthlyOverviewContent | null
+  loading?: boolean
+  monthLabel: string
+}
+
+// Feed 页面顶部的「本月概览」板块：按主题分组展示当月持续进行的事项。
+// 无数据时显示轻量空状态，不渲染破碎卡片。
+const MonthlyOverview = ({ data, loading, monthLabel }: MonthlyOverviewProps) => {
+  const hasThemes = Boolean(data && data.themes.length > 0)
+
+  return (
+    <section className="feed-overview" aria-label="本月概览">
+      <div className="feed-overview__dot" aria-hidden="true" />
+      <header className="feed-overview__head">
+        <span className="feed-overview__mark" aria-hidden="true">◆</span>
+        <h2 className="feed-overview__title">本月概览</h2>
+        <span className="feed-overview__month">{monthLabel}</span>
+      </header>
+
+      {loading && !hasThemes ? (
+        <p className="feed-overview__empty">正在整理这个月的持续事项…</p>
+      ) : null}
+
+      {!loading && !hasThemes ? (
+        <p className="feed-overview__empty">这个月还没有持续追踪的事项，攒一攒就有了。</p>
+      ) : null}
+
+      {hasThemes ? (
+        <div className="feed-overview__themes">
+          {data!.themes.map((theme, themeIndex) => (
+            <article className="feed-overview__theme" key={`${theme.theme}-${themeIndex}`}>
+              <h3 className="feed-overview__theme-title">{theme.theme}</h3>
+              <ul className="feed-overview__items">
+                {theme.items.map((entry, entryIndex) => (
+                  <li className="feed-overview__item" key={entryIndex}>
+                    <span className="feed-overview__bullet" aria-hidden="true" />
+                    <span className="feed-overview__text">{entry.text}</span>
+                    {entry.archive_candidate ? (
+                      <span className="feed-overview__flag" title="可沉淀进档案">待沉淀</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+export default MonthlyOverview

--- a/src/lib/agentFeed.ts
+++ b/src/lib/agentFeed.ts
@@ -133,6 +133,110 @@ export const fetchAgentFeedItems = async (userId: string): Promise<AgentFeedItem
   return (data ?? []) as AgentFeedItem[]
 }
 
+// ── 月度概览（monthly_overview）────────────────────────────────
+// Feed 页面顶部的“本月概览”板块：按主题展示当月持续进行的事项。
+// 数据来源同样是 agent_feed_items，但 type=monthly_overview，content 为 JSON。
+
+export type MonthlyOverviewEntry = {
+  text: string
+  source_feed_ids: string[]
+  archive_candidate: boolean
+}
+
+export type MonthlyOverviewTheme = {
+  theme: string
+  items: MonthlyOverviewEntry[]
+}
+
+export type MonthlyOverviewContent = {
+  month: string | null
+  themes: MonthlyOverviewTheme[]
+}
+
+// 当前月份键（本地时区），形如 2026-06。
+export const getCurrentMonthKey = (now: Date = new Date()): string => {
+  const year = now.getFullYear()
+  const month = `${now.getMonth() + 1}`.padStart(2, '0')
+  return `${year}-${month}`
+}
+
+const asString = (value: unknown): string | null => (typeof value === 'string' ? value : null)
+
+// 容错解析 monthly_overview 的 content（JSON 字符串或已解析对象）。
+// 任何结构异常都不抛错，返回 null 以便上层降级为空状态，不影响其它 Feed 卡片。
+export const parseMonthlyOverviewContent = (item: AgentFeedItem): MonthlyOverviewContent | null => {
+  if (!item.content) return null
+  let raw: unknown = item.content
+  if (typeof raw === 'string') {
+    try {
+      raw = JSON.parse(raw)
+    } catch {
+      return null
+    }
+  }
+  if (!raw || typeof raw !== 'object') return null
+  const record = raw as Record<string, unknown>
+  const rawThemes = Array.isArray(record.themes) ? record.themes : []
+  const themes: MonthlyOverviewTheme[] = []
+  rawThemes.forEach((themeEntry) => {
+    if (!themeEntry || typeof themeEntry !== 'object') return
+    const themeRecord = themeEntry as Record<string, unknown>
+    const themeName = asString(themeRecord.theme)?.trim()
+    const rawItems = Array.isArray(themeRecord.items) ? themeRecord.items : []
+    const items: MonthlyOverviewEntry[] = []
+    rawItems.forEach((itemEntry) => {
+      if (!itemEntry || typeof itemEntry !== 'object') return
+      const itemRecord = itemEntry as Record<string, unknown>
+      const text = asString(itemRecord.text)?.trim()
+      if (!text) return
+      const sourceIds = Array.isArray(itemRecord.source_feed_ids)
+        ? itemRecord.source_feed_ids.filter((id): id is string => typeof id === 'string')
+        : []
+      items.push({
+        text,
+        source_feed_ids: sourceIds,
+        archive_candidate: itemRecord.archive_candidate === true,
+      })
+    })
+    if (!themeName || items.length === 0) return
+    themes.push({ theme: themeName, items })
+  })
+  return { month: asString(record.month), themes }
+}
+
+// 读取当前月份、active 的月度概览记录（取最新一条）。
+// 失败时返回 null，调用方据此降级为空状态，绝不影响其它 Feed 内容。
+export const fetchMonthlyOverview = async (
+  userId: string,
+  month: string = getCurrentMonthKey(),
+): Promise<MonthlyOverviewContent | null> => {
+  if (!supabase) return null
+  const nowIso = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('agent_feed_items')
+    .select(AGENT_FEED_COLUMNS)
+    .eq('user_id', userId)
+    .eq('type', 'monthly_overview')
+    .or(`visible_from.is.null,visible_from.lte.${nowIso}`)
+    .order('created_at', { ascending: false })
+    .limit(20)
+
+  if (error) {
+    console.warn('加载月度概览失败', error)
+    return null
+  }
+
+  const candidates = (data ?? []) as AgentFeedItem[]
+  for (const item of candidates) {
+    const meta = (item.metadata ?? {}) as Record<string, unknown>
+    if (asString(meta.month) !== month) continue
+    if (asString(meta.status) !== 'active') continue
+    const parsed = parseMonthlyOverviewContent(item)
+    if (parsed && parsed.themes.length > 0) return parsed
+  }
+  return null
+}
+
 export const updateAgentFeedStatus = async (
   userId: string,
   itemId: string,

--- a/src/pages/AgentFeedPage.css
+++ b/src/pages/AgentFeedPage.css
@@ -183,6 +183,138 @@
   background: rgba(255, 246, 251, 0.95);
 }
 
+/* ── Monthly overview ─────────────────────────── */
+
+.feed-overview {
+  position: relative;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 20px;
+  padding: 16px;
+  background:
+    radial-gradient(circle at 88% 0%, rgba(255, 224, 238, 0.6), transparent 46%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.97) 0%, rgba(255, 246, 251, 0.97) 100%);
+  box-shadow: 0 10px 22px rgba(255, 196, 222, 0.2);
+  overflow: hidden;
+  display: grid;
+  gap: 12px;
+}
+
+.feed-overview__dot {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.5) 1.1px, transparent 1.1px);
+  background-size: 18px 18px;
+  opacity: 0.22;
+}
+
+.feed-overview__head {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.feed-overview__mark {
+  color: #f29cc3;
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.feed-overview__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: #68485e;
+}
+
+.feed-overview__month {
+  margin-left: auto;
+  font-size: 12px;
+  color: #b27f98;
+  letter-spacing: 0.04em;
+}
+
+.feed-overview__empty {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #9a7b8c;
+  border: 1px dashed rgba(242, 156, 195, 0.6);
+  border-radius: 14px;
+  background: rgba(255, 246, 251, 0.85);
+  padding: 14px 14px;
+  text-align: center;
+}
+
+.feed-overview__themes {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 12px;
+}
+
+.feed-overview__theme {
+  display: grid;
+  gap: 7px;
+}
+
+.feed-overview__theme-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: #76556c;
+  padding-bottom: 4px;
+  border-bottom: 1px dashed rgba(242, 156, 195, 0.55);
+}
+
+.feed-overview__items {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.feed-overview__item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: #5a4a54;
+}
+
+.feed-overview__bullet {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  margin-top: 7px;
+  border-radius: 999px;
+  background: #ff9ec4;
+  box-shadow: 0 0 0 3px rgba(255, 214, 231, 0.4);
+}
+
+.feed-overview__text {
+  flex: 1;
+  word-break: break-word;
+}
+
+.feed-overview__flag {
+  flex-shrink: 0;
+  align-self: center;
+  font-size: 10px;
+  font-weight: 600;
+  color: #9a8390;
+  background: #f4eef1;
+  border: 1px solid rgba(255, 214, 231, 0.7);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
 /* ── Calendar ─────────────────────────────────── */
 
 .feed-calendar {

--- a/src/pages/AgentFeedPage.tsx
+++ b/src/pages/AgentFeedPage.tsx
@@ -2,12 +2,15 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { useNavigate } from 'react-router-dom'
 import MarkdownRenderer from '../components/MarkdownRenderer'
+import MonthlyOverview from '../components/MonthlyOverview'
 import {
   agentFeedPriorityLabels,
   agentFeedStatusLabels,
   agentFeedTypeOptions,
   computeAgentFeedStats,
   fetchAgentFeedItems,
+  fetchMonthlyOverview,
+  getCurrentMonthKey,
   isAgentFeedExpired,
   resolveAgentFeedStatus,
   sortAgentFeedItems,
@@ -16,6 +19,7 @@ import {
   typeLabel,
   updateAgentFeedStatus,
   type AgentFeedItem,
+  type MonthlyOverviewContent,
 } from '../lib/agentFeed'
 import './AgentFeedPage.css'
 
@@ -53,7 +57,13 @@ const getMonthRange = (anchor: Date) => {
 const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
   const navigate = useNavigate()
   const today = useMemo(() => getTodayKey(), [])
+  const overviewMonthLabel = useMemo(() => {
+    const [year, month] = getCurrentMonthKey().split('-')
+    return `${year}年${Number(month)}月`
+  }, [])
   const [items, setItems] = useState<AgentFeedItem[]>([])
+  const [overview, setOverview] = useState<MonthlyOverviewContent | null>(null)
+  const [overviewLoading, setOverviewLoading] = useState(true)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
@@ -72,6 +82,7 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
     setLoading(true)
     setError(null)
     setNowMs(Date.now())
+    setOverviewLoading(true)
     try {
       const data = await fetchAgentFeedItems(user.id)
       setItems(data)
@@ -80,6 +91,16 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
       setError('暂时读不到 Syzygy Feed，请检查登录状态后重试。')
     } finally {
       setLoading(false)
+    }
+    // 月度概览单独读取，失败时静默降级为空状态，不影响其它 Feed 卡片。
+    try {
+      const overviewData = await fetchMonthlyOverview(user.id)
+      setOverview(overviewData)
+    } catch (overviewError) {
+      console.warn('加载月度概览失败', overviewError)
+      setOverview(null)
+    } finally {
+      setOverviewLoading(false)
     }
   }, [user])
 
@@ -225,6 +246,8 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
 
       {error ? <p className="feed-alert">{error}</p> : null}
       {actionError ? <p className="feed-alert feed-alert--soft">{actionError}</p> : null}
+
+      <MonthlyOverview data={overview} loading={overviewLoading} monthLabel={overviewMonthLabel} />
 
       <section className="feed-calendar" aria-label="按日期浏览">
         <div className="feed-calendar__dot" aria-hidden="true" />


### PR DESCRIPTION
## 概述

在仓鼠小窝 Feed 页面（`/feed`，`AgentFeedPage`）靠前位置新增「本月概览」板块，读取 `agent_feed_items` 中 `type=monthly_overview`、当前月份且 `active` 的记录，按主题分组展示当月持续进行的事项。

本任务仅做前端读取与展示，**不改 Supabase schema**。

## 改动内容

**数据层 (`src/lib/agentFeed.ts`)**
- 新增 `MonthlyOverviewContent` / `MonthlyOverviewTheme` / `MonthlyOverviewEntry` 类型
- `getCurrentMonthKey()` — 本地时区当前月份（`YYYY-MM`）
- `parseMonthlyOverviewContent()` — 容错解析 `content`（支持 JSON 字符串或对象），逐层校验 themes/items 结构，过滤空文本与空主题；任何异常都返回 `null` 而不抛错
- `fetchMonthlyOverview()` — 按 `type=monthly_overview`、`visible_from <= now()` 查询，再筛选 `metadata.month=当前月` 且 `metadata.status=active`，取最新一条有内容的记录；读取失败返回 `null`

**组件 (`src/components/MonthlyOverview.tsx`)**
- 标题「本月概览」+ 当前月份标签
- 按 theme 分组、每组短事项列表，文本保持压缩形式
- `archive_candidate` 用很轻的「待沉淀」灰色标记
- 无数据 / 无 active 记录时显示轻量虚线空状态，不渲染破碎卡片
- `source_feed_ids` 已解析保留，暂不做跳转（后续可扩展来源追踪）

**页面接入 (`src/pages/AgentFeedPage.tsx`)**
- 板块放在 hero 与日历之间（靠前位置）
- 月度概览独立读取，自带 try/catch 静默降级，不影响其它 Feed 卡片

**样式 (`src/pages/AgentFeedPage.css`)**
- 与 Feed 页粉色系保持统一，加入虚线下划线、粉色圆点、几何点阵等装饰

## 验收对照
1. ✅ 多主题能分组显示
2. ✅ 没有 monthly_overview 时页面不报错、不出现破碎 JSON
3. ✅ content 解析失败时容错（返回 null），不影响其它 Feed 卡片

## 验证
- `tsc` 类型检查通过
- `eslint` 通过
- `vite build` 构建通过

> 注：当前 Supabase 中暂无 `monthly_overview` 记录，板块会自动显示轻量空状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQQ1qbeTazEv9booUVB3Ew)_