### PR TITLE
V4 Phase 2 · 审批执行回流表 approval_executions

### DIFF
--- a/supabase/migrations/20260713125852_v4_phase2_approval_executions.sql
+++ b/supabase/migrations/20260713125852_v4_phase2_approval_executions.sql
@@ -1,0 +1,41 @@
+-- V4 Phase 2 · 审批执行回流表 approval_executions
+-- 依据：开发清单 §6「Mac mini 新增审批监听器，复用 claimed/idempotency 防重范式」。
+-- claim 即 INSERT：unique(approval_id) 保证同一审批只被一个执行器认领一次；
+-- 状态与结果由执行方（service_role）维护，客户端只读（authenticated 仅 SELECT own）。
+
+create table public.approval_executions (
+  id uuid primary key default gen_random_uuid(),
+  approval_id uuid not null unique references public.approval_requests(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  executor text not null,
+  status text not null default 'claimed'
+    check (status in ('claimed', 'running', 'succeeded', 'failed', 'stale_skipped')),
+  claimed_at timestamptz not null default now(),
+  started_at timestamptz,
+  finished_at timestamptz,
+  exit_code integer,
+  output_excerpt text,
+  error_message text
+);
+
+comment on table public.approval_executions is
+  '审批执行回流（V4 Phase 2）：监听器 claim 即插入，unique(approval_id) 防止同一审批执行两次；写入全走 service_role，客户端只读。';
+comment on column public.approval_executions.executor is
+  '执行方标识（如 mac_mini），多执行器时用于排查归属。';
+comment on column public.approval_executions.status is
+  'claimed → running → succeeded/failed；stale_skipped = 批准时间超出新鲜窗口，认领后跳过执行。';
+comment on column public.approval_executions.output_excerpt is
+  '执行输出摘录（截断），不含敏感密钥；完整输出留在执行方本地日志。';
+
+alter table public.approval_executions enable row level security;
+
+create policy "approval_executions_select_own"
+  on public.approval_executions
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+-- 事实回流表：不为 authenticated 开 INSERT/UPDATE/DELETE，写入全走 service_role。
+
+create index approval_executions_user_claimed_at_idx
+  on public.approval_executions (user_id, claimed_at desc);


### PR DESCRIPTION
## 变更

新增 migration `20260713125852_v4_phase2_approval_executions.sql`（**已 apply 生产库**，本 PR 为仓库存档）：

- 新表 `approval_executions`：Mac mini 审批监听器的 claim 防重 + 执行结果回流表
- **claim 即 INSERT**：`unique(approval_id)` 保证同一审批只被认领/执行一次（清单 §6「复用 claimed/idempotency 防重范式」）
- 状态机：`claimed → running → succeeded/failed`；另有 `stale_skipped`（批准时间超出新鲜窗口，认领后跳过执行，防止监听器宕机后补执行陈旧命令）
- RLS：authenticated 仅 SELECT own（App 后续可展示执行结果）；**不开放任何客户端写入**，写入全走 service_role；零 anon
- 索引：`(user_id, claimed_at desc)`；`approval_id` 唯一约束自带索引

## 验证证据

- 生产库 `BEGIN…ROLLBACK` 全量事务演练：DDL 全部执行 + DO 块断言（RLS 开启 / 恰好 1 条策略 / 零 anon / unique 约束在 / status check 在）→ 回滚零残留，随后经 MCP `apply_migration` 正式应用
- advisors 复核：安全侧**零新增告警**（存量均为历史遗留）；性能侧仅新索引 unused INFO（新表出生预期，同既有惯例观察）

## 风险

- 低：纯新增表，不触碰任何现有表/策略/函数；App 与 Edge Functions 均未引用

## 回滚方式

```sql
drop table public.approval_executions;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)