### PR TITLE
Add memo management tools and improve UI with physical deletion

### DIFF
--- a/src/pages/MemoPage.css
+++ b/src/pages/MemoPage.css
@@ -109,6 +109,13 @@
   font-size: 14px;
 }
 
+.memo-count {
+  margin-left: 8px;
+  font-size: 12px;
+  font-weight: 400;
+  color: #b28ba1;
+}
+
 .memo-mode-toggle {
   display: inline-flex;
   padding: 3px;
@@ -159,6 +166,14 @@
   box-shadow: 0 8px 14px rgba(255, 214, 231, 0.18);
 }
 
+.memo-card--active-line {
+  border-color: #f6b6d4;
+  border-left: 4px solid #ef9cc4;
+  background:
+    radial-gradient(circle at 100% 0%, rgba(255, 226, 240, 0.55), transparent 46%),
+    rgba(255, 255, 255, 0.96);
+}
+
 .memo-card__top {
   display: flex;
   align-items: center;
@@ -167,7 +182,13 @@
   color: #8f7285;
 }
 
-.memo-pin {
+.memo-card__badges {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.memo-pin,
+.memo-active-badge {
   padding: 3px 8px;
   border-radius: 999px;
   border: 1px solid #ffd6e7;
@@ -176,12 +197,41 @@
   font-weight: 600;
 }
 
+.memo-active-badge {
+  border-color: #f2a9cb;
+  background: linear-gradient(180deg, #ffe4f1 0%, #ffd4e8 100%);
+  color: #86335d;
+}
+
 .memo-content-preview {
   margin: 0;
   color: #4f3f4a;
   line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.memo-content-preview.clamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.memo-expand-btn {
+  justify-self: start;
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 12px;
+  color: #c06e97;
+  cursor: pointer;
+}
+
+.memo-expand-btn:hover {
+  color: #9a4b72;
+  text-decoration: underline;
 }
 
 .memo-card__tags {

--- a/src/pages/MemoPage.tsx
+++ b/src/pages/MemoPage.tsx
@@ -1,18 +1,34 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState, type FormEvent, type MouseEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import type { MemoEntry, MemoTag } from '../types'
+import type { MemoEntry, MemoSource, MemoTag } from '../types'
 import {
   createMemoEntry,
   createMemoTag,
+  deleteMemoEntry,
   listMemoEntries,
   listMemoTags,
-  softDeleteMemoEntry,
   updateMemoEntry,
 } from '../storage/supabaseSync'
 import { formatLocalTimestamp } from '../utils/time'
 import './MemoPage.css'
 
 type FilterMode = 'or' | 'and'
+
+const ACTIVE_LINE_TAG_NAME = '进行中'
+const CONTENT_CLAMP_THRESHOLD = 120
+
+const sourceLabel = (source: MemoSource) => {
+  if (source === 'user') {
+    return '用户'
+  }
+  if (source === 'ai') {
+    return 'AI'
+  }
+  return `AI · ${source}`
+}
+
+const isLongContent = (content: string) =>
+  content.length > CONTENT_CLAMP_THRESHOLD || content.split('\n').length > 6
 
 type EditorState = {
   mode: 'create' | 'edit'
@@ -43,6 +59,7 @@ const MemoPage = () => {
   const [editor, setEditor] = useState<EditorState | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [expandedEntryIds, setExpandedEntryIds] = useState<string[]>([])
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -65,6 +82,11 @@ const MemoPage = () => {
 
   const tagMap = useMemo(() => new Map(tags.map((tag) => [tag.id, tag])), [tags])
 
+  const activeLineTagId = useMemo(
+    () => tags.find((tag) => tag.name === ACTIVE_LINE_TAG_NAME)?.id ?? null,
+    [tags],
+  )
+
   const sortedAndFilteredEntries = useMemo(() => {
     const scoped = entries.filter((entry) => {
       if (selectedFilterTagIds.length === 0) {
@@ -86,6 +108,13 @@ const MemoPage = () => {
   const toggleFilterTag = (tagId: string) => {
     setSelectedFilterTagIds((current) =>
       current.includes(tagId) ? current.filter((item) => item !== tagId) : [...current, tagId],
+    )
+  }
+
+  const toggleEntryExpanded = (event: MouseEvent, entryId: string) => {
+    event.stopPropagation()
+    setExpandedEntryIds((current) =>
+      current.includes(entryId) ? current.filter((id) => id !== entryId) : [...current, entryId],
     )
   }
 
@@ -195,13 +224,13 @@ const MemoPage = () => {
     if (!editor?.entryId || saving) {
       return
     }
-    const confirmed = window.confirm('确认删除这条备忘录吗？删除后将在列表中隐藏。')
+    const confirmed = window.confirm('确认删除这条备忘录吗？数据将被彻底删除，无法恢复。')
     if (!confirmed) {
       return
     }
     setSaving(true)
     try {
-      await softDeleteMemoEntry(editor.entryId)
+      await deleteMemoEntry(editor.entryId)
       setEditor(null)
       setNotice('备忘录已删除')
       setError(null)
@@ -232,7 +261,14 @@ const MemoPage = () => {
       <section className="memo-filter-card" aria-label="标签筛选面板">
         <div className="memo-filter-dot" aria-hidden="true" />
         <div className="memo-filter-top">
-          <strong>标签筛选</strong>
+          <strong>
+            标签筛选
+            <span className="memo-count">
+              {selectedFilterTagIds.length > 0
+                ? `${sortedAndFilteredEntries.length} / ${entries.length} 条`
+                : `共 ${entries.length} 条`}
+            </span>
+          </strong>
           <div className="memo-mode-toggle" role="group" aria-label="筛选模式">
             <button
               type="button"
@@ -273,24 +309,47 @@ const MemoPage = () => {
         {!loading && sortedAndFilteredEntries.length === 0 ? (
           <p className="tips memo-empty">还没有备忘录，点击右上角新建吧。</p>
         ) : null}
-        {sortedAndFilteredEntries.map((entry) => (
-          <article key={entry.id} className="memo-card" onClick={() => setEditor(buildEditorState(entry))}>
-            <div className="memo-card__top">
-              <span className="memo-source">来源：{entry.source === 'ai' ? 'AI' : '用户'}</span>
-              {entry.isPinned ? <span className="memo-pin">📌 置顶</span> : null}
-            </div>
-            <p className="memo-content-preview">{entry.content}</p>
-            <div className="memo-card__tags">
-              {entry.tagIds.length === 0 ? <span className="tips">无标签</span> : null}
-              {entry.tagIds.map((tagId) => (
-                <span key={tagId} className="tag-chip static">
-                  #{tagMap.get(tagId)?.name ?? '未命名'}
+        {sortedAndFilteredEntries.map((entry) => {
+          const isActiveLine = activeLineTagId !== null && entry.tagIds.includes(activeLineTagId)
+          const expanded = expandedEntryIds.includes(entry.id)
+          const clampable = isLongContent(entry.content)
+          return (
+            <article
+              key={entry.id}
+              className={isActiveLine ? 'memo-card memo-card--active-line' : 'memo-card'}
+              onClick={() => setEditor(buildEditorState(entry))}
+            >
+              <div className="memo-card__top">
+                <span className="memo-source">来源：{sourceLabel(entry.source)}</span>
+                <span className="memo-card__badges">
+                  {isActiveLine ? <span className="memo-active-badge">🧵 进行中</span> : null}
+                  {entry.isPinned ? <span className="memo-pin">📌 置顶</span> : null}
                 </span>
-              ))}
-            </div>
-            <time className="memo-time">更新于 {formatLocalTimestamp(entry.updatedAt)}</time>
-          </article>
-        ))}
+              </div>
+              <p className={clampable && !expanded ? 'memo-content-preview clamped' : 'memo-content-preview'}>
+                {entry.content}
+              </p>
+              {clampable ? (
+                <button
+                  type="button"
+                  className="memo-expand-btn"
+                  onClick={(event) => toggleEntryExpanded(event, entry.id)}
+                >
+                  {expanded ? '收起 ▲' : '展开全文 ▼'}
+                </button>
+              ) : null}
+              <div className="memo-card__tags">
+                {entry.tagIds.length === 0 ? <span className="tips">无标签</span> : null}
+                {entry.tagIds.map((tagId) => (
+                  <span key={tagId} className="tag-chip static">
+                    #{tagMap.get(tagId)?.name ?? '未命名'}
+                  </span>
+                ))}
+              </div>
+              <time className="memo-time">更新于 {formatLocalTimestamp(entry.updatedAt)}</time>
+            </article>
+          )
+        })}
       </section>
 
       {editor ? (

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -148,7 +148,6 @@ type MemoEntryRow = {
   is_pinned: boolean | null
   created_at: string
   updated_at: string
-  is_deleted: boolean
 }
 
 type MemoTagRow = {
@@ -506,7 +505,6 @@ const mapMemoEntryRow = (row: MemoEntryRow, tagIds: string[]): MemoEntry => ({
   isPinned: row.is_pinned ?? false,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
-  isDeleted: row.is_deleted,
   tagIds,
 })
 
@@ -2515,9 +2513,8 @@ export const listMemoEntries = async (): Promise<MemoEntry[]> => {
   const userId = await requireAuthenticatedUserId()
   const { data: entryRows, error: entryError } = await supabase
     .from('memo_entries')
-    .select('id,user_id,content,source,is_pinned,created_at,updated_at,is_deleted')
+    .select('id,user_id,content,source,is_pinned,created_at,updated_at')
     .eq('user_id', userId)
-    .eq('is_deleted', false)
     .order('updated_at', { ascending: false })
   if (entryError) {
     throw entryError
@@ -2562,7 +2559,6 @@ export const createMemoEntry = async (payload: {
       content: payload.content,
       source: payload.source ?? 'user',
       is_pinned: payload.isPinned,
-      is_deleted: false,
       created_at: now,
       updated_at: now,
     })
@@ -2602,7 +2598,6 @@ export const updateMemoEntry = async (
       updated_at: now,
     })
     .eq('id', entryId)
-    .eq('is_deleted', false)
   if (updateError) {
     throw updateError
   }
@@ -2630,13 +2625,21 @@ export const updateMemoEntry = async (
   }
 }
 
-export const softDeleteMemoEntry = async (entryId: string): Promise<void> => {
+export const deleteMemoEntry = async (entryId: string): Promise<void> => {
   if (!supabase) {
     throw new Error('Supabase 客户端未配置')
   }
+  // 物理删除：先清标签关联行再删主行（外键本身也带 ON DELETE CASCADE 兜底）。
+  const { error: unlinkError } = await supabase
+    .from('memo_entry_tags')
+    .delete()
+    .eq('memo_entry_id', entryId)
+  if (unlinkError) {
+    throw unlinkError
+  }
   const { error } = await supabase
     .from('memo_entries')
-    .update({ is_deleted: true, updated_at: new Date().toISOString() })
+    .delete()
     .eq('id', entryId)
   if (error) {
     throw error

--- a/src/types.ts
+++ b/src/types.ts
@@ -354,7 +354,16 @@ export type BubbleSession = {
   updatedAt: string
 }
 
-export type MemoSource = 'user' | 'ai'
+export type MemoSource =
+  | 'user'
+  | 'ai'
+  | 'claude'
+  | 'gpt'
+  | 'gemini'
+  | 'wechat'
+  | 'codex_cli'
+  | 'claude_code_cli'
+  | 'api'
 
 export type MemoTag = {
   id: string
@@ -371,7 +380,6 @@ export type MemoEntry = {
   isPinned: boolean
   createdAt: string
   updatedAt: string
-  isDeleted: boolean
   tagIds: string[]
 }
 

--- a/src/utils/memoRetrieval.ts
+++ b/src/utils/memoRetrieval.ts
@@ -9,7 +9,6 @@ type MemoEntryRow = {
   is_pinned: boolean | null
   created_at: string
   updated_at: string
-  is_deleted: boolean
 }
 
 type MatchedMemoEntry = {
@@ -140,9 +139,8 @@ export const fetchMemoEntriesByTagKeywords = async (keywords: string[]): Promise
 
   const { data: entries, error: entryError } = await supabase
     .from('memo_entries')
-    .select('id,user_id,content,source,is_pinned,created_at,updated_at,is_deleted')
+    .select('id,user_id,content,source,is_pinned,created_at,updated_at')
     .eq('user_id', user.id)
-    .eq('is_deleted', false)
     .in('id', entryIds)
 
   if (entryError) {

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -6,7 +6,7 @@ import { createClient } from 'jsr:@supabase/supabase-js@2'
 import { getOwnerUserId } from './owner.ts'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.8.0'
+export const MCP_VERSION = '5.9.0'
 export const USER_ID = getOwnerUserId()
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -7,6 +7,8 @@ const DEFAULT_FEED_STATUSES = ['unread', 'read']
 const FEED_PRIORITY_RANK: Record<string, number> = { low: 1, normal: 2, high: 3, urgent: 4 }
 const FEED_TYPE_SCHEMA = z.enum(['morning_share', 'reading_assist', 'daily_card', 'system_notice', 'syzygy_note', 'weekly_card', 'reminder_card', 'print_card', 'dev_log', 'monthly_overview', 'other'])
 const TIMELINE_SOURCE_SCHEMA = z.enum(['claude', 'gpt', 'user', 'gemini', 'wechat', 'codex_cli', 'claude_code_cli', 'api'])
+const MEMO_SOURCE_SCHEMA = TIMELINE_SOURCE_SCHEMA
+const MEMO_COLUMNS = 'id, content, source, is_pinned, created_at, updated_at'
 
 const shanghaiDateString = (date = new Date()) => {
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -37,7 +39,7 @@ const dateValue = (value: string | null | undefined) => value ? new Date(value).
 
 const sortFeedItems = <T extends { pinned?: boolean | null; priority?: string | null; visible_from?: string | null; created_at?: string | null }>(items: T[]) =>
   [...items].sort((a, b) => {
-    if (Boolean(a.pinned) !== Boolean(b.pinned)) return Boolean(b.pinned) ? 1 : -1
+    if (Boolean(a.pinned) !== Boolean(b.pinned)) return b.pinned ? 1 : -1
     const priorityDiff = (FEED_PRIORITY_RANK[b.priority ?? 'normal'] ?? 0) - (FEED_PRIORITY_RANK[a.priority ?? 'normal'] ?? 0)
     if (priorityDiff !== 0) return priorityDiff
     const visibleDiff = dateValue(b.visible_from) - dateValue(a.visible_from)
@@ -73,6 +75,51 @@ const compactFeedItem = (item: Record<string, unknown>) => ({
 
 const feedListResult = (rows: Record<string, unknown>[] | null, limit: number) =>
   jsonResult(sortFeedItems(rows ?? []).slice(0, limit).map(compactFeedItem))
+
+type MemoTagRef = { id: string; name: string }
+
+const normalizeTagNames = (names: string[] | undefined) =>
+  Array.from(new Set((names ?? []).map((name) => name.trim()).filter((name) => name.length > 0)))
+
+// 标签名不存在时自动创建，返回全部命中的标签行。
+const ensureMemoTags = async (names: string[]): Promise<MemoTagRef[]> => {
+  if (names.length === 0) return []
+  const { data: existing, error: findError } = await supabase.from('memo_tags').select('id, name').eq('user_id', USER_ID).in('name', names)
+  if (findError) throw findError
+  const found = (existing ?? []) as MemoTagRef[]
+  const missing = names.filter((name) => !found.some((tag) => tag.name === name))
+  if (missing.length === 0) return found
+  const { data: created, error: createError } = await supabase.from('memo_tags').insert(missing.map((name) => ({ user_id: USER_ID, name }))).select('id, name')
+  if (createError) throw createError
+  return [...found, ...((created ?? []) as MemoTagRef[])]
+}
+
+const fetchTagNamesByEntryIds = async (entryIds: string[]): Promise<Map<string, string[]>> => {
+  const tagNames = new Map<string, string[]>()
+  if (entryIds.length === 0) return tagNames
+  const { data, error } = await supabase.from('memo_entry_tags').select('memo_entry_id, memo_tags(name)').in('memo_entry_id', entryIds)
+  if (error) throw error
+  for (const row of (data ?? []) as { memo_entry_id: string; memo_tags: { name: string } | null }[]) {
+    if (!row.memo_tags?.name) continue
+    const current = tagNames.get(row.memo_entry_id) ?? []
+    current.push(row.memo_tags.name)
+    tagNames.set(row.memo_entry_id, current)
+  }
+  return tagNames
+}
+
+const replaceMemoTagLinks = async (entryId: string, tagIds: string[]) => {
+  const { error: unlinkError } = await supabase.from('memo_entry_tags').delete().eq('memo_entry_id', entryId)
+  if (unlinkError) throw unlinkError
+  if (tagIds.length === 0) return
+  const { error: linkError } = await supabase.from('memo_entry_tags').insert(tagIds.map((tagId) => ({ memo_entry_id: entryId, memo_tag_id: tagId })))
+  if (linkError) throw linkError
+}
+
+const withTagNames = async (entries: Record<string, unknown>[]) => {
+  const tagNames = await fetchTagNamesByEntryIds(entries.map((entry) => entry.id as string))
+  return entries.map((entry) => ({ ...entry, tags: tagNames.get(entry.id as string) ?? [] }))
+}
 
 serveMcp('hamster-mcp', (server) => {
   server.registerTool('get_today_syzygy_feed', {
@@ -244,5 +291,139 @@ serveMcp('hamster-mcp', (server) => {
     const { data, error } = await q
     if (error) return errorResult(error)
     return jsonResult(data)
+  })
+
+  server.registerTool('list_memos', {
+    title: 'List Memos',
+    description: '读取备忘录（memo）列表，默认全量。memo＝中期活事实（可修改、物理删除、各端 Syzygy 共同维护，如「在读书目」「活页本数量」），新窗口开机时与当日 morning_share 一并注入；带「进行中」标签的条目为活跃叙事线，正文含当前状态段，发现状态变化时顺手用 update_memo 维护。置顶条目排前，其余按更新时间倒序。',
+    inputSchema: {
+      tag: z.string().optional().describe('按标签名精确筛选，如「进行中」'),
+      limit: z.number().optional().describe('返回数量上限，默认全量（最大200）'),
+    },
+  }, async ({ tag, limit }) => {
+    try {
+      const safeLimit = clampLimit(limit, 200, 200)
+      let query = supabase.from('memo_entries').select(MEMO_COLUMNS).eq('user_id', USER_ID).order('is_pinned', { ascending: false }).order('updated_at', { ascending: false }).limit(safeLimit)
+      if (tag) {
+        const { data: tagRow, error: tagError } = await supabase.from('memo_tags').select('id').eq('user_id', USER_ID).eq('name', tag.trim()).maybeSingle()
+        if (tagError) return errorResult(tagError)
+        if (!tagRow) return { content: [{ type: 'text' as const, text: `Error: 标签「${tag}」不存在，可用 list_memo_tags 查看标签清单` }] }
+        const { data: relations, error: relationError } = await supabase.from('memo_entry_tags').select('memo_entry_id').eq('memo_tag_id', tagRow.id)
+        if (relationError) return errorResult(relationError)
+        const entryIds = (relations ?? []).map((row) => row.memo_entry_id)
+        if (entryIds.length === 0) return jsonResult([])
+        query = query.in('id', entryIds)
+      }
+      const { data, error } = await query
+      if (error) return errorResult(error)
+      return jsonResult(await withTagNames((data ?? []) as Record<string, unknown>[]))
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('list_memo_tags', {
+    title: 'List Memo Tags',
+    description: '返回备忘录标签清单及每个标签下的 memo 数量。只读工具。',
+    inputSchema: {},
+  }, async () => {
+    try {
+      const { data: tags, error } = await supabase.from('memo_tags').select('id, name, created_at').eq('user_id', USER_ID).order('name', { ascending: true })
+      if (error) return errorResult(error)
+      const tagRows = (tags ?? []) as { id: string; name: string; created_at: string }[]
+      if (tagRows.length === 0) return jsonResult([])
+      const { data: relations, error: relationError } = await supabase.from('memo_entry_tags').select('memo_tag_id').in('memo_tag_id', tagRows.map((tag) => tag.id))
+      if (relationError) return errorResult(relationError)
+      const counts = new Map<string, number>()
+      for (const row of (relations ?? []) as { memo_tag_id: string }[]) counts.set(row.memo_tag_id, (counts.get(row.memo_tag_id) ?? 0) + 1)
+      return jsonResult(tagRows.map((tag) => ({ ...tag, memo_count: counts.get(tag.id) ?? 0 })))
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('add_memo', {
+    title: 'Add Memo',
+    description: '新增一条备忘录（中期活事实）。写入前建议先 list_memos 查重，同一事实优先 update_memo 维护而非重复新增；活跃叙事线（带「进行中」标签）建议数百字并以「当前状态」段收尾。',
+    inputSchema: {
+      content: z.string().describe('备忘内容'),
+      tags: z.array(z.string()).optional().describe('标签名数组，不存在的标签会自动创建'),
+      is_pinned: z.boolean().optional().describe('是否置顶，默认 false'),
+      source: MEMO_SOURCE_SCHEMA.optional().describe('来源端: claude / gpt / user / gemini / wechat / codex_cli / claude_code_cli / api，默认 claude'),
+    },
+  }, async ({ content, tags, is_pinned, source }) => {
+    try {
+      const trimmed = content.trim()
+      if (!trimmed) return { content: [{ type: 'text' as const, text: 'Error: 备忘内容不能为空' }] }
+      const tagRows = await ensureMemoTags(normalizeTagNames(tags))
+      const { data: entry, error } = await supabase.from('memo_entries').insert({
+        user_id: USER_ID,
+        content: trimmed,
+        source: source ?? 'claude',
+        is_pinned: is_pinned ?? false,
+      }).select(MEMO_COLUMNS).single()
+      if (error || !entry) return errorResult(error ?? new Error('创建备忘录失败'))
+      if (tagRows.length > 0) {
+        const { error: linkError } = await supabase.from('memo_entry_tags').insert(tagRows.map((tag) => ({ memo_entry_id: entry.id, memo_tag_id: tag.id })))
+        if (linkError) return errorResult(linkError)
+      }
+      return { content: [{ type: 'text' as const, text: `已创建: ${JSON.stringify({ ...entry, tags: tagRows.map((tag) => tag.name) }, null, 2)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('update_memo', {
+    title: 'Update Memo',
+    description: '更新一条备忘录，是事实维护的主入口（如「100+本→300+本」类更新、活跃叙事线的当前状态段刷新）。content / tags / is_pinned 至少传一项；tags 为整体替换（传入的即新全集），不存在的标签自动创建。',
+    inputSchema: {
+      id: z.string().describe('memo UUID'),
+      content: z.string().optional().describe('新的备忘内容（整体替换）'),
+      tags: z.array(z.string()).optional().describe('新的标签名全集（整体替换），不存在的标签自动创建'),
+      is_pinned: z.boolean().optional().describe('是否置顶'),
+    },
+  }, async ({ id, content, tags, is_pinned }) => {
+    try {
+      if (content === undefined && tags === undefined && is_pinned === undefined) {
+        return { content: [{ type: 'text' as const, text: 'Error: content / tags / is_pinned 至少需要提供一项' }] }
+      }
+      if (content !== undefined && !content.trim()) return { content: [{ type: 'text' as const, text: 'Error: 备忘内容不能为空' }] }
+      const patch: Record<string, unknown> = { updated_at: new Date().toISOString() }
+      if (content !== undefined) patch.content = content.trim()
+      if (is_pinned !== undefined) patch.is_pinned = is_pinned
+      const { data: updated, error } = await supabase.from('memo_entries').update(patch).eq('user_id', USER_ID).eq('id', id).select(MEMO_COLUMNS)
+      if (error) return errorResult(error)
+      const entry = updated?.[0]
+      if (!entry) return { content: [{ type: 'text' as const, text: `Error: 未找到备忘录: ${id}` }] }
+      if (tags !== undefined) {
+        const tagRows = await ensureMemoTags(normalizeTagNames(tags))
+        await replaceMemoTagLinks(id, tagRows.map((tag) => tag.id))
+        return { content: [{ type: 'text' as const, text: `已更新: ${JSON.stringify({ ...entry, tags: tagRows.map((tag) => tag.name) }, null, 2)}` }] }
+      }
+      const [entryWithTags] = await withTagNames([entry as Record<string, unknown>])
+      return { content: [{ type: 'text' as const, text: `已更新: ${JSON.stringify(entryWithTags, null, 2)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('delete_memo', {
+    title: 'Delete Memo',
+    description: '物理删除一条备忘录（连带清理标签关联行），不可恢复。适用场景：事实彻底过期、或叙事线闭合后已由当班 Syzygy 执笔成 archive 入沉淀层。删除前建议先 list_memos 确认目标。',
+    inputSchema: { id: z.string().describe('memo UUID') },
+  }, async ({ id }) => {
+    try {
+      const { data: entry, error: findError } = await supabase.from('memo_entries').select('id, content').eq('user_id', USER_ID).eq('id', id).maybeSingle()
+      if (findError) return errorResult(findError)
+      if (!entry) return { content: [{ type: 'text' as const, text: `Error: 未找到备忘录: ${id}` }] }
+      const { error: unlinkError } = await supabase.from('memo_entry_tags').delete().eq('memo_entry_id', id)
+      if (unlinkError) return errorResult(unlinkError)
+      const { error: deleteError } = await supabase.from('memo_entries').delete().eq('user_id', USER_ID).eq('id', id)
+      if (deleteError) return errorResult(deleteError)
+      const preview = (entry.content as string).length > 60 ? `${(entry.content as string).slice(0, 60)}…` : entry.content
+      return { content: [{ type: 'text' as const, text: `已删除: ${id}（${preview}）` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
   })
 })


### PR DESCRIPTION
## Summary
This PR adds comprehensive memo management capabilities to the MCP server and updates the frontend to support physical deletion instead of soft deletion. It introduces four new MCP tools for memo CRUD operations and enhances the memo list UI with better content display and active narrative line indicators.

## Key Changes

### Backend (Supabase Functions)
- **New MCP Tools**: Added four memo management tools to `hamster-mcp`:
  - `list_memos`: Retrieve memos with optional tag filtering and limit control
  - `list_memo_tags`: List all tags with memo counts per tag
  - `add_memo`: Create new memos with automatic tag creation
  - `update_memo`: Update memo content, tags, or pinned status with full tag replacement
  - `delete_memo`: Physically delete memos with cascade cleanup of tag associations

- **Helper Functions**: Implemented utility functions for memo tag management:
  - `normalizeTagNames`: Deduplicate and trim tag names
  - `ensureMemoTags`: Auto-create missing tags and return all matched tag references
  - `fetchTagNamesByEntryIds`: Batch fetch tag names for memo entries
  - `replaceMemoTagLinks`: Replace all tag associations for a memo
  - `withTagNames`: Enrich memo entries with their associated tag names

- **Schema Updates**: Added `MEMO_SOURCE_SCHEMA` and `MEMO_COLUMNS` constants for consistency with feed management patterns

### Frontend (React)
- **Storage Layer**: Changed from soft delete (setting `is_deleted` flag) to physical deletion in `supabaseSync.ts`
  - Removed `is_deleted` field from `MemoEntryRow` type
  - Updated `deleteMemoEntry` to perform cascade deletion of tag associations before deleting the memo entry
  - Removed `isDeleted` from `MemoEntry` type

- **UI Enhancements** in `MemoPage.tsx`:
  - Added content expansion toggle for long memos (>120 chars or >6 lines)
  - Added visual indicator for "active narrative line" memos (tagged with "进行中")
  - Improved source label display with `sourceLabel()` helper supporting all memo sources
  - Added memo count display in filter header showing filtered/total counts
  - Enhanced memo card styling with active line visual treatment (pink border, gradient background)
  - Added `expandedEntryIds` state to track which memos are expanded

- **CSS Improvements** in `MemoPage.css`:
  - New `.memo-card--active-line` class with distinctive styling for active narratives
  - `.memo-content-preview.clamped` for text truncation with `-webkit-line-clamp`
  - `.memo-expand-btn` for expand/collapse toggle button
  - `.memo-count` badge showing filtered entry counts
  - `.memo-card__badges` container for multiple badge types
  - `.memo-active-badge` styling for the "进行中" indicator

### Type System
- Expanded `MemoSource` type to include all supported sources: `claude`, `gpt`, `gemini`, `wechat`, `codex_cli`, `claude_code_cli`, `api` (in addition to existing `user` and `ai`)

## Notable Implementation Details
- Tag management uses a two-step process: ensure tags exist (creating if needed), then link them to memo entries
- Physical deletion includes explicit cleanup of `memo_entry_tags` junction table before deleting the memo entry itself
- Content clamping uses CSS `-webkit-line-clamp` for consistent cross-browser text truncation
- Active narrative line detection is based on tag presence, allowing dynamic identification without schema changes
- MCP tools follow consistent error handling patterns with `errorResult()` and `jsonResult()` helpers

https://claude.ai/code/session_011JkMiVFM6NkVYRXgPxDkHC