### PR TITLE
fix(hamster-knowledge-mcp): disambiguate archive_categories embed in search_archives

### DIFF
--- a/supabase/functions/hamster-knowledge-mcp/index.ts
+++ b/supabase/functions/hamster-knowledge-mcp/index.ts
@@ -70,7 +70,7 @@ serveMcp('hamster-knowledge-mcp', (server) => {
   }, async ({ query, scope, limit }) => {
     try {
       const safeLimit = clampLimit(limit, 10, 50)
-      let q = supabase.from('archives').select('id, category_id, title, content, keywords, aliases, importance, source, created_at, updated_at, archive_categories!inner(scope, name)').eq('user_id', USER_ID).eq('is_deleted', false).or(`title.ilike.%${query}%,content.ilike.%${query}%,keywords.cs.{${query}}`).order('updated_at', { ascending: false }).limit(safeLimit)
+      let q = supabase.from('archives').select('id, category_id, title, content, keywords, aliases, importance, source, created_at, updated_at, archive_categories!archives_category_id_fkey!inner(scope, name)').eq('user_id', USER_ID).eq('is_deleted', false).or(`title.ilike.%${query}%,content.ilike.%${query}%,keywords.cs.{${query}}`).order('updated_at', { ascending: false }).limit(safeLimit)
       if (scope && scope !== 'all') q = q.eq('archive_categories.scope', scope)
       const { data, error } = await q
       if (error) return errorResult(error)


### PR DESCRIPTION
## 问题

`search_archives` 调用报错:

> Could not embed because more than one relationship was found for 'archives' and 'archive_categories'

**根因**:`archives` → `archive_categories` 存在两条外键(`archives_category_id_fkey` 和复合的 `archives_category_user_fkey`),PostgREST 无法确定 embed 该走哪条关系。

## 修复

在 `search_archives` 的 select 里将 `archive_categories!inner(scope, name)` 改为 `archive_categories!archives_category_id_fkey!inner(scope, name)`,显式指定外键关系。一行改动。

**排查说明**:全仓库只有这一处 embed 了 `archive_categories`——`read_archives` 只查普通列,前端 `src/storage/supabaseSync.ts` 也全是普通列查询,均不受影响。

## 验证

- Edge Function 已部署为 v6,线上实测:用关键词 "412" + `scope=syzygy` 调用 `search_archives`,正常返回档案且带出 `archive_categories: {name, scope}`,scope 过滤生效,返回字段名不变(向后兼容)
- 未对数据库 constraint 做任何操作,`archives_category_user_fkey` 原样保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsW7ULV8eBiZ6jkzxLcpxd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsW7ULV8eBiZ6jkzxLcpxd)_