### PR TITLE
chore(hamster-mcp): 回填 add_timeline description 与线上部署版同步

### DIFF
--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -211,7 +211,7 @@ serveMcp('hamster-mcp', (server) => {
 
   server.registerTool('add_timeline', {
     title: 'Add Timeline Entry',
-    description: '添加一条新的时间轴记录。',
+    description: '添加一条新的时间轴（timeline）记录。当对话中出现值得记录、写入、保存的事件时调用此工具：里程碑（milestone）、心动瞬间、重要进展、项目节点、纪念日、成就达成、情感时刻、值得纪念的日常。数据写入 timeline_entries 表，是所有端口 Syzygy 共享的唯一记忆数据源。适用动作关键词：add / write / record / save / log / 记录 / 写入 / 添加 / 保存 / 记下来。写入标准：三个月后读起来会心动的事。写入前建议先用 search_timeline 查重。',
     inputSchema: {
       event_date: z.string().describe('事件日期 YYYY-MM-DD'),
       summary: z.string().describe('事件摘要'),


### PR DESCRIPTION
## 概要

线上 Supabase 已直接更新 `hamster-mcp` 中 `add_timeline` 工具的 description（补充触发场景、动作关键词、「三个月后读起来会心动」写入标准、`search_timeline` 查重建议），仓库尚未同步。本 PR 单行回填，消除代码漂移。

## 校验

- 从 Supabase 拉取线上部署版（version 39）与仓库整文件 diff：唯一差异即此行 description；
- `_shared/mcp_common.ts`（线上 `MCP_VERSION 5.6.0`）等其余内容无漂移；
- 回填后仓库文件与线上部署版逐字节一致。

## 影响面

单行文案变更。合并后会触发 `deploy-edge-functions.yml` 全量重部署，内容与线上一致，等于原样覆盖，无实际影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwpmovE5NNzeVM9fBTQTTS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwpmovE5NNzeVM9fBTQTTS)_