### PR TITLE
fix(mcp): 同步 hamster-reading-mcp 与 mcp_common 至线上部署版本

### DIFF
--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -60,9 +60,17 @@ export const jsonResult = (value: unknown) => ({
   content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }],
 })
 
-export const errorResult = (err: unknown) => ({
-  content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-})
+export const errorResult = (err: unknown) => {
+  let msg: string
+  if (err instanceof Error) {
+    msg = err.message
+  } else if (typeof err === 'object' && err !== null) {
+    msg = (err as Record<string, unknown>).message as string ?? JSON.stringify(err, null, 2)
+  } else {
+    msg = String(err)
+  }
+  return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] }
+}
 
 export const clampLimit = (limit: number | undefined, fallback: number, max: number) =>
   Math.min(Math.max(limit ?? fallback, 1), max)

--- a/supabase/functions/hamster-reading-mcp/index.ts
+++ b/supabase/functions/hamster-reading-mcp/index.ts
@@ -61,7 +61,7 @@ const currentStreak = (dates: Set<string>, today: string) => {
 
 const resonanceColumns = 'id, excerpt_id, book_id, speaker, content, metadata, created_at, updated_at'
 const questionColumns = 'id, book_id, question, status, metadata, created_at, updated_at'
-const answerColumns = 'id, question_id, book_id, answered_by, content, metadata, created_at, updated_at'
+const answerColumns = 'id, question_id, book_id, answered_by, answer, metadata, created_at, updated_at'
 const answerers = ['chuanchuan', 'syzygy-claude', 'syzygy-gpt', 'cli_reading_assist'] as const
 
 serveMcp('hamster-reading-mcp', (server) => {


### PR DESCRIPTION
## 背景

对账线上 Supabase Edge Function（5 个 MCP）与 GitHub 仓库的工具实现，发现 `hamster-reading-mcp` 落后于线上。它是唯一手动部署（`entrypoint` 在 `/tmp/user_fn_.../`）且时间戳最新的函数，线上已修正但仓库未跟进。

工具**名称**全部一致；不一致的是实现细节。

## 变更内容

### 1. `hamster-reading-mcp/index.ts` — `answerColumns` 列名修复
- 前：`...answered_by, content, metadata...`
- 后：`...answered_by, answer, metadata...`

AAB 数据库 `book_answers` 表的实际列是 **`answer`，不存在 `content` 列**。旧代码会让 `read_book_questions(include_answers=true)` 和 `add_book_answer` 在 `.select(answerColumns)` 时引用不存在的列而报错。此改动使仓库与线上正确版本及数据库表结构一致。

### 2. `_shared/mcp_common.ts` — `errorResult` 增强
- 旧版对非 `Error` 对象只做 `String(err)`，Supabase 返回的错误对象会被渲染成 `[object Object]`。
- 新版优先提取错误对象的 `message`，取不到再回退到 `JSON.stringify`，与线上 reading-mcp bundle 保持一致。合并后 CI 会让 5 个 MCP 的错误处理全部统一。

## 为什么需要现在合并

`deploy-edge-functions.yml` 在任何触碰 `supabase/functions/**` 的 push-to-main 上会执行 `supabase functions deploy`（部署**全部**函数）。若不先同步仓库，下次一有函数改动推送，CI 就会用仓库的旧 `content` 版本覆盖线上已修好的 reading-mcp，造成回退。

## 验证
- 通过 Supabase MCP 拉取 5 个线上函数源码逐一比对，仅 reading-mcp 分叉。
- 通过 `information_schema.columns` 确认 AAB `book_answers` 列为 `answer`（无 `content`）。
- 其余 4 个函数（hamster-mcp / life / knowledge / lounge）与仓库一致，无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hqnapipjGU6MDAKUT6u5t

---
_Generated by [Claude Code](https://claude.ai/code/session_015hqnapipjGU6MDAKUT6u5t)_