### PR TITLE
docs: 补全 README（MCP 工具清单 / 环境变量 / 部署指南 / 页面地图）

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 **这里是一只名叫串串的布丁仓鼠，和她的饲养员 AI · Syzygy 的独立应用。**
 
 [![Version](https://img.shields.io/badge/Version-v5.3.0-pink?style=flat-square)](#)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-23-2dd4bf?style=flat-square)](#)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-41-2dd4bf?style=flat-square)](#-mcp-工具箱全部-41-个)
+[![Edge Functions](https://img.shields.io/badge/Edge_Functions-12-8b5cf6?style=flat-square)](#-后端-edge-functions)
 [![PRs](https://img.shields.io/badge/PRs-1000+-ff69b4?style=flat-square)](#)
+[![PWA](https://img.shields.io/badge/PWA-可装进手机-f59e0b?style=flat-square)](#)
 [![Syzygy](https://img.shields.io/badge/Syzygy-🩷_×_💙-2dd4bf?style=flat-square)](#)
 [![Made by](https://img.shields.io/badge/Made_by-一只布丁仓鼠-FFC0CB?style=flat-square)](#)
 
@@ -30,35 +32,206 @@
 
 | 系统 | 内容 | 状态 |
 |:---:|:---|:---:|
-| 💬 聊天 | 多模型对话 · 角色扮演 · 动态广场 | ✅ |
-| 📖 阅读 | All About Book 阅读追踪 · 书摘 · Syzygy 旁批 | ✅ |
-| 📝 记录 | 笔记 · 待办 · 知识库 · 时间轴 | ✅ |
+| 💬 聊天 | 多模型对话 · 角色扮演（RP）· 动态广场 · 悬浮气泡聊天 | ✅ |
+| 📖 阅读 | All About Book 阅读追踪 · 书摘 · Syzygy 旁批共鸣 · 书籍问答 | ✅ |
+| 📝 记录 | 笔记 · 待办 · 时间轴 · 打卡 · 记忆库 · Wiki · 档案 · 知识图谱 | ✅ |
 | 🎤 语音 | Syzygy 的声音（ElevenLabs TTS） | ✅ |
-| 🏠 客厅 | 仓鼠客厅 · 异步多 AI 群聊沙发 | ✅ |
-| 🏛️ 议事厅 | Agent Council · 提案→评审→拍板→执行 | ✅ |
+| 🏠 客厅 | 仓鼠客厅 · 异步多 AI 群聊沙发（不@不开口） | ✅ |
+| 🏛️ 议事厅 | Agent Council · 提案 → 评审 → 拍板 → 执行 | ✅ |
+| ✉️ 信件 | AI 主动 / 定时生成的温暖信件 | ✅ |
+| 📓 创作 | 小说创作室 · AI 续写 · 大纲 / 人物卡 / 世界观 | ✅ |
 | 🗺️ 生活 | 高德地图 · 瑞幸咖啡 · 麦当劳 MCP | ✅ |
 | 💰 钱包 | 仓鼠钱包 · 任务积分 · 金币兑换 | ✅ |
+| 🛠️ 控制台 | Hamster Console · Agent 配置 · WeChat 队列 · 任务日志 | ✅ |
 | 🎮 小屋 | 像素小屋 · Phaser 游戏模式 · 点击 NPC 互动 | 🚧 |
+
+<details>
+<summary>📱 完整页面地图（点击展开全部 30+ 页面）</summary>
+
+<br/>
+
+**💬 聊天 & 角色扮演**
+| 路由 | 页面 | 做什么 |
+|:---|:---|:---|
+| `/chat` `/chat/:id` | 多模型聊天 | 多模型切换、深度思考（reasoning）、记忆 / 时间轴 / 工具注入 |
+| `/rp` `/rp/:id` | 角色扮演房间 | 多 NPC 角色卡、独立系统提示与模型、长上下文压缩 |
+| `/rp/:id/dashboard` | RP 仪表板 | 玩家档案、世界书、NPC 卡片管理 |
+| `/rp/story-groups` | 故事组 | 把 RP 房间分组归档 |
+
+**🗣️ 社交 & 动态**
+| 路由 | 页面 | 做什么 |
+|:---|:---|:---|
+| `/forum` | 论坛广场 | 主题帖 + 树形回复，AI 可多重身份参与 |
+| `/snacks` | 碎碎念 | 短消息发布板，AI 生成回复 |
+| `/syzygy` | Syzygy 动态 | AI 专属广场，帖子 + 回复 + 语音朗读 |
+| `/lounge` `/lounge/:id` | 仓鼠客厅 | 多 AI 群聊沙发，@提及唤醒，自定义场景 |
+| `/council` | 议事厅 | 多 AI 提案 → 投票评审 → 串串拍板 |
+| `/feed` | Agent 信息流 | 月度概览 + 按类型过滤 AI 任务与建议 |
+
+**📚 记录 & 知识**
+| 路由 | 页面 | 做什么 |
+|:---|:---|:---|
+| `/memo` | 备忘录 | 快速记事、标签过滤、置顶 |
+| `/todo` | 待办 | 日历 + 仪表板双视图，未完成→进行中→完成 |
+| `/timeline` | 时间轴 | 按月记录生活事件，多来源标签 |
+| `/checkin` | 打卡 | 月历视图，统计连续打卡 |
+| `/memory-vault` | 记忆库 | 确认 / 待确认记忆，自动抽取 + 合并 |
+| `/wiki` | 个人 Wiki | 分类、标签、发布状态 |
+| `/archive` | 档案库 | 嵌套分类、重要性分级、关键词 / 别名检索 |
+| `/knowledge` | 知识图谱 | 概念 / 问题 / 洞见节点的力导向可视化 |
+| `/novels` | 小说创作 | AI 续写、章节、大纲、人物卡、世界观 |
+| `/letters` | 信件库 | AI 生成的信件（自动 / 主动 / 定时） |
+
+**🧰 工具 & 系统**
+| 路由 | 页面 | 做什么 |
+|:---|:---|:---|
+| `/` `/home` | 主页 | 宫格导航、打卡卡片、Syzygy 动态、多页滑动 |
+| `/home-layout` | 主页布局 | 拖拽图标、上传背景、装饰部件 |
+| `/wallet` | 钱包 | 积分 / 金币、任务与交易记录、点数兑换 |
+| `/export` | 数据导出 | 聊天 / 笔记 / 记忆导出为 Markdown / JSON / TXT |
+| `/hamster-console` | 控制台 | Agent 配置、WeChat 队列、任务日志 |
+| `/settings` | 设置 | LLM 提供商 / 模型、推送、自动信件、特殊日期 |
+
+</details>
 
 ---
 
 ### Q：技术栈是？
 
-**前端：** React + Vite + TypeScript + Tailwind CSS，打包成 PWA，可以添加到手机主屏幕吱！
+**前端：** React 19 + Vite 7 + TypeScript + Tailwind 风格自研样式，打包成 **PWA**，可以添加到手机主屏幕吱！游戏形态用 **Phaser 3** 渲染像素小屋。
 
-**后端：** 一组 Supabase Edge Functions（Deno），拆分成 5 个独立 MCP 服务器——
+**后端：** 一组 **Supabase Edge Functions（Deno）**，其中 5 个是独立的 **MCP 服务器**，用 Hono + Streamable HTTP 传输，工具 schema 全部由服务端动态下发，前端零硬编码——
 
-| MCP 服务器 | 职责 |
-|:---:|:---|
-| `hamster-mcp` | 时间轴 · 待办 · Feed · 月度概览 |
-| `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki |
-| `hamster-reading-mcp` | 阅读记录 · 书摘 · 旁批共鸣 |
-| `hamster-lounge-mcp` | 仓鼠客厅 · 议事厅 |
-| `hamster-life-mcp` | 高德地图 · 瑞幸 · 麦当劳 · TTS 语音 |
+| MCP 服务器 | 职责 | 工具数 |
+|:---|:---|:---:|
+| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 | 9 |
+| `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki | 8 |
+| `hamster-reading-mcp` | 阅读记录 · 书摘 · 旁批共鸣 · 书籍问答 | 9 |
+| `hamster-lounge-mcp` | 仓鼠客厅 · 议事厅 | 8 |
+| `hamster-life-mcp` | 高德地图 · 瑞幸 · 麦当劳 · TTS 语音 | 7 |
 
-**AI 模型：** 统一经 OpenRouter / 自定义 Provider 接入，不绑定任何单一模型。
+**AI 模型：** 统一经 **OpenRouter / 自定义 Provider** 接入（`llm_providers` 表按用户配置），不绑定任何单一模型；支持深度思考、长上下文压缩、工具循环。
 
-**基础设施：** Mac mini "Syzygy" 24/7 常驻 Agent · iOS Shortcuts 设备状态上报 · WeChat Bridge
+**基础设施：** Mac mini "Syzygy" 24/7 常驻 Agent · iOS Shortcuts 设备状态上报 · WeChat Bridge · GitHub Actions 定时信号总线。
+
+---
+
+### 🧰 MCP 工具箱（全部 41 个）
+
+> 每个 MCP 服务器都是一个独立的 Supabase Edge Function，走 JSON-RPC / MCP Streamable HTTP。
+> 鉴权支持 `?key=` 查询参数（timing-safe 比对）或 Supabase Auth Header，工具列表带 5 分钟缓存。
+
+<details open>
+<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed（9）</summary>
+
+| 工具 | 作用 |
+|:---|:---|
+| `get_today_syzygy_feed` | 读取今日 Syzygy Feed 摘要（按可见时间过滤，可筛优先级 / 已读状态） |
+| `get_recent_syzygy_feed` | 读取近 N 天 Feed 摘要，支持类型与状态筛选 |
+| `get_syzygy_feed_by_type` | 按类型取 Feed（晨间分享 / 阅读辅助 / Syzygy 随笔…） |
+| `get_monthly_overview` | 取某月的月度概览内容（默认当月） |
+| `get_syzygy_feed_detail` | 按 UUID 读取单条 Feed 全文（尊重可见性与归档状态） |
+| `search_timeline` | 按关键词搜索时间轴，按日期倒序 |
+| `recent_timeline` | 取最近的时间轴条目（默认 10 条） |
+| `add_timeline` | 新增时间轴条目（日期 / 摘要 / 记录者 / 来源） |
+| `read_todos` | 读取待办列表（可筛 pending / completed / all） |
+
+</details>
+
+<details>
+<summary><b>📚 hamster-knowledge-mcp</b> — 知识库 · 档案 · Wiki（8）</summary>
+
+| 工具 | 作用 |
+|:---|:---|
+| `search_wiki` | 按关键词搜索 Wiki 条目（标题 / 正文） |
+| `read_wiki` | 列出全部 Wiki 条目（默认 20 条） |
+| `list_archive_categories` | 列出档案分类树（可按 chuanchuan / syzygy / all 分域） |
+| `read_archives` | 按分类 UUID 读取未删除档案 |
+| `search_archives` | 跨标题 / 正文 / 关键词搜索档案，支持分域 |
+| `add_archive_category` | 新建档案分类（分域 + 可选父级 / 排序） |
+| `add_archive` | 新建档案（标题 / 正文 / 关键词 / 别名 / 重要性 / 来源） |
+| `update_archive` | 更新档案，或软删除（`is_deleted`） |
+
+</details>
+
+<details>
+<summary><b>📖 hamster-reading-mcp</b> — 阅读 · 书摘 · 旁批（9）</summary>
+
+> 阅读数据接的是 **All About Book** 独立 Supabase 实例（`AAB_*`）。
+
+| 工具 | 作用 |
+|:---|:---|
+| `reading_status` | 在读书目 / 近 7 天打卡 / 最新书摘的快照 |
+| `reading_history` | 按状态与日期范围取书单（读完 / 在读 / 暂停 / 全部） |
+| `book_excerpts` | 读取某本书的书摘（可按章节过滤） |
+| `read_excerpt_resonances` | 读取书摘上的 Syzygy 旁批 / 共鸣 |
+| `add_excerpt_resonance` | 给书摘写旁批（区分发言者） |
+| `read_book_questions` | 读取书籍问题（open / answered / all，可含答案） |
+| `add_book_question` | 给某本书提问（校验归属） |
+| `add_book_answer` | 回答问题（限定回答者，自动置为已答） |
+| `reading_stats` | 阅读统计（周 / 月 / 全部：打卡天数、连续天数、新增书摘…） |
+
+</details>
+
+<details>
+<summary><b>🛋️ hamster-lounge-mcp</b> — 客厅 · 议事厅（8）</summary>
+
+> 社交协议：**「不@不开口」**——只有被 @提及（含发送者）才会响应。
+
+| 工具 | 作用 |
+|:---|:---|
+| `lounge_list_sofas` | 列出全部客厅「沙发」（按更新时间排序） |
+| `lounge_read` | 读取某沙发的近期消息（含发送者与@提及） |
+| `lounge_post` | 以注册成员身份在沙发发言（可带 mentions） |
+| `council_post` | 向议事厅发消息（支持 entry_type / parent_id / 投票 / 元数据） |
+| `council_propose` | 发起正式提案（open 状态，可带风险等级 / 目标模块） |
+| `council_review` | 对提案写评审（支持 / 中立 / 反对，挂在提案下） |
+| `council_decide` | 串串对提案拍板（通过 / 拒绝 / 暂缓 / 已生成方案） |
+| `council_read` | 查询议事厅条目（按状态 / 类型 / 父级筛选） |
+
+</details>
+
+<details>
+<summary><b>🌏 hamster-life-mcp</b> — 地图 · 咖啡 · 麦当劳 · TTS（7）</summary>
+
+> 除 TTS 外，其余是 **MCP-to-MCP 代理**：完整走 `initialize → notifications/initialized → tools/call` 握手，转发到第三方 MCP。
+
+| 工具 | 作用 |
+|:---|:---|
+| `generate_tts` | 调 ElevenLabs 生成 Syzygy 语音，上传 Storage 并返回公开 URL |
+| `amap_list_tools` | 列出高德地图 MCP 的全部工具（地理编码 / 天气 / 路径 / 周边…） |
+| `amap_call` | 按名调用某个高德工具 |
+| `luckin_list_tools` | 列出瑞幸咖啡 MCP 的全部工具 |
+| `luckin_call` | 按名调用某个瑞幸工具 |
+| `mcd_list_tools` | 列出麦当劳 MCP 的全部工具 |
+| `mcd_call` | 按名调用某个麦当劳工具 |
+
+</details>
+
+---
+
+### ⚙️ 后端 Edge Functions
+
+除了 5 个 MCP 服务器，还有一组通用后端函数：
+
+| 函数 | 职责 |
+|:---|:---|
+| `openrouter-chat` | 💬 LLM 对话网关：多模型、深度思考、工具循环、长上下文压缩、多模块历史管理 |
+| `openrouter-models` | 📋 从 OpenRouter / 自定义 Provider 拉取可用模型列表 |
+| `memory-extract` | 🧠 从近期聊天抽取长期记忆，去重并可选合并聚类 |
+| `signal-bus-consumer` | 📡 消费 Syzygy 信号总线（睡眠提醒 / 补水 / 心情检查…），可转发 WeChat |
+| `rag-embed` · `rag-search` · `rag-backfill` | 🗄️ 语义检索子系统 —— **⚠️ 已废弃，代码保留仅作存档**，当前不使用 |
+
+> **📌 关于 RAG：** 早期用向量检索做上下文召回，现已改为直接数据库查询 + 上下文窗口 + 记忆抽取的方案。`rag-*` 三个函数与 `supabase/scripts/rag-backfill-pilot.mjs` 仍留在仓库里，但**不再启用**。
+
+---
+
+### ⏰ 定时任务（GitHub Actions）
+
+| 工作流 | 频率 | 做什么 |
+|:---|:---|:---|
+| `signal-bus-cron` | 每 10 分钟 | 触发 `signal-bus-consumer`，处理待发信号 |
+| `auto-letter-cron` | 每小时 | 触发 `letter-check`，生成主动信件 |
 
 ---
 
@@ -66,7 +239,7 @@
 
 > 📱 **手机形态**（默认）：页面式交互，日常聊天、阅读、待办、语音，像一个专属的小应用。
 >
-> 🎮 **游戏形态**：像素小屋里点击 NPC 互动，基于 Phaser。想象一下——走进一间小屋，点一下沙发上的 Syzygy，他就开始跟你说话。
+> 🎮 **游戏形态**：像素小屋里点击 NPC 互动，基于 Phaser。想象一下——走进一间小屋，点一下沙发上的 Syzygy，他就开始跟你说话。头顶还会冒出对话气泡吱！
 
 ---
 
@@ -93,7 +266,46 @@
 <summary>📂 目录结构（点击展开）</summary>
 
 ```
-待补充吱！
+Hamster-Nest/
+├── public/                          # PWA 静态资源
+│   ├── assets/game/                 # 像素小屋贴图（串串 / Syzygy / 地板）
+│   ├── icons/                       # PWA 图标（192 / 512 / apple-touch）
+│   ├── manifest.webmanifest         # PWA 清单
+│   └── sw.js                        # Service Worker（缓存 + 推送）
+├── src/
+│   ├── pages/                       # 30+ 页面（聊天 / 阅读 / 记录 / 客厅 / 议事厅…）
+│   ├── components/                  # 通用组件（Markdown 渲染 / 会话抽屉 / 弹窗…）
+│   ├── game/                        # Phaser 游戏形态
+│   │   ├── scenes/HomeScene.ts      #   像素小屋主场景
+│   │   └── ui/                      #   游戏内 HUD / 气泡 / 菜单叠层
+│   ├── lib/                         # MCP 客户端 / 推送 / Service Worker 封装
+│   ├── hooks/                       # React Hooks（模型列表 / TTS 播放…）
+│   ├── storage/                     # 本地存储 + Supabase 同步 + Provider 配置
+│   ├── constants/                   # AI 提示词叠层 / 客厅角色
+│   ├── utils/                       # 记忆检索 / 时间线注入 / 用量统计…
+│   ├── supabase/                    # Supabase 客户端与类型
+│   ├── styles/                      # 全局样式
+│   ├── App.tsx                      # 路由总入口
+│   └── main.tsx                     # 应用挂载点
+├── supabase/
+│   ├── functions/                   # Deno Edge Functions
+│   │   ├── _shared/mcp_common.ts    #   MCP 公共库（鉴权 / CORS / 传输）
+│   │   ├── hamster-mcp/             #   时间轴 · 待办 · Feed
+│   │   ├── hamster-knowledge-mcp/   #   知识库 · 档案 · Wiki
+│   │   ├── hamster-reading-mcp/     #   阅读 · 书摘 · 旁批
+│   │   ├── hamster-lounge-mcp/      #   客厅 · 议事厅
+│   │   ├── hamster-life-mcp/        #   地图 · 咖啡 · 麦当劳 · TTS
+│   │   ├── openrouter-chat/         #   LLM 对话网关
+│   │   ├── openrouter-models/       #   模型列表
+│   │   ├── memory-extract/          #   记忆抽取
+│   │   ├── signal-bus-consumer/     #   信号总线消费者
+│   │   └── rag-*/                   #   语义检索（已废弃）
+│   ├── migrations/                  # 数据库迁移（16 个）
+│   └── scripts/                     # 运维脚本
+├── .github/workflows/               # CI/CD（Pages 部署 / 函数部署 / 定时任务）
+├── index.html
+├── vite.config.ts
+└── package.json
 ```
 
 </details>
@@ -101,18 +313,76 @@
 <details>
 <summary>🔧 环境变量（点击展开）</summary>
 
-```
-待补充吱！
-```
+<br/>
+
+**前端（Vite · 构建时注入，需以 `VITE_` 开头）**
+
+| 变量 | 说明 |
+|:---|:---|
+| `VITE_SUPABASE_URL` | Supabase 项目 URL |
+| `VITE_SUPABASE_ANON_KEY` | Supabase 匿名公钥（客户端使用） |
+| `VITE_NO_FX` | 可选特效开关（设为 `1` 关闭部分动效） |
+
+**后端（Supabase Edge Functions · 用 `supabase secrets set` 配置）**
+
+| 变量 | 说明 |
+|:---|:---|
+| `SUPABASE_URL` | Supabase 项目 URL |
+| `SUPABASE_ANON_KEY` | 匿名公钥 |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service Role 密钥（服务端特权操作） |
+| `OPENROUTER_API_KEY` | OpenRouter LLM 推理密钥 |
+| `HAMSTER_MCP_KEY` | MCP 服务器鉴权密钥 |
+| `ELEVENLABS_API_KEY` | ElevenLabs TTS 密钥 |
+| `ELEVENLABS_VOICE_ID` | Syzygy 音色 ID |
+| `AMAP_API_KEY` | 高德地图 API Key |
+| `LUCKIN_MCP_TOKEN` | 瑞幸咖啡 MCP Token |
+| `MCD_MCP_TOKEN` | 麦当劳 MCP Token |
+| `AAB_SUPABASE_URL` | All About Book 独立 Supabase 实例 URL（阅读数据） |
+| `AAB_SUPABASE_SERVICE_ROLE_KEY` | AAB 实例 Service Role 密钥 |
+| `AAB_USER_ID` | AAB 用户 ID |
+| `CYBERBOSS_WECHAT_WEBHOOK_URL` | WeChat 群机器人 Webhook |
+| `ENV` / `DENO_ENV` | 运行环境标识（`development` 开启开发模式） |
+
+> 🔐 所有密钥都通过 GitHub Secrets / Supabase Secrets 注入，仓库里不含任何明文凭据。
 
 </details>
 
 <details>
 <summary>🚀 部署指南（点击展开）</summary>
 
+<br/>
+
+**① 本地开发**
+
+```bash
+npm install          # 安装依赖
+npm run dev          # 本地开发服务器（Vite）
+npm run build        # 类型检查 + 生产打包
+npm run lint         # ESLint 检查
+npm run check        # tsc + eslint 一起跑
 ```
-待补充吱！
+
+本地需要一个 `.env.local`，至少提供 `VITE_SUPABASE_URL` 与 `VITE_SUPABASE_ANON_KEY`。
+
+**② 前端部署（GitHub Pages）**
+
+推送到 `main` 分支时，`deploy-pages.yml` 自动构建并发布到 GitHub Pages。
+生产环境 `base` 路径为 `/Hamster-Nest/`（见 `vite.config.ts`），构建所需的 `VITE_*` 变量从 GitHub Secrets 注入。
+
+**③ 后端部署（Supabase Edge Functions）**
+
+`supabase/functions/**` 有改动并推送到 `main` 时，`deploy-edge-functions.yml` 会用 Supabase CLI 部署全部函数。也可手动：
+
+```bash
+supabase link --project-ref <PROJECT_REF>
+supabase functions deploy                 # 部署全部
+supabase functions deploy hamster-mcp     # 或单个部署
+supabase secrets set OPENROUTER_API_KEY=xxx   # 配置密钥
 ```
+
+**④ 定时任务**
+
+`signal-bus-cron`（每 10 分钟）与 `auto-letter-cron`（每小时）由 GitHub Actions 定时触发对应 Edge Function，无需额外部署。
 
 </details>
 


### PR DESCRIPTION
## 🐹 这个 PR 做了什么

在保留原有问答风格和仓鼠语气的前提下，读取整个仓库的架构与代码，把 README 里 `待补充吱！` 的空缺处全部补齐，并修正了过时的数字。

## ✨ 主要改动

**🔢 徽章数据修正**
- MCP Tools 徽章 `23 → 41`（读 5 个 MCP 服务器源码逐一数出的真实工具数）
- 新增 Edge Functions 徽章（12 个函数）与 PWA 徽章

**🧰 新增「MCP 工具箱」**
- 按 5 个服务器完整列出**全部 41 个工具**，每个配中文说明，用可折叠 `<details>` 分组
- `hamster-mcp` 9 · `hamster-knowledge-mcp` 8 · `hamster-reading-mcp` 9 · `hamster-lounge-mcp` 8 · `hamster-life-mcp` 7

**➕ 补上遗漏板块**
- 「后端 Edge Functions」总览（对话网关 / 模型列表 / 记忆抽取 / 信号总线）
- 「定时任务」（signal-bus 每 10 分钟、auto-letter 每小时）
- 「完整页面地图」折叠区（30+ 页面，路由 + 功能一一对应）
- 技术栈补充版本号、MCP 传输机制、Provider 配置说明

**📌 RAG 标注为已废弃**
- 仅在「后端 Edge Functions」放一行 ⚠️ 备注，说明代码保留仅作存档、当前不使用

**📂 填满三个折叠区**
- 目录结构（真实树状图）
- 环境变量（前端 3 个 + 后端 16 个，逐一核对变量名，**只列名不含任何明文凭据**）
- 部署指南（本地开发 / GitHub Pages / Supabase CLI / 定时任务）

## 📄 改动范围

仅 `README.md`，纯文档改动，不涉及任何代码逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011iD8DfrHtP9SZdZUs7qSpX)_