### PR TITLE
feat: 议事厅分类升级——提案分类可改 + 8 个固定槽位支持改名

### DIFF
--- a/src/pages/AgentCouncilPage.css
+++ b/src/pages/AgentCouncilPage.css
@@ -66,6 +66,22 @@
 .category-tag { border-radius:999px; padding:2px 8px; font-size:11px; font-weight:600; background:#f4effc; border:1px solid rgba(210,190,240,.7); color:#6b4fa3; }
 .executor-tag { border-radius:999px; padding:2px 8px; font-size:11px; font-weight:600; background:#eef7f2; border:1px solid rgba(150,214,180,.7); color:#2f7a56; }
 
+/* 分类管理（8 个固定槽位改名） */
+.council-list-header { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.council-list-header h2 { margin:0; }
+.category-manager { display:grid; gap:6px; border:1px solid rgba(210,190,240,.5); border-radius:12px; padding:10px; background:#fbf8ff; }
+.category-manager__row { display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; }
+.category-manager__key { font-size:11px; color:#8a7ba3; background:#f0ebfa; border-radius:6px; padding:3px 7px; min-width:64px; text-align:center; }
+.category-manager__row input { border:1px solid rgba(210,190,240,.7); border-radius:10px; padding:6px 10px; font:inherit; background:#fff; color:#1f2937; min-width:0; }
+.category-manager__save { border-radius:999px; border:1px solid rgba(210,190,240,.8); background:#fff; color:#6b4fa3; padding:5px 13px; font-size:12px; cursor:pointer; }
+.category-manager__save:hover:not(:disabled) { background:#f0e8fc; }
+.category-manager__save:disabled { opacity:.45; cursor:default; }
+
+/* 详情页分类下拉（即改即存） */
+.category-select { display:inline-flex; align-items:center; gap:6px; font-size:11px; color:#6b4fa3; }
+.category-select__label { font-weight:600; }
+.category-select select { border:1px solid rgba(210,190,240,.7); border-radius:999px; padding:3px 8px; font-size:12px; background:#f4effc; color:#6b4fa3; font-weight:600; }
+
 /* 两维筛选：状态分组 × 分类 */
 .council-filters { display:grid; gap:6px; }
 .filter-row { display:flex; flex-wrap:wrap; gap:6px; }

--- a/src/pages/AgentCouncilPage.tsx
+++ b/src/pages/AgentCouncilPage.tsx
@@ -9,7 +9,10 @@ import {
   deleteAgentCouncilProposal,
   deleteAgentCouncilTopic,
   listAgentCouncilMessages,
+  listCouncilCategories,
+  renameCouncilCategory,
   submitAgentCouncilReport,
+  updateAgentCouncilProposalCategory,
 } from '../storage/supabaseSync'
 import type {
   AgentCouncilCategory,
@@ -19,6 +22,7 @@ import type {
   AgentCouncilReportResult,
   AgentCouncilSpeaker,
   AgentCouncilVote,
+  CouncilCategorySlot,
 } from '../types'
 import './AgentCouncilPage.css'
 
@@ -68,8 +72,9 @@ const STATUS_GROUPS = [
 
 type StatusGroupKey = (typeof STATUS_GROUPS)[number]['key']
 
-// 分类值域由 MCP 工具层维护；这里只管展示文案，未知分类原样显示不崩。
-const CATEGORY_META: Record<string, string> = {
+// 分类是 8 个固定槽位：key 恒定，label 存 council_categories 表、可改名。
+// 这份内置表只做表还没加载出来时的兜底文案，权威名称以表数据为准。
+const CATEGORY_FALLBACK: Record<string, string> = {
   app: 'App 施工',
   memory: '记忆机制',
   infra: '基建运维',
@@ -80,19 +85,9 @@ const CATEGORY_META: Record<string, string> = {
   other: '其他',
 }
 
-const getCategoryLabel = (category: string | null) =>
-  category ? (CATEGORY_META[category] ?? category) : null
-
-const CATEGORY_OPTIONS: AgentCouncilCategory[] = [
-  'app',
-  'memory',
-  'infra',
-  'ritual',
-  'reading',
-  'game',
-  'council',
-  'other',
-]
+const CATEGORY_FALLBACK_SLOTS: CouncilCategorySlot[] = Object.entries(CATEGORY_FALLBACK).map(
+  ([key, label], index) => ({ key, label, sortOrder: index + 1 }),
+)
 
 const EXECUTOR_META: Record<AgentCouncilExecutor, string> = {
   codex_cli: 'Codex CLI',
@@ -176,6 +171,11 @@ const AgentCouncilPage = () => {
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
 
+  // 分类槽位（8 个固定 key，label 可改名）；加载失败时用内置兜底
+  const [categories, setCategories] = useState<CouncilCategorySlot[]>(CATEGORY_FALLBACK_SLOTS)
+  const [categoryManagerOpen, setCategoryManagerOpen] = useState(false)
+  const [categoryEdits, setCategoryEdits] = useState<Record<string, string>>({})
+
   // 列表两维筛选：状态分组 × 分类
   const [statusGroup, setStatusGroup] = useState<StatusGroupKey>('all')
   const [categoryFilter, setCategoryFilter] = useState<string>('all')
@@ -222,7 +222,28 @@ const AgentCouncilPage = () => {
     } finally {
       setLoading(false)
     }
+    // 分类表加载失败不阻塞页面，保留兜底文案即可
+    try {
+      const slots = await listCouncilCategories()
+      if (slots.length > 0) {
+        setCategories(slots)
+      }
+    } catch (categoryError) {
+      console.warn('加载分类槽位失败，使用内置兜底', categoryError)
+    }
   }, [])
+
+  const categoryLabelMap = useMemo(() => {
+    const map = new Map<string, string>()
+    categories.forEach((slot) => map.set(slot.key, slot.label))
+    return map
+  }, [categories])
+
+  const getCategoryLabel = useCallback(
+    (category: string | null) =>
+      category ? (categoryLabelMap.get(category) ?? CATEGORY_FALLBACK[category] ?? category) : null,
+    [categoryLabelMap],
+  )
 
   useEffect(() => {
     void refresh()
@@ -414,6 +435,50 @@ const AgentCouncilPage = () => {
     }
   }
 
+  // 提案分类事后可改：主行 + 子条目一并更新，保持继承一致。
+  const handleChangeProposalCategory = async (category: string) => {
+    if (!activeProposal || category === (activeProposal.category ?? 'other')) {
+      return
+    }
+    setSaving(true)
+    try {
+      await updateAgentCouncilProposalCategory(activeProposal.id, category)
+      setNotice(`分类已改为「${getCategoryLabel(category)}」`)
+      setError(null)
+      await refresh()
+    } catch (categoryError) {
+      console.warn('修改提案分类失败', categoryError)
+      setError('修改提案分类失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleRenameCategory = async (key: string) => {
+    const nextLabel = (categoryEdits[key] ?? '').trim()
+    const current = categories.find((slot) => slot.key === key)
+    if (!current || !nextLabel || nextLabel === current.label) {
+      return
+    }
+    setSaving(true)
+    try {
+      await renameCouncilCategory(key, nextLabel)
+      setNotice(`分类「${current.label}」已改名为「${nextLabel}」`)
+      setError(null)
+      await refresh()
+    } catch (renameError) {
+      console.warn('分类改名失败', renameError)
+      setError('分类改名失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const openCategoryManager = () => {
+    setCategoryEdits(Object.fromEntries(categories.map((slot) => [slot.key, slot.label])))
+    setCategoryManagerOpen(true)
+  }
+
   const handleSubmitReport = async (event: FormEvent) => {
     event.preventDefault()
     if (!activeProposal) {
@@ -524,8 +589,8 @@ const AgentCouncilPage = () => {
             <label className="council-field">
               <span>主题分类</span>
               <select value={newCategory} onChange={(e) => setNewCategory(e.target.value as AgentCouncilCategory)}>
-                {CATEGORY_OPTIONS.map((category) => (
-                  <option key={category} value={category}>{CATEGORY_META[category]}</option>
+                {categories.map((slot) => (
+                  <option key={slot.key} value={slot.key}>{slot.label}</option>
                 ))}
               </select>
             </label>
@@ -541,7 +606,41 @@ const AgentCouncilPage = () => {
       </section>
 
       <section className="council-panel">
-        <h2>主提案列表</h2>
+        <div className="council-list-header">
+          <h2>主提案列表</h2>
+          <button
+            type="button"
+            className="legacy-toggle"
+            onClick={() => (categoryManagerOpen ? setCategoryManagerOpen(false) : openCategoryManager())}
+          >
+            {categoryManagerOpen ? '收起分类管理' : '管理分类'}
+          </button>
+        </div>
+        {categoryManagerOpen ? (
+          <div className="category-manager">
+            <p className="decision-hint">
+              8 个分类槽位固定、不增不删，只能改名；改名后新旧提案统一显示新名称（数据里存的 key 不变，Agent 端不受影响）。
+            </p>
+            {categories.map((slot) => (
+              <div key={slot.key} className="category-manager__row">
+                <code className="category-manager__key">{slot.key}</code>
+                <input
+                  value={categoryEdits[slot.key] ?? slot.label}
+                  onChange={(e) => setCategoryEdits((prev) => ({ ...prev, [slot.key]: e.target.value }))}
+                  maxLength={20}
+                />
+                <button
+                  type="button"
+                  className="category-manager__save"
+                  onClick={() => void handleRenameCategory(slot.key)}
+                  disabled={saving || (categoryEdits[slot.key] ?? slot.label).trim() === slot.label || !(categoryEdits[slot.key] ?? slot.label).trim()}
+                >
+                  改名
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : null}
         <div className="council-filters">
           <div className="filter-row">
             {STATUS_GROUPS.map((group) => (
@@ -649,9 +748,21 @@ const AgentCouncilPage = () => {
             </div>
             <CollapsibleMarkdown content={activeProposal.message} />
             <div className="proposal-item__meta">
-              {getCategoryLabel(activeProposal.category) ? (
-                <span className="category-tag">{getCategoryLabel(activeProposal.category)}</span>
-              ) : null}
+              <label className="category-select">
+                <span className="category-select__label">分类</span>
+                <select
+                  value={activeProposal.category ?? 'other'}
+                  onChange={(e) => void handleChangeProposalCategory(e.target.value)}
+                  disabled={saving}
+                >
+                  {categories.map((slot) => (
+                    <option key={slot.key} value={slot.key}>{slot.label}</option>
+                  ))}
+                  {activeProposal.category && !categoryLabelMap.has(activeProposal.category) ? (
+                    <option value={activeProposal.category}>{activeProposal.category}</option>
+                  ) : null}
+                </select>
+              </label>
               {activeProposal.executor ? (
                 <span className="executor-tag">执行方：{EXECUTOR_META[activeProposal.executor]}</span>
               ) : null}

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -16,6 +16,7 @@ import type {
   AgentCouncilCategory,
   AgentCouncilExecutor,
   AgentCouncilReportResult,
+  CouncilCategorySlot,
   CheckinEntry,
   ForumAiProfile,
   ForumReply,
@@ -3164,6 +3165,65 @@ export const decideAgentCouncilProposal = async (payload: {
   })
   if (insertError) {
     throw insertError
+  }
+}
+
+// 分类槽位：固定 8 个 key，label 可改名（council_categories 表，见 migration 20260716070023）。
+export const listCouncilCategories = async (): Promise<CouncilCategorySlot[]> => {
+  if (!supabase) {
+    return []
+  }
+  const { data, error } = await supabase
+    .from('council_categories')
+    .select('key,label,sort_order')
+    .order('sort_order', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => ({
+    key: row.key as string,
+    label: row.label as string,
+    sortOrder: row.sort_order as number,
+  }))
+}
+
+// 给分类槽位改名（只允许动 label；key/槽位数量由 DB 权限锁死）。
+export const renameCouncilCategory = async (key: string, label: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const trimmed = label.trim()
+  if (!trimmed) {
+    throw new Error('分类名称不能为空')
+  }
+  const { error } = await supabase.from('council_categories').update({ label: trimmed }).eq('key', key)
+  if (error) {
+    throw error
+  }
+}
+
+// 修改提案的主题分类：主行更新，且子条目（评估/拍板/回执）一并跟随，保持继承一致。
+export const updateAgentCouncilProposalCategory = async (
+  proposalId: string,
+  category: string,
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const nowIso = new Date().toISOString()
+  const { error: mainError } = await supabase
+    .from('agent_council')
+    .update({ category, updated_at: nowIso })
+    .eq('id', proposalId)
+  if (mainError) {
+    throw mainError
+  }
+  const { error: childError } = await supabase
+    .from('agent_council')
+    .update({ category })
+    .eq('parent_id', proposalId)
+  if (childError) {
+    throw childError
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,6 +304,13 @@ export type AgentCouncilCategory =
 
 export type AgentCouncilExecutor = 'codex_cli' | 'claude_code_cli' | 'client' | 'chuanchuan'
 
+// 分类槽位（council_categories 表）：key 恒定 8 个，label 可改名。
+export type CouncilCategorySlot = {
+  key: string
+  label: string
+  sortOrder: number
+}
+
 export type AgentCouncilReportResult = 'succeeded' | 'partial' | 'failed'
 
 export type AgentCouncilMetadata = {

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -5,7 +5,7 @@ import { Hono } from 'npm:hono@^4.9.7'
 import { createClient } from 'jsr:@supabase/supabase-js@2'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.7.0'
+export const MCP_VERSION = '5.8.0'
 export const USER_ID = '94dd24be-e136-45bb-836b-6820c09c4292'
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-lounge-mcp/index.ts
+++ b/supabase/functions/hamster-lounge-mcp/index.ts
@@ -8,7 +8,8 @@ const READ_ENTRY_TYPE_SCHEMA = z.enum(['proposal', 'review', 'decision', 'report
 const PROPOSAL_STATUS_SCHEMA = z.enum(['open', 'approved', 'rejected', 'deferred', 'plan_generated', 'done', 'failed'])
 const VOTE_SCHEMA = z.enum(['support', 'neutral', 'against'])
 const METADATA_SCHEMA = z.record(z.string(), z.unknown())
-// 分类值域只在工具层校验（DB 不加 CHECK）——加新分类改这里重新部署即可，家规：新分类先提案再启用。
+// 分类是 8 个固定槽位：key 恒定（即本枚举，不增不删），展示名称存 council_categories 表、可在 Web 议事厅改名。
+// 拿不准当前各 key 对应什么名称时，先调 council_list_categories 查看再落分类。
 const CATEGORY_SCHEMA = z.enum(['app', 'memory', 'infra', 'ritual', 'reading', 'game', 'council', 'other'])
 // 执行方：只有 codex_cli / claude_code_cli 会唤醒 Mac mini 接单脚本；client=串串+客户端聊天完成；chuanchuan=纯手工。
 const EXECUTOR_SCHEMA = z.enum(['codex_cli', 'claude_code_cli', 'client', 'chuanchuan'])
@@ -17,6 +18,16 @@ const REPORT_RESULT_SCHEMA = z.enum(['succeeded', 'partial', 'failed'])
 const councilColumns = 'id, user_id, parent_id, speaker, topic, message, entry_type, proposal_status, vote, category, executor, metadata, read_by, created_at, updated_at'
 
 serveMcp('hamster-lounge-mcp', (server) => {
+  server.registerTool('council_list_categories', {
+    title: 'List Council Categories',
+    description: '列出议事厅 8 个固定分类槽位（key + 当前展示名称 label）。key 恒定不增不删；label 串串可在 Web 议事厅改名——发提案选分类前拿不准就先看一眼这里。',
+    inputSchema: {},
+  }, async () => {
+    const { data, error } = await supabase.from('council_categories').select('key, label, sort_order').order('sort_order', { ascending: true })
+    if (error) return errorResult(error)
+    return jsonResult(data)
+  })
+
   server.registerTool('lounge_list_sofas', {
     title: 'List Lounge Sofas',
     description: '列出仓鼠客厅的所有沙发（群聊会话）。不需要任何参数。客厅家规：不@不开口——只有被 @ 点名（mentions 包含你的 sender）时才在沙发上发言。',
@@ -91,12 +102,12 @@ serveMcp('hamster-lounge-mcp', (server) => {
 
   server.registerTool('council_propose', {
     title: 'Create Council Proposal',
-    description: '发起一条 Agent Council 正式提案。默认 proposal_status=open。请务必带 category 主题分类（缺省落 other）；家规：想加新分类先开提案讨论，通过后再改工具枚举启用。',
+    description: '发起一条 Agent Council 正式提案。默认 proposal_status=open。请务必带 category 主题分类（缺省落 other）。分类是 8 个固定槽位：key 恒定不增不删，展示名称可能被串串在 Web 改过——拿不准就先调 council_list_categories 查当前名称。',
     inputSchema: {
       speaker: SPEAKER_SCHEMA.describe('发起者'),
       topic: z.string().describe('提案主题'),
       message: z.string().describe('提案正文：背景、方案、收益、风险'),
-      category: CATEGORY_SCHEMA.optional().describe('主题分类：app（Expo/App 施工）/ memory（记忆机制）/ infra（数据库/MCP/mini/运维安全）/ ritual（打印/来信/收束）/ reading（阅读线）/ game（游戏区）/ council（议事厅自身）/ other（兜底，缺省值）'),
+      category: CATEGORY_SCHEMA.optional().describe('主题分类 key（8 个固定槽位，当前名称用 council_list_categories 查）；缺省落 other'),
       metadata: METADATA_SCHEMA.optional().describe('结构化元数据，如 risk_level / target_module / executable'),
     },
   }, async ({ speaker, topic, message, category, metadata }) => {

--- a/supabase/migrations/20260716070023_council_categories_fixed_slots.sql
+++ b/supabase/migrations/20260716070023_council_categories_fixed_slots.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- 议事厅分类槽位表：固定 8 个，key 恒定不增不删，label 可在 Web 改名
+-- agent_council.category 继续存 key，改名零数据迁移；
+-- 「固定 8 个」由 RLS/授权保证：客户端只有 SELECT + UPDATE(label)。
+-- ============================================================
+
+create table public.council_categories (
+  key text primary key,
+  label text not null check (btrim(label) <> ''),
+  sort_order int not null
+);
+
+comment on table public.council_categories is
+  '议事厅主题分类槽位：固定 8 个，key 恒定（agent_council.category 存 key），label 可在 Web 议事厅改名。不开放增删——多了不方便（2026-07-16 串串定）。';
+
+insert into public.council_categories (key, label, sort_order) values
+  ('app', 'App 施工', 1),
+  ('memory', '记忆机制', 2),
+  ('infra', '基建运维', 3),
+  ('ritual', '仪式', 4),
+  ('reading', '阅读线', 5),
+  ('game', '游戏区', 6),
+  ('council', '议事厅', 7),
+  ('other', '其他', 8);
+
+alter table public.council_categories enable row level security;
+
+create policy council_categories_select on public.council_categories
+  for select to authenticated using (true);
+-- 只允许已登录用户改名（单用户家庭应用；不建 INSERT/DELETE 策略 = 槽位数量锁死）
+create policy council_categories_update on public.council_categories
+  for update to authenticated
+  using ((select auth.uid()) is not null)
+  with check ((select auth.uid()) is not null);
+
+-- 列级权限收紧：改名只能动 label，key / sort_order 客户端不可写
+revoke all on table public.council_categories from anon;
+revoke insert, update, delete on table public.council_categories from authenticated;
+grant update (label) on public.council_categories to authenticated;
+
+-- category 列注释同步新语义（原「分类演进免 migration」表述由固定槽位+改名取代）
+comment on column public.agent_council.category is
+  '提案主题分类 key（8 个固定槽位，见 council_categories；label 可改名，key 恒定）。子条目由工具层从父提案继承。';


### PR DESCRIPTION
## 概要

议事厅分类机制补强（继 #473）：提案的主题分类事后可以改；分类固定 8 个槽位不增不删，但名称可以随时改。

设计要点：新建 `council_categories` 槽位表——`key` 恒定 8 个（`agent_council.category` 继续存 key，改名零数据迁移、Agent 端零影响），`label` 可改名。「固定 8 个」直接由数据库授权锁死：客户端只有 `SELECT` + `UPDATE(label)`，动 key、增行、删行都会被拒。

## 变更内容

**DB migration `20260716070023`（已直接上生产，文件随本 PR 入仓）**
- 新建 `council_categories`（key/label/sort_order），种子 8 行沿用现有分类
- RLS + 列级授权：authenticated 仅可改 label；无 INSERT/DELETE 策略
- `agent_council.category` 列注释同步「固定槽位 + 可改名」新语义

**`hamster-lounge-mcp`（v22 已按本分支源码部署；合并后 CI 重部署同内容）**
- 新增 `council_list_categories` 工具：列出 8 个槽位的 key + 当前名称，Agent 发提案拿不准分类时先查一眼
- `council_propose` / `council_read` 描述更新为固定槽位语义；category key 枚举不变，老调用全兼容
- `MCP_VERSION` → 5.8.0

**Web 议事厅页面**
- 分类下拉、筛选 chips、徽标全部改读 `council_categories`（带内置兜底，表加载失败不崩页面）
- 提案详情：分类变为下拉即改即存，主行 + 子条目（评估/拍板/回执）联动更新，保持继承一致
- 主提案列表新增「管理分类」折叠面板：8 个槽位逐个改名，界面上直接标注 key 恒定的规则

## 验证

- 权限锁实测：模拟 authenticated 角色改 label 放行；改 key、INSERT、DELETE 均 insufficient_privilege 拒绝；8 槽完整
- 提案改分类主行 + 子条目联动实测正确，测试数据零残留
- migration 后 advisors 零新增告警（改名策略未触发宽策略警告）
- `tsc -b`、eslint、`vite build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRefHCe9opUykJE5M2riRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRefHCe9opUykJE5M2riRQ)_