### PR TITLE
Security: drop open "Allow service insert" policies, revoke anon exec on definer functions

### DIFF
--- a/supabase/migrations/20260702100000_security_remove_open_insert_policies_and_anon_definer_exec.sql
+++ b/supabase/migrations/20260702100000_security_remove_open_insert_policies_and_anon_definer_exec.sql
@@ -3,9 +3,11 @@
 DROP POLICY "Allow service insert" ON public.wallet_transactions;
 DROP POLICY "Allow service insert" ON public.quests;
 
--- 2. 收回匿名角色对四个SECURITY DEFINER函数的执行权
--- （authenticated暂保留，前端登录态可能在用软删除）
-REVOKE EXECUTE ON FUNCTION public.soft_delete_snack_post(uuid) FROM anon;
-REVOKE EXECUTE ON FUNCTION public.restore_snack_post(uuid) FROM anon;
-REVOKE EXECUTE ON FUNCTION public.soft_delete_snack_reply(uuid) FROM anon;
-REVOKE EXECUTE ON FUNCTION public.touch_session_updated_at_from_messages() FROM anon;
+-- 2. 收回匿名侧对四个SECURITY DEFINER函数的执行权
+-- 线上核实：三个snack函数上anon并无直接授权，其执行权来自PUBLIC默认授权（=X/postgres），
+-- 只REVOKE anon是空操作，必须连PUBLIC一起收回。
+-- （authenticated在四个函数上均有显式授权，不受影响；前端登录态可能在用软删除）
+REVOKE EXECUTE ON FUNCTION public.soft_delete_snack_post(uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.restore_snack_post(uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.soft_delete_snack_reply(uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.touch_session_updated_at_from_messages() FROM PUBLIC, anon;

--- a/supabase/migrations/20260702100000_security_remove_open_insert_policies_and_anon_definer_exec.sql
+++ b/supabase/migrations/20260702100000_security_remove_open_insert_policies_and_anon_definer_exec.sql
@@ -1,0 +1,11 @@
+-- 1. 移除误解service_role机制的全放行INSERT策略
+-- （service_role天然绕过RLS无需策略，这两条实际效果是向anon敞开写入）
+DROP POLICY "Allow service insert" ON public.wallet_transactions;
+DROP POLICY "Allow service insert" ON public.quests;
+
+-- 2. 收回匿名角色对四个SECURITY DEFINER函数的执行权
+-- （authenticated暂保留，前端登录态可能在用软删除）
+REVOKE EXECUTE ON FUNCTION public.soft_delete_snack_post(uuid) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.restore_snack_post(uuid) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.soft_delete_snack_reply(uuid) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.touch_session_updated_at_from_messages() FROM anon;


### PR DESCRIPTION
## 内容（止血波，范围严格限定）

新增 migration `20260702100000_security_remove_open_insert_policies_and_anon_definer_exec.sql`：

1. **删除 `wallet_transactions` / `quests` 上的 `Allow service insert` INSERT 策略**
   这两条策略是对 service_role 机制的误解——service_role 天然绕过 RLS 不需要策略，它们的实际效果是 `with_check: true` 对 `public`（含 anon）全放行写入。
2. **收回匿名侧对四个 SECURITY DEFINER 函数的 EXECUTE 权限**
   `soft_delete_snack_post(uuid)`、`restore_snack_post(uuid)`、`soft_delete_snack_reply(uuid)`、`touch_session_updated_at_from_messages()`。

## 与工单原文的一处偏差（经确认，bc67ca9）

REVOKE 语句由 `FROM anon` 改为 `FROM PUBLIC, anon`：线上 ACL 核实，三个 snack 函数上 anon 并无直接授权，其执行权来自 PUBLIC 默认授权（`=X/postgres`），只收 anon 是静默空操作。`authenticated` 在四个函数上均有显式授权，不受影响。对象范围未扩大。

## 线上核对（提交前已验证）

- 两条 `Allow service insert` 策略确实存在于线上，roles `{public}`、`with_check: true`。
- 四个函数均为 SECURITY DEFINER 且 anon 当前可执行（经由 PUBLIC 或直接授权）。
- 备注：`checkin_logs` 上也存在一条同名的 `Allow service insert` 策略，按红线不在本 PR 处理，仅记录上报。

## 验收计划

Merge 后立即冒烟测试：前端路径建一个任务、完成一笔钱包积分流转。失败则 revert 本 PR 并改用限定策略方案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C39LGTj4cSqhFGG7e6YS67