### PR TITLE
V4.0 Phase 1 推送后端：三表 migration + push-dispatch + webhook

### DIFF
--- a/docs/security-boundary.md
+++ b/docs/security-boundary.md
@@ -45,6 +45,7 @@
 | `wechat-reply` | **A/B（2026-07-06 修复）** | 500/天 | 同上 |
 | `tts-generate` | **A/B（2026-07-06 新增）** | 200/天 | 原先完全裸奔；前端调用已补 session JWT |
 | `device-report` | **C（`DEVICE_REPORT_SECRET`，2026-07-06 新建）** | – | iOS 快捷指令上报通道，替代 anon 直写 |
+| `push-dispatch` | **C（header `x-push-dispatch-secret`，2026-07-12 新建；密钥唯一存 Vault `push_dispatch_secret`，函数经 service_role 专属 RPC `get_push_dispatch_secret` 读取后 timing-safe 比对，轮换只改 Vault）** | 200/天 | agent_events AFTER INSERT webhook（pg_net）/ Mac mini sweep / receipts 回查；推送只携标题+实体 id+路由，正文零敏感内容 |
 
 额度护栏（1-3）：`usage_quota` 表 + `consume_usage_quota(user, scope)`，按北京时区自然日计数。
 护栏**失败时放行**（fail-open）并打日志——它是成本刹车，不是鉴权门；鉴权在它之前已完成。

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -58,3 +58,6 @@ verify_jwt = false
 
 [functions.device-report]
 verify_jwt = false
+
+[functions.push-dispatch]
+verify_jwt = false

--- a/supabase/functions/push-dispatch/index.ts
+++ b/supabase/functions/push-dispatch/index.ts
@@ -1,0 +1,351 @@
+// push-dispatch: agent_events → Expo Push relay (V4.0 Phase 1 · 开发清单 5.3).
+//
+// Callers are machine-side only and authenticate with the shared secret
+// header x-push-dispatch-secret (mode C in docs/security-boundary.md):
+//   1. the agent_events AFTER INSERT trigger (pg_net http_post, secret from Vault);
+//   2. the Mac mini reconciliation sweep re-dispatching missed events
+//      ({ "agent_event_id": N }, idempotent);
+//   3. receipts polling ({ "action": "check_receipts" }).
+// The expected secret lives ONLY in Vault (push_dispatch_secret): this
+// function reads it through the service_role-only RPC
+// public.get_push_dispatch_secret and compares timing-safe. Rotation is a
+// single Vault update — no Edge secret to keep in sync. Fails closed (401)
+// when the header is absent or the Vault secret is unreadable.
+//
+// Importance routing (V4.0): low → never push; normal/high/urgent → push
+// immediately; Beijing quiet hours [23:00, 08:00) suppress everything except
+// urgent. Digest/merge pushes for normal importance are V4.1 scope.
+// Every attempt lands in notification_events (queued/sent/failed/skipped).
+// Push content carries title + entity id + routing data only — never
+// sensitive bodies, tokens, or raw payloads (红线清单 11).
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { timingSafeEqual } from '../_shared/auth.ts'
+import { consumeQuota } from '../_shared/quota.ts'
+import { getBeijingDate } from '../_shared/time.ts'
+
+const PUSH_DAILY_LIMIT = 200
+const QUIET_HOUR_START = 23 // 北京时区静默时段 [23:00, 08:00)，urgent 豁免
+const QUIET_HOUR_END = 8
+const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send'
+const EXPO_RECEIPTS_URL = 'https://exp.host/--/api/v2/push/getReceipts'
+const RECEIPT_WINDOW_HOURS = 24
+const RECEIPT_BATCH_LIMIT = 300
+
+type AgentEvent = {
+  id: number
+  user_id: string
+  actor: string
+  event_type: string
+  entity_type: string | null
+  entity_id: string | null
+  title: string
+  payload: Record<string, unknown> | null
+  importance: string
+  created_at: string
+}
+
+type ExpoTicket = {
+  status: string
+  id?: string
+  message?: string
+  details?: { error?: string }
+}
+
+const json = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const serviceClient = () =>
+  createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+
+// 期望密钥只存 Vault；经 service_role 专属 RPC 读取，进程内缓存。
+let cachedSecret: string | null = null
+const verifyDispatchSecret = async (
+  req: Request,
+  supabase: ReturnType<typeof serviceClient>,
+): Promise<boolean> => {
+  const provided = req.headers.get('x-push-dispatch-secret')?.trim()
+  if (!provided) return false
+  if (!cachedSecret) {
+    const { data, error } = await supabase.rpc('get_push_dispatch_secret')
+    if (error || typeof data !== 'string' || data.length === 0) {
+      console.error('push_dispatch secret unavailable', error?.message ?? 'empty')
+      return false
+    }
+    cachedSecret = data
+  }
+  return timingSafeEqual(provided, cachedSecret)
+}
+
+const isQuietHour = (hour: number) => hour >= QUIET_HOUR_START || hour < QUIET_HOUR_END
+
+// Navigation data mirrors the {screen, params, url} contract shared with
+// sw.js and the Expo app; url is the web-only fallback.
+const buildNavigationData = (event: AgentEvent) => {
+  const payload = (event.payload ?? {}) as Record<string, unknown>
+  let screen = typeof payload.screen === 'string' ? payload.screen : null
+  if (!screen) {
+    screen = event.entity_type === 'approval_request' ? 'approval_detail' : 'home'
+  }
+  let params: Record<string, string> = {}
+  const rawParams = payload.params
+  if (rawParams && typeof rawParams === 'object' && !Array.isArray(rawParams)) {
+    for (const [key, value] of Object.entries(rawParams as Record<string, unknown>)) {
+      if (typeof value === 'string') params[key] = value
+    }
+  } else if (event.entity_id) {
+    params = { id: event.entity_id }
+  }
+  const url = typeof payload.url === 'string' ? payload.url : '/#/'
+  return { screen, params, url }
+}
+
+const disableToken = async (
+  supabase: ReturnType<typeof serviceClient>,
+  expoPushToken: string,
+) => {
+  const { error } = await supabase
+    .from('device_tokens')
+    .update({ enabled: false })
+    .eq('expo_push_token', expoPushToken)
+  if (error) console.error('device_tokens disable failed', error.message)
+}
+
+const skipEvent = async (
+  supabase: ReturnType<typeof serviceClient>,
+  event: AgentEvent,
+  reason: string,
+) => {
+  const { error } = await supabase.from('notification_events').insert({
+    user_id: event.user_id,
+    agent_event_id: event.id,
+    channel: 'expo_push',
+    status: 'skipped',
+    error_message: reason,
+  })
+  if (error) console.error('notification_events skip insert failed', error.message)
+  return json(200, { ok: true, result: 'skipped', reason })
+}
+
+const dispatchEvent = async (
+  supabase: ReturnType<typeof serviceClient>,
+  event: AgentEvent,
+) => {
+  // 幂等护栏：同一事件已有任何 expo_push 尝试记录（含 skipped）即不再处理，
+  // webhook 重放与 sweep 补调都安全。
+  const { data: existing, error: existingError } = await supabase
+    .from('notification_events')
+    .select('id')
+    .eq('agent_event_id', event.id)
+    .eq('channel', 'expo_push')
+    .limit(1)
+  if (existingError) return json(500, { error: 'idempotency check failed' })
+  if (existing && existing.length > 0) {
+    return json(200, { ok: true, result: 'already_dispatched' })
+  }
+
+  if (event.importance === 'low') {
+    return skipEvent(supabase, event, 'low importance')
+  }
+  if (event.importance !== 'urgent' && isQuietHour(getBeijingDate().hour)) {
+    return skipEvent(supabase, event, 'quiet hours')
+  }
+
+  const quota = await consumeQuota('push', event.user_id, PUSH_DAILY_LIMIT)
+  if (!quota.allowed) {
+    return skipEvent(supabase, event, 'daily push quota exceeded')
+  }
+
+  const { data: tokens, error: tokenError } = await supabase
+    .from('device_tokens')
+    .select('expo_push_token')
+    .eq('user_id', event.user_id)
+    .eq('enabled', true)
+    .in('platform', ['ios', 'android'])
+  if (tokenError) return json(500, { error: 'device_tokens read failed' })
+  if (!tokens || tokens.length === 0) {
+    return skipEvent(supabase, event, 'no enabled device')
+  }
+
+  const data = buildNavigationData(event)
+  const isApproval = event.entity_type === 'approval_request'
+  const highPriority = event.importance === 'high' || event.importance === 'urgent'
+
+  // 先落 queued 审计行再发送：函数中途失败也留有痕迹（清单 5.3 全记录）。
+  const { data: queued, error: queueError } = await supabase
+    .from('notification_events')
+    .insert(
+      tokens.map((token) => ({
+        user_id: event.user_id,
+        agent_event_id: event.id,
+        channel: 'expo_push',
+        status: 'queued',
+        target: token.expo_push_token,
+      })),
+    )
+    .select('id, target')
+  if (queueError || !queued) return json(500, { error: 'queue insert failed' })
+  const rowByToken = new Map(queued.map((row) => [row.target as string, row.id as string]))
+
+  const messages = tokens.map((token) => ({
+    to: token.expo_push_token,
+    title: event.title,
+    data,
+    sound: 'default',
+    priority: highPriority ? 'high' : 'default',
+    ...(isApproval ? { categoryId: 'approval' } : {}),
+  }))
+
+  let tickets: ExpoTicket[]
+  try {
+    const response = await fetch(EXPO_PUSH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(messages),
+    })
+    if (!response.ok) throw new Error(`expo push http ${response.status}`)
+    tickets = ((await response.json()).data ?? []) as ExpoTicket[]
+  } catch (caught) {
+    const message = caught instanceof Error ? caught.message : String(caught)
+    console.error('expo push send failed', message)
+    for (const row of queued) {
+      await supabase
+        .from('notification_events')
+        .update({ status: 'failed', error_message: `send failed: ${message}` })
+        .eq('id', row.id)
+    }
+    return json(502, { error: 'expo push send failed' })
+  }
+
+  let sent = 0
+  let failed = 0
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i].expo_push_token
+    const rowId = rowByToken.get(token)
+    if (!rowId) continue
+    const ticket = tickets[i]
+    if (ticket && ticket.status === 'ok') {
+      sent += 1
+      await supabase
+        .from('notification_events')
+        .update({
+          status: 'sent',
+          sent_at: new Date().toISOString(),
+          ticket_id: ticket.id ?? null,
+        })
+        .eq('id', rowId)
+    } else {
+      failed += 1
+      const detail = ticket?.details?.error ?? ''
+      await supabase
+        .from('notification_events')
+        .update({
+          status: 'failed',
+          error_message: `${ticket?.message ?? 'no ticket returned'}${detail ? ` (${detail})` : ''}`,
+        })
+        .eq('id', rowId)
+      if (detail === 'DeviceNotRegistered') await disableToken(supabase, token)
+    }
+  }
+
+  return json(200, { ok: true, result: 'dispatched', sent, failed })
+}
+
+const checkReceipts = async (supabase: ReturnType<typeof serviceClient>) => {
+  const sinceIso = new Date(Date.now() - RECEIPT_WINDOW_HOURS * 3600 * 1000).toISOString()
+  const { data: rows, error } = await supabase
+    .from('notification_events')
+    .select('id, ticket_id, target')
+    .eq('channel', 'expo_push')
+    .eq('status', 'sent')
+    .not('ticket_id', 'is', null)
+    .is('receipt_checked_at', null)
+    .gte('sent_at', sinceIso)
+    .limit(RECEIPT_BATCH_LIMIT)
+  if (error) return json(500, { error: 'receipt query failed' })
+  if (!rows || rows.length === 0) return json(200, { ok: true, checked: 0 })
+
+  let receipts: Record<string, { status: string; message?: string; details?: { error?: string } }>
+  try {
+    const response = await fetch(EXPO_RECEIPTS_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: rows.map((row) => row.ticket_id) }),
+    })
+    if (!response.ok) throw new Error(`expo receipts http ${response.status}`)
+    receipts = (await response.json()).data ?? {}
+  } catch (caught) {
+    console.error('expo receipts fetch failed', String(caught))
+    return json(502, { error: 'expo receipts fetch failed' })
+  }
+
+  const now = new Date().toISOString()
+  let confirmed = 0
+  let failedCount = 0
+  for (const row of rows) {
+    const receipt = receipts[row.ticket_id as string]
+    if (!receipt) continue // 回执尚未生成，下一轮再查
+    if (receipt.status === 'ok') {
+      confirmed += 1
+      await supabase
+        .from('notification_events')
+        .update({ receipt_checked_at: now })
+        .eq('id', row.id)
+    } else {
+      failedCount += 1
+      const detail = receipt.details?.error ?? ''
+      await supabase
+        .from('notification_events')
+        .update({
+          status: 'failed',
+          receipt_checked_at: now,
+          error_message: `receipt: ${receipt.message ?? 'error'}${detail ? ` (${detail})` : ''}`,
+        })
+        .eq('id', row.id)
+      if (detail === 'DeviceNotRegistered' && row.target) {
+        await disableToken(supabase, row.target as string)
+      }
+    }
+  }
+  return json(200, { ok: true, checked: rows.length, confirmed, failed: failedCount })
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'POST') return json(405, { error: 'method not allowed' })
+
+  const supabase = serviceClient()
+  if (!(await verifyDispatchSecret(req, supabase))) {
+    return json(401, { error: 'unauthorized' })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return json(400, { error: 'bad request' })
+  }
+
+  if (body.action === 'check_receipts') return checkReceipts(supabase)
+
+  let event: AgentEvent | null = null
+  if (body.record && typeof body.record === 'object' && !Array.isArray(body.record)) {
+    event = body.record as AgentEvent
+  } else if (typeof body.agent_event_id === 'number') {
+    // Mac mini sweep 补调路径：按 id 回读事件（幂等由 dispatchEvent 护栏保证）。
+    const { data, error } = await supabase
+      .from('agent_events')
+      .select('*')
+      .eq('id', body.agent_event_id)
+      .maybeSingle()
+    if (error) return json(500, { error: 'event read failed' })
+    if (data) event = data as AgentEvent
+  }
+
+  if (!event || typeof event.id !== 'number' || typeof event.user_id !== 'string') {
+    return json(400, { error: 'missing agent event' })
+  }
+  return dispatchEvent(supabase, event)
+})

--- a/supabase/migrations/20260712064810_v4_phase1_push_notification_tables.sql
+++ b/supabase/migrations/20260712064810_v4_phase1_push_notification_tables.sql
@@ -1,0 +1,98 @@
+-- ============================================================
+-- V4.0 Phase 1 · 推送通知闭环：device_tokens / agent_events / notification_events
+-- 依据：v4-expo-native-app-plan.md 附录 A（2026-07-11 第四审定稿版）之 Phase 1 范围；
+--       approval_requests / agent_heartbeats / respond_to_approval RPC 属 Phase 2，不在本迁移。
+-- 规范：docs/security-boundary.md（2026-07-06）加表守则——
+--       出生即 RLS、零 anon 策略、authenticated 统一 (select auth.uid()) = user_id 谓词。
+--       service_role 天然 bypassrls，不为其建策略。
+-- ============================================================
+
+-- 1. device_tokens：原生推送 token + 设备注册（与 push_subscriptions 的边界见主方案 6.2 裁定）
+create table public.device_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+  platform text not null check (platform in ('ios','android','web')),
+  device_name text,
+  expo_push_token text not null,
+  native_push_token text,
+  app_version text,
+  enabled boolean not null default true,
+  last_seen_at timestamptz,
+  created_at timestamptz not null default now(),
+  unique (user_id, expo_push_token)
+);
+
+comment on table public.device_tokens is
+  '原生推送地址 + 设备注册表（V4.0 新建）。Web Push 订阅继续走 push_subscriptions，V4.1+ 再评估统一。';
+comment on column public.device_tokens.platform is
+  'V4.0 只写 ios/android；web 仅为未来统一设备表预留，V4.0 不写 web 行。';
+
+alter table public.device_tokens enable row level security;
+
+create policy device_tokens_select_own on public.device_tokens
+  for select to authenticated using (user_id = (select auth.uid()));
+create policy device_tokens_insert_own on public.device_tokens
+  for insert to authenticated with check (user_id = (select auth.uid()));
+create policy device_tokens_update_own on public.device_tokens
+  for update to authenticated using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+create policy device_tokens_delete_own on public.device_tokens
+  for delete to authenticated using (user_id = (select auth.uid()));
+
+-- 2. agent_events：多端事件流（事实日志，仅追加；bigint 自增 id 供 last_seen_event_id 补账）
+create table public.agent_events (
+  id bigint generated always as identity primary key,
+  user_id uuid not null references auth.users(id),
+  actor text not null,
+  event_type text not null,
+  entity_type text,
+  entity_id uuid,
+  title text not null,
+  payload jsonb not null default '{}'::jsonb,
+  importance text not null default 'normal'
+    check (importance in ('low','normal','high','urgent')),
+  created_at timestamptz not null default now()
+);
+
+comment on table public.agent_events is
+  '多端事件流（事实日志）。V4.0 仅追加不删除，归档/保留策略 V4.1 议定；任何端写入即可能触发 push-dispatch 推送。';
+
+create index agent_events_user_created_idx on public.agent_events (user_id, id desc);
+
+alter table public.agent_events enable row level security;
+
+create policy agent_events_select_own on public.agent_events
+  for select to authenticated using (user_id = (select auth.uid()));
+create policy agent_events_insert_own on public.agent_events
+  for insert to authenticated with check (user_id = (select auth.uid()));
+-- 事实日志：不建 authenticated UPDATE/DELETE 策略；Agent 侧写入走 service_role。
+
+-- 3. notification_events：通知尝试审计日志（queued/sent/failed/skipped 全记录）
+create table public.notification_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+  agent_event_id bigint references public.agent_events(id),
+  channel text not null check (channel in ('expo_push','wechat_bridge','email','local')),
+  status text not null default 'queued'
+    check (status in ('queued','sent','failed','skipped')),
+  target text,
+  error_message text,
+  sent_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+comment on table public.notification_events is
+  '通知尝试审计日志。客户端只读；写入全部由 service_role（push-dispatch / Mac mini 对账 sweep）完成。';
+
+-- 对账 sweep 按 agent_event_id 反查漏发；FK 覆盖索引沿用 2026-07-06 惯例
+create index notification_events_agent_event_idx on public.notification_events (agent_event_id);
+create index notification_events_user_created_idx on public.notification_events (user_id, created_at desc);
+
+alter table public.notification_events enable row level security;
+
+create policy notification_events_select_own on public.notification_events
+  for select to authenticated using (user_id = (select auth.uid()));
+-- 只读给 authenticated；无 INSERT/UPDATE/DELETE 策略。
+
+-- 4. Realtime：App 前台 postgres_changes 订阅 agent_events（approval_requests 随 Phase 2 加入）
+alter publication supabase_realtime add table public.agent_events;

--- a/supabase/migrations/20260712073230_v4_phase1_push_dispatch_webhook.sql
+++ b/supabase/migrations/20260712073230_v4_phase1_push_dispatch_webhook.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- V4.0 Phase 1 · 5.3 push-dispatch 发送侧：
+-- notification_events receipts 回查列 + pg_net + agent_events AFTER INSERT webhook
+-- 密钥策略：webhook 密钥存 Vault（push_dispatch_secret），迁移文件零密钥内容。
+-- ============================================================
+
+-- 1. notification_events 增补 Expo ticket 关联与 receipts 回查标记（清单 5.3）
+alter table public.notification_events add column ticket_id text;
+alter table public.notification_events add column receipt_checked_at timestamptz;
+
+comment on column public.notification_events.ticket_id is
+  'Expo push ticket id，供 receipts 回查（清单 5.3）；仅 status=sent 行有值。';
+comment on column public.notification_events.receipt_checked_at is
+  'receipts 回查完成时间；null = 已发送但尚未回查。';
+
+-- 回查扫描专用部分索引：只覆盖「已发送未回查」的窄集合
+create index notification_events_receipt_pending_idx
+  on public.notification_events (sent_at)
+  where status = 'sent' and receipt_checked_at is null;
+
+-- 2. pg_net：Database Webhook 所需（首次启用）
+create extension if not exists pg_net;
+
+-- 3. agent_events AFTER INSERT → push-dispatch Edge Function
+--    密钥运行时从 Vault 读取；事件写入不因通知链路失败而回滚，
+--    漏发由 Mac mini 对账 sweep 幂等补调（清单 5.3）。
+create or replace function public.notify_push_dispatch()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_secret text;
+begin
+  select decrypted_secret into v_secret
+    from vault.decrypted_secrets
+   where name = 'push_dispatch_secret'
+   limit 1;
+  if v_secret is null then
+    raise warning 'notify_push_dispatch: vault secret push_dispatch_secret missing, skip';
+    return new;
+  end if;
+  perform net.http_post(
+    url := 'https://crfhiumxzmaszkapanrb.supabase.co/functions/v1/push-dispatch',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-push-dispatch-secret', v_secret
+    ),
+    body := jsonb_build_object('record', to_jsonb(new)),
+    timeout_milliseconds := 5000
+  );
+  return new;
+exception
+  when others then
+    raise warning 'notify_push_dispatch failed: %', sqlerrm;
+    return new;
+end;
+$$;
+
+revoke all on function public.notify_push_dispatch() from public;
+
+create trigger agent_events_push_dispatch
+  after insert on public.agent_events
+  for each row
+  execute function public.notify_push_dispatch();
+
+-- 4. push-dispatch 函数侧密钥读取通道：service_role 专属 RPC。
+--    密钥唯一存 Vault，函数运行时读取比对（timing-safe），轮换只改 Vault 一处；
+--    Mac mini sweep 亦经此 RPC 取密钥后调用函数。零 anon / 零 authenticated。
+create or replace function public.get_push_dispatch_secret()
+returns text
+language sql
+security definer
+set search_path = ''
+as $$
+  select decrypted_secret
+    from vault.decrypted_secrets
+   where name = 'push_dispatch_secret'
+   limit 1;
+$$;
+
+revoke all on function public.get_push_dispatch_secret() from public, anon, authenticated;
+grant execute on function public.get_push_dispatch_secret() to service_role;


### PR DESCRIPTION
## 变更（两个提交）

**7ba1c6b · 三表 migration**（`20260712064810`）：`device_tokens` / `agent_events` / `notification_events`，出生即 RLS、零 anon、owner 子查询谓词；agent_events 进 supabase_realtime publication；事实日志无客户端 UPDATE/DELETE。已 apply 生产库，advisors 零新增告警。

**d5f5c78 · push-dispatch 发送侧**（`20260712073230` + 新函数）：
- `push-dispatch` Edge Function：共享密钥 header 鉴权（模式 C，fail-closed 401）；**密钥唯一存 Vault `push_dispatch_secret`**，函数经 service_role 专属 RPC `get_push_dispatch_secret` 读取后 timing-safe 比对——轮换只改 Vault 一处，webhook 触发器与函数自动同步
- importance 路由：low 不推；normal/high/urgent 即推；北京时区静默时段 23:00–08:00（urgent 豁免）；normal 合并/摘要推送按裁定留 V4.1
- `consume_usage_quota('push')` 护栏 200/天（fail-open 成本刹车）
- queued → sent/failed 全量审计写 `notification_events`（skipped 含原因）；Expo tickets 落库（新列 `ticket_id`）；receipts 回查（新列 `receipt_checked_at` + 部分索引）；`DeviceNotRegistered` 自动禁用 token
- pg_net 首次启用；`agent_events` AFTER INSERT 触发器（SECURITY DEFINER，异常不回滚事件写入，漏发由 Mac mini sweep 幂等补调——sweep 接口已备好：POST `{agent_event_id}`）
- `config.toml` 登记 verify_jwt=false；`docs/security-boundary.md` 鉴权矩阵新增 push-dispatch 行

## 验证证据

- 两个 migration 均先经生产库 BEGIN…ROLLBACK 全量演练（含**事务内插入测试事件实测触发器往 pg_net 队列排入请求**）再正式 apply
- 函数已部署生产（CLI 2.107.0，含 _shared 依赖）
- **端到端实测通过（2026-07-12）**：agent_events 写入 → webhook 200 → Expo `sent:1, failed:0` → ticket 落库 → **iPhone 真机横幅到达，全程 3 秒**
- 密钥 RPC 权限实测：service_role ✓ / authenticated ✗ / anon ✗

## 遗留

- deploy-edge-functions.yml 的 CLI 版本钉死（latest → 2.107.0）被 gh OAuth 缺 workflow scope 挡住，待 `gh auth refresh -s workflow` 后单独提交
- Mac mini 对账 sweep 属 mini-agent 侧施工，接口与幂等护栏已就绪
- Watch 镜像与响应矩阵随 5.4 真机日实测

## 回滚方式

```sql
drop trigger agent_events_push_dispatch on public.agent_events;
drop function public.notify_push_dispatch();
drop function public.get_push_dispatch_secret();
alter table public.notification_events drop column ticket_id, drop column receipt_checked_at;
```
函数下线：Dashboard 删除 push-dispatch；Vault 密钥可随时轮换/删除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)