### PR TITLE
ci: 固定 Supabase CLI 版本为 2.107.0

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.107.0
 
       - name: Link Supabase project
         run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.107.0
 
       - name: Link Supabase project
         env:


### PR DESCRIPTION
## 变更

两个部署工作流的 `supabase/setup-cli` 从 `version: latest` 钉为 `version: 2.107.0`（与本机施工基线一致）：

- `deploy-edge-functions.yml`（Phase 1 挡在 gh OAuth 缺 workflow scope 的补推项）
- `deploy-supabase-functions.yml`（同类漂移风险，顺手同批钉版）

## 验证

- 本机 `supabase` CLI 即 2.107.0，7-12 全天 push-dispatch 部署/迁移均以此版本完成。
- 纯 CI 配置变更，不触碰函数与库。

## 风险与回滚

- 风险：无新增；钉版本身是为了消除 latest 漂移风险。
- 回滚：还原两行 `version: latest` 即可。
- 后续升级 CLI 时：本机先验证新版本 → 同步改此处版本号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)