### PR TITLE
feat: 议事厅调度台升级——executor 指派 / category 分类 / report 回执闭环

### DIFF
--- a/src/pages/AgentCouncilPage.css
+++ b/src/pages/AgentCouncilPage.css
@@ -55,12 +55,59 @@
 .status-rejected { background:#ffe9ec; color:#b13f4d; }
 .status-deferred { background:#fff4e0; color:#9a6a1f; }
 .status-plan { background:#e9f0ff; color:#3f5fb1; }
+.status-done { background:#e3f2e9; color:#1f6b40; }
+.status-failed { background:#ffe4e8; color:#a3273a; }
 .status-decision { background:#fbeafd; color:#8a3f9c; }
 .vote-tag { border-radius:999px; padding:2px 8px; font-size:11px; font-weight:600; }
 .vote-support { background:#e7f7ec; color:#2f8a52; }
 .vote-neutral { background:#eef2f7; color:#5a6675; }
 .vote-against { background:#ffe9ec; color:#b13f4d; }
 .meta-chip { border-radius:999px; padding:2px 8px; font-size:11px; background:#fff2f8; border:1px solid rgba(255,214,231,.7); color:#8a6b7d; }
+.category-tag { border-radius:999px; padding:2px 8px; font-size:11px; font-weight:600; background:#f4effc; border:1px solid rgba(210,190,240,.7); color:#6b4fa3; }
+.executor-tag { border-radius:999px; padding:2px 8px; font-size:11px; font-weight:600; background:#eef7f2; border:1px solid rgba(150,214,180,.7); color:#2f7a56; }
+
+/* 两维筛选：状态分组 × 分类 */
+.council-filters { display:grid; gap:6px; }
+.filter-row { display:flex; flex-wrap:wrap; gap:6px; }
+.filter-chip { border-radius:999px; border:1px solid rgba(255,214,231,.8); background:#fff; color:#8a6b7d; padding:5px 12px; font-size:12px; cursor:pointer; }
+.filter-chip.active { border-color:#f29cc3; background:linear-gradient(180deg,#ffdeec 0%,#ffcfe5 100%); color:#9c3f69; font-weight:600; }
+.filter-chip--category { border-color:rgba(210,190,240,.6); }
+.filter-chip--category.active { border-color:#b79ae0; background:linear-gradient(180deg,#f0e8fc 0%,#e6d9f8 100%); color:#6b4fa3; }
+
+/* 执行回执 */
+.report-item { background:#f5faf7; border-color:rgba(170,220,190,.6); }
+.report-tag { border-radius:999px; padding:2px 8px; font-size:11px; font-weight:600; }
+.report-succeeded { background:#e3f2e9; color:#1f6b40; }
+.report-partial { background:#fff4e0; color:#9a6a1f; }
+.report-failed { background:#ffe4e8; color:#a3273a; }
+.report-extras { display:grid; gap:4px; margin-top:8px; font-size:12px; }
+.report-extras__label { font-weight:600; color:#68485e; font-size:11px; }
+.report-extras ul { margin:0; padding-left:18px; display:grid; gap:2px; color:#5f4b57; }
+.report-extras a { color:#3f5fb1; word-break:break-all; }
+.report-form { border-top:1px dashed rgba(170,220,190,.8); padding-top:10px; }
+
+/* 密集文本：Markdown 渲染 + 长文折叠 */
+.council-markdown { display:grid; gap:6px; }
+.council-markdown__body { font-size:13.5px; line-height:1.75; color:#3b3340; word-break:break-word; }
+.council-markdown__body > :first-child { margin-top:0; }
+.council-markdown__body > :last-child { margin-bottom:0; }
+.council-markdown__body p { margin:0 0 .65em; }
+.council-markdown__body h1,.council-markdown__body h2,.council-markdown__body h3,.council-markdown__body h4 { margin:.9em 0 .4em; font-size:1.05em; color:#68485e; }
+.council-markdown__body ul,.council-markdown__body ol { margin:0 0 .65em; padding-left:20px; }
+.council-markdown__body li { margin:.15em 0; }
+.council-markdown__body code { background:#f6eef5; border-radius:6px; padding:1px 5px; font-size:.9em; color:#8a3f6b; }
+.council-markdown__body pre { background:#f8f4f8; border:1px solid rgba(255,214,231,.6); border-radius:10px; padding:10px; overflow-x:auto; margin:0 0 .65em; }
+.council-markdown__body pre code { background:transparent; padding:0; color:#4a3a4f; }
+.council-markdown__body blockquote { margin:0 0 .65em; padding:4px 12px; border-left:3px solid #f3b8d4; color:#7d5d70; background:#fff6fa; border-radius:0 8px 8px 0; }
+.council-markdown__body table { border-collapse:collapse; margin:0 0 .65em; display:block; overflow-x:auto; max-width:100%; }
+.council-markdown__body th,.council-markdown__body td { border:1px solid rgba(255,214,231,.9); padding:4px 8px; font-size:12.5px; }
+.council-markdown__body th { background:#fff2f8; color:#68485e; }
+.council-markdown__body hr { border:none; border-top:1px dashed rgba(255,214,231,.9); margin:.8em 0; }
+.council-markdown__body.is-collapsed { max-height:190px; overflow:hidden;
+  -webkit-mask-image:linear-gradient(180deg,#000 62%,transparent 100%);
+  mask-image:linear-gradient(180deg,#000 62%,transparent 100%); }
+.collapse-toggle { justify-self:start; border:1px solid rgba(255,214,231,.9); border-radius:999px; background:#fff; color:#9c3f69; padding:4px 14px; font-size:12px; cursor:pointer; }
+.collapse-toggle:hover { background:#fff2f8; }
 
 /* 提案列表 */
 .proposal-list { display:grid; gap:10px; }

--- a/src/pages/AgentCouncilPage.tsx
+++ b/src/pages/AgentCouncilPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ConfirmDialog from '../components/ConfirmDialog'
+import MarkdownRenderer from '../components/MarkdownRenderer'
 import {
   createAgentCouncilProposal,
   createAgentCouncilReview,
@@ -8,10 +9,14 @@ import {
   deleteAgentCouncilProposal,
   deleteAgentCouncilTopic,
   listAgentCouncilMessages,
+  submitAgentCouncilReport,
 } from '../storage/supabaseSync'
 import type {
+  AgentCouncilCategory,
+  AgentCouncilExecutor,
   AgentCouncilMessage,
   AgentCouncilProposalStatus,
+  AgentCouncilReportResult,
   AgentCouncilSpeaker,
   AgentCouncilVote,
 } from '../types'
@@ -41,14 +46,62 @@ const SPEAKER_OPTIONS: AgentCouncilSpeaker[] = [
 
 const STATUS_META: Record<AgentCouncilProposalStatus, { label: string; className: string }> = {
   open: { label: '待讨论', className: 'status-open' },
-  approved: { label: '已拍板，待生成执行案', className: 'status-approved' },
+  approved: { label: '已拍板，待执行', className: 'status-approved' },
   rejected: { label: '已拒绝', className: 'status-rejected' },
   deferred: { label: '暂缓', className: 'status-deferred' },
   plan_generated: { label: '执行案已生成', className: 'status-plan' },
+  done: { label: '已完成', className: 'status-done' },
+  failed: { label: '执行失败', className: 'status-failed' },
 }
 
 const getStatusMeta = (status: AgentCouncilProposalStatus | null) =>
   status ? STATUS_META[status] : STATUS_META.open
+
+// 状态分组：列表第一维筛选。进行中=还没闭环的；失败单列出来等改派。
+const STATUS_GROUPS = [
+  { key: 'all', label: '全部', statuses: null },
+  { key: 'active', label: '进行中', statuses: ['open', 'approved', 'plan_generated'] },
+  { key: 'done', label: '已完成', statuses: ['done'] },
+  { key: 'failed', label: '失败', statuses: ['failed'] },
+  { key: 'closed', label: '已关闭', statuses: ['rejected', 'deferred'] },
+] as const
+
+type StatusGroupKey = (typeof STATUS_GROUPS)[number]['key']
+
+// 分类值域由 MCP 工具层维护；这里只管展示文案，未知分类原样显示不崩。
+const CATEGORY_META: Record<string, string> = {
+  app: 'App 施工',
+  memory: '记忆机制',
+  infra: '基建运维',
+  ritual: '仪式',
+  reading: '阅读线',
+  game: '游戏区',
+  council: '议事厅',
+  other: '其他',
+}
+
+const getCategoryLabel = (category: string | null) =>
+  category ? (CATEGORY_META[category] ?? category) : null
+
+const CATEGORY_OPTIONS: AgentCouncilCategory[] = [
+  'app',
+  'memory',
+  'infra',
+  'ritual',
+  'reading',
+  'game',
+  'council',
+  'other',
+]
+
+const EXECUTOR_META: Record<AgentCouncilExecutor, string> = {
+  codex_cli: 'Codex CLI',
+  claude_code_cli: 'Claude Code CLI',
+  client: '客户端聊天',
+  chuanchuan: '串串手工',
+}
+
+const EXECUTOR_OPTIONS: AgentCouncilExecutor[] = ['codex_cli', 'claude_code_cli', 'client', 'chuanchuan']
 
 const VOTE_META: Record<AgentCouncilVote, { label: string; className: string }> = {
   support: { label: '支持', className: 'vote-support' },
@@ -66,6 +119,17 @@ const DECISION_META: Record<DecisionAction, { label: string; className: string }
   deferred: { label: '暂缓', className: 'decision-deferred' },
 }
 
+const REPORT_RESULT_META: Record<AgentCouncilReportResult, { label: string; className: string }> = {
+  succeeded: { label: '成功', className: 'report-succeeded' },
+  partial: { label: '部分完成', className: 'report-partial' },
+  failed: { label: '失败', className: 'report-failed' },
+}
+
+const REPORT_RESULT_OPTIONS: AgentCouncilReportResult[] = ['succeeded', 'partial', 'failed']
+
+// 回执表单只对拍板后的提案开放；done 时用于补发修正回执（家规：不改写历史，再发一条）。
+const REPORTABLE_STATUSES: AgentCouncilProposalStatus[] = ['approved', 'plan_generated', 'failed', 'done']
+
 const formatTime = (value: string | null) =>
   value ? new Date(value).toLocaleString('zh-CN', { hour12: false }) : '—'
 
@@ -73,6 +137,35 @@ const summarize = (text: string, max = 80) => {
   const normalized = text.replace(/\s+/g, ' ').trim()
   return normalized.length > max ? `${normalized.slice(0, max)}…` : normalized
 }
+
+// 提案正文普遍是密集长文：超过阈值默认折叠，展开后再读全文。
+const COLLAPSE_THRESHOLD = 360
+
+const CollapsibleMarkdown = ({ content }: { content: string }) => {
+  const [expanded, setExpanded] = useState(false)
+  const needsCollapse = content.length > COLLAPSE_THRESHOLD
+  return (
+    <div className="council-markdown">
+      <div className={`council-markdown__body ${needsCollapse && !expanded ? 'is-collapsed' : ''}`}>
+        <MarkdownRenderer content={content} />
+      </div>
+      {needsCollapse ? (
+        <button type="button" className="collapse-toggle" onClick={() => setExpanded((prev) => !prev)}>
+          {expanded ? '收起' : '展开全文'}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+// 每行一条 → string[]，供回执的产出物/遗留项输入。
+const splitLines = (value: string): string[] =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+const isHttpUrl = (value: string) => /^https?:\/\//i.test(value)
 
 const AgentCouncilPage = () => {
   const navigate = useNavigate()
@@ -83,10 +176,15 @@ const AgentCouncilPage = () => {
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
 
+  // 列表两维筛选：状态分组 × 分类
+  const [statusGroup, setStatusGroup] = useState<StatusGroupKey>('all')
+  const [categoryFilter, setCategoryFilter] = useState<string>('all')
+
   // 发起提案表单
   const [newSpeaker, setNewSpeaker] = useState<AgentCouncilSpeaker>('chuanchuan')
   const [newTopic, setNewTopic] = useState('')
   const [newMessage, setNewMessage] = useState('')
+  const [newCategory, setNewCategory] = useState<AgentCouncilCategory>('other')
   const [newRiskLevel, setNewRiskLevel] = useState('')
   const [newTargetModule, setNewTargetModule] = useState('')
 
@@ -95,8 +193,16 @@ const AgentCouncilPage = () => {
   const [reviewVote, setReviewVote] = useState<AgentCouncilVote>('support')
   const [reviewMessage, setReviewMessage] = useState('')
 
-  // 拍板说明
+  // 拍板：说明 + 执行方指派（'' = 暂不指派，不唤醒任何脚本）
   const [decisionNote, setDecisionNote] = useState('')
+  const [decisionExecutor, setDecisionExecutor] = useState<AgentCouncilExecutor | ''>('')
+
+  // 执行回执表单
+  const [reportSpeaker, setReportSpeaker] = useState<AgentCouncilSpeaker>('chuanchuan')
+  const [reportResult, setReportResult] = useState<AgentCouncilReportResult>('succeeded')
+  const [reportMessage, setReportMessage] = useState('')
+  const [reportArtifacts, setReportArtifacts] = useState('')
+  const [reportFollowUps, setReportFollowUps] = useState('')
 
   // 删除确认
   const [pendingDeleteProposalId, setPendingDeleteProposalId] = useState<string | null>(null)
@@ -133,6 +239,27 @@ const AgentCouncilPage = () => {
       })
   }, [messages])
 
+  // 分类筛选 chips 只列实际出现过的分类，避免一排空标签。
+  const presentCategories = useMemo(() => {
+    const set = new Set<string>()
+    proposals.forEach((item) => {
+      if (item.category) set.add(item.category)
+    })
+    return Array.from(set).sort()
+  }, [proposals])
+
+  const filteredProposals = useMemo(() => {
+    const group = STATUS_GROUPS.find((item) => item.key === statusGroup)
+    return proposals.filter((item) => {
+      if (group?.statuses) {
+        const status = item.proposalStatus ?? 'open'
+        if (!(group.statuses as readonly string[]).includes(status)) return false
+      }
+      if (categoryFilter !== 'all' && (item.category ?? 'other') !== categoryFilter) return false
+      return true
+    })
+  }, [proposals, statusGroup, categoryFilter])
+
   // 旧历史消息：没有 entry_type（或非 proposal）且无 parent_id，按 topic 归组，单独展示避免崩溃
   const legacyTopics = useMemo(() => {
     const map = new Map<string, AgentCouncilMessage[]>()
@@ -159,23 +286,28 @@ const AgentCouncilPage = () => {
     [proposals, activeProposalId],
   )
 
-  const activeReviews = useMemo(() => {
-    if (!activeProposalId) {
-      return []
-    }
-    return messages
-      .filter((item) => item.parentId === activeProposalId && item.entryType === 'review')
-      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-  }, [activeProposalId, messages])
+  // 切换提案时，把拍板指派复位为当前主行的 executor，回执表单清空。
+  useEffect(() => {
+    setDecisionExecutor(activeProposal?.executor ?? '')
+    setReportMessage('')
+    setReportArtifacts('')
+    setReportFollowUps('')
+    setReportResult('succeeded')
+  }, [activeProposal?.id, activeProposal?.executor])
 
-  const activeDecisions = useMemo(() => {
-    if (!activeProposalId) {
-      return []
-    }
-    return messages
-      .filter((item) => item.parentId === activeProposalId && item.entryType === 'decision')
-      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-  }, [activeProposalId, messages])
+  const activeChildren = useCallback(
+    (entryType: AgentCouncilMessage['entryType']) => {
+      if (!activeProposalId) return []
+      return messages
+        .filter((item) => item.parentId === activeProposalId && item.entryType === entryType)
+        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    },
+    [activeProposalId, messages],
+  )
+
+  const activeReviews = useMemo(() => activeChildren('review'), [activeChildren])
+  const activeDecisions = useMemo(() => activeChildren('decision'), [activeChildren])
+  const activeReports = useMemo(() => activeChildren('report'), [activeChildren])
 
   const handleCreateProposal = async (event: FormEvent) => {
     event.preventDefault()
@@ -198,12 +330,14 @@ const AgentCouncilPage = () => {
         topic,
         message,
         speaker: newSpeaker,
+        category: newCategory,
         metadata,
       })
       setNewTopic('')
       setNewMessage('')
       setNewRiskLevel('')
       setNewTargetModule('')
+      setNewCategory('other')
       setActiveProposalId(created.id)
       setNotice('新提案已发起')
       setError(null)
@@ -234,6 +368,7 @@ const AgentCouncilPage = () => {
         message,
         vote: reviewVote,
         speaker: reviewSpeaker,
+        category: activeProposal.category,
       })
       setReviewMessage('')
       setNotice('评估回复已提交')
@@ -253,20 +388,61 @@ const AgentCouncilPage = () => {
     }
     setSaving(true)
     try {
+      const executor = status === 'approved' && decisionExecutor ? decisionExecutor : null
       await decideAgentCouncilProposal({
         proposalId: activeProposal.id,
         topic: activeProposal.topic,
         status,
         note: decisionNote,
         speaker: 'chuanchuan',
+        executor,
+        category: activeProposal.category,
       })
       setDecisionNote('')
-      setNotice(`串串已拍板：${DECISION_META[status].label}`)
+      setNotice(
+        status === 'approved' && executor
+          ? `串串已拍板：${DECISION_META[status].label}，指派 ${EXECUTOR_META[executor]}`
+          : `串串已拍板：${DECISION_META[status].label}`,
+      )
       setError(null)
       await refresh()
     } catch (decideError) {
       console.warn('拍板失败', decideError)
       setError('拍板失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSubmitReport = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!activeProposal) {
+      return
+    }
+    const message = reportMessage.trim()
+    if (!message) {
+      setError('回执正文不能为空：干了什么 / 怎么验证的 / 遗留什么')
+      return
+    }
+    setSaving(true)
+    try {
+      await submitAgentCouncilReport({
+        proposalId: activeProposal.id,
+        speaker: reportSpeaker,
+        message,
+        result: reportResult,
+        artifacts: splitLines(reportArtifacts),
+        followUps: splitLines(reportFollowUps),
+      })
+      setReportMessage('')
+      setReportArtifacts('')
+      setReportFollowUps('')
+      setNotice(`执行回执已提交（${REPORT_RESULT_META[reportResult].label}）`)
+      setError(null)
+      await refresh()
+    } catch (reportError) {
+      console.warn('提交回执失败', reportError)
+      setError('提交回执失败，请稍后重试')
     } finally {
       setSaving(false)
     }
@@ -315,6 +491,10 @@ const AgentCouncilPage = () => {
     }
   }
 
+  const canReport = activeProposal
+    ? REPORTABLE_STATUSES.includes(activeProposal.proposalStatus ?? 'open')
+    : false
+
   return (
     <div className="council-page">
       <header className="council-header">
@@ -332,16 +512,26 @@ const AgentCouncilPage = () => {
       <section className="council-panel">
         <h2>发起新提案</h2>
         <form className="council-form" onSubmit={handleCreateProposal}>
-          <label className="council-field">
-            <span>发起身份</span>
-            <select value={newSpeaker} onChange={(e) => setNewSpeaker(e.target.value as AgentCouncilSpeaker)}>
-              {SPEAKER_OPTIONS.map((speaker) => (
-                <option key={speaker} value={speaker}>{SPEAKER_META[speaker].label}</option>
-              ))}
-            </select>
-          </label>
+          <div className="council-field-row">
+            <label className="council-field">
+              <span>发起身份</span>
+              <select value={newSpeaker} onChange={(e) => setNewSpeaker(e.target.value as AgentCouncilSpeaker)}>
+                {SPEAKER_OPTIONS.map((speaker) => (
+                  <option key={speaker} value={speaker}>{SPEAKER_META[speaker].label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="council-field">
+              <span>主题分类</span>
+              <select value={newCategory} onChange={(e) => setNewCategory(e.target.value as AgentCouncilCategory)}>
+                {CATEGORY_OPTIONS.map((category) => (
+                  <option key={category} value={category}>{CATEGORY_META[category]}</option>
+                ))}
+              </select>
+            </label>
+          </div>
           <input value={newTopic} onChange={(e) => setNewTopic(e.target.value)} placeholder="议题名称（topic）" />
-          <textarea value={newMessage} onChange={(e) => setNewMessage(e.target.value)} rows={4} placeholder="提案全文" />
+          <textarea value={newMessage} onChange={(e) => setNewMessage(e.target.value)} rows={4} placeholder="提案全文（支持 Markdown）" />
           <div className="council-field-row">
             <input value={newRiskLevel} onChange={(e) => setNewRiskLevel(e.target.value)} placeholder="风险等级（可选）" />
             <input value={newTargetModule} onChange={(e) => setNewTargetModule(e.target.value)} placeholder="目标模块（可选）" />
@@ -352,14 +542,52 @@ const AgentCouncilPage = () => {
 
       <section className="council-panel">
         <h2>主提案列表</h2>
+        <div className="council-filters">
+          <div className="filter-row">
+            {STATUS_GROUPS.map((group) => (
+              <button
+                key={group.key}
+                type="button"
+                className={`filter-chip ${statusGroup === group.key ? 'active' : ''}`}
+                onClick={() => setStatusGroup(group.key)}
+              >
+                {group.label}
+              </button>
+            ))}
+          </div>
+          {presentCategories.length > 0 ? (
+            <div className="filter-row">
+              <button
+                type="button"
+                className={`filter-chip filter-chip--category ${categoryFilter === 'all' ? 'active' : ''}`}
+                onClick={() => setCategoryFilter('all')}
+              >
+                全部分类
+              </button>
+              {presentCategories.map((category) => (
+                <button
+                  key={category}
+                  type="button"
+                  className={`filter-chip filter-chip--category ${categoryFilter === category ? 'active' : ''}`}
+                  onClick={() => setCategoryFilter(category)}
+                >
+                  {getCategoryLabel(category)}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
         {loading ? <p className="council-empty">加载中…</p> : null}
         {!loading && proposals.length === 0 ? <p className="council-empty">暂时还没有正式提案。</p> : null}
+        {!loading && proposals.length > 0 && filteredProposals.length === 0 ? (
+          <p className="council-empty">这个筛选条件下没有提案。</p>
+        ) : null}
         <div className="proposal-list">
-          {proposals.map((proposal) => {
+          {filteredProposals.map((proposal) => {
             const statusMeta = getStatusMeta(proposal.proposalStatus)
             const speakerMeta = getSpeakerMeta(proposal.speaker)
+            const categoryLabel = getCategoryLabel(proposal.category)
             const riskLevel = proposal.metadata?.risk_level
-            const targetModule = proposal.metadata?.target_module
             return (
               <div
                 key={proposal.id}
@@ -377,11 +605,12 @@ const AgentCouncilPage = () => {
                   <p className="proposal-item__summary">{summarize(proposal.message)}</p>
                   <div className="proposal-item__meta">
                     <span className={`speaker-tag ${speakerMeta.className}`}>{speakerMeta.label}</span>
+                    {categoryLabel ? <span className="category-tag">{categoryLabel}</span> : null}
+                    {proposal.executor ? (
+                      <span className="executor-tag">→ {EXECUTOR_META[proposal.executor]}</span>
+                    ) : null}
                     {typeof riskLevel === 'string' && riskLevel ? (
                       <span className="meta-chip">风险：{riskLevel}</span>
-                    ) : null}
-                    {typeof targetModule === 'string' && targetModule ? (
-                      <span className="meta-chip">模块：{targetModule}</span>
                     ) : null}
                   </div>
                   <div className="proposal-item__time">
@@ -418,8 +647,14 @@ const AgentCouncilPage = () => {
                 {getStatusMeta(activeProposal.proposalStatus).label}
               </span>
             </div>
-            <p className="detail-proposal__body">{activeProposal.message}</p>
+            <CollapsibleMarkdown content={activeProposal.message} />
             <div className="proposal-item__meta">
+              {getCategoryLabel(activeProposal.category) ? (
+                <span className="category-tag">{getCategoryLabel(activeProposal.category)}</span>
+              ) : null}
+              {activeProposal.executor ? (
+                <span className="executor-tag">执行方：{EXECUTOR_META[activeProposal.executor]}</span>
+              ) : null}
               {typeof activeProposal.metadata?.risk_level === 'string' && activeProposal.metadata.risk_level ? (
                 <span className="meta-chip">风险：{activeProposal.metadata.risk_level}</span>
               ) : null}
@@ -452,7 +687,7 @@ const AgentCouncilPage = () => {
                         <time>{formatTime(review.createdAt)}</time>
                       </div>
                     </div>
-                    <p>{review.message}</p>
+                    <CollapsibleMarkdown content={review.message} />
                   </article>
                 )
               })}
@@ -476,7 +711,7 @@ const AgentCouncilPage = () => {
                   </select>
                 </label>
               </div>
-              <textarea value={reviewMessage} onChange={(e) => setReviewMessage(e.target.value)} rows={3} placeholder="评估意见" />
+              <textarea value={reviewMessage} onChange={(e) => setReviewMessage(e.target.value)} rows={3} placeholder="评估意见（支持 Markdown）" />
               <button type="submit" disabled={saving}>提交评估</button>
             </form>
           </div>
@@ -487,10 +722,11 @@ const AgentCouncilPage = () => {
             <div className="message-list">
               {activeDecisions.map((decision) => {
                 const speakerMeta = getSpeakerMeta(decision.speaker)
-                const decisionStatus = decision.metadata?.decision_status
+                // Web 旧写法把拍板状态放 metadata.decision_status；MCP 写在行内 proposal_status。两处都认。
+                const rawStatus = decision.proposalStatus ?? decision.metadata?.decision_status
                 const statusLabel =
-                  typeof decisionStatus === 'string' && decisionStatus in STATUS_META
-                    ? STATUS_META[decisionStatus as AgentCouncilProposalStatus].label
+                  typeof rawStatus === 'string' && rawStatus in STATUS_META
+                    ? STATUS_META[rawStatus as AgentCouncilProposalStatus].label
                     : null
                 return (
                   <article key={decision.id} className="message-item decision-item">
@@ -507,6 +743,18 @@ const AgentCouncilPage = () => {
               })}
             </div>
             <div className="decision-box">
+              <label className="council-field">
+                <span>指派执行方（仅「拍板执行」时生效）</span>
+                <select
+                  value={decisionExecutor}
+                  onChange={(e) => setDecisionExecutor(e.target.value as AgentCouncilExecutor | '')}
+                >
+                  <option value="">暂不指派（不唤醒任何脚本）</option>
+                  {EXECUTOR_OPTIONS.map((executor) => (
+                    <option key={executor} value={executor}>{EXECUTOR_META[executor]}</option>
+                  ))}
+                </select>
+              </label>
               <textarea
                 value={decisionNote}
                 onChange={(e) => setDecisionNote(e.target.value)}
@@ -514,7 +762,7 @@ const AgentCouncilPage = () => {
                 placeholder="拍板说明（可选）"
               />
               <p className="decision-hint">
-                拍板「{DECISION_META.approved.label}」只代表允许后续由 Mac mini 监听脚本生成本地执行方案，不会自动执行代码或数据库操作。
+                只有指派 Codex CLI / Claude Code CLI 才会唤醒 Mac mini 接单脚本；「暂不指派」「客户端聊天」「串串手工」都不会触发任何自动执行。再次拍板即可改派。
               </p>
               <div className="decision-actions">
                 {(['approved', 'rejected', 'deferred'] as DecisionAction[]).map((action) => (
@@ -530,6 +778,107 @@ const AgentCouncilPage = () => {
                 ))}
               </div>
             </div>
+          </div>
+
+          <div className="detail-section">
+            <h3>执行回执（{activeReports.length}）</h3>
+            {activeReports.length === 0 ? <p className="council-empty">还没有执行回执。</p> : null}
+            <div className="message-list">
+              {activeReports.map((report) => {
+                const speakerMeta = getSpeakerMeta(report.speaker)
+                const result = report.metadata?.result
+                const resultMeta =
+                  typeof result === 'string' && result in REPORT_RESULT_META
+                    ? REPORT_RESULT_META[result as AgentCouncilReportResult]
+                    : null
+                const artifacts = Array.isArray(report.metadata?.artifacts)
+                  ? (report.metadata.artifacts as unknown[]).filter((item): item is string => typeof item === 'string')
+                  : []
+                const followUps = Array.isArray(report.metadata?.follow_ups)
+                  ? (report.metadata.follow_ups as unknown[]).filter((item): item is string => typeof item === 'string')
+                  : []
+                return (
+                  <article key={report.id} className="message-item report-item">
+                    <div className="message-meta">
+                      <span className={`speaker-tag ${speakerMeta.className}`}>{speakerMeta.label}</span>
+                      <div className="message-meta__right">
+                        {resultMeta ? <span className={`report-tag ${resultMeta.className}`}>{resultMeta.label}</span> : null}
+                        <time>{formatTime(report.createdAt)}</time>
+                      </div>
+                    </div>
+                    <CollapsibleMarkdown content={report.message} />
+                    {artifacts.length > 0 ? (
+                      <div className="report-extras">
+                        <span className="report-extras__label">产出物</span>
+                        <ul>
+                          {artifacts.map((item, index) => (
+                            <li key={`${report.id}-artifact-${index}`}>
+                              {isHttpUrl(item) ? <a href={item} target="_blank" rel="noreferrer">{item}</a> : item}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                    {followUps.length > 0 ? (
+                      <div className="report-extras">
+                        <span className="report-extras__label">遗留事项</span>
+                        <ul>
+                          {followUps.map((item, index) => (
+                            <li key={`${report.id}-followup-${index}`}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                  </article>
+                )
+              })}
+            </div>
+            {canReport ? (
+              <form className="council-form report-form" onSubmit={handleSubmitReport}>
+                <div className="council-field-row">
+                  <label className="council-field">
+                    <span>执行方（谁执行谁执笔）</span>
+                    <select value={reportSpeaker} onChange={(e) => setReportSpeaker(e.target.value as AgentCouncilSpeaker)}>
+                      {SPEAKER_OPTIONS.map((speaker) => (
+                        <option key={speaker} value={speaker}>{SPEAKER_META[speaker].label}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="council-field">
+                    <span>执行结果</span>
+                    <select value={reportResult} onChange={(e) => setReportResult(e.target.value as AgentCouncilReportResult)}>
+                      {REPORT_RESULT_OPTIONS.map((result) => (
+                        <option key={result} value={result}>{REPORT_RESULT_META[result].label}</option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <textarea
+                  value={reportMessage}
+                  onChange={(e) => setReportMessage(e.target.value)}
+                  rows={3}
+                  placeholder="回执正文：干了什么 / 怎么验证的 / 遗留什么（支持 Markdown）"
+                />
+                <textarea
+                  value={reportArtifacts}
+                  onChange={(e) => setReportArtifacts(e.target.value)}
+                  rows={2}
+                  placeholder="产出物（可选，每行一条：PR 链接 / migration 版本 / 文件路径）"
+                />
+                <textarea
+                  value={reportFollowUps}
+                  onChange={(e) => setReportFollowUps(e.target.value)}
+                  rows={2}
+                  placeholder="遗留事项（可选，每行一条；部分完成时建议填写）"
+                />
+                <p className="decision-hint">
+                  提交后自动闭环：成功/部分完成 → 已完成；失败 → 执行失败（等改派或重试），并推送横幅通知。回执写错不改写，再发一条修正即可。
+                </p>
+                <button type="submit" disabled={saving}>提交回执</button>
+              </form>
+            ) : (
+              <p className="council-empty">拍板执行后才能提交回执。</p>
+            )}
           </div>
         </section>
       ) : null}
@@ -581,7 +930,7 @@ const AgentCouncilPage = () => {
       <ConfirmDialog
         open={pendingDeleteProposalId !== null}
         title="删除提案"
-        description="确定要删除这条提案吗？该提案下的全部评估与拍板记录都会一并删除，且无法恢复。"
+        description="确定要删除这条提案吗？该提案下的全部评估、拍板与回执记录都会一并删除，且无法恢复。"
         confirmLabel={deleting ? '删除中…' : '删除'}
         cancelLabel="取消"
         confirmDisabled={deleting}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -13,6 +13,9 @@ import type {
   AgentCouncilProposalStatus,
   AgentCouncilVote,
   AgentCouncilMetadata,
+  AgentCouncilCategory,
+  AgentCouncilExecutor,
+  AgentCouncilReportResult,
   CheckinEntry,
   ForumAiProfile,
   ForumReply,
@@ -359,6 +362,8 @@ type AgentCouncilRow = {
   entry_type: string | null
   proposal_status: string | null
   vote: string | null
+  category: string | null
+  executor: string | null
   metadata: Record<string, unknown> | null
 }
 
@@ -405,18 +410,26 @@ const mapSyzygyReplyRow = (row: SyzygyReplyRow): SyzygyReply => ({
   modelId: row.model_id ?? null,
 })
 
-const AGENT_COUNCIL_ENTRY_TYPES: AgentCouncilEntryType[] = ['proposal', 'review', 'decision']
+const AGENT_COUNCIL_ENTRY_TYPES: AgentCouncilEntryType[] = ['proposal', 'review', 'decision', 'report']
 const AGENT_COUNCIL_PROPOSAL_STATUSES: AgentCouncilProposalStatus[] = [
   'open',
   'approved',
   'rejected',
   'deferred',
   'plan_generated',
+  'done',
+  'failed',
 ]
 const AGENT_COUNCIL_VOTES: AgentCouncilVote[] = ['support', 'neutral', 'against']
+const AGENT_COUNCIL_EXECUTORS: AgentCouncilExecutor[] = [
+  'codex_cli',
+  'claude_code_cli',
+  'client',
+  'chuanchuan',
+]
 
 const AGENT_COUNCIL_SELECT_FIELDS =
-  'id,speaker,topic,message,created_at,updated_at,parent_id,entry_type,proposal_status,vote,metadata'
+  'id,speaker,topic,message,created_at,updated_at,parent_id,entry_type,proposal_status,vote,category,executor,metadata'
 
 // 旧数据的 entry_type / proposal_status / vote 可能为空或不在白名单内，统一归一化为 null，避免前端崩溃。
 const normalizeAgentCouncilEnum = <T extends string>(value: string | null, allowed: T[]): T | null =>
@@ -433,6 +446,9 @@ const mapAgentCouncilRow = (row: AgentCouncilRow): AgentCouncilMessage => ({
   entryType: normalizeAgentCouncilEnum(row.entry_type, AGENT_COUNCIL_ENTRY_TYPES),
   proposalStatus: normalizeAgentCouncilEnum(row.proposal_status, AGENT_COUNCIL_PROPOSAL_STATUSES),
   vote: normalizeAgentCouncilEnum(row.vote, AGENT_COUNCIL_VOTES),
+  // category 值域由工具层演进，前端不做白名单过滤，原样展示未知分类。
+  category: row.category ?? null,
+  executor: normalizeAgentCouncilEnum(row.executor, AGENT_COUNCIL_EXECUTORS),
   metadata: (row.metadata ?? {}) as AgentCouncilMetadata,
 })
 
@@ -3044,6 +3060,7 @@ export const createAgentCouncilProposal = async (payload: {
   topic: string
   message: string
   speaker?: AgentCouncilSpeaker
+  category?: AgentCouncilCategory
   metadata?: AgentCouncilMetadata
 }): Promise<AgentCouncilMessage> => {
   if (!supabase) {
@@ -3060,6 +3077,7 @@ export const createAgentCouncilProposal = async (payload: {
       entry_type: 'proposal',
       proposal_status: 'open',
       parent_id: null,
+      category: payload.category ?? 'other',
       metadata: payload.metadata ?? {},
     })
     .select(AGENT_COUNCIL_SELECT_FIELDS)
@@ -3070,13 +3088,14 @@ export const createAgentCouncilProposal = async (payload: {
   return mapAgentCouncilRow(data as AgentCouncilRow)
 }
 
-// 给某条主提案添加一条评估回复（entry_type=review），并记录态度 vote。
+// 给某条主提案添加一条评估回复（entry_type=review），并记录态度 vote；category 从父提案继承。
 export const createAgentCouncilReview = async (payload: {
   parentId: string
   topic: string
   message: string
   vote: AgentCouncilVote
   speaker?: AgentCouncilSpeaker
+  category?: string | null
 }): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
@@ -3090,29 +3109,34 @@ export const createAgentCouncilReview = async (payload: {
     entry_type: 'review',
     parent_id: payload.parentId,
     vote: payload.vote,
+    category: payload.category ?? null,
   })
   if (error) {
     throw error
   }
 }
 
-// 串串拍板：更新主提案 proposal_status，并插入一条 entry_type=decision 的记录保留拍板说明。
-// approved 仅代表“允许生成本地执行方案”，不代表自动执行；真正的执行案由 Mac mini 监听脚本生成。
+// 串串拍板：更新主提案 proposal_status（approved 时一并落 executor 指派），并插入 decision 记录留痕。
+// executor 语义与 MCP 工具 council_decide 一致：只有 codex_cli / claude_code_cli 会唤醒 Mac mini 接单脚本；
+// 缺省 NULL = 不唤醒任何脚本（安全默认）；重复拍板即改派；非 approved 拍板清空 executor。
 export const decideAgentCouncilProposal = async (payload: {
   proposalId: string
   topic: string
   status: 'approved' | 'rejected' | 'deferred'
   note?: string
   speaker?: AgentCouncilSpeaker
+  executor?: AgentCouncilExecutor | null
+  category?: string | null
 }): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
   const userId = await requireAuthenticatedUserId()
   const nowIso = new Date().toISOString()
+  const nextExecutor = payload.status === 'approved' ? (payload.executor ?? null) : null
   const { error: updateError } = await supabase
     .from('agent_council')
-    .update({ proposal_status: payload.status, updated_at: nowIso })
+    .update({ proposal_status: payload.status, executor: nextExecutor, updated_at: nowIso })
     .eq('id', payload.proposalId)
   if (updateError) {
     throw updateError
@@ -3120,7 +3144,11 @@ export const decideAgentCouncilProposal = async (payload: {
   const statusLabel =
     payload.status === 'approved' ? '已拍板' : payload.status === 'rejected' ? '已拒绝' : '暂缓'
   const note = payload.note?.trim()
-  const message = note ? note : `串串拍板：${statusLabel}`
+  const message = note
+    ? note
+    : nextExecutor
+      ? `串串拍板：${statusLabel}，指派 ${nextExecutor} 执行`
+      : `串串拍板：${statusLabel}`
   const { error: insertError } = await supabase.from('agent_council').insert({
     user_id: userId,
     speaker: payload.speaker ?? 'chuanchuan',
@@ -3128,10 +3156,40 @@ export const decideAgentCouncilProposal = async (payload: {
     message,
     entry_type: 'decision',
     parent_id: payload.proposalId,
-    metadata: { decision_status: payload.status },
+    category: payload.category ?? null,
+    metadata: {
+      decision_status: payload.status,
+      ...(nextExecutor ? { executor: nextExecutor } : {}),
+    },
   })
   if (insertError) {
     throw insertError
+  }
+}
+
+// 提交执行回执：调用 DB 函数 council_submit_report（写回标准的唯一实现，与 MCP 工具 council_report 同源）。
+// 一次完成：插 report 子条目 / 翻主提案状态（succeeded、partial→done，failed→failed）/ 写 agent_events 推横幅。
+export const submitAgentCouncilReport = async (payload: {
+  proposalId: string
+  speaker: AgentCouncilSpeaker
+  message: string
+  result: AgentCouncilReportResult
+  artifacts?: string[]
+  followUps?: string[]
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase.rpc('council_submit_report', {
+    p_proposal_id: payload.proposalId,
+    p_speaker: payload.speaker,
+    p_message: payload.message,
+    p_result: payload.result,
+    p_artifacts: payload.artifacts && payload.artifacts.length > 0 ? payload.artifacts : null,
+    p_follow_ups: payload.followUps && payload.followUps.length > 0 ? payload.followUps : null,
+  })
+  if (error) {
+    throw error
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,7 +278,7 @@ export type AgentCouncilSpeaker =
   | 'codex_cli'
   | 'claude_code_cli'
 
-export type AgentCouncilEntryType = 'proposal' | 'review' | 'decision'
+export type AgentCouncilEntryType = 'proposal' | 'review' | 'decision' | 'report'
 
 export type AgentCouncilProposalStatus =
   | 'open'
@@ -286,12 +286,33 @@ export type AgentCouncilProposalStatus =
   | 'rejected'
   | 'deferred'
   | 'plan_generated'
+  | 'done'
+  | 'failed'
 
 export type AgentCouncilVote = 'support' | 'neutral' | 'against'
+
+// 分类值域由 MCP 工具层维护（DB 无 CHECK）；前端把 category 当普通字符串容忍未知值，仅用于展示与筛选。
+export type AgentCouncilCategory =
+  | 'app'
+  | 'memory'
+  | 'infra'
+  | 'ritual'
+  | 'reading'
+  | 'game'
+  | 'council'
+  | 'other'
+
+export type AgentCouncilExecutor = 'codex_cli' | 'claude_code_cli' | 'client' | 'chuanchuan'
+
+export type AgentCouncilReportResult = 'succeeded' | 'partial' | 'failed'
 
 export type AgentCouncilMetadata = {
   risk_level?: string
   target_module?: string
+  result?: AgentCouncilReportResult
+  artifacts?: string[]
+  follow_ups?: string[]
+  executor?: string
   [key: string]: unknown
 }
 
@@ -306,6 +327,8 @@ export type AgentCouncilMessage = {
   entryType: AgentCouncilEntryType | null
   proposalStatus: AgentCouncilProposalStatus | null
   vote: AgentCouncilVote | null
+  category: string | null
+  executor: AgentCouncilExecutor | null
   metadata: AgentCouncilMetadata
 }
 

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -5,7 +5,7 @@ import { Hono } from 'npm:hono@^4.9.7'
 import { createClient } from 'jsr:@supabase/supabase-js@2'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.6.0'
+export const MCP_VERSION = '5.7.0'
 export const USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-lounge-mcp/index.ts
+++ b/supabase/functions/hamster-lounge-mcp/index.ts
@@ -2,12 +2,19 @@ import { z } from 'npm:zod@^4.1.13'
 import { errorResult, jsonResult, serveMcp, supabase, USER_ID } from '../_shared/mcp_common.ts'
 
 const SPEAKER_SCHEMA = z.enum(['claude', 'gpt', 'gemini', 'chuanchuan', 'codex_cli', 'claude_code_cli'])
-const ENTRY_TYPE_SCHEMA = z.enum(['proposal', 'review', 'decision'])
-const PROPOSAL_STATUS_SCHEMA = z.enum(['open', 'approved', 'rejected', 'deferred', 'plan_generated'])
+// council_post 只许写前三种；report 是执行回执，必须走 council_report（唯一写回入口）。
+const POST_ENTRY_TYPE_SCHEMA = z.enum(['proposal', 'review', 'decision'])
+const READ_ENTRY_TYPE_SCHEMA = z.enum(['proposal', 'review', 'decision', 'report'])
+const PROPOSAL_STATUS_SCHEMA = z.enum(['open', 'approved', 'rejected', 'deferred', 'plan_generated', 'done', 'failed'])
 const VOTE_SCHEMA = z.enum(['support', 'neutral', 'against'])
 const METADATA_SCHEMA = z.record(z.string(), z.unknown())
+// 分类值域只在工具层校验（DB 不加 CHECK）——加新分类改这里重新部署即可，家规：新分类先提案再启用。
+const CATEGORY_SCHEMA = z.enum(['app', 'memory', 'infra', 'ritual', 'reading', 'game', 'council', 'other'])
+// 执行方：只有 codex_cli / claude_code_cli 会唤醒 Mac mini 接单脚本；client=串串+客户端聊天完成；chuanchuan=纯手工。
+const EXECUTOR_SCHEMA = z.enum(['codex_cli', 'claude_code_cli', 'client', 'chuanchuan'])
+const REPORT_RESULT_SCHEMA = z.enum(['succeeded', 'partial', 'failed'])
 
-const councilColumns = 'id, user_id, parent_id, speaker, topic, message, entry_type, proposal_status, vote, metadata, read_by, created_at, updated_at'
+const councilColumns = 'id, user_id, parent_id, speaker, topic, message, entry_type, proposal_status, vote, category, executor, metadata, read_by, created_at, updated_at'
 
 serveMcp('hamster-lounge-mcp', (server) => {
   server.registerTool('lounge_list_sofas', {
@@ -61,8 +68,8 @@ serveMcp('hamster-lounge-mcp', (server) => {
       topic: z.string().describe('话题'),
       message: z.string().describe('消息内容'),
       parent_id: z.string().optional().describe('父提案 UUID；评估/拍板时传入'),
-      entry_type: ENTRY_TYPE_SCHEMA.optional().describe('proposal / review / decision'),
-      proposal_status: PROPOSAL_STATUS_SCHEMA.optional().describe('open / approved / rejected / deferred / plan_generated'),
+      entry_type: POST_ENTRY_TYPE_SCHEMA.optional().describe('proposal / review / decision（执行回执请走 council_report）'),
+      proposal_status: PROPOSAL_STATUS_SCHEMA.optional().describe('open / approved / rejected / deferred / plan_generated / done / failed'),
       vote: VOTE_SCHEMA.optional().describe('support / neutral / against'),
       metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 risk_level / target_module / command_id'),
     },
@@ -84,14 +91,15 @@ serveMcp('hamster-lounge-mcp', (server) => {
 
   server.registerTool('council_propose', {
     title: 'Create Council Proposal',
-    description: '发起一条 V3.1 Agent Council 正式提案。默认 proposal_status=open。',
+    description: '发起一条 Agent Council 正式提案。默认 proposal_status=open。请务必带 category 主题分类（缺省落 other）；家规：想加新分类先开提案讨论，通过后再改工具枚举启用。',
     inputSchema: {
       speaker: SPEAKER_SCHEMA.describe('发起者'),
       topic: z.string().describe('提案主题'),
       message: z.string().describe('提案正文：背景、方案、收益、风险'),
+      category: CATEGORY_SCHEMA.optional().describe('主题分类：app（Expo/App 施工）/ memory（记忆机制）/ infra（数据库/MCP/mini/运维安全）/ ritual（打印/来信/收束）/ reading（阅读线）/ game（游戏区）/ council（议事厅自身）/ other（兜底，缺省值）'),
       metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 risk_level / target_module / executable'),
     },
-  }, async ({ speaker, topic, message, metadata }) => {
+  }, async ({ speaker, topic, message, category, metadata }) => {
     const { data, error } = await supabase.from('agent_council').insert({
       user_id: USER_ID,
       speaker,
@@ -99,6 +107,7 @@ serveMcp('hamster-lounge-mcp', (server) => {
       message,
       entry_type: 'proposal',
       proposal_status: 'open',
+      category: category ?? 'other',
       metadata: metadata ?? {},
     }).select(councilColumns).single()
     if (error) return errorResult(error)
@@ -116,7 +125,7 @@ serveMcp('hamster-lounge-mcp', (server) => {
       metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 risk_notes / alternative_plan'),
     },
   }, async ({ proposal_id, speaker, message, vote, metadata }) => {
-    const { data: proposal, error: proposalError } = await supabase.from('agent_council').select('id, topic').eq('id', proposal_id).maybeSingle()
+    const { data: proposal, error: proposalError } = await supabase.from('agent_council').select('id, topic, category').eq('id', proposal_id).maybeSingle()
     if (proposalError) return errorResult(proposalError)
     if (!proposal) return { content: [{ type: 'text' as const, text: `Error: proposal not found: ${proposal_id}` }] }
     const { data, error } = await supabase.from('agent_council').insert({
@@ -127,6 +136,7 @@ serveMcp('hamster-lounge-mcp', (server) => {
       message,
       entry_type: 'review',
       vote,
+      category: proposal.category ?? null,
       metadata: metadata ?? {},
     }).select(councilColumns).single()
     if (error) return errorResult(error)
@@ -135,52 +145,84 @@ serveMcp('hamster-lounge-mcp', (server) => {
 
   server.registerTool('council_decide', {
     title: 'Decide Council Proposal',
-    description: '由串串对 Council 提案拍板，并同步更新主提案 proposal_status。approved 只表示允许生成执行方案，不代表自动执行。',
+    description: '由串串对 Council 提案拍板，并同步更新主提案 proposal_status。approved 时可用 executor 指派执行方：只有指派 codex_cli / claude_code_cli 才会唤醒 Mac mini 接单脚本；不带 executor 则主行落 NULL=不唤醒任何脚本（安全默认，云端/客户端就能做的活不必唤醒 CLI）。允许对同一提案重复 decide 改派（更新主行 executor，照常追加 decision 子条目留痕）；非 approved 拍板会清空 executor。',
     inputSchema: {
       proposal_id: z.string().describe('主提案 UUID'),
       decision: z.enum(['approved', 'rejected', 'deferred', 'plan_generated']).describe('拍板状态'),
+      executor: EXECUTOR_SCHEMA.optional().describe('执行方（仅 decision=approved 时生效）：codex_cli / claude_code_cli（唤醒 mini 脚本）/ client（串串+客户端聊天完成）/ chuanchuan（纯手工）；缺省 NULL=不唤醒'),
       message: z.string().optional().describe('拍板说明'),
       speaker: SPEAKER_SCHEMA.optional().describe('拍板者，默认 chuanchuan'),
       metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 generated_plan_path / command_id'),
     },
-  }, async ({ proposal_id, decision, message, speaker, metadata }) => {
+  }, async ({ proposal_id, decision, executor, message, speaker, metadata }) => {
     const actor = speaker ?? 'chuanchuan'
-    const { data: proposal, error: proposalError } = await supabase.from('agent_council').select('id, topic, metadata').eq('id', proposal_id).maybeSingle()
+    const { data: proposal, error: proposalError } = await supabase.from('agent_council').select('id, topic, category, metadata').eq('id', proposal_id).maybeSingle()
     if (proposalError) return errorResult(proposalError)
     if (!proposal) return { content: [{ type: 'text' as const, text: `Error: proposal not found: ${proposal_id}` }] }
+    // executor 只随 approved 落主行；重复 decide 即改派；rejected/deferred/plan_generated 不保留指派。
+    const nextExecutor = decision === 'approved' ? (executor ?? null) : null
     const nextMetadata = { ...((proposal.metadata ?? {}) as Record<string, unknown>), ...(metadata ?? {}) }
     const now = new Date().toISOString()
-    const { error: updateError } = await supabase.from('agent_council').update({ proposal_status: decision, metadata: nextMetadata, updated_at: now }).eq('id', proposal_id)
+    const { error: updateError } = await supabase.from('agent_council').update({ proposal_status: decision, executor: nextExecutor, metadata: nextMetadata, updated_at: now }).eq('id', proposal_id)
     if (updateError) return errorResult(updateError)
     const { data, error } = await supabase.from('agent_council').insert({
       user_id: USER_ID,
       parent_id: proposal_id,
       speaker: actor,
       topic: proposal.topic,
-      message: message ?? `串串拍板：${decision}`,
+      message: message ?? (nextExecutor ? `串串拍板：${decision}，指派 ${nextExecutor} 执行` : `串串拍板：${decision}`),
       entry_type: 'decision',
       proposal_status: decision,
-      metadata: metadata ?? {},
+      category: proposal.category ?? null,
+      metadata: { ...(metadata ?? {}), ...(nextExecutor ? { executor: nextExecutor } : {}) },
     }).select(councilColumns).single()
     if (error) return errorResult(error)
-    return jsonResult({ proposal_id, proposal_status: decision, decision_entry: data })
+    return jsonResult({ proposal_id, proposal_status: decision, executor: nextExecutor, decision_entry: data })
   })
 
   server.registerTool('council_read', {
     title: 'Read Council',
-    description: '阅读 Agent Council 消息；可按 proposal_status / entry_type / parent_id 筛选。',
+    description: '阅读 Agent Council 消息；可按 proposal_status / entry_type / category / executor / parent_id 组合筛选。',
     inputSchema: {
       limit: z.number().optional().describe('返回数量，默认10'),
-      proposal_status: PROPOSAL_STATUS_SCHEMA.optional().describe('按提案状态筛选'),
-      entry_type: ENTRY_TYPE_SCHEMA.optional().describe('按条目类型筛选'),
-      parent_id: z.string().optional().describe('读取某个主提案下的评估/拍板记录'),
+      proposal_status: PROPOSAL_STATUS_SCHEMA.optional().describe('按提案状态筛选：open / approved / rejected / deferred / plan_generated / done / failed'),
+      entry_type: READ_ENTRY_TYPE_SCHEMA.optional().describe('按条目类型筛选：proposal / review / decision / report'),
+      category: CATEGORY_SCHEMA.optional().describe('按主题分类筛选'),
+      executor: EXECUTOR_SCHEMA.optional().describe('按指派执行方筛选（主提案行才有值）'),
+      parent_id: z.string().optional().describe('读取某个主提案下的评估/拍板/回执记录'),
     },
-  }, async ({ limit, proposal_status, entry_type, parent_id }) => {
+  }, async ({ limit, proposal_status, entry_type, category, executor, parent_id }) => {
     let query = supabase.from('agent_council').select(councilColumns).order('created_at', { ascending: false }).limit(limit ?? 10)
     if (proposal_status) query = query.eq('proposal_status', proposal_status)
     if (entry_type) query = query.eq('entry_type', entry_type)
+    if (category) query = query.eq('category', category)
+    if (executor) query = query.eq('executor', executor)
     if (parent_id) query = query.eq('parent_id', parent_id)
     const { data, error } = await query
+    if (error) return errorResult(error)
+    return jsonResult(data)
+  })
+
+  server.registerTool('council_report', {
+    title: 'Report Council Execution',
+    description: '提交执行回执（谁执行谁执笔）——议事厅写回标准的唯一入口，内部调用 DB 函数 council_submit_report，一次完成三件事：插入 entry_type=report 子条目（继承父提案 category）、翻主提案状态（succeeded/partial → done；failed → failed，等串串改派或重试）、写 agent_events 推送横幅。回执写错不改写历史，再发一条修正。字段语义见 hamster-nest-app 仓库 docs/council-report-standard.md。',
+    inputSchema: {
+      proposal_id: z.string().describe('主提案 UUID'),
+      speaker: SPEAKER_SCHEMA.describe('执行方（回执执笔人）'),
+      message: z.string().describe('回执正文，三五句人话：干了什么 / 怎么验证的 / 遗留什么'),
+      result: REPORT_RESULT_SCHEMA.describe('执行结果：succeeded 全部完成 / partial 部分完成（遗留项写 follow_ups，建议另开提案）/ failed 失败（卡点写在正文）'),
+      artifacts: z.array(z.string()).optional().describe('产出物清单：PR 链接 / migration 版本号 / 文件路径等'),
+      follow_ups: z.array(z.string()).optional().describe('遗留事项清单（partial 时必填为宜）'),
+    },
+  }, async ({ proposal_id, speaker, message, result, artifacts, follow_ups }) => {
+    const { data, error } = await supabase.rpc('council_submit_report', {
+      p_proposal_id: proposal_id,
+      p_speaker: speaker,
+      p_message: message,
+      p_result: result,
+      p_artifacts: artifacts ?? null,
+      p_follow_ups: follow_ups ?? null,
+    })
     if (error) return errorResult(error)
     return jsonResult(data)
   })

--- a/supabase/migrations/20260716035105_council_scheduler_executor_category_report.sql
+++ b/supabase/migrations/20260716035105_council_scheduler_executor_category_report.sql
@@ -1,0 +1,126 @@
+-- ============================================================
+-- 议事厅调度台升级：executor 指派 / category 主题 / report 执行回执
+-- 方案：hamster-nest-app docs/plans/2026-07-15-council-scheduler-upgrade.md
+--（2026-07-16 敲定版：failed 独立状态；写回标准下沉为 council_submit_report RPC，
+--  MCP 工具与 Web 回执表单共用同一实现）
+-- ============================================================
+
+-- 1. 新列：主题分类 + 执行方指派
+alter table public.agent_council add column if not exists category text;
+alter table public.agent_council add column if not exists executor text;
+
+comment on column public.agent_council.category is
+  '提案主题分类。值域由 MCP 工具层校验（app/memory/infra/ritual/reading/game/council/other），不加 DB CHECK——分类演进免 migration；子条目由工具层从父提案继承。';
+comment on column public.agent_council.executor is
+  '拍板时指派的执行方。NULL = 不唤醒任何脚本（opt-in 语义）；只有 codex_cli / claude_code_cli 会唤醒 Mac mini 接单脚本。';
+
+-- 2. entry_type 值域 + report（执行回执，第四种发言）
+alter table public.agent_council drop constraint agent_council_entry_type_check;
+alter table public.agent_council add constraint agent_council_entry_type_check
+  check (entry_type is null or entry_type = any (array['proposal','review','decision','report']));
+
+-- 3. proposal_status 值域 + done / failed
+--    done = 回执 succeeded/partial；failed = 回执 failed（区别于「刚拍板没人动」的 approved，
+--    重派 = 串串重新 decide 回 approved，留痕在 decision 子条目）
+alter table public.agent_council drop constraint agent_council_proposal_status_check;
+alter table public.agent_council add constraint agent_council_proposal_status_check
+  check (proposal_status is null or proposal_status = any (array['open','approved','rejected','deferred','plan_generated','done','failed']));
+
+-- 4. executor 值域（出生即约束）
+alter table public.agent_council add constraint agent_council_executor_check
+  check (executor is null or executor = any (array['codex_cli','claude_code_cli','client','chuanchuan']));
+
+-- 5. 存量提案回填兜底分类
+update public.agent_council set category = 'other'
+  where entry_type = 'proposal' and category is null;
+
+-- 6. 写回标准的唯一实现：council_submit_report
+--    一次调用完成三件事：插 report 子条目 / 翻主提案状态 / 写 agent_events 推横幅。
+--    MCP 工具 council_report 与 Web 回执表单都只调这一个函数，各端不得自行写回。
+--    字段语义见 hamster-nest-app docs/council-report-standard.md。
+create or replace function public.council_submit_report(
+  p_proposal_id uuid,
+  p_speaker text,
+  p_message text,
+  p_result text,
+  p_artifacts text[] default null,
+  p_follow_ups text[] default null
+) returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_proposal public.agent_council%rowtype;
+  v_report_id uuid;
+  v_next_status text;
+  v_event_id bigint;
+  v_title text;
+begin
+  if p_result is null or p_result not in ('succeeded', 'partial', 'failed') then
+    raise exception 'council_submit_report: result 必须是 succeeded / partial / failed，收到 %', coalesce(p_result, 'null');
+  end if;
+  if p_message is null or btrim(p_message) = '' then
+    raise exception 'council_submit_report: message 不能为空（三五句人话：干了什么/怎么验证/遗留什么）';
+  end if;
+
+  select * into v_proposal
+    from public.agent_council
+   where id = p_proposal_id and entry_type = 'proposal'
+     for update;
+  if not found then
+    raise exception 'council_submit_report: 主提案不存在或不是 proposal: %', p_proposal_id;
+  end if;
+
+  -- succeeded / partial → done（partial 的遗留项建议另开提案，写进 follow_ups）；
+  -- failed → failed（完成是事实不是愿望；卡点写在回执里，等串串改派或重试）。
+  v_next_status := case when p_result = 'failed' then 'failed' else 'done' end;
+
+  insert into public.agent_council
+    (user_id, parent_id, speaker, topic, message, entry_type, category, metadata)
+  values
+    (v_proposal.user_id, v_proposal.id, p_speaker, v_proposal.topic, p_message, 'report',
+     v_proposal.category,
+     jsonb_strip_nulls(jsonb_build_object(
+       'result', p_result,
+       'artifacts', case when p_artifacts is null or cardinality(p_artifacts) = 0
+                         then null else to_jsonb(p_artifacts) end,
+       'follow_ups', case when p_follow_ups is null or cardinality(p_follow_ups) = 0
+                          then null else to_jsonb(p_follow_ups) end
+     )))
+  returning id into v_report_id;
+
+  update public.agent_council
+     set proposal_status = v_next_status, updated_at = now()
+   where id = v_proposal.id;
+
+  v_title := case p_result
+    when 'succeeded' then '✅ 议事厅回执：' || v_proposal.topic
+    when 'partial'   then '🟡 议事厅回执（部分完成）：' || v_proposal.topic
+    else                  '❌ 议事厅回执（失败）：' || v_proposal.topic
+  end;
+
+  -- screen=home 已在 App 推送白名单内（push-payload.ts），entity_id 供客户端补账定位。
+  insert into public.agent_events
+    (user_id, actor, event_type, entity_type, entity_id, title, payload, importance)
+  values
+    (v_proposal.user_id, p_speaker, 'council_report', 'council_proposal', v_proposal.id,
+     v_title,
+     jsonb_build_object('screen', 'home', 'result', p_result, 'topic', v_proposal.topic),
+     'normal')
+  returning id into v_event_id;
+
+  return jsonb_build_object(
+    'proposal_id', v_proposal.id,
+    'proposal_status', v_next_status,
+    'report_id', v_report_id,
+    'agent_event_id', v_event_id
+  );
+end;
+$$;
+
+comment on function public.council_submit_report(uuid, text, text, text, text[], text[]) is
+  '议事厅执行回执的唯一写回入口（写回标准见 hamster-nest-app docs/council-report-standard.md）。谁执行谁执笔；回执写错不改写，再发一条修正。';
+
+revoke all on function public.council_submit_report(uuid, text, text, text, text[], text[]) from public, anon;
+grant execute on function public.council_submit_report(uuid, text, text, text, text[], text[]) to authenticated, service_role;


### PR DESCRIPTION
## 概要

议事厅从讨论室升级为调度台：拍板时指派执行方（只有指派 CLI 才唤醒 mini 脚本）、提案带主题分类、执行方写回执闭环状态，并优化密集文本的阅读体验。

方案与修订记录见 hamster-nest-app 仓库 `docs/plans/2026-07-15-council-scheduler-upgrade.md`（含 2026-07-16 敲定版修订）。

## 变更内容

**DB migration `20260716035105`（已直接上生产，migration 文件随本 PR 入仓）**
- `agent_council` 新增 `category` / `executor` 列；`entry_type` 增 `report`；`proposal_status` 增 `done` / `failed`；存量提案回填 `other`
- 新增 `council_submit_report` RPC（security invoker）：写回标准的唯一实现，一次完成插回执子条目 / 翻主提案状态 / 写 `agent_events` 推横幅

**`hamster-lounge-mcp`（v20 已按本分支源码部署；合并后 CI 重部署同内容，无漂移）**
- `council_propose` + `category`（缺省 `other`，老调用兼容）
- `council_decide` + `executor`：仅 approved 落主行，缺省 NULL=不唤醒；重复 decide 改派；非 approved 清空
- `council_read` + `category` / `executor` 筛选
- 新增 `council_report` 工具（调 RPC）；`council_post` 禁写 `report`
- `MCP_VERSION` → 5.7.0

**Web 议事厅页面**
- 拍板区「指派执行方」选择器（默认暂不指派）；发案表单分类选择器
- 状态分组（进行中/已完成/失败/已关闭）× 分类 chips 两维筛选；分类/执行方/新状态徽标
- 提案、评估、回执 Markdown 渲染 + 长文折叠；执行回执表单与回执时间线（调同一 RPC）

## 验证

- 端到端实测：propose → decide(executor) → report(failed) → 改派 → report(succeeded)，状态机、category 继承、留痕全部正确；`agent_events` 落表、推送 `notification_events.status=sent`（手机横幅实收）；测试数据已清理
- migration 后 `get_advisors` 零新增告警；线上函数与仓库源码一致
- `tsc -b`、`vite build`、eslint 通过

## ⚠️ 合并后注意

mini 唤醒脚本改完 WHERE 之前，旧脚本仍是「approved 即接单」——过渡期护栏与 mini 交接清单见 hamster-nest-app `docs/plans/2026-07-16-council-mini-followup.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRefHCe9opUykJE5M2riRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRefHCe9opUykJE5M2riRQ)_