### PR TITLE
V4 Phase 2 · approval_executions 加入 Realtime publication

### DIFF
--- a/supabase/migrations/20260713134547_v4_phase2_approval_executions_realtime.sql
+++ b/supabase/migrations/20260713134547_v4_phase2_approval_executions_realtime.sql
@@ -1,0 +1,4 @@
+-- V4 Phase 2 · approval_executions 加入 Realtime publication
+-- App 审批详情页需要实时看到执行状态翻转（claimed → running → succeeded/failed）；
+-- postgres_changes 走 WAL RLS，authenticated 仅能收到本人行（owner SELECT 策略）。
+alter publication supabase_realtime add table public.approval_executions;


### PR DESCRIPTION
## 变更

一行 migration（**已 apply 生产库**，本 PR 为仓库存档）：`approval_executions` 加入 `supabase_realtime` publication，App 审批详情页可实时看到执行状态翻转（claimed → running → succeeded/failed）。

## 验证证据

- 生产库 `BEGIN…ROLLBACK` 演练：publication 登记断言通过 → 回滚零残留 → MCP apply。
- 安全边界不变：postgres_changes 走 WAL RLS，authenticated 仅能收到本人行（owner SELECT 策略），零 anon。

## 风险 / 回滚

低（纯 publication 登记）。回滚：`alter publication supabase_realtime drop table public.approval_executions;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)