### PR TITLE
ci: 一次性 workflow —— 下线线上 rag-* edge functions

### DIFF
--- a/.github/workflows/cleanup-rag-functions.yml
+++ b/.github/workflows/cleanup-rag-functions.yml
@@ -1,0 +1,22 @@
+# One-off cleanup: delete the retired rag-* Edge Functions from Supabase.
+# Safe to remove this workflow after it has run successfully.
+name: Cleanup RAG Functions
+
+on:
+  workflow_dispatch:
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Delete retired rag-* functions
+        run: |
+          supabase functions delete rag-embed --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase functions delete rag-search --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase functions delete rag-backfill --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
RAG 清理第 ② 步的执行载体：本地与 MCP 均无删除线上 edge function 的通道，故借用仓库已有的 `SUPABASE_ACCESS_TOKEN` / `SUPABASE_PROJECT_REF` secrets，通过一次性 `workflow_dispatch` workflow 执行：

```
supabase functions delete rag-embed / rag-search / rag-backfill
```

跑完并确认三个函数下线后，会另开 PR 移除本 workflow 文件，不留痕迹。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CNBV1YjBJQtH2RpyLgMNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017CNBV1YjBJQtH2RpyLgMNZ)_