### PR TITLE
ci: cleanup workflow 改为 push 触发

### DIFF
--- a/.github/workflows/cleanup-rag-functions.yml
+++ b/.github/workflows/cleanup-rag-functions.yml
@@ -3,6 +3,11 @@
 name: Cleanup RAG Functions
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/cleanup-rag-functions.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
GitHub MCP 集成没有 `actions:write` 权限，无法手动 dispatch #449 合入的一次性 workflow。改为 `push` 触发（paths 仅限该 workflow 文件自身）：本 PR 合并产生的 push 事件即触发 rag-* 函数删除；之后移除该文件的 PR 不会再触发（文件已不在 HEAD）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CNBV1YjBJQtH2RpyLgMNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017CNBV1YjBJQtH2RpyLgMNZ)_