### PR TITLE
fix(feed): 本月概览不计入入口小组件未读统计

### DIFF
--- a/src/lib/agentFeed.ts
+++ b/src/lib/agentFeed.ts
@@ -317,6 +317,11 @@ export const computeAgentFeedStats = (items: AgentFeedItem[], now = Date.now()):
   let lastUpdated: number | null = null
 
   items.forEach((item) => {
+    // 页面级类型（如 monthly_overview / 本月概览）有专门的展示区域，
+    // 不参与未读 / 已读与高优先级统计，避免在入口小组件里一直显示一条“未读”。
+    if (isPageLevelFeedType(item.type)) {
+      return
+    }
     const status = resolveAgentFeedStatus(item, now)
     if (status === 'unread') {
       unread += 1


### PR DESCRIPTION
Syzygy Feed 入口小组件一直显示 1 条未读，根因是 computeAgentFeedStats 直接统计 fetchAgentFeedItems 返回的全部记录，其中包含 type=monthly_overview （本月概览）这条页面级记录，其 status 为 unread 故被计为未读。

让 computeAgentFeedStats 跳过页面级类型（isPageLevelFeedType，即 monthly_overview）， 使其不参与未读/已读与高优先级统计。Feed 页（AgentFeedPage）此前已在
传入前过滤掉这些类型，行为保持一致。仅调整统计/UI 提示，不改动写入机制。


Claude-Session: https://claude.ai/code/session_01MZrPwscqpN3JhNGTTixCdi