### PR TITLE
feat(archive): 档案卡片支持展开查看全文

### DIFF
--- a/src/pages/ArchivePage.css
+++ b/src/pages/ArchivePage.css
@@ -360,30 +360,51 @@
 
 .archive-card {
   display: grid;
-  gap: 6px;
   text-align: left;
   border: 1px solid var(--arc-soft);
   border-radius: 14px;
   background: #fff;
-  padding: 10px 12px;
-  cursor: pointer;
   box-shadow: 0 2px 8px var(--arc-soft-faint);
-  transition: background 140ms ease, border-color 140ms ease;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+  overflow: hidden;
 }
 
 .archive-card:hover {
-  background: var(--arc-tile);
   border-color: var(--arc-accent-strong);
+}
+
+.archive-card--expanded {
+  border-color: var(--arc-accent-strong);
+  box-shadow: 0 6px 16px var(--arc-soft-faint);
+}
+
+.archive-card__toggle {
+  appearance: none;
+  width: 100%;
+  display: grid;
+  gap: 6px;
+  text-align: left;
+  border: none;
+  background: transparent;
+  padding: 10px 12px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: background 140ms ease;
+}
+
+.archive-card__toggle:hover {
+  background: var(--arc-tile);
 }
 
 .archive-card__top {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
 }
 
 .archive-card__title {
+  flex: 1;
   font-size: 14px;
   font-weight: 700;
   color: var(--arc-heading);
@@ -391,6 +412,26 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.archive-card--expanded .archive-card__title {
+  font-size: 15px;
+  line-height: 1.4;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: unset;
+}
+
+.archive-card__chevron {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--arc-accent-strong);
+  transform: rotate(-90deg);
+  transition: transform 180ms ease;
+}
+
+.archive-card--expanded .archive-card__chevron {
+  transform: rotate(0deg);
 }
 
 .archive-card__excerpt {
@@ -427,6 +468,69 @@
   background: var(--arc-tile);
   padding: 1px 8px;
   color: var(--arc-heading);
+}
+
+/* ── Expanded card detail ─────────────────────── */
+
+.archive-card__detail {
+  display: grid;
+  gap: 10px;
+  padding: 0 14px 12px;
+}
+
+.archive-card__content {
+  margin: 0;
+  padding-top: 12px;
+  border-top: 1px dashed var(--arc-accent);
+  font-size: 13.5px;
+  line-height: 1.85;
+  color: var(--arc-text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.archive-card__content--empty {
+  color: #9a8b94;
+}
+
+.archive-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.archive-card__chip--alias {
+  background: #fff;
+  color: var(--arc-kicker);
+  border-style: dashed;
+}
+
+.archive-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--arc-soft-faint);
+}
+
+.archive-card__footinfo {
+  font-size: 11px;
+  color: #9a8b94;
+}
+
+.archive-card__footactions {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.archive-mini-btn--ghost {
+  background: #fff;
+  border-color: var(--arc-soft);
+  font-weight: 500;
 }
 
 /* ── Importance badge ─────────────────────────── */

--- a/src/pages/ArchivePage.tsx
+++ b/src/pages/ArchivePage.tsx
@@ -147,6 +147,7 @@ const ArchivePage = () => {
   const [archives, setArchives] = useState<Archive[]>([])
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null)
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
+  const [expandedArchiveIds, setExpandedArchiveIds] = useState<Set<string>>(() => new Set())
   const [search, setSearch] = useState('')
 
   const [loadingCategories, setLoadingCategories] = useState(true)
@@ -216,6 +217,7 @@ const ArchivePage = () => {
 
   useEffect(() => {
     setSearch('')
+    setExpandedArchiveIds(new Set())
     void refreshArchives(selectedCategoryId)
   }, [selectedCategoryId, refreshArchives])
 
@@ -263,6 +265,18 @@ const ArchivePage = () => {
     setCategories([])
     setArchives([])
     setScope(next)
+  }
+
+  const toggleArchiveExpanded = (archiveId: string) => {
+    setExpandedArchiveIds((current) => {
+      const next = new Set(current)
+      if (next.has(archiveId)) {
+        next.delete(archiveId)
+      } else {
+        next.add(archiveId)
+      }
+      return next
+    })
   }
 
   const toggleCollapse = (categoryId: string) => {
@@ -620,32 +634,97 @@ const ArchivePage = () => {
           <p className="archive-empty">{search.trim() ? '没有匹配的档案。' : '该目录下还没有档案条目。'}</p>
         ) : (
           <div className="archive-list">
-            {filteredArchives.map((archive) => (
-              <button
-                key={archive.id}
-                type="button"
-                className="archive-card"
-                onClick={() => openEditArchive(archive)}
-              >
-                <div className="archive-card__top">
-                  <span className="archive-card__title">{archive.title}</span>
-                  <span className={`archive-importance archive-importance--${archive.importance}`}>
-                    {IMPORTANCE_META[archive.importance].label}
-                  </span>
-                </div>
-                {archive.content ? (
-                  <p className="archive-card__excerpt">{archive.content}</p>
-                ) : null}
-                <div className="archive-card__meta">
-                  {archive.keywords.slice(0, 4).map((keyword) => (
-                    <span key={keyword} className="archive-card__chip">
-                      #{keyword}
-                    </span>
-                  ))}
-                  <time>{formatTime(archive.updatedAt)}</time>
-                </div>
-              </button>
-            ))}
+            {filteredArchives.map((archive) => {
+              const isExpanded = expandedArchiveIds.has(archive.id)
+              return (
+                <article
+                  key={archive.id}
+                  className={`archive-card ${isExpanded ? 'archive-card--expanded' : ''}`}
+                >
+                  <button
+                    type="button"
+                    className="archive-card__toggle"
+                    onClick={() => toggleArchiveExpanded(archive.id)}
+                    aria-expanded={isExpanded}
+                    title={isExpanded ? '收起' : '展开查看全文'}
+                  >
+                    <div className="archive-card__top">
+                      <span className="archive-card__title">{archive.title}</span>
+                      <span className={`archive-importance archive-importance--${archive.importance}`}>
+                        {IMPORTANCE_META[archive.importance].label}
+                      </span>
+                      <span className="archive-card__chevron" aria-hidden="true">
+                        ▾
+                      </span>
+                    </div>
+                    {!isExpanded ? (
+                      <>
+                        {archive.content ? (
+                          <p className="archive-card__excerpt">{archive.content}</p>
+                        ) : null}
+                        <div className="archive-card__meta">
+                          {archive.keywords.slice(0, 4).map((keyword) => (
+                            <span key={keyword} className="archive-card__chip">
+                              #{keyword}
+                            </span>
+                          ))}
+                          <time>{formatTime(archive.updatedAt)}</time>
+                        </div>
+                      </>
+                    ) : null}
+                  </button>
+                  {isExpanded ? (
+                    <div className="archive-card__detail">
+                      <p
+                        className={`archive-card__content ${
+                          archive.content ? '' : 'archive-card__content--empty'
+                        }`}
+                      >
+                        {archive.content || '（这条档案还没有正文）'}
+                      </p>
+                      {archive.keywords.length > 0 || archive.aliases.length > 0 ? (
+                        <div className="archive-card__tags">
+                          {archive.keywords.map((keyword) => (
+                            <span key={`kw-${keyword}`} className="archive-card__chip">
+                              #{keyword}
+                            </span>
+                          ))}
+                          {archive.aliases.map((alias) => (
+                            <span
+                              key={`alias-${alias}`}
+                              className="archive-card__chip archive-card__chip--alias"
+                            >
+                              @{alias}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                      <div className="archive-card__footer">
+                        <span className="archive-card__footinfo">
+                          来源：{archive.source || 'manual'} · 更新于 {formatTime(archive.updatedAt)}
+                        </span>
+                        <div className="archive-card__footactions">
+                          <button
+                            type="button"
+                            className="archive-mini-btn"
+                            onClick={() => openEditArchive(archive)}
+                          >
+                            ✎ 编辑
+                          </button>
+                          <button
+                            type="button"
+                            className="archive-mini-btn archive-mini-btn--ghost"
+                            onClick={() => toggleArchiveExpanded(archive.id)}
+                          >
+                            收起 ▴
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+                </article>
+              )
+            })}
           </div>
         )}
       </section>


### PR DESCRIPTION
点击档案卡片不再直接进入编辑弹窗，而是原地展开/收起卡片：
- 展开后显示完整正文（加大字号、1.85 行高、保留换行）， 以虚线分割线与标题区分隔，方便阅读
- 展开态展示全部关键词与别名标签、来源和更新时间
- 编辑入口改为展开后的「编辑」按钮，另有「收起」按钮
- 折叠态保留原有两行摘要与标签预览，右侧新增展开指示箭头
- 切换目录时自动重置展开状态

仅前端 UI 调整，不涉及数据与业务逻辑改动。


Claude-Session: https://claude.ai/code/session_01CATnPd7NWf36GLMDx8PHfF