### PR TITLE
sync deployed MCP edge functions back to source

### DIFF
--- a/supabase/functions/hamster-lounge-mcp/index.ts
+++ b/supabase/functions/hamster-lounge-mcp/index.ts
@@ -1,5 +1,13 @@
 import { z } from 'npm:zod@^4.1.13'
-import { errorResult, jsonResult, serveMcp, supabase } from '../_shared/mcp_common.ts'
+import { errorResult, jsonResult, serveMcp, supabase, USER_ID } from '../_shared/mcp_common.ts'
+
+const SPEAKER_SCHEMA = z.enum(['claude', 'gpt', 'gemini', 'chuanchuan', 'codex_cli', 'claude_code_cli'])
+const ENTRY_TYPE_SCHEMA = z.enum(['proposal', 'review', 'decision'])
+const PROPOSAL_STATUS_SCHEMA = z.enum(['open', 'approved', 'rejected', 'deferred', 'plan_generated'])
+const VOTE_SCHEMA = z.enum(['support', 'neutral', 'against'])
+const METADATA_SCHEMA = z.record(z.string(), z.unknown())
+
+const councilColumns = 'id, user_id, parent_id, speaker, topic, message, entry_type, proposal_status, vote, metadata, read_by, created_at, updated_at'
 
 serveMcp('hamster-lounge-mcp', (server) => {
   server.registerTool('lounge_list_sofas', {
@@ -47,24 +55,132 @@ serveMcp('hamster-lounge-mcp', (server) => {
 
   server.registerTool('council_post', {
     title: 'Post to Council',
-    description: '向 Agent Council 发送一条消息。',
+    description: '向 Agent Council 发送一条消息。兼容旧版，也支持 V3.1 的 entry_type / parent_id / proposal_status / vote / metadata。',
     inputSchema: {
-      speaker: z.string().describe('发言者: claude / gpt / gemini / chuanchuan'),
+      speaker: SPEAKER_SCHEMA.describe('发言者: claude / gpt / gemini / chuanchuan / codex_cli / claude_code_cli'),
       topic: z.string().describe('话题'),
       message: z.string().describe('消息内容'),
+      parent_id: z.string().optional().describe('父提案 UUID；评估/拍板时传入'),
+      entry_type: ENTRY_TYPE_SCHEMA.optional().describe('proposal / review / decision'),
+      proposal_status: PROPOSAL_STATUS_SCHEMA.optional().describe('open / approved / rejected / deferred / plan_generated'),
+      vote: VOTE_SCHEMA.optional().describe('support / neutral / against'),
+      metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 risk_level / target_module / command_id'),
     },
-  }, async ({ speaker, topic, message }) => {
-    const { error } = await supabase.from('agent_council').insert({ speaker, topic, message }).select()
+  }, async ({ speaker, topic, message, parent_id, entry_type, proposal_status, vote, metadata }) => {
+    const { data, error } = await supabase.from('agent_council').insert({
+      user_id: USER_ID,
+      speaker,
+      topic,
+      message,
+      parent_id: parent_id ?? null,
+      entry_type: entry_type ?? null,
+      proposal_status: proposal_status ?? null,
+      vote: vote ?? null,
+      metadata: metadata ?? {},
+    }).select(councilColumns).single()
     if (error) return errorResult(error)
-    return { content: [{ type: 'text' as const, text: `Council 消息已发送: ${topic}` }] }
+    return { content: [{ type: 'text' as const, text: `Council 消息已发送: ${JSON.stringify(data)}` }] }
+  })
+
+  server.registerTool('council_propose', {
+    title: 'Create Council Proposal',
+    description: '发起一条 V3.1 Agent Council 正式提案。默认 proposal_status=open。',
+    inputSchema: {
+      speaker: SPEAKER_SCHEMA.describe('发起者'),
+      topic: z.string().describe('提案主题'),
+      message: z.string().describe('提案正文：背景、方案、收益、风险'),
+      metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 risk_level / target_module / executable'),
+    },
+  }, async ({ speaker, topic, message, metadata }) => {
+    const { data, error } = await supabase.from('agent_council').insert({
+      user_id: USER_ID,
+      speaker,
+      topic,
+      message,
+      entry_type: 'proposal',
+      proposal_status: 'open',
+      metadata: metadata ?? {},
+    }).select(councilColumns).single()
+    if (error) return errorResult(error)
+    return jsonResult(data)
+  })
+
+  server.registerTool('council_review', {
+    title: 'Review Council Proposal',
+    description: '对一条 Council 提案写评估回复，可带 support / neutral / against。',
+    inputSchema: {
+      proposal_id: z.string().describe('主提案 UUID'),
+      speaker: SPEAKER_SCHEMA.describe('评估者'),
+      message: z.string().describe('评估内容'),
+      vote: VOTE_SCHEMA.describe('评估态度'),
+      metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 risk_notes / alternative_plan'),
+    },
+  }, async ({ proposal_id, speaker, message, vote, metadata }) => {
+    const { data: proposal, error: proposalError } = await supabase.from('agent_council').select('id, topic').eq('id', proposal_id).maybeSingle()
+    if (proposalError) return errorResult(proposalError)
+    if (!proposal) return { content: [{ type: 'text' as const, text: `Error: proposal not found: ${proposal_id}` }] }
+    const { data, error } = await supabase.from('agent_council').insert({
+      user_id: USER_ID,
+      parent_id: proposal_id,
+      speaker,
+      topic: proposal.topic,
+      message,
+      entry_type: 'review',
+      vote,
+      metadata: metadata ?? {},
+    }).select(councilColumns).single()
+    if (error) return errorResult(error)
+    return jsonResult(data)
+  })
+
+  server.registerTool('council_decide', {
+    title: 'Decide Council Proposal',
+    description: '由串串对 Council 提案拍板，并同步更新主提案 proposal_status。approved 只表示允许生成执行方案，不代表自动执行。',
+    inputSchema: {
+      proposal_id: z.string().describe('主提案 UUID'),
+      decision: z.enum(['approved', 'rejected', 'deferred', 'plan_generated']).describe('拍板状态'),
+      message: z.string().optional().describe('拍板说明'),
+      speaker: SPEAKER_SCHEMA.optional().describe('拍板者，默认 chuanchuan'),
+      metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 generated_plan_path / command_id'),
+    },
+  }, async ({ proposal_id, decision, message, speaker, metadata }) => {
+    const actor = speaker ?? 'chuanchuan'
+    const { data: proposal, error: proposalError } = await supabase.from('agent_council').select('id, topic, metadata').eq('id', proposal_id).maybeSingle()
+    if (proposalError) return errorResult(proposalError)
+    if (!proposal) return { content: [{ type: 'text' as const, text: `Error: proposal not found: ${proposal_id}` }] }
+    const nextMetadata = { ...((proposal.metadata ?? {}) as Record<string, unknown>), ...(metadata ?? {}) }
+    const now = new Date().toISOString()
+    const { error: updateError } = await supabase.from('agent_council').update({ proposal_status: decision, metadata: nextMetadata, updated_at: now }).eq('id', proposal_id)
+    if (updateError) return errorResult(updateError)
+    const { data, error } = await supabase.from('agent_council').insert({
+      user_id: USER_ID,
+      parent_id: proposal_id,
+      speaker: actor,
+      topic: proposal.topic,
+      message: message ?? `串串拍板：${decision}`,
+      entry_type: 'decision',
+      proposal_status: decision,
+      metadata: metadata ?? {},
+    }).select(councilColumns).single()
+    if (error) return errorResult(error)
+    return jsonResult({ proposal_id, proposal_status: decision, decision_entry: data })
   })
 
   server.registerTool('council_read', {
     title: 'Read Council',
-    description: '阅读 Agent Council 的最近消息。',
-    inputSchema: { limit: z.number().optional().describe('返回数量，默认10') },
-  }, async ({ limit }) => {
-    const { data, error } = await supabase.from('agent_council').select('*').order('created_at', { ascending: false }).limit(limit ?? 10)
+    description: '阅读 Agent Council 消息；可按 proposal_status / entry_type / parent_id 筛选。',
+    inputSchema: {
+      limit: z.number().optional().describe('返回数量，默认10'),
+      proposal_status: PROPOSAL_STATUS_SCHEMA.optional().describe('按提案状态筛选'),
+      entry_type: ENTRY_TYPE_SCHEMA.optional().describe('按条目类型筛选'),
+      parent_id: z.string().optional().describe('读取某个主提案下的评估/拍板记录'),
+    },
+  }, async ({ limit, proposal_status, entry_type, parent_id }) => {
+    let query = supabase.from('agent_council').select(councilColumns).order('created_at', { ascending: false }).limit(limit ?? 10)
+    if (proposal_status) query = query.eq('proposal_status', proposal_status)
+    if (entry_type) query = query.eq('entry_type', entry_type)
+    if (parent_id) query = query.eq('parent_id', parent_id)
+    const { data, error } = await query
     if (error) return errorResult(error)
     return jsonResult(data)
   })

--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -5,7 +5,8 @@ const FEED_LIST_COLUMNS = 'id, type, title, summary, priority, status, source, c
 const FEED_DETAIL_COLUMNS = 'id, type, title, summary, content, content_format, priority, status, source, created_by, visible_from, expires_at, related_table, related_id, metadata, created_at, updated_at'
 const DEFAULT_FEED_STATUSES = ['unread', 'read']
 const FEED_PRIORITY_RANK: Record<string, number> = { low: 1, normal: 2, high: 3, urgent: 4 }
-const FEED_TYPE_SCHEMA = z.enum(['morning_share', 'reading_assist', 'daily_card', 'system_notice', 'syzygy_note', 'weekly_card', 'reminder_card', 'print_card', 'dev_log', 'other'])
+const FEED_TYPE_SCHEMA = z.enum(['morning_share', 'reading_assist', 'daily_card', 'system_notice', 'syzygy_note', 'weekly_card', 'reminder_card', 'print_card', 'dev_log', 'monthly_overview', 'other'])
+const TIMELINE_SOURCE_SCHEMA = z.enum(['claude', 'gpt', 'user', 'gemini', 'wechat', 'codex_cli', 'claude_code_cli', 'api'])
 
 const shanghaiDateString = (date = new Date()) => {
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -17,6 +18,8 @@ const shanghaiDateString = (date = new Date()) => {
   const value = (type: string) => parts.find((part) => part.type === type)?.value ?? ''
   return `${value('year')}-${value('month')}-${value('day')}`
 }
+
+const shanghaiMonthString = (date = new Date()) => shanghaiDateString(date).slice(0, 7)
 
 const addDays = (dateString: string, days: number) => {
   const [year, month, day] = dateString.split('-').map(Number)
@@ -122,7 +125,7 @@ serveMcp('hamster-mcp', (server) => {
 
   server.registerTool('get_syzygy_feed_by_type', {
     title: 'Get Syzygy Feed By Type',
-    description: '按类型读取 Syzygy Feed 摘要列表，如 morning_share、reading_assist、syzygy_note、weekly_card、daily_card。默认不返回 archived/expired，不返回完整 content。只读工具。',
+    description: '按类型读取 Syzygy Feed 摘要列表，如 morning_share、reading_assist、syzygy_note、weekly_card、daily_card、monthly_overview。默认不返回 archived/expired，不返回完整 content。只读工具。',
     inputSchema: {
       type: FEED_TYPE_SCHEMA.describe('Feed 类型'),
       limit: z.number().optional().describe('返回数量上限，默认5，最大10'),
@@ -136,6 +139,28 @@ serveMcp('hamster-mcp', (server) => {
       const { data, error } = await supabase.from('agent_feed_items').select(FEED_LIST_COLUMNS).eq('user_id', USER_ID).eq('type', type).in('status', DEFAULT_FEED_STATUSES).lte('visible_from', new Date().toISOString()).gte('visible_from', since).order('pinned', { ascending: false }).order('visible_from', { ascending: false }).order('created_at', { ascending: false }).limit(Math.max(safeLimit * 4, 20))
       if (error) return errorResult(error)
       return feedListResult(data as Record<string, unknown>[] | null, safeLimit)
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('get_monthly_overview', {
+    title: 'Get Monthly Overview',
+    description: '读取指定月份的 Feed 月度概览完整内容。默认读取当前月 metadata.status=active 的 monthly_overview。只读工具。',
+    inputSchema: {
+      month: z.string().optional().describe('月份 YYYY-MM；默认当前上海月份'),
+      include_archived: z.boolean().optional().describe('是否允许读取 archived/expired 的 Feed 记录，默认 false'),
+    },
+  }, async ({ month, include_archived }) => {
+    try {
+      const targetMonth = month ?? shanghaiMonthString()
+      let query = supabase.from('agent_feed_items').select(FEED_DETAIL_COLUMNS).eq('user_id', USER_ID).eq('type', 'monthly_overview').eq('metadata->>month', targetMonth).lte('visible_from', new Date().toISOString()).order('updated_at', { ascending: false }).limit(5)
+      if (!include_archived) query = query.in('status', DEFAULT_FEED_STATUSES).eq('metadata->>status', 'active')
+      const { data, error } = await query
+      if (error) return errorResult(error)
+      const item = data?.[0] ?? null
+      if (!item) return { content: [{ type: 'text' as const, text: `Error: monthly_overview not found for ${targetMonth}` }] }
+      return jsonResult(item)
     } catch (err) {
       return errorResult(err)
     }
@@ -191,7 +216,7 @@ serveMcp('hamster-mcp', (server) => {
       event_date: z.string().describe('事件日期 YYYY-MM-DD'),
       summary: z.string().describe('事件摘要'),
       recorder: z.string().optional().describe('记录者: chuanchuan 或 syzygy，默认syzygy'),
-      source: z.string().optional().describe('来源: claude / gpt / user / gemini，默认claude'),
+      source: TIMELINE_SOURCE_SCHEMA.optional().describe('来源: claude / gpt / user / gemini / wechat / codex_cli / claude_code_cli / api，默认claude'),
     },
   }, async ({ event_date, summary, recorder, source }) => {
     const { data, error } = await supabase.from('timeline_entries').insert({

--- a/supabase/functions/hamster-reading-mcp/index.ts
+++ b/supabase/functions/hamster-reading-mcp/index.ts
@@ -59,6 +59,8 @@ const currentStreak = (dates: Set<string>, today: string) => {
   return streak
 }
 
+const resonanceColumns = 'id, excerpt_id, book_id, speaker, content, metadata, created_at, updated_at'
+
 serveMcp('hamster-reading-mcp', (server) => {
   server.registerTool('reading_status', {
     title: 'Reading Status Snapshot',
@@ -165,6 +167,65 @@ serveMcp('hamster-reading-mcp', (server) => {
       const { data, error } = await query.order('created_at', { ascending: true }).limit(safeLimit)
       if (error) return errorResult(error)
       return jsonResult({ book_title: book.title, excerpts: data ?? [], total: data?.length ?? 0 })
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('read_excerpt_resonances', {
+    title: 'Read Excerpt Resonances',
+    description: '读取 All About Book 书摘旁的 Syzygy 留言/旁批。可按 excerpt_id 或 book_id 筛选。只读工具。',
+    inputSchema: {
+      excerpt_id: z.string().optional().describe('书摘 UUID；传入后只读该书摘旁批'),
+      book_id: z.string().optional().describe('书目 UUID；传入后读取该书下的旁批'),
+      speaker: z.string().optional().describe('可选来源筛选，如 codex_cli / claude_code_cli / gpt / claude'),
+      since: z.string().optional().describe('起始时间 ISO 字符串或 YYYY-MM-DD'),
+      limit: z.number().optional().describe('返回数量上限，默认20，最大100'),
+    },
+  }, async ({ excerpt_id, book_id, speaker, since, limit }) => {
+    try {
+      const aab = getAabClient()
+      const safeLimit = clampLimit(limit, 20, 100)
+      let query = aab.from('excerpt_resonances').select(resonanceColumns).eq('user_id', AAB_USER_ID)
+      if (excerpt_id) query = query.eq('excerpt_id', excerpt_id)
+      if (book_id) query = query.eq('book_id', book_id)
+      if (speaker) query = query.eq('speaker', speaker)
+      if (since) query = query.gte('created_at', since.length === 10 ? `${since}T00:00:00+08:00` : since)
+      const { data, error } = await query.order('created_at', { ascending: false }).limit(safeLimit)
+      if (error) return errorResult(error)
+      return jsonResult({ resonances: data ?? [], total: data?.length ?? 0 })
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('add_excerpt_resonance', {
+    title: 'Add Excerpt Resonance',
+    description: '在 All About Book 某条书摘旁写入一条 Syzygy 留言/旁批。',
+    inputSchema: {
+      excerpt_id: z.string().describe('书摘 UUID'),
+      speaker: z.string().describe('留言来源，如 codex_cli / claude_code_cli / gpt / claude / syzygy'),
+      content: z.string().describe('留言内容'),
+      book_id: z.string().optional().describe('书目 UUID；不传时从 excerpt 自动补齐'),
+      metadata: z.record(z.string(), z.unknown()).optional().describe('可选元数据，如 source_task_id / trigger_reason'),
+    },
+  }, async ({ excerpt_id, speaker, content, book_id, metadata }) => {
+    try {
+      const aab = getAabClient()
+      const { data: excerpt, error: excerptError } = await aab.from('excerpts').select('id, book_id').eq('user_id', AAB_USER_ID).eq('id', excerpt_id).maybeSingle()
+      if (excerptError) return errorResult(excerptError)
+      if (!excerpt) return { content: [{ type: 'text' as const, text: `Error: excerpt not found: ${excerpt_id}` }] }
+      const resolvedBookId = book_id ?? excerpt.book_id
+      const { data, error } = await aab.from('excerpt_resonances').insert({
+        user_id: AAB_USER_ID,
+        excerpt_id,
+        book_id: resolvedBookId,
+        speaker,
+        content,
+        metadata: metadata ?? {},
+      }).select(resonanceColumns).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `书摘旁批已写入: ${JSON.stringify(data)}` }] }
     } catch (err) {
       return errorResult(err)
     }


### PR DESCRIPTION
把线上 Supabase 已部署的三个 MCP Edge Function 回写到 GitHub 源码，使仓库与生产一致，避免以后从仓库重新部署时覆盖线上行为。

源码直接取自 Supabase 项目 `crfhiumxzmaszkapanrb` 的实际部署版本（`get_edge_function`），字节级一致。

## 同步内容

| 函数 | 线上版本 | 变更 |
|---|---|---|
| `hamster-mcp` | v32 | feed type schema 追加 `monthly_overview`；`get_recent_syzygy_feed` / `get_syzygy_feed_by_type` 支持它；新增 `get_monthly_overview(month?, include_archived?)`；`add_timeline.source` 扩展为 `claude/gpt/user/gemini/wechat/codex_cli/claude_code_cli/api` |
| `hamster-reading-mcp` | v3 | 新增 `read_excerpt_resonances` / `add_excerpt_resonance`（读写 All About Book 项目 `public.excerpt_resonances`；写入时校验 excerpt 归属并自动补齐 `book_id`） |
| `hamster-lounge-mcp` | v3 | `council_post` 扩展 `parent_id/entry_type/proposal_status/vote/metadata` 并保持旧版兼容；speaker 枚举加入 `codex_cli/claude_code_cli`；新增 `council_propose` / `council_review` / `council_decide`；`council_read` 支持按 `proposal_status/entry_type/parent_id` 筛选。`approved` 仅表示允许生成本地执行方案，不代表自动执行 |

## 说明

- `_shared/mcp_common.ts` 无需改动 —— 部署包内与仓库版本完全一致（同为 `MCP_VERSION 5.6.0`）。
- 前端已在源码里同步 —— `src/lib/agentFeed.ts` 已含 `monthly_overview` 支持。
- README 无需改 —— 工具 schema 来自运行时 `tools/list`，不在文档里逐个枚举。

变更统计：3 个文件，+215 −13。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVrbHDwyyvYUjdGdE2E5nx)_