### PR TITLE
security: remove legacy anon key fallbacks

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -32,7 +32,7 @@ export const getBearerToken = (req: Request): string | null => {
 export const isVerifiedUserJwt = async (req: Request): Promise<boolean> => {
   const authHeader = req.headers.get('authorization')
   if (!authHeader) return false
-  const apikey = req.headers.get('apikey') ?? Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+  const apikey = req.headers.get('apikey')?.trim() ?? ''
   if (!apikey) return false
   try {
     const authResponse = await fetch(`${Deno.env.get('SUPABASE_URL')}/auth/v1/user`, {

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -45,7 +45,7 @@ const isAuthorizedRequest = async (req: Request): Promise<boolean> => {
 
   const authHeader = req.headers.get('authorization')
   if (!authHeader) return false
-  const apikey = req.headers.get('apikey') ?? Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+  const apikey = req.headers.get('apikey')?.trim() ?? ''
   if (!apikey) return false
   try {
     const authResponse = await fetch(`${Deno.env.get('SUPABASE_URL')}/auth/v1/user`, {

--- a/supabase/functions/memory-extract/index.ts
+++ b/supabase/functions/memory-extract/index.ts
@@ -274,8 +274,7 @@ serve(async (req) => {
     }
 
     const supabaseUrl = Deno.env.get('SUPABASE_URL')
-    const anonKey = Deno.env.get('SUPABASE_ANON_KEY')
-    if (!supabaseUrl || !anonKey) {
+    if (!supabaseUrl) {
       return jsonResponse({ error: 'Supabase 环境变量未配置' }, 500)
     }
 
@@ -285,7 +284,7 @@ serve(async (req) => {
       return jsonResponse({ error: '缺少身份令牌' }, 401)
     }
 
-    const supabase = createClient(supabaseUrl, anonKey, {
+    const supabase = createClient(supabaseUrl, apikey, {
       global: {
         headers: {
           Authorization: authHeader,


### PR DESCRIPTION
## What changed

- require callers to provide an explicit `apikey` when validating user JWTs
- remove the implicit `SUPABASE_ANON_KEY` fallback from the shared MCP/auth paths
- initialize `memory-extract` with the caller-provided publishable key

## Why

Supabase disables legacy `anon` and `service_role` API keys together. The shared auth helpers and `memory-extract` still referenced the legacy anon environment variable, which could break user authentication after the legacy-key switch was turned off.

## Validation

- targeted ESLint and `git diff --check` passed
- deployed the five MCP functions, four user-auth functions, and `memory-extract`
- all five MCP `initialize` calls passed; unauthenticated calls returned 401
- new secret-key Data API write/read/delete smoke test passed and the test row was removed
- Mini remained running with Realtime `SUBSCRIBED` and the WeChat worker ready
- legacy anon and service-role values now return 401 when used as `apikey`

## Operational note

Disabling legacy API keys does not revoke the old JWT as a Bearer token. Full revocation requires a separate JWT signing-key migration and is intentionally outside this patch.
