### PR TITLE
feat(council): 议事厅提案与串串拍板工作流

### DIFF
--- a/src/pages/AgentCouncilPage.css
+++ b/src/pages/AgentCouncilPage.css
@@ -36,4 +36,70 @@
 .speaker-gpt { background:#ecfdf5; color:#2f7d5a; }
 .speaker-gemini { background:#fff6e8; color:#9a5f1f; }
 .speaker-chuanchuan { background:#ffe8f1; color:#9c3f69; }
-.message-item p { margin:0; white-space:pre-wrap; }
+.speaker-codex { background:#eef0ff; color:#4b4fa3; }
+.speaker-claude-code { background:#f0ebff; color:#6b4fa3; }
+.speaker-unknown { background:#f1f1f4; color:#6b6b76; }
+.message-item p { margin:0; white-space:pre-wrap; word-break:break-word; }
+
+/* 表单字段 */
+.council-field { display:grid; gap:4px; font-size:12px; color:#7d5d70; }
+.council-field span { font-size:12px; color:#8a6b7d; }
+.council-field select { border:1px solid #ffd6e7; border-radius:12px; padding:8px 10px; font:inherit; background:#fff; color:#1f2937; }
+.council-field-row { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+.council-form select { width:100%; }
+
+/* 状态 / 态度标签 */
+.status-tag { border-radius:999px; padding:3px 9px; font-size:11px; font-weight:600; white-space:nowrap; }
+.status-open { background:#eef2f7; color:#5a6675; }
+.status-approved { background:#e7f7ec; color:#2f8a52; }
+.status-rejected { background:#ffe9ec; color:#b13f4d; }
+.status-deferred { background:#fff4e0; color:#9a6a1f; }
+.status-plan { background:#e9f0ff; color:#3f5fb1; }
+.status-decision { background:#fbeafd; color:#8a3f9c; }
+.vote-tag { border-radius:999px; padding:2px 8px; font-size:11px; font-weight:600; }
+.vote-support { background:#e7f7ec; color:#2f8a52; }
+.vote-neutral { background:#eef2f7; color:#5a6675; }
+.vote-against { background:#ffe9ec; color:#b13f4d; }
+.meta-chip { border-radius:999px; padding:2px 8px; font-size:11px; background:#fff2f8; border:1px solid rgba(255,214,231,.7); color:#8a6b7d; }
+
+/* 提案列表 */
+.proposal-list { display:grid; gap:10px; }
+.proposal-item { display:flex; align-items:stretch; gap:8px; border:1px solid rgba(255,214,231,.7); border-radius:14px; background:#fff7fb; padding:8px 8px 8px 10px; }
+.proposal-item.active { border-color:#f29cc3; background:linear-gradient(180deg,#ffeef6 0%,#ffe1ef 100%); }
+.proposal-item__select { flex:1; min-width:0; text-align:left; border:none; background:transparent; padding:4px 2px; display:grid; gap:6px; font:inherit; color:inherit; cursor:pointer; }
+.proposal-item__head { display:flex; align-items:center; gap:8px; justify-content:space-between; }
+.proposal-item__head strong { word-break:break-word; }
+.proposal-item__summary { margin:0; font-size:13px; color:#6b5566; word-break:break-word; }
+.proposal-item__meta { display:flex; flex-wrap:wrap; align-items:center; gap:6px; }
+.proposal-item__time { display:flex; flex-wrap:wrap; gap:10px; font-size:11px; color:#9a7f8d; }
+.proposal-item__delete { align-self:flex-start; flex-shrink:0; border-radius:999px; border:1px solid rgba(255,181,192,.7); background:#fff; color:#b13f4d; padding:5px 11px; font-size:12px; cursor:pointer; }
+.proposal-item__delete:hover { background:#ffe8ec; }
+.proposal-item__delete:disabled { opacity:.6; cursor:default; }
+
+/* 提案详情 */
+.proposal-detail { gap:14px; }
+.detail-proposal { border:1px solid rgba(255,214,231,.65); border-radius:14px; padding:12px; background:#fff8fb; display:grid; gap:8px; }
+.detail-proposal__body { margin:0; white-space:pre-wrap; word-break:break-word; color:#3b3340; }
+.detail-section { display:grid; gap:8px; border-top:1px dashed rgba(255,214,231,.8); padding-top:12px; }
+.detail-section h3 { margin:0; font-size:14px; color:#68485e; }
+.message-meta__right { display:flex; align-items:center; gap:8px; }
+.decision-item { background:#fdf4ff; border-color:rgba(232,200,240,.7); }
+
+/* 拍板 */
+.decision-box { display:grid; gap:8px; border:1px solid rgba(255,214,231,.7); border-radius:14px; padding:10px; background:#fff; }
+.decision-box textarea { width:100%; border:1px solid #ffd6e7; border-radius:12px; padding:9px 10px; font:inherit; background:#fff; color:#1f2937; }
+.decision-hint { margin:0; font-size:11px; color:#9a7f8d; line-height:1.5; }
+.decision-actions { display:flex; flex-wrap:wrap; gap:8px; }
+.decision-btn { border-radius:999px; border:1px solid transparent; padding:7px 16px; font-size:13px; font-weight:600; cursor:pointer; }
+.decision-btn:disabled { opacity:.6; cursor:default; }
+.decision-approved { background:linear-gradient(180deg,#d9f5e2 0%,#c4eed3 100%); color:#2f7d52; border-color:rgba(126,211,167,.6); }
+.decision-rejected { background:#fff; color:#b13f4d; border-color:rgba(255,181,192,.7); }
+.decision-deferred { background:#fff7e6; color:#9a6a1f; border-color:rgba(247,210,150,.7); }
+
+/* 历史消息 */
+.legacy-header { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.legacy-toggle { border-radius:999px; border:1px solid #ffd6e7; background:#fff; color:#7d5d70; padding:5px 12px; font-size:12px; cursor:pointer; }
+.legacy-list { display:grid; gap:12px; }
+.legacy-topic { display:grid; gap:8px; border:1px solid rgba(255,214,231,.6); border-radius:12px; padding:10px; background:rgba(255,250,253,.9); }
+.legacy-topic__head { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.legacy-topic__head strong { word-break:break-word; }

--- a/src/pages/AgentCouncilPage.tsx
+++ b/src/pages/AgentCouncilPage.tsx
@@ -1,8 +1,20 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ConfirmDialog from '../components/ConfirmDialog'
-import { createAgentCouncilMessage, deleteAgentCouncilTopic, listAgentCouncilMessages } from '../storage/supabaseSync'
-import type { AgentCouncilMessage, AgentCouncilSpeaker } from '../types'
+import {
+  createAgentCouncilProposal,
+  createAgentCouncilReview,
+  decideAgentCouncilProposal,
+  deleteAgentCouncilProposal,
+  deleteAgentCouncilTopic,
+  listAgentCouncilMessages,
+} from '../storage/supabaseSync'
+import type {
+  AgentCouncilMessage,
+  AgentCouncilProposalStatus,
+  AgentCouncilSpeaker,
+  AgentCouncilVote,
+} from '../types'
 import './AgentCouncilPage.css'
 
 const SPEAKER_META: Record<AgentCouncilSpeaker, { label: string; className: string }> = {
@@ -10,23 +22,87 @@ const SPEAKER_META: Record<AgentCouncilSpeaker, { label: string; className: stri
   gpt: { label: 'Syzygy·GPT', className: 'speaker-gpt' },
   gemini: { label: 'Syzygy·Gemini', className: 'speaker-gemini' },
   chuanchuan: { label: '串串', className: 'speaker-chuanchuan' },
+  codex_cli: { label: 'Codex CLI', className: 'speaker-codex' },
+  claude_code_cli: { label: 'Claude Code CLI', className: 'speaker-claude-code' },
 }
 
-const formatTime = (value: string) => new Date(value).toLocaleString('zh-CN', { hour12: false })
+// 旧数据可能出现未知 speaker，做一次兜底，避免页面崩溃。
+const getSpeakerMeta = (speaker: string) =>
+  SPEAKER_META[speaker as AgentCouncilSpeaker] ?? { label: speaker || '未知', className: 'speaker-unknown' }
+
+const SPEAKER_OPTIONS: AgentCouncilSpeaker[] = [
+  'chuanchuan',
+  'claude',
+  'gpt',
+  'gemini',
+  'codex_cli',
+  'claude_code_cli',
+]
+
+const STATUS_META: Record<AgentCouncilProposalStatus, { label: string; className: string }> = {
+  open: { label: '待讨论', className: 'status-open' },
+  approved: { label: '已拍板，待生成执行案', className: 'status-approved' },
+  rejected: { label: '已拒绝', className: 'status-rejected' },
+  deferred: { label: '暂缓', className: 'status-deferred' },
+  plan_generated: { label: '执行案已生成', className: 'status-plan' },
+}
+
+const getStatusMeta = (status: AgentCouncilProposalStatus | null) =>
+  status ? STATUS_META[status] : STATUS_META.open
+
+const VOTE_META: Record<AgentCouncilVote, { label: string; className: string }> = {
+  support: { label: '支持', className: 'vote-support' },
+  neutral: { label: '中立', className: 'vote-neutral' },
+  against: { label: '反对', className: 'vote-against' },
+}
+
+const VOTE_OPTIONS: AgentCouncilVote[] = ['support', 'neutral', 'against']
+
+type DecisionAction = 'approved' | 'rejected' | 'deferred'
+
+const DECISION_META: Record<DecisionAction, { label: string; className: string }> = {
+  approved: { label: '拍板执行', className: 'decision-approved' },
+  rejected: { label: '拒绝', className: 'decision-rejected' },
+  deferred: { label: '暂缓', className: 'decision-deferred' },
+}
+
+const formatTime = (value: string | null) =>
+  value ? new Date(value).toLocaleString('zh-CN', { hour12: false }) : '—'
+
+const summarize = (text: string, max = 80) => {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  return normalized.length > max ? `${normalized.slice(0, max)}…` : normalized
+}
 
 const AgentCouncilPage = () => {
   const navigate = useNavigate()
   const [messages, setMessages] = useState<AgentCouncilMessage[]>([])
-  const [activeTopic, setActiveTopic] = useState<string | null>(null)
+  const [activeProposalId, setActiveProposalId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+
+  // 发起提案表单
+  const [newSpeaker, setNewSpeaker] = useState<AgentCouncilSpeaker>('chuanchuan')
   const [newTopic, setNewTopic] = useState('')
   const [newMessage, setNewMessage] = useState('')
-  const [replyMessage, setReplyMessage] = useState('')
-  const [pendingDeleteTopic, setPendingDeleteTopic] = useState<string | null>(null)
+  const [newRiskLevel, setNewRiskLevel] = useState('')
+  const [newTargetModule, setNewTargetModule] = useState('')
+
+  // 评估回复表单
+  const [reviewSpeaker, setReviewSpeaker] = useState<AgentCouncilSpeaker>('chuanchuan')
+  const [reviewVote, setReviewVote] = useState<AgentCouncilVote>('support')
+  const [reviewMessage, setReviewMessage] = useState('')
+
+  // 拍板说明
+  const [decisionNote, setDecisionNote] = useState('')
+
+  // 删除确认
+  const [pendingDeleteProposalId, setPendingDeleteProposalId] = useState<string | null>(null)
+  const [pendingDeleteLegacyTopic, setPendingDeleteLegacyTopic] = useState<string | null>(null)
   const [deleting, setDeleting] = useState(false)
+  const [showLegacy, setShowLegacy] = useState(false)
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -46,100 +122,194 @@ const AgentCouncilPage = () => {
     void refresh()
   }, [refresh])
 
-  const topicSummaries = useMemo(() => {
+  // 主提案：parent_id 为空且 entry_type=proposal，按更新/创建时间倒序
+  const proposals = useMemo(() => {
+    return messages
+      .filter((item) => !item.parentId && item.entryType === 'proposal')
+      .sort((a, b) => {
+        const at = new Date(a.updatedAt ?? a.createdAt).getTime()
+        const bt = new Date(b.updatedAt ?? b.createdAt).getTime()
+        return bt - at
+      })
+  }, [messages])
+
+  // 旧历史消息：没有 entry_type（或非 proposal）且无 parent_id，按 topic 归组，单独展示避免崩溃
+  const legacyTopics = useMemo(() => {
     const map = new Map<string, AgentCouncilMessage[]>()
-    messages.forEach((item) => {
-      const arr = map.get(item.topic) ?? []
-      arr.push(item)
-      map.set(item.topic, arr)
-    })
+    messages
+      .filter((item) => !item.parentId && item.entryType !== 'proposal')
+      .forEach((item) => {
+        const arr = map.get(item.topic) ?? []
+        arr.push(item)
+        map.set(item.topic, arr)
+      })
     return Array.from(map.entries())
       .map(([topic, items]) => {
-        const latest = items.reduce((prev, current) =>
-          new Date(current.createdAt).getTime() > new Date(prev.createdAt).getTime() ? current : prev,
-        items[0])
-        return { topic, items, latest }
+        const sorted = [...items].sort(
+          (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        )
+        const latest = sorted[sorted.length - 1]
+        return { topic, items: sorted, latest }
       })
       .sort((a, b) => new Date(b.latest.createdAt).getTime() - new Date(a.latest.createdAt).getTime())
   }, [messages])
 
-  const activeMessages = useMemo(() => {
-    if (!activeTopic) {
+  const activeProposal = useMemo(
+    () => proposals.find((item) => item.id === activeProposalId) ?? null,
+    [proposals, activeProposalId],
+  )
+
+  const activeReviews = useMemo(() => {
+    if (!activeProposalId) {
       return []
     }
     return messages
-      .filter((item) => item.topic === activeTopic)
+      .filter((item) => item.parentId === activeProposalId && item.entryType === 'review')
       .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-  }, [activeTopic, messages])
+  }, [activeProposalId, messages])
 
-  const handleCreateTopic = async (event: FormEvent) => {
+  const activeDecisions = useMemo(() => {
+    if (!activeProposalId) {
+      return []
+    }
+    return messages
+      .filter((item) => item.parentId === activeProposalId && item.entryType === 'decision')
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+  }, [activeProposalId, messages])
+
+  const handleCreateProposal = async (event: FormEvent) => {
     event.preventDefault()
     const topic = newTopic.trim()
     const message = newMessage.trim()
     if (!topic || !message) {
-      setError('议题和发言内容都不能为空')
+      setError('议题和提案内容都不能为空')
       return
+    }
+    const metadata: Record<string, string> = {}
+    if (newRiskLevel.trim()) {
+      metadata.risk_level = newRiskLevel.trim()
+    }
+    if (newTargetModule.trim()) {
+      metadata.target_module = newTargetModule.trim()
     }
     setSaving(true)
     try {
-      await createAgentCouncilMessage({ topic, message })
+      const created = await createAgentCouncilProposal({
+        topic,
+        message,
+        speaker: newSpeaker,
+        metadata,
+      })
       setNewTopic('')
       setNewMessage('')
-      setActiveTopic(topic)
-      setNotice('新议题已发起')
+      setNewRiskLevel('')
+      setNewTargetModule('')
+      setActiveProposalId(created.id)
+      setNotice('新提案已发起')
       setError(null)
       await refresh()
     } catch (saveError) {
-      console.warn('发起议题失败', saveError)
-      setError('发起议题失败，请稍后重试')
+      console.warn('发起提案失败', saveError)
+      setError('发起提案失败，请稍后重试')
     } finally {
       setSaving(false)
     }
   }
 
-  const handleReply = async (event: FormEvent) => {
+  const handleAddReview = async (event: FormEvent) => {
     event.preventDefault()
-    if (!activeTopic) {
+    if (!activeProposal) {
       return
     }
-    const message = replyMessage.trim()
+    const message = reviewMessage.trim()
     if (!message) {
-      setError('回复内容不能为空')
+      setError('评估内容不能为空')
       return
     }
     setSaving(true)
     try {
-      await createAgentCouncilMessage({ topic: activeTopic, message })
-      setReplyMessage('')
-      setNotice('回复已发送')
+      await createAgentCouncilReview({
+        parentId: activeProposal.id,
+        topic: activeProposal.topic,
+        message,
+        vote: reviewVote,
+        speaker: reviewSpeaker,
+      })
+      setReviewMessage('')
+      setNotice('评估回复已提交')
       setError(null)
       await refresh()
     } catch (saveError) {
-      console.warn('回复失败', saveError)
-      setError('回复失败，请稍后重试')
+      console.warn('提交评估失败', saveError)
+      setError('提交评估失败，请稍后重试')
     } finally {
       setSaving(false)
     }
   }
 
-  const handleConfirmDelete = async () => {
-    if (!pendingDeleteTopic) {
+  const handleDecide = async (status: DecisionAction) => {
+    if (!activeProposal) {
       return
     }
-    const topic = pendingDeleteTopic
+    setSaving(true)
+    try {
+      await decideAgentCouncilProposal({
+        proposalId: activeProposal.id,
+        topic: activeProposal.topic,
+        status,
+        note: decisionNote,
+        speaker: 'chuanchuan',
+      })
+      setDecisionNote('')
+      setNotice(`串串已拍板：${DECISION_META[status].label}`)
+      setError(null)
+      await refresh()
+    } catch (decideError) {
+      console.warn('拍板失败', decideError)
+      setError('拍板失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleConfirmDeleteProposal = async () => {
+    if (!pendingDeleteProposalId) {
+      return
+    }
+    const proposalId = pendingDeleteProposalId
     setDeleting(true)
     try {
-      await deleteAgentCouncilTopic(topic)
-      if (activeTopic === topic) {
-        setActiveTopic(null)
+      await deleteAgentCouncilProposal(proposalId)
+      if (activeProposalId === proposalId) {
+        setActiveProposalId(null)
       }
-      setPendingDeleteTopic(null)
-      setNotice('议题已删除')
+      setPendingDeleteProposalId(null)
+      setNotice('提案已删除')
       setError(null)
       await refresh()
     } catch (deleteError) {
-      console.warn('删除议题失败', deleteError)
-      setError('删除议题失败，请稍后重试')
+      console.warn('删除提案失败', deleteError)
+      setError('删除提案失败，请稍后重试')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const handleConfirmDeleteLegacy = async () => {
+    if (!pendingDeleteLegacyTopic) {
+      return
+    }
+    const topic = pendingDeleteLegacyTopic
+    setDeleting(true)
+    try {
+      await deleteAgentCouncilTopic(topic)
+      setPendingDeleteLegacyTopic(null)
+      setNotice('历史消息已删除')
+      setError(null)
+      await refresh()
+    } catch (deleteError) {
+      console.warn('删除历史消息失败', deleteError)
+      setError('删除历史消息失败，请稍后重试')
     } finally {
       setDeleting(false)
     }
@@ -160,80 +330,276 @@ const AgentCouncilPage = () => {
       {error ? <p className="council-error">{error}</p> : null}
 
       <section className="council-panel">
-        <h2>议题列表</h2>
-        {loading ? <p className="council-empty">加载中…</p> : null}
-        {!loading && topicSummaries.length === 0 ? <p className="council-empty">暂时还没有议题。</p> : null}
-        <div className="topic-list">
-          {topicSummaries.map((summary) => (
-            <div
-              key={summary.topic}
-              className={`topic-item ${activeTopic === summary.topic ? 'active' : ''}`}
-            >
-              <button
-                type="button"
-                className="topic-item__select"
-                onClick={() => setActiveTopic(summary.topic)}
-              >
-                <strong>{summary.topic}</strong>
-                <span>{SPEAKER_META[summary.latest.speaker].label} · {formatTime(summary.latest.createdAt)}</span>
-              </button>
-              <button
-                type="button"
-                className="topic-item__delete"
-                onClick={() => setPendingDeleteTopic(summary.topic)}
-                aria-label={`删除议题 ${summary.topic}`}
-              >
-                删除
-              </button>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="council-panel">
-        <h2>发起新议题</h2>
-        <form className="council-form" onSubmit={handleCreateTopic}>
+        <h2>发起新提案</h2>
+        <form className="council-form" onSubmit={handleCreateProposal}>
+          <label className="council-field">
+            <span>发起身份</span>
+            <select value={newSpeaker} onChange={(e) => setNewSpeaker(e.target.value as AgentCouncilSpeaker)}>
+              {SPEAKER_OPTIONS.map((speaker) => (
+                <option key={speaker} value={speaker}>{SPEAKER_META[speaker].label}</option>
+              ))}
+            </select>
+          </label>
           <input value={newTopic} onChange={(e) => setNewTopic(e.target.value)} placeholder="议题名称（topic）" />
-          <textarea value={newMessage} onChange={(e) => setNewMessage(e.target.value)} rows={3} placeholder="第一条发言" />
-          <button type="submit" disabled={saving}>发起</button>
+          <textarea value={newMessage} onChange={(e) => setNewMessage(e.target.value)} rows={4} placeholder="提案全文" />
+          <div className="council-field-row">
+            <input value={newRiskLevel} onChange={(e) => setNewRiskLevel(e.target.value)} placeholder="风险等级（可选）" />
+            <input value={newTargetModule} onChange={(e) => setNewTargetModule(e.target.value)} placeholder="目标模块（可选）" />
+          </div>
+          <button type="submit" disabled={saving}>发起提案</button>
         </form>
       </section>
 
       <section className="council-panel">
-        <h2>议题详情 {activeTopic ? `· ${activeTopic}` : ''}</h2>
-        {activeTopic ? (
-          <>
-            <div className="message-list">
-              {activeMessages.map((item) => (
-                <article key={item.id} className="message-item">
-                  <div className="message-meta">
-                    <span className={`speaker-tag ${SPEAKER_META[item.speaker].className}`}>{SPEAKER_META[item.speaker].label}</span>
-                    <time>{formatTime(item.createdAt)}</time>
+        <h2>主提案列表</h2>
+        {loading ? <p className="council-empty">加载中…</p> : null}
+        {!loading && proposals.length === 0 ? <p className="council-empty">暂时还没有正式提案。</p> : null}
+        <div className="proposal-list">
+          {proposals.map((proposal) => {
+            const statusMeta = getStatusMeta(proposal.proposalStatus)
+            const speakerMeta = getSpeakerMeta(proposal.speaker)
+            const riskLevel = proposal.metadata?.risk_level
+            const targetModule = proposal.metadata?.target_module
+            return (
+              <div
+                key={proposal.id}
+                className={`proposal-item ${activeProposalId === proposal.id ? 'active' : ''}`}
+              >
+                <button
+                  type="button"
+                  className="proposal-item__select"
+                  onClick={() => setActiveProposalId((prev) => (prev === proposal.id ? null : proposal.id))}
+                >
+                  <div className="proposal-item__head">
+                    <strong>{proposal.topic}</strong>
+                    <span className={`status-tag ${statusMeta.className}`}>{statusMeta.label}</span>
                   </div>
-                  <p>{item.message}</p>
-                </article>
-              ))}
-            </div>
-            <form className="council-form" onSubmit={handleReply}>
-              <textarea value={replyMessage} onChange={(e) => setReplyMessage(e.target.value)} rows={3} placeholder="在当前议题下回复（将以串串身份发送）" />
-              <button type="submit" disabled={saving}>发送回复</button>
-            </form>
-          </>
-        ) : (
-          <p className="council-empty">请先从上方选择一个议题。</p>
-        )}
+                  <p className="proposal-item__summary">{summarize(proposal.message)}</p>
+                  <div className="proposal-item__meta">
+                    <span className={`speaker-tag ${speakerMeta.className}`}>{speakerMeta.label}</span>
+                    {typeof riskLevel === 'string' && riskLevel ? (
+                      <span className="meta-chip">风险：{riskLevel}</span>
+                    ) : null}
+                    {typeof targetModule === 'string' && targetModule ? (
+                      <span className="meta-chip">模块：{targetModule}</span>
+                    ) : null}
+                  </div>
+                  <div className="proposal-item__time">
+                    <span>发起 {formatTime(proposal.createdAt)}</span>
+                    {proposal.updatedAt && proposal.updatedAt !== proposal.createdAt ? (
+                      <span>更新 {formatTime(proposal.updatedAt)}</span>
+                    ) : null}
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  className="proposal-item__delete"
+                  onClick={() => setPendingDeleteProposalId(proposal.id)}
+                  aria-label={`删除提案 ${proposal.topic}`}
+                >
+                  删除
+                </button>
+              </div>
+            )
+          })}
+        </div>
       </section>
 
+      {activeProposal ? (
+        <section className="council-panel proposal-detail">
+          <h2>提案详情 · {activeProposal.topic}</h2>
+
+          <article className="detail-proposal">
+            <div className="message-meta">
+              <span className={`speaker-tag ${getSpeakerMeta(activeProposal.speaker).className}`}>
+                {getSpeakerMeta(activeProposal.speaker).label}
+              </span>
+              <span className={`status-tag ${getStatusMeta(activeProposal.proposalStatus).className}`}>
+                {getStatusMeta(activeProposal.proposalStatus).label}
+              </span>
+            </div>
+            <p className="detail-proposal__body">{activeProposal.message}</p>
+            <div className="proposal-item__meta">
+              {typeof activeProposal.metadata?.risk_level === 'string' && activeProposal.metadata.risk_level ? (
+                <span className="meta-chip">风险：{activeProposal.metadata.risk_level}</span>
+              ) : null}
+              {typeof activeProposal.metadata?.target_module === 'string' && activeProposal.metadata.target_module ? (
+                <span className="meta-chip">模块：{activeProposal.metadata.target_module}</span>
+              ) : null}
+            </div>
+            <div className="proposal-item__time">
+              <span>发起 {formatTime(activeProposal.createdAt)}</span>
+              {activeProposal.updatedAt && activeProposal.updatedAt !== activeProposal.createdAt ? (
+                <span>更新 {formatTime(activeProposal.updatedAt)}</span>
+              ) : null}
+            </div>
+          </article>
+
+          <div className="detail-section">
+            <h3>评估回复（{activeReviews.length}）</h3>
+            {activeReviews.length === 0 ? <p className="council-empty">还没有评估回复。</p> : null}
+            <div className="message-list">
+              {activeReviews.map((review) => {
+                const speakerMeta = getSpeakerMeta(review.speaker)
+                return (
+                  <article key={review.id} className="message-item">
+                    <div className="message-meta">
+                      <span className={`speaker-tag ${speakerMeta.className}`}>{speakerMeta.label}</span>
+                      <div className="message-meta__right">
+                        {review.vote ? (
+                          <span className={`vote-tag ${VOTE_META[review.vote].className}`}>{VOTE_META[review.vote].label}</span>
+                        ) : null}
+                        <time>{formatTime(review.createdAt)}</time>
+                      </div>
+                    </div>
+                    <p>{review.message}</p>
+                  </article>
+                )
+              })}
+            </div>
+            <form className="council-form" onSubmit={handleAddReview}>
+              <div className="council-field-row">
+                <label className="council-field">
+                  <span>评估身份</span>
+                  <select value={reviewSpeaker} onChange={(e) => setReviewSpeaker(e.target.value as AgentCouncilSpeaker)}>
+                    {SPEAKER_OPTIONS.map((speaker) => (
+                      <option key={speaker} value={speaker}>{SPEAKER_META[speaker].label}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="council-field">
+                  <span>态度</span>
+                  <select value={reviewVote} onChange={(e) => setReviewVote(e.target.value as AgentCouncilVote)}>
+                    {VOTE_OPTIONS.map((vote) => (
+                      <option key={vote} value={vote}>{VOTE_META[vote].label}</option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <textarea value={reviewMessage} onChange={(e) => setReviewMessage(e.target.value)} rows={3} placeholder="评估意见" />
+              <button type="submit" disabled={saving}>提交评估</button>
+            </form>
+          </div>
+
+          <div className="detail-section">
+            <h3>串串拍板记录（{activeDecisions.length}）</h3>
+            {activeDecisions.length === 0 ? <p className="council-empty">还没有拍板记录。</p> : null}
+            <div className="message-list">
+              {activeDecisions.map((decision) => {
+                const speakerMeta = getSpeakerMeta(decision.speaker)
+                const decisionStatus = decision.metadata?.decision_status
+                const statusLabel =
+                  typeof decisionStatus === 'string' && decisionStatus in STATUS_META
+                    ? STATUS_META[decisionStatus as AgentCouncilProposalStatus].label
+                    : null
+                return (
+                  <article key={decision.id} className="message-item decision-item">
+                    <div className="message-meta">
+                      <span className={`speaker-tag ${speakerMeta.className}`}>{speakerMeta.label}</span>
+                      <div className="message-meta__right">
+                        {statusLabel ? <span className="status-tag status-decision">{statusLabel}</span> : null}
+                        <time>{formatTime(decision.createdAt)}</time>
+                      </div>
+                    </div>
+                    <p>{decision.message}</p>
+                  </article>
+                )
+              })}
+            </div>
+            <div className="decision-box">
+              <textarea
+                value={decisionNote}
+                onChange={(e) => setDecisionNote(e.target.value)}
+                rows={2}
+                placeholder="拍板说明（可选）"
+              />
+              <p className="decision-hint">
+                拍板「{DECISION_META.approved.label}」只代表允许后续由 Mac mini 监听脚本生成本地执行方案，不会自动执行代码或数据库操作。
+              </p>
+              <div className="decision-actions">
+                {(['approved', 'rejected', 'deferred'] as DecisionAction[]).map((action) => (
+                  <button
+                    key={action}
+                    type="button"
+                    className={`decision-btn ${DECISION_META[action].className}`}
+                    onClick={() => void handleDecide(action)}
+                    disabled={saving}
+                  >
+                    {DECISION_META[action].label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {legacyTopics.length > 0 ? (
+        <section className="council-panel">
+          <div className="legacy-header">
+            <h2>历史消息（旧版）</h2>
+            <button type="button" className="legacy-toggle" onClick={() => setShowLegacy((prev) => !prev)}>
+              {showLegacy ? '收起' : `展开（${legacyTopics.length}）`}
+            </button>
+          </div>
+          {showLegacy ? (
+            <div className="legacy-list">
+              {legacyTopics.map((group) => (
+                <div key={group.topic} className="legacy-topic">
+                  <div className="legacy-topic__head">
+                    <strong>{group.topic}</strong>
+                    <button
+                      type="button"
+                      className="proposal-item__delete"
+                      onClick={() => setPendingDeleteLegacyTopic(group.topic)}
+                      aria-label={`删除历史议题 ${group.topic}`}
+                    >
+                      删除
+                    </button>
+                  </div>
+                  <div className="message-list">
+                    {group.items.map((item) => {
+                      const speakerMeta = getSpeakerMeta(item.speaker)
+                      return (
+                        <article key={item.id} className="message-item">
+                          <div className="message-meta">
+                            <span className={`speaker-tag ${speakerMeta.className}`}>{speakerMeta.label}</span>
+                            <time>{formatTime(item.createdAt)}</time>
+                          </div>
+                          <p>{item.message}</p>
+                        </article>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
       <ConfirmDialog
-        open={pendingDeleteTopic !== null}
-        title="删除议题"
-        description={pendingDeleteTopic ? `确定要删除议题「${pendingDeleteTopic}」吗？该议题下的全部发言都会一并删除，且无法恢复。` : undefined}
+        open={pendingDeleteProposalId !== null}
+        title="删除提案"
+        description="确定要删除这条提案吗？该提案下的全部评估与拍板记录都会一并删除，且无法恢复。"
         confirmLabel={deleting ? '删除中…' : '删除'}
         cancelLabel="取消"
         confirmDisabled={deleting}
         cancelDisabled={deleting}
-        onConfirm={() => void handleConfirmDelete()}
-        onCancel={() => setPendingDeleteTopic(null)}
+        onConfirm={() => void handleConfirmDeleteProposal()}
+        onCancel={() => setPendingDeleteProposalId(null)}
+      />
+
+      <ConfirmDialog
+        open={pendingDeleteLegacyTopic !== null}
+        title="删除历史消息"
+        description={pendingDeleteLegacyTopic ? `确定要删除历史议题「${pendingDeleteLegacyTopic}」下的全部消息吗？此操作无法恢复。` : undefined}
+        confirmLabel={deleting ? '删除中…' : '删除'}
+        cancelLabel="取消"
+        confirmDisabled={deleting}
+        cancelDisabled={deleting}
+        onConfirm={() => void handleConfirmDeleteLegacy()}
+        onCancel={() => setPendingDeleteLegacyTopic(null)}
       />
     </div>
   )

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -9,6 +9,10 @@ import type {
   ChatSession,
   AgentCouncilMessage,
   AgentCouncilSpeaker,
+  AgentCouncilEntryType,
+  AgentCouncilProposalStatus,
+  AgentCouncilVote,
+  AgentCouncilMetadata,
   CheckinEntry,
   ForumAiProfile,
   ForumReply,
@@ -350,6 +354,12 @@ type AgentCouncilRow = {
   topic: string
   message: string
   created_at: string
+  updated_at: string | null
+  parent_id: string | null
+  entry_type: string | null
+  proposal_status: string | null
+  vote: string | null
+  metadata: Record<string, unknown> | null
 }
 
 
@@ -395,12 +405,35 @@ const mapSyzygyReplyRow = (row: SyzygyReplyRow): SyzygyReply => ({
   modelId: row.model_id ?? null,
 })
 
+const AGENT_COUNCIL_ENTRY_TYPES: AgentCouncilEntryType[] = ['proposal', 'review', 'decision']
+const AGENT_COUNCIL_PROPOSAL_STATUSES: AgentCouncilProposalStatus[] = [
+  'open',
+  'approved',
+  'rejected',
+  'deferred',
+  'plan_generated',
+]
+const AGENT_COUNCIL_VOTES: AgentCouncilVote[] = ['support', 'neutral', 'against']
+
+const AGENT_COUNCIL_SELECT_FIELDS =
+  'id,speaker,topic,message,created_at,updated_at,parent_id,entry_type,proposal_status,vote,metadata'
+
+// 旧数据的 entry_type / proposal_status / vote 可能为空或不在白名单内，统一归一化为 null，避免前端崩溃。
+const normalizeAgentCouncilEnum = <T extends string>(value: string | null, allowed: T[]): T | null =>
+  value && (allowed as string[]).includes(value) ? (value as T) : null
+
 const mapAgentCouncilRow = (row: AgentCouncilRow): AgentCouncilMessage => ({
   id: row.id,
   speaker: row.speaker,
   topic: row.topic,
   message: row.message,
   createdAt: row.created_at,
+  updatedAt: row.updated_at ?? null,
+  parentId: row.parent_id ?? null,
+  entryType: normalizeAgentCouncilEnum(row.entry_type, AGENT_COUNCIL_ENTRY_TYPES),
+  proposalStatus: normalizeAgentCouncilEnum(row.proposal_status, AGENT_COUNCIL_PROPOSAL_STATUSES),
+  vote: normalizeAgentCouncilEnum(row.vote, AGENT_COUNCIL_VOTES),
+  metadata: (row.metadata ?? {}) as AgentCouncilMetadata,
 })
 
 const mapMemoryEntryRow = (row: MemoryEntryRow): MemoryEntry => ({
@@ -2998,7 +3031,7 @@ export const listAgentCouncilMessages = async (): Promise<AgentCouncilMessage[]>
   }
   const { data, error } = await supabase
     .from('agent_council')
-    .select('id,speaker,topic,message,created_at')
+    .select(AGENT_COUNCIL_SELECT_FIELDS)
     .order('created_at', { ascending: true })
   if (error) {
     throw error
@@ -3006,23 +3039,114 @@ export const listAgentCouncilMessages = async (): Promise<AgentCouncilMessage[]>
   return (data ?? []).map((row) => mapAgentCouncilRow(row as AgentCouncilRow))
 }
 
-export const createAgentCouncilMessage = async (payload: {
+// 发起一条正式主提案（parent_id 为空、entry_type=proposal、初始状态 open）。
+export const createAgentCouncilProposal = async (payload: {
   topic: string
   message: string
+  speaker?: AgentCouncilSpeaker
+  metadata?: AgentCouncilMetadata
+}): Promise<AgentCouncilMessage> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('agent_council')
+    .insert({
+      user_id: userId,
+      speaker: payload.speaker ?? 'chuanchuan',
+      topic: payload.topic,
+      message: payload.message,
+      entry_type: 'proposal',
+      proposal_status: 'open',
+      parent_id: null,
+      metadata: payload.metadata ?? {},
+    })
+    .select(AGENT_COUNCIL_SELECT_FIELDS)
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('发起提案失败')
+  }
+  return mapAgentCouncilRow(data as AgentCouncilRow)
+}
+
+// 给某条主提案添加一条评估回复（entry_type=review），并记录态度 vote。
+export const createAgentCouncilReview = async (payload: {
+  parentId: string
+  topic: string
+  message: string
+  vote: AgentCouncilVote
+  speaker?: AgentCouncilSpeaker
 }): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
+  const userId = await requireAuthenticatedUserId()
   const { error } = await supabase.from('agent_council').insert({
-    speaker: 'chuanchuan',
+    user_id: userId,
+    speaker: payload.speaker ?? 'chuanchuan',
     topic: payload.topic,
     message: payload.message,
+    entry_type: 'review',
+    parent_id: payload.parentId,
+    vote: payload.vote,
   })
   if (error) {
     throw error
   }
 }
 
+// 串串拍板：更新主提案 proposal_status，并插入一条 entry_type=decision 的记录保留拍板说明。
+// approved 仅代表“允许生成本地执行方案”，不代表自动执行；真正的执行案由 Mac mini 监听脚本生成。
+export const decideAgentCouncilProposal = async (payload: {
+  proposalId: string
+  topic: string
+  status: 'approved' | 'rejected' | 'deferred'
+  note?: string
+  speaker?: AgentCouncilSpeaker
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const nowIso = new Date().toISOString()
+  const { error: updateError } = await supabase
+    .from('agent_council')
+    .update({ proposal_status: payload.status, updated_at: nowIso })
+    .eq('id', payload.proposalId)
+  if (updateError) {
+    throw updateError
+  }
+  const statusLabel =
+    payload.status === 'approved' ? '已拍板' : payload.status === 'rejected' ? '已拒绝' : '暂缓'
+  const note = payload.note?.trim()
+  const message = note ? note : `串串拍板：${statusLabel}`
+  const { error: insertError } = await supabase.from('agent_council').insert({
+    user_id: userId,
+    speaker: payload.speaker ?? 'chuanchuan',
+    topic: payload.topic,
+    message,
+    entry_type: 'decision',
+    parent_id: payload.proposalId,
+    metadata: { decision_status: payload.status },
+  })
+  if (insertError) {
+    throw insertError
+  }
+}
+
+// 删除一条主提案；其下的评估/拍板记录通过外键 ON DELETE CASCADE 一并删除。
+export const deleteAgentCouncilProposal = async (proposalId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase.from('agent_council').delete().eq('id', proposalId)
+  if (error) {
+    throw error
+  }
+}
+
+// 删除整条 topic 下的全部消息（用于清理旧版历史消息）。
 export const deleteAgentCouncilTopic = async (topic: string): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,7 +270,30 @@ export type RpStoryGroup = {
   updatedAt: string | null
 }
 
-export type AgentCouncilSpeaker = 'claude' | 'gpt' | 'gemini' | 'chuanchuan'
+export type AgentCouncilSpeaker =
+  | 'claude'
+  | 'gpt'
+  | 'gemini'
+  | 'chuanchuan'
+  | 'codex_cli'
+  | 'claude_code_cli'
+
+export type AgentCouncilEntryType = 'proposal' | 'review' | 'decision'
+
+export type AgentCouncilProposalStatus =
+  | 'open'
+  | 'approved'
+  | 'rejected'
+  | 'deferred'
+  | 'plan_generated'
+
+export type AgentCouncilVote = 'support' | 'neutral' | 'against'
+
+export type AgentCouncilMetadata = {
+  risk_level?: string
+  target_module?: string
+  [key: string]: unknown
+}
 
 export type AgentCouncilMessage = {
   id: string
@@ -278,6 +301,12 @@ export type AgentCouncilMessage = {
   topic: string
   message: string
   createdAt: string
+  updatedAt: string | null
+  parentId: string | null
+  entryType: AgentCouncilEntryType | null
+  proposalStatus: AgentCouncilProposalStatus | null
+  vote: AgentCouncilVote | null
+  metadata: AgentCouncilMetadata
 }
 
 export type RpSessionGroup = {


### PR DESCRIPTION
## 背景

V3.1 已扩展 `agent_council` 表（新增 `user_id / parent_id / entry_type / proposal_status / vote / metadata / updated_at`），用于支持「提案 → 多端评估 → 串串拍板 → Codex CLI 写本地执行方案 MD」的链路。本 PR 改造议事厅前端，使其支持正式提案、评估回复与串串拍板状态写入。

## 改动内容

**类型层 (`src/types.ts`)**
- `AgentCouncilSpeaker` 新增 `codex_cli`、`claude_code_cli`
- 新增 `AgentCouncilEntryType` / `AgentCouncilProposalStatus` / `AgentCouncilVote` / `AgentCouncilMetadata`
- `AgentCouncilMessage` 扩展 `updatedAt / parentId / entryType / proposalStatus / vote / metadata`

**存储层 (`src/storage/supabaseSync.ts`)**
- 读取全部新字段；对旧数据的 `entry_type/proposal_status/vote` 做白名单归一化（空值或非法值 → `null`）
- `createAgentCouncilProposal`：写入 `entry_type=proposal`、`proposal_status=open`、`metadata`
- `createAgentCouncilReview`：写入 `entry_type=review` 与 `vote`
- `decideAgentCouncilProposal`：更新主提案 `proposal_status`，并插入一条 `entry_type=decision`、`parent_id=提案 id` 的记录保留拍板说明
- `deleteAgentCouncilProposal`（外键 `ON DELETE CASCADE` 连带删除评估/拍板）+ 保留 `deleteAgentCouncilTopic` 清理旧历史消息

**页面 (`src/pages/AgentCouncilPage.tsx` / `.css`)**
- 主提案列表：`parent_id` 为空且 `entry_type=proposal`，卡片展示 topic / 摘要 / speaker / 状态徽章 / 发起·更新时间 / `metadata.risk_level`·`target_module`
- 提案详情：全文 + 评估回复（带 support/neutral/against 态度标识）+ 串串拍板记录
- 发起提案 / 评估回复：可选发起身份、态度、风险等级、目标模块
- 串串拍板：拍板执行(approved) / 拒绝(rejected) / 暂缓(deferred)，附拍板说明，并提示 approved 仅代表允许 Mac mini 生成执行案、不自动执行
- 状态文案：open 待讨论 / approved 已拍板，待生成执行案 / rejected 已拒绝 / deferred 暂缓 / plan_generated 执行案已生成
- 旧历史消息（`entry_type` 为空）单独折叠展示，页面不崩溃

## 边界

前端仅负责展示与写入提案/评估/拍板状态，不写 `syzygy_commands`，不执行真实代码或数据库操作。`approved` 只代表「允许生成本地执行方案」，由 Mac mini 监听脚本后续读取。

## 验收对照

1. ✅ 创建 `entry_type=proposal` 的主提案
2. ✅ 给提案添加 `review` 回复并写入 `vote`
3. ✅ 串串可将提案状态改为 approved / rejected / deferred
4. ✅ approved 文案显示「已拍板，待生成执行案」，不显示「执行中」
5. ✅ plan_generated 显示「执行案已生成」
6. ✅ 旧 `agent_council` 历史消息 `entry_type` 为空时页面不崩溃

## 验证

- `tsc -b` 通过、`vite build` 成功；改动文件 eslint 零告警
- 对真实 Supabase 项目 `crfhiumxzmaszkapanrb` 跑通「提案 → 评估 → 改状态 → 拍板 → 级联删除」全链路，无残留测试数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYwJjLFa6bVaNjyPSrCbRK)_