### PR TITLE
fix(feed): 修复 monthly_overview 展示位置错误

### DIFF
--- a/src/components/MonthlyOverview.tsx
+++ b/src/components/MonthlyOverview.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+import MarkdownRenderer from './MarkdownRenderer'
 import type { MonthlyOverviewContent } from '../lib/agentFeed'
 
 type MonthlyOverviewProps = {
@@ -6,10 +8,18 @@ type MonthlyOverviewProps = {
   monthLabel: string
 }
 
-// Feed 页面顶部的「本月概览」板块：按主题分组展示当月持续进行的事项。
-// 无数据时显示轻量空状态，不渲染破碎卡片。
+// Feed 页面顶部的「本月概览」板块：展示当月持续进行的事项。
+// 内容兼容两种结构：
+//   - JSON 主题结构 { themes: [{ theme, items }] } → 按主题分组展示。
+//   - markdown / 纯文本 → 直接渲染原文。
+// 只有完全查不到 monthly_overview（data 为 null）时才显示空状态。
+// 卡片支持收起 / 展开。
 const MonthlyOverview = ({ data, loading, monthLabel }: MonthlyOverviewProps) => {
+  const [collapsed, setCollapsed] = useState(false)
   const hasThemes = Boolean(data && data.themes.length > 0)
+  const rawText = data?.raw?.trim() ?? ''
+  const hasRaw = !hasThemes && rawText.length > 0
+  const hasContent = hasThemes || hasRaw
 
   return (
     <section className="feed-overview" aria-label="本月概览">
@@ -18,35 +28,55 @@ const MonthlyOverview = ({ data, loading, monthLabel }: MonthlyOverviewProps) =>
         <span className="feed-overview__mark" aria-hidden="true">◆</span>
         <h2 className="feed-overview__title">本月概览</h2>
         <span className="feed-overview__month">{monthLabel}</span>
+        {hasContent ? (
+          <button
+            type="button"
+            className="feed-overview__toggle"
+            onClick={() => setCollapsed((current) => !current)}
+            aria-expanded={!collapsed}
+          >
+            {collapsed ? '展开' : '收起'}
+          </button>
+        ) : null}
       </header>
 
-      {loading && !hasThemes ? (
+      {loading && !hasContent ? (
         <p className="feed-overview__empty">正在整理这个月的持续事项…</p>
       ) : null}
 
-      {!loading && !hasThemes ? (
+      {!loading && !hasContent ? (
         <p className="feed-overview__empty">这个月还没有持续追踪的事项，攒一攒就有了。</p>
       ) : null}
 
-      {hasThemes ? (
-        <div className="feed-overview__themes">
-          {data!.themes.map((theme, themeIndex) => (
-            <article className="feed-overview__theme" key={`${theme.theme}-${themeIndex}`}>
-              <h3 className="feed-overview__theme-title">{theme.theme}</h3>
-              <ul className="feed-overview__items">
-                {theme.items.map((entry, entryIndex) => (
-                  <li className="feed-overview__item" key={entryIndex}>
-                    <span className="feed-overview__bullet" aria-hidden="true" />
-                    <span className="feed-overview__text">{entry.text}</span>
-                    {entry.archive_candidate ? (
-                      <span className="feed-overview__flag" title="可沉淀进档案">待沉淀</span>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            </article>
-          ))}
-        </div>
+      {hasContent && !collapsed ? (
+        hasThemes ? (
+          <div className="feed-overview__themes">
+            {data!.themes.map((theme, themeIndex) => (
+              <article className="feed-overview__theme" key={`${theme.theme}-${themeIndex}`}>
+                <h3 className="feed-overview__theme-title">{theme.theme}</h3>
+                <ul className="feed-overview__items">
+                  {theme.items.map((entry, entryIndex) => (
+                    <li className="feed-overview__item" key={entryIndex}>
+                      <span className="feed-overview__bullet" aria-hidden="true" />
+                      <span className="feed-overview__text">{entry.text}</span>
+                      {entry.archive_candidate ? (
+                        <span className="feed-overview__flag" title="可沉淀进档案">待沉淀</span>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="feed-overview__raw">
+            {data!.format === 'markdown' ? (
+              <MarkdownRenderer content={rawText} />
+            ) : (
+              <p className="feed-overview__plain">{rawText}</p>
+            )}
+          </div>
+        )
       ) : null}
     </section>
   )

--- a/src/lib/agentFeed.ts
+++ b/src/lib/agentFeed.ts
@@ -151,7 +151,18 @@ export type MonthlyOverviewTheme = {
 export type MonthlyOverviewContent = {
   month: string | null
   themes: MonthlyOverviewTheme[]
+  // 当 content 不是 JSON 主题结构（markdown / plain）时，保留原文用于直接渲染。
+  raw: string | null
+  format: 'markdown' | 'plain' | 'json' | string | null
+  title: string | null
 }
+
+// 普通 Feed 列表里需要排除的页面级类型：monthly_overview 是「本月概览」板块的数据，
+// 不应作为日常 Feed 卡片渲染。
+export const PAGE_LEVEL_FEED_TYPES = new Set(['monthly_overview'])
+
+export const isPageLevelFeedType = (type: string | null): boolean =>
+  type ? PAGE_LEVEL_FEED_TYPES.has(type) : false
 
 // 当前月份键（本地时区），形如 2026-06。
 export const getCurrentMonthKey = (now: Date = new Date()): string => {
@@ -162,19 +173,45 @@ export const getCurrentMonthKey = (now: Date = new Date()): string => {
 
 const asString = (value: unknown): string | null => (typeof value === 'string' ? value : null)
 
-// 容错解析 monthly_overview 的 content（JSON 字符串或已解析对象）。
-// 任何结构异常都不抛错，返回 null 以便上层降级为空状态，不影响其它 Feed 卡片。
-export const parseMonthlyOverviewContent = (item: AgentFeedItem): MonthlyOverviewContent | null => {
-  if (!item.content) return null
+// 从任意时间字符串推断所属月份（本地时区），形如 2026-06。
+const monthKeyFromDate = (value: string | null): string | null => {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, '0')}`
+}
+
+// 从标题里兜底解析月份，形如「2026年6月 月度概览」「2026-06」「2026/6」。
+const monthKeyFromTitle = (title: string | null): string | null => {
+  if (!title) return null
+  const match = title.match(/(\d{4})\s*[年\-/.]\s*(\d{1,2})/)
+  if (!match) return null
+  return `${match[1]}-${match[2].padStart(2, '0')}`
+}
+
+// 解析一条 monthly_overview 归属的月份：metadata.month 优先，其次标题，最后 created_at。
+const resolveOverviewMonth = (item: AgentFeedItem): string | null => {
+  const meta = (item.metadata ?? {}) as Record<string, unknown>
+  return (
+    asString(meta.month) ??
+    monthKeyFromTitle(item.title) ??
+    monthKeyFromDate(item.created_at)
+  )
+}
+
+// 容错解析 monthly_overview content 里的 JSON 主题结构（JSON 字符串或已解析对象）。
+// content 不是合法 JSON、或结构不符合预期时返回空数组，上层据此降级为 markdown/纯文本渲染。
+export const parseMonthlyOverviewThemes = (item: AgentFeedItem): MonthlyOverviewTheme[] => {
+  if (!item.content) return []
   let raw: unknown = item.content
   if (typeof raw === 'string') {
     try {
       raw = JSON.parse(raw)
     } catch {
-      return null
+      return []
     }
   }
-  if (!raw || typeof raw !== 'object') return null
+  if (!raw || typeof raw !== 'object') return []
   const record = raw as Record<string, unknown>
   const rawThemes = Array.isArray(record.themes) ? record.themes : []
   const themes: MonthlyOverviewTheme[] = []
@@ -201,11 +238,25 @@ export const parseMonthlyOverviewContent = (item: AgentFeedItem): MonthlyOvervie
     if (!themeName || items.length === 0) return
     themes.push({ theme: themeName, items })
   })
-  return { month: asString(record.month), themes }
+  return themes
 }
 
-// 读取当前月份、active 的月度概览记录（取最新一条）。
-// 失败时返回 null，调用方据此降级为空状态，绝不影响其它 Feed 内容。
+// 把一条 monthly_overview 记录转成「本月概览」板块所需的展示数据。
+// 既支持 JSON 主题结构，也支持 markdown / 纯文本（保留原文给上层直接渲染）。
+const buildMonthlyOverviewContent = (item: AgentFeedItem): MonthlyOverviewContent => {
+  const themes = parseMonthlyOverviewThemes(item)
+  return {
+    month: resolveOverviewMonth(item),
+    themes,
+    raw: asString(item.content),
+    format: item.content_format ?? null,
+    title: item.title ?? null,
+  }
+}
+
+// 读取当前月份的月度概览记录（取最新一条，按 updated_at / created_at 倒序）。
+// 只要查到归属当前月份的 monthly_overview 就返回；查不到才返回 null（上层显示空状态）。
+// 不再要求 content 必须是 JSON，也不再强制 metadata.status=active，兼容 markdown / plain。
 export const fetchMonthlyOverview = async (
   userId: string,
   month: string = getCurrentMonthKey(),
@@ -218,6 +269,7 @@ export const fetchMonthlyOverview = async (
     .eq('user_id', userId)
     .eq('type', 'monthly_overview')
     .or(`visible_from.is.null,visible_from.lte.${nowIso}`)
+    .order('updated_at', { ascending: false })
     .order('created_at', { ascending: false })
     .limit(20)
 
@@ -227,14 +279,9 @@ export const fetchMonthlyOverview = async (
   }
 
   const candidates = (data ?? []) as AgentFeedItem[]
-  for (const item of candidates) {
-    const meta = (item.metadata ?? {}) as Record<string, unknown>
-    if (asString(meta.month) !== month) continue
-    if (asString(meta.status) !== 'active') continue
-    const parsed = parseMonthlyOverviewContent(item)
-    if (parsed && parsed.themes.length > 0) return parsed
-  }
-  return null
+  const matched = candidates.find((item) => resolveOverviewMonth(item) === month)
+  if (!matched) return null
+  return buildMonthlyOverviewContent(matched)
 }
 
 export const updateAgentFeedStatus = async (

--- a/src/pages/AgentFeedPage.css
+++ b/src/pages/AgentFeedPage.css
@@ -236,6 +236,37 @@
   letter-spacing: 0.04em;
 }
 
+.feed-overview__toggle {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: #b27f98;
+  background: rgba(255, 246, 251, 0.9);
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 999px;
+  padding: 2px 12px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.feed-overview__toggle:hover {
+  background: rgba(255, 224, 238, 0.9);
+  color: #76556c;
+}
+
+.feed-overview__raw {
+  position: relative;
+  z-index: 1;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #5a4a54;
+  word-break: break-word;
+}
+
+.feed-overview__plain {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
 .feed-overview__empty {
   position: relative;
   z-index: 1;

--- a/src/pages/AgentFeedPage.tsx
+++ b/src/pages/AgentFeedPage.tsx
@@ -12,6 +12,7 @@ import {
   fetchMonthlyOverview,
   getCurrentMonthKey,
   isAgentFeedExpired,
+  isPageLevelFeedType,
   resolveAgentFeedStatus,
   sortAgentFeedItems,
   toLocalDateKey,
@@ -85,7 +86,9 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
     setOverviewLoading(true)
     try {
       const data = await fetchAgentFeedItems(user.id)
-      setItems(data)
+      // 页面级类型（如 monthly_overview）有专门的展示区域，不混入普通 Feed 列表 /
+      // 日期分组 / 日历计数 / 类型筛选。
+      setItems(data.filter((item) => !isPageLevelFeedType(item.type)))
     } catch (loadError) {
       console.warn('加载 Syzygy Feed 失败', loadError)
       setError('暂时读不到 Syzygy Feed，请检查登录状态后重试。')


### PR DESCRIPTION
## 背景

V3.1 月度概览（`agent_feed_items.type = monthly_overview`）展示位置错误：

1. 它被当成普通 Feed 卡片，混在日期分组列表里显示。
2. 上方独立的「本月概览」板块却显示空状态「这个月还没有持续追踪的事项」。

**根因**：实际数据是 `content_format = "markdown"`（不是 JSON 主题结构），但旧逻辑只在解析出 JSON `themes` 时才渲染「本月概览」，markdown 内容被判为空；同时该记录未从普通 Feed 列表中过滤。

## 改动

**`src/lib/agentFeed.ts`**
- `MonthlyOverviewContent` 新增 `raw` / `format` / `title`，承载非 JSON 原文。
- 新增 `isPageLevelFeedType`，标记 `monthly_overview` 为页面级类型。
- 归属月份解析顺序：`metadata.month` → 标题（如「2026年6月」）→ `created_at` 兜底。
- `fetchMonthlyOverview` 改为按 `updated_at` / `created_at` 倒序取最新一条，只匹配月份，不再强制 content 为 JSON、不再要求 `metadata.status=active`。

**`src/pages/AgentFeedPage.tsx`**
- fetch 后过滤掉页面级类型，普通列表 / 日期分组 / 日历计数 / 类型筛选都不再包含 `monthly_overview`。

**`src/components/MonthlyOverview.tsx`**
- 内容兼容两种结构：JSON 主题结构按主题分组；markdown 用 `MarkdownRenderer` 渲染；纯文本原样渲染。
- 只有完全查不到记录（`data` 为 null）时才显示空状态。
- 卡片头部新增「收起 / 展开」按钮。

**`src/pages/AgentFeedPage.css`**
- 新增 toggle / raw / plain 样式。

仅改前端展示逻辑，不动数据库 schema，不删除现有数据，不把 `monthly_overview` 塞回普通 Feed。

## 验收对照

1. ✅ `2026年6月 月度概览` 不再出现在 2026-06-27 普通 Feed 日期卡片里。
2. ✅ 上方「本月概览」板块能展示该概览内容，并支持卡片收缩。
3. ✅ JSON 与 markdown 两种格式都能正常显示。
4. ✅ 没有 `monthly_overview` 时才显示空状态。

## 验证

`tsc -p tsconfig.app.json`、`eslint`、`vite build` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvtD5HonRD4UmXZnyMwJpT)_