### PR TITLE
security: migrate edge functions to scoped secret keys

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -11,10 +11,10 @@
 # `/auth/v1/user` with the caller's Authorization/apikey headers and return
 # 401 on failure, so this is not a security regression for them.
 #
-# Functions that run with SUPABASE_SERVICE_ROLE_KEY (signal-bus-consumer)
-# never performed user-JWT verification — they rely on being invoked only
-# from trusted callers (cron jobs, other Edge Functions) that hold the
-# service-role key. Their exposure profile is unchanged by this setting.
+# Machine-only Functions use dedicated shared-secret headers. Functions that
+# need privileged database access read the named edge_functions_20260715 key
+# from SUPABASE_SECRET_KEYS; the legacy service-role Bearer token is not an
+# accepted request credential.
 project_id = "crfhiumxzmaszkapanrb"
 
 [functions.hamster-mcp]

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,8 +1,7 @@
 // Shared fail-closed auth helpers for Edge Functions.
 //
 // Accepted credentials:
-//   1. the project service-role key (timing-safe exact match) — cron jobs,
-//      the Mac-mini agent, and function-to-function calls;
+//   1. a configured sb_secret_ key in the apikey header — machine callers;
 //   2. a real user JWT, re-verified against GoTrue via /auth/v1/user — the
 //      web frontend. The gateway cannot verify ES256 tokens (see
 //      supabase/config.toml), so functions must re-verify here.
@@ -10,6 +9,8 @@
 // The public anon key is NOT an accepted credential: it ships inside the
 // frontend bundle and must be treated as a public constant. GoTrue rejects
 // it at /auth/v1/user because it carries no user claims.
+
+import { isConfiguredSupabaseSecretKey } from './supabase_secret.ts'
 
 export const timingSafeEqual = (a: string, b: string): boolean => {
   const encoder = new TextEncoder()
@@ -28,12 +29,6 @@ export const getBearerToken = (req: Request): string | null => {
   return token.length > 0 ? token : null
 }
 
-export const isServiceRoleKey = (token: string): boolean => {
-  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')?.trim()
-  if (!serviceKey) return false
-  return timingSafeEqual(token, serviceKey)
-}
-
 export const isVerifiedUserJwt = async (req: Request): Promise<boolean> => {
   const authHeader = req.headers.get('authorization')
   if (!authHeader) return false
@@ -49,11 +44,14 @@ export const isVerifiedUserJwt = async (req: Request): Promise<boolean> => {
   }
 }
 
-// Service-role key or verified user JWT. No pattern-matching shortcuts.
+// Configured secret API key or verified user JWT. Secret keys are checked
+// against SUPABASE_SECRET_KEYS, never by prefix alone.
 export const verifyAuth = async (req: Request): Promise<boolean> => {
+  const apiKey = req.headers.get('apikey')?.trim()
+  if (apiKey && isConfiguredSupabaseSecretKey(apiKey)) return true
+
   const token = getBearerToken(req)
   if (!token) return false
-  if (isServiceRoleKey(token)) return true
   return await isVerifiedUserJwt(req)
 }
 

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -3,13 +3,14 @@ import { McpServer } from 'npm:@modelcontextprotocol/sdk@1.25.3/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from 'npm:@modelcontextprotocol/sdk@1.25.3/server/webStandardStreamableHttp.js'
 import { Hono } from 'npm:hono@^4.9.7'
 import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { getSupabaseAdminKey } from './supabase_secret.ts'
 
 export const MCP_VERSION = '5.6.0'
 export const USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'
 
 export const supabase = createClient(
   Deno.env.get('SUPABASE_URL')!,
-  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  getSupabaseAdminKey(),
 )
 
 const allowedOrigins = ['https://chuan-101.github.io', /^http:\/\/localhost:\d+$/]

--- a/supabase/functions/_shared/quota.ts
+++ b/supabase/functions/_shared/quota.ts
@@ -7,6 +7,7 @@
 // brick chat or letters. Auth must already have been enforced by then.
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { getSupabaseAdminKey } from './supabase_secret.ts'
 
 export const consumeQuota = async (
   scope: string,
@@ -16,7 +17,7 @@ export const consumeQuota = async (
   try {
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+      getSupabaseAdminKey(),
     )
     const { data, error } = await supabase.rpc('consume_usage_quota', {
       p_user_id: userId,

--- a/supabase/functions/_shared/supabase_secret.ts
+++ b/supabase/functions/_shared/supabase_secret.ts
@@ -1,0 +1,56 @@
+const ADMIN_SECRET_KEY_NAME = 'edge_functions_20260715'
+
+const timingSafeEqual = (left: string, right: string): boolean => {
+  const encoder = new TextEncoder()
+  const leftBytes = encoder.encode(left)
+  const rightBytes = encoder.encode(right)
+  if (leftBytes.length !== rightBytes.length) return false
+
+  let diff = 0
+  for (let index = 0; index < leftBytes.length; index += 1) {
+    diff |= leftBytes[index] ^ rightBytes[index]
+  }
+  return diff === 0
+}
+
+const readSecretKeys = (): Record<string, string> => {
+  const raw = Deno.env.get('SUPABASE_SECRET_KEYS')?.trim()
+  if (!raw) throw new Error('SUPABASE_SECRET_KEYS is not configured')
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error('SUPABASE_SECRET_KEYS is not valid JSON')
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('SUPABASE_SECRET_KEYS must be a JSON object')
+  }
+
+  return Object.fromEntries(
+    Object.entries(parsed as Record<string, unknown>)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      .map(([name, value]) => [name, value.trim()])
+      .filter(([, value]) => value.length > 0),
+  )
+}
+
+export const getSupabaseAdminKey = (): string => {
+  const key = readSecretKeys()[ADMIN_SECRET_KEY_NAME]
+  if (!key || !key.startsWith('sb_secret_')) {
+    throw new Error(`Supabase secret key ${ADMIN_SECRET_KEY_NAME} is not configured`)
+  }
+  return key
+}
+
+export const isConfiguredSupabaseSecretKey = (candidate: string): boolean => {
+  const normalized = candidate.trim()
+  if (!normalized.startsWith('sb_secret_')) return false
+
+  try {
+    return Object.values(readSecretKeys()).some((key) => timingSafeEqual(normalized, key))
+  } catch {
+    return false
+  }
+}

--- a/supabase/functions/device-report/index.ts
+++ b/supabase/functions/device-report/index.ts
@@ -11,6 +11,7 @@
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { verifySharedSecret } from '../_shared/auth.ts'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 const USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'
 
@@ -73,7 +74,7 @@ Deno.serve(async (req: Request) => {
 
   const supabase = createClient(
     Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    getSupabaseAdminKey(),
   )
 
   const { error } = await supabase.from('device_status').insert(row)

--- a/supabase/functions/letter-check/index.ts
+++ b/supabase/functions/letter-check/index.ts
@@ -6,10 +6,11 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { verifyAuth } from '../_shared/auth.ts'
 import { getBeijingDate } from '../_shared/time.ts'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 const buildServiceClient = () => {
   const url = Deno.env.get('SUPABASE_URL')!
-  const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const key = getSupabaseAdminKey()
   return createClient(url, key)
 }
 
@@ -23,12 +24,12 @@ const isInActiveHours = (currentHour: number, start: number, end: number): boole
 
 const callLetterGenerate = async (userId: string, triggerType: string, triggerReason: string) => {
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const serviceKey = getSupabaseAdminKey()
 
   const resp = await fetch(`${supabaseUrl}/functions/v1/letter-generate`, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${serviceKey}`,
+      apikey: serviceKey,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({

--- a/supabase/functions/letter-generate/index.ts
+++ b/supabase/functions/letter-generate/index.ts
@@ -8,10 +8,11 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { verifyAuth } from '../_shared/auth.ts'
 import { getBeijingTimeString } from '../_shared/time.ts'
 import { consumeQuota, quotaExceededResponse } from '../_shared/quota.ts'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 const buildServiceClient = () => {
   const url = Deno.env.get('SUPABASE_URL')!
-  const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const key = getSupabaseAdminKey()
   return createClient(url, key)
 }
 

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -1,6 +1,7 @@
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { consumeQuota } from '../_shared/quota.ts'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 const DAILY_QUOTA = 1000
 
@@ -557,12 +558,11 @@ const fetchConversationMessages = async (
 
 const buildSupabaseServiceRoleClient = () => {
   const supabaseUrl = Deno.env.get('SUPABASE_URL')
-  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-  if (!supabaseUrl || !serviceRoleKey) {
-    throw new Error('Supabase env missing for service-role compression cache')
+  if (!supabaseUrl) {
+    throw new Error('Supabase URL missing for compression cache')
   }
 
-  return createClient(supabaseUrl, serviceRoleKey)
+  return createClient(supabaseUrl, getSupabaseAdminKey())
 }
 
 const resolveActiveProviderConfig = async (userId: string): Promise<RuntimeProviderConfig | null> => {

--- a/supabase/functions/openrouter-models/index.ts
+++ b/supabase/functions/openrouter-models/index.ts
@@ -1,5 +1,6 @@
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -98,9 +99,8 @@ serve(async (req) => {
   let providerRow: ProviderConfig | null = null
   try {
     const supabaseUrl = Deno.env.get('SUPABASE_URL')
-    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-    if (supabaseUrl && serviceRoleKey && userId) {
-      const admin = createClient(supabaseUrl, serviceRoleKey)
+    if (supabaseUrl && userId) {
+      const admin = createClient(supabaseUrl, getSupabaseAdminKey())
       let query = admin
         .from('llm_providers')
         .select('id,name,base_url,secret_name,active')

--- a/supabase/functions/push-dispatch/index.ts
+++ b/supabase/functions/push-dispatch/index.ts
@@ -23,6 +23,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { timingSafeEqual } from '../_shared/auth.ts'
 import { consumeQuota } from '../_shared/quota.ts'
 import { getBeijingDate } from '../_shared/time.ts'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 const PUSH_DAILY_LIMIT = 200
 const QUIET_HOUR_START = 23 // 北京时区静默时段 [23:00, 08:00)，urgent 豁免
@@ -59,7 +60,7 @@ const json = (status: number, body: Record<string, unknown>) =>
   })
 
 const serviceClient = () =>
-  createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+  createClient(Deno.env.get('SUPABASE_URL')!, getSupabaseAdminKey())
 
 // 期望密钥只存 Vault；经 service_role 专属 RPC 读取，进程内缓存。
 let cachedSecret: string | null = null

--- a/supabase/functions/signal-bus-consumer/index.ts
+++ b/supabase/functions/signal-bus-consumer/index.ts
@@ -1,5 +1,6 @@
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 type SignalStatus = 'pending' | 'processing' | 'processed' | 'failed' | 'expired'
 type SignalType = 'sleep_alert' | 'hydration_boost' | 'calendar_aware' | 'mood_check' | 'custom'
@@ -331,11 +332,11 @@ serve(async (req) => {
   }
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL')
-  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+  const serviceRoleKey = getSupabaseAdminKey()
   const wechatWebhookUrl = Deno.env.get('CYBERBOSS_WECHAT_WEBHOOK_URL')
 
-  if (!supabaseUrl || !serviceRoleKey) {
-    return jsonResponse({ error: 'Supabase service role env is missing' }, 500, origin)
+  if (!supabaseUrl) {
+    return jsonResponse({ error: 'Supabase URL env is missing' }, 500, origin)
   }
 
   const payload = ((await req.json().catch(() => ({}))) ?? {}) as ConsumePayload

--- a/supabase/functions/wechat-reply/index.ts
+++ b/supabase/functions/wechat-reply/index.ts
@@ -2,10 +2,11 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { verifyAuth } from '../_shared/auth.ts'
 import { getBeijingTimeString, formatBeijingClock } from '../_shared/time.ts'
 import { consumeQuota, quotaExceededResponse } from '../_shared/quota.ts'
+import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
 
 const buildServiceClient = () => {
   const url = Deno.env.get('SUPABASE_URL')!
-  const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const key = getSupabaseAdminKey()
   return createClient(url, key)
 }
 
@@ -39,7 +40,7 @@ Deno.serve(async (req: Request) => {
       status: 204,
       headers: {
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'authorization, content-type',
+        'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
       },
     })


### PR DESCRIPTION
## Summary
- read Edge Function admin credentials from the named edge_functions_20260715 key in SUPABASE_SECRET_KEYS
- allow machine callers via configured secret keys in apikey, while keeping verified user JWT auth
- remove legacy service-role Bearer acceptance
- migrate function-to-function and admin clients off SUPABASE_SERVICE_ROLE_KEY

## Validation
- Mini REST and supabase-js read/write/delete smoke tests passed
- Mini restarted with the new key; Realtime resubscribed and WeChat worker ready
- five MCP legal calls passed; unauthorized calls returned 401
- TTS and WeChat new-key auth reached expected 400 validation; the old legacy key returned 401
- signal-bus shared-secret call returned 200 with fetched=0
- all nine unauthenticated Edge Function checks returned 401
- remote function sources matched GitHub HEAD before deployment
- targeted ESLint and git diff --check passed

## Existing check note
The full npm run check remains blocked by a pre-existing no-extra-boolean-cast error in supabase/functions/hamster-mcp/index.ts plus five existing React warnings; the changed TypeScript files pass targeted ESLint.