### PR TITLE
Make monthly overview follow calendar month and be collapsible

### DIFF
--- a/src/components/MonthlyOverview.tsx
+++ b/src/components/MonthlyOverview.tsx
@@ -28,55 +28,58 @@ const MonthlyOverview = ({ data, loading, monthLabel }: MonthlyOverviewProps) =>
         <span className="feed-overview__mark" aria-hidden="true">◆</span>
         <h2 className="feed-overview__title">本月概览</h2>
         <span className="feed-overview__month">{monthLabel}</span>
-        {hasContent ? (
-          <button
-            type="button"
-            className="feed-overview__toggle"
-            onClick={() => setCollapsed((current) => !current)}
-            aria-expanded={!collapsed}
-          >
-            {collapsed ? '展开' : '收起'}
-          </button>
-        ) : null}
+        <button
+          type="button"
+          className="feed-overview__toggle"
+          onClick={() => setCollapsed((current) => !current)}
+          aria-expanded={!collapsed}
+          aria-controls="feed-monthly-overview-body"
+        >
+          {collapsed ? '展开' : '收起'}
+        </button>
       </header>
 
-      {loading && !hasContent ? (
-        <p className="feed-overview__empty">正在整理这个月的持续事项…</p>
-      ) : null}
+      {!collapsed ? (
+        <div id="feed-monthly-overview-body" className="feed-overview__body">
+          {loading && !hasContent ? (
+            <p className="feed-overview__empty">正在整理这个月的持续事项…</p>
+          ) : null}
 
-      {!loading && !hasContent ? (
-        <p className="feed-overview__empty">这个月还没有持续追踪的事项，攒一攒就有了。</p>
-      ) : null}
+          {!loading && !hasContent ? (
+            <p className="feed-overview__empty">这个月还没有持续追踪的事项，攒一攒就有了。</p>
+          ) : null}
 
-      {hasContent && !collapsed ? (
-        hasThemes ? (
-          <div className="feed-overview__themes">
-            {data!.themes.map((theme, themeIndex) => (
-              <article className="feed-overview__theme" key={`${theme.theme}-${themeIndex}`}>
-                <h3 className="feed-overview__theme-title">{theme.theme}</h3>
-                <ul className="feed-overview__items">
-                  {theme.items.map((entry, entryIndex) => (
-                    <li className="feed-overview__item" key={entryIndex}>
-                      <span className="feed-overview__bullet" aria-hidden="true" />
-                      <span className="feed-overview__text">{entry.text}</span>
-                      {entry.archive_candidate ? (
-                        <span className="feed-overview__flag" title="可沉淀进档案">待沉淀</span>
-                      ) : null}
-                    </li>
-                  ))}
-                </ul>
-              </article>
-            ))}
-          </div>
-        ) : (
-          <div className="feed-overview__raw">
-            {data!.format === 'markdown' ? (
-              <MarkdownRenderer content={rawText} />
+          {hasContent ? (
+            hasThemes ? (
+              <div className="feed-overview__themes">
+                {data!.themes.map((theme, themeIndex) => (
+                  <article className="feed-overview__theme" key={`${theme.theme}-${themeIndex}`}>
+                    <h3 className="feed-overview__theme-title">{theme.theme}</h3>
+                    <ul className="feed-overview__items">
+                      {theme.items.map((entry, entryIndex) => (
+                        <li className="feed-overview__item" key={entryIndex}>
+                          <span className="feed-overview__bullet" aria-hidden="true" />
+                          <span className="feed-overview__text">{entry.text}</span>
+                          {entry.archive_candidate ? (
+                            <span className="feed-overview__flag" title="可沉淀进档案">待沉淀</span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  </article>
+                ))}
+              </div>
             ) : (
-              <p className="feed-overview__plain">{rawText}</p>
-            )}
-          </div>
-        )
+              <div className="feed-overview__raw">
+                {data!.format === 'markdown' ? (
+                  <MarkdownRenderer content={rawText} />
+                ) : (
+                  <p className="feed-overview__plain">{rawText}</p>
+                )}
+              </div>
+            )
+          ) : null}
+        </div>
       ) : null}
     </section>
   )

--- a/src/pages/AgentFeedPage.tsx
+++ b/src/pages/AgentFeedPage.tsx
@@ -135,6 +135,8 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
     return groups
   }, [items])
 
+  const monthRange = useMemo(() => getMonthRange(monthCursor), [monthCursor])
+
   const calendarCells = useMemo(() => {
     const year = monthCursor.getFullYear()
     const month = monthCursor.getMonth()
@@ -156,23 +158,27 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
     return cells
   }, [itemsByDate, monthCursor, nowMs])
 
-  // 默认选中：今天（若有内容）否则最近有内容的一天。
+  // 选中日期始终跟随日历月份：切换月份后落到该月日期，
+  // 这样月度概览与“当前浏览月份”保持一致，不再依赖某天是否有月总结记录。
   useEffect(() => {
-    if (items.length === 0) {
-      setSelectedDate(null)
-      return
-    }
+    const year = monthCursor.getFullYear()
+    const month = monthCursor.getMonth()
+    const monthKey = `${year}-${`${month + 1}`.padStart(2, '0')}`
+    const firstDayOfMonth = `${monthKey}-01`
+
     setSelectedDate((current) => {
-      if (current && itemsByDate.has(current)) {
+      if (current?.startsWith(monthKey)) {
         return current
       }
-      if (itemsByDate.has(today)) {
+      if (today.startsWith(monthKey)) {
         return today
       }
-      const latest = Array.from(itemsByDate.keys()).sort((a, b) => b.localeCompare(a))[0]
-      return latest ?? null
+      const latestInMonth = Array.from(itemsByDate.keys())
+        .filter((dateKey) => dateKey.startsWith(monthKey))
+        .sort((a, b) => b.localeCompare(a))[0]
+      return latestInMonth ?? firstDayOfMonth
     })
-  }, [items, itemsByDate, today])
+  }, [itemsByDate, monthCursor, today])
 
   const selectedItems = useMemo(() => {
     if (!selectedDate) return []
@@ -210,7 +216,6 @@ const AgentFeedPage = ({ user }: AgentFeedPageProps) => {
     return null
   }
 
-  const monthRange = getMonthRange(monthCursor)
   // 「本月概览」跟随日历游标：切到哪个月就展示哪个月，查不到则由子组件显示空状态。
   const overview = overviews.get(monthRange.monthKey) ?? null
 


### PR DESCRIPTION
### Motivation
- Ensure the monthly overview card is visible above the calendar and follows the calendar month instead of being tied to the specific day that last updated the overview. 
- Allow the monthly overview to be expanded/collapsed consistently while keeping loading and empty states inside the same card. 

### Description
- Keep a `monthRange` memo derived from `monthCursor` and use it to pick the overview for the currently displayed calendar month so the overview follows calendar navigation (`src/pages/AgentFeedPage.tsx`).
- Change the selected-date logic so `selectedDate` always lands in the current calendar month (or falls back to the first day) when switching months, allowing the overview to be visible for any date in that month (`src/pages/AgentFeedPage.tsx`).
- Make the `MonthlyOverview` card always render an expand/collapse toggle and move loading, empty and content rendering into a single collapsible body, with `aria-controls` for accessibility (`src/components/MonthlyOverview.tsx`).
- Minor JSX/structure adjustments to keep overview display and accessibility consistent when switching months and toggling collapse. 

### Testing
- Ran `npx eslint src/pages/AgentFeedPage.tsx src/components/MonthlyOverview.tsx` and the checked files passed linting.
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run check` which reported existing, unrelated lint errors in `supabase/functions/hamster-mcp/index.ts` and some preexisting hook warnings, but these are not introduced by the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a467849ee44833092a2ff2cec4f92d6)