### PR TITLE
feat(feed): 月度概览跟随日历切换月份

### DIFF
--- a/src/lib/agentFeed.ts
+++ b/src/lib/agentFeed.ts
@@ -254,14 +254,15 @@ const buildMonthlyOverviewContent = (item: AgentFeedItem): MonthlyOverviewConten
   }
 }
 
-// 读取当前月份的月度概览记录（取最新一条，按 updated_at / created_at 倒序）。
-// 只要查到归属当前月份的 monthly_overview 就返回；查不到才返回 null（上层显示空状态）。
-// 不再要求 content 必须是 JSON，也不再强制 metadata.status=active，兼容 markdown / plain。
-export const fetchMonthlyOverview = async (
+// 一次性读取全部月度概览记录，按月份键（YYYY-MM）归桶，每月保留最新一条
+// （按 updated_at / created_at 倒序，故每月首次出现的即为最新）。
+// 供 Feed 页在日历切换月份时即时切换「本月概览」，无需逐月往返查询。
+// 不要求 content 必须是 JSON，也不强制 metadata.status=active，兼容 markdown / plain。
+export const fetchMonthlyOverviews = async (
   userId: string,
-  month: string = getCurrentMonthKey(),
-): Promise<MonthlyOverviewContent | null> => {
-  if (!supabase) return null
+): Promise<Map<string, MonthlyOverviewContent>> => {
+  const result = new Map<string, MonthlyOverviewContent>()
+  if (!supabase) return result
   const nowIso = new Date().toISOString()
   const { data, error } = await supabase
     .from('agent_feed_items')
@@ -271,17 +272,29 @@ export const fetchMonthlyOverview = async (
     .or(`visible_from.is.null,visible_from.lte.${nowIso}`)
     .order('updated_at', { ascending: false })
     .order('created_at', { ascending: false })
-    .limit(20)
+    .limit(60)
 
   if (error) {
     console.warn('加载月度概览失败', error)
-    return null
+    return result
   }
 
   const candidates = (data ?? []) as AgentFeedItem[]
-  const matched = candidates.find((item) => resolveOverviewMonth(item) === month)
-  if (!matched) return null
-  return buildMonthlyOverviewContent(matched)
+  candidates.forEach((item) => {
+    const month = resolveOverviewMonth(item)
+    if (!month || result.has(month)) return
+    result.set(month, buildMonthlyOverviewContent(item))
+  })
+  return result
+}
+
+// 读取指定月份（默认当前月）的月度概览记录；查不到返回 null（上层显示空状态）。
+export const fetchMonthlyOverview = async (
+  userId: string,
+  month: string = getCurrentMonthKey(),
+): Promise<MonthlyOverviewContent | null> => {
+  const overviews = await fetchMonthlyOverviews(userId)
+  return overviews.get(month) ?? null
 }
 
 export const updateAgentFeedStatus = async (

--- a/src/pages/AgentFeedPage.tsx
+++ b/src/pages/AgentFeedPage.tsx
@@ -9,8 +9,7 @@ import {
   agentFeedTypeOptions,
   computeAgentFeedStats,
   fetchAgentFeedItems,
-  fetchMonthlyOverview,
-  getCurrentMonthKey,
+  fetchMonthlyOverviews,
   isAgentFeedExpired,
   isPageLevelFeedType,
   resolveAgentFeedStatus,
@@ -52,18 +51,18 @@ const formatUpdatedLabel = (iso: string | null) => {
 const getMonthRange = (anchor: Date) => {
   const year = anchor.getFullYear()
   const month = anchor.getMonth()
-  return { monthLabel: `${year}年${month + 1}月` }
+  return {
+    monthKey: `${year}-${`${month + 1}`.padStart(2, '0')}`,
+    monthLabel: `${year}年${month + 1}月`,
+  }
 }
 
 const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
   const navigate = useNavigate()
   const today = useMemo(() => getTodayKey(), [])
-  const overviewMonthLabel = useMemo(() => {
-    const [year, month] = getCurrentMonthKey().split('-')
-    return `${year}年${Number(month)}月`
-  }, [])
   const [items, setItems] = useState<AgentFeedItem[]>([])
-  const [overview, setOverview] = useState<MonthlyOverviewContent | null>(null)
+  // 所有月份的「本月概览」一次读入，按 YYYY-MM 归桶，随日历游标切换即时展示。
+  const [overviews, setOverviews] = useState<Map<string, MonthlyOverviewContent>>(() => new Map())
   const [overviewLoading, setOverviewLoading] = useState(true)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -97,11 +96,11 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
     }
     // 月度概览单独读取，失败时静默降级为空状态，不影响其它 Feed 卡片。
     try {
-      const overviewData = await fetchMonthlyOverview(user.id)
-      setOverview(overviewData)
+      const overviewMap = await fetchMonthlyOverviews(user.id)
+      setOverviews(overviewMap)
     } catch (overviewError) {
       console.warn('加载月度概览失败', overviewError)
-      setOverview(null)
+      setOverviews(new Map())
     } finally {
       setOverviewLoading(false)
     }
@@ -212,6 +211,8 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
   }
 
   const monthRange = getMonthRange(monthCursor)
+  // 「本月概览」跟随日历游标：切到哪个月就展示哪个月，查不到则由子组件显示空状态。
+  const overview = overviews.get(monthRange.monthKey) ?? null
 
   return (
     <div className="feed-page">
@@ -250,7 +251,7 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
       {error ? <p className="feed-alert">{error}</p> : null}
       {actionError ? <p className="feed-alert feed-alert--soft">{actionError}</p> : null}
 
-      <MonthlyOverview data={overview} loading={overviewLoading} monthLabel={overviewMonthLabel} />
+      <MonthlyOverview data={overview} loading={overviewLoading} monthLabel={monthRange.monthLabel} />
 
       <section className="feed-calendar" aria-label="按日期浏览">
         <div className="feed-calendar__dot" aria-hidden="true" />


### PR DESCRIPTION
## 背景

Syzygy Feed 页（`/feed` 的 `AgentFeedPage`）顶部的「本月概览」写死读取**当前月**——月份标题和数据获取都用默认的当前月，完全没有跟日历游标 `monthCursor` 联动。所以下方月历切换月份时，上面的月度总结纹丝不动。

本次改动让「本月概览」跟随日历切换：切到哪个月，上方就展示哪个月的月度总结。

## 改动

**`src/lib/agentFeed.ts`**
- 新增 `fetchMonthlyOverviews(userId)`：一次性读入全部月度概览，按 `YYYY-MM` 归桶（每月保留最新一条），读取上限 20 → 60 以覆盖更多历史月份。
- `fetchMonthlyOverview` 改为复用它（`overviews.get(month)`），去掉重复的查询逻辑。

**`src/pages/AgentFeedPage.tsx`**
- 单条 `overview` 状态改为 `overviews` 按月 Map，随 `refresh` 一次读入。
- 展示的 `overview` 由 `monthCursor` 对应的月份键派生：`overviews.get(monthRange.monthKey)`。
- 月份标题从写死的当前月改用 `monthRange.monthLabel`（与月历标题同源）。
- 移除不再需要的 `overviewMonthLabel` / `getCurrentMonthKey` 引用。

## 效果

- 点「上月 / 下月」→ 概览内容与「20XX年X月」标题一起切到对应月份。
- 切到没有概览的月份 → 自然显示空状态「这个月还没有持续追踪的事项」。
- 点「今天」回到当前月，概览同步归位。
- 所有月份一次读入内存，切月即时、不额外发请求。

## 验证

- `tsc -b` 类型检查通过
- 生产构建 `npm run build` 通过
- lint 仅有的报错/警告均位于未改动文件，与本次改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0124MnBBMPUtMRbe7pxE3V7j)_