### PR TITLE
db: device_status 开放 authenticated owner INSERT（V4.0 Phase 3）

### DIFF
--- a/supabase/migrations/20260718092130_v4_phase3_device_status_app_insert.sql
+++ b/supabase/migrations/20260718092130_v4_phase3_device_status_app_insert.sql
@@ -1,0 +1,13 @@
+-- V4.0 Phase 3：Expo App 以 authenticated owner 身份直写 device_status。
+-- 背景：device_status 此前只有 SELECT 策略（device_status_select_authenticated），
+-- 写入全部经 device-report Edge Function（快捷指令降级通道，service_role 服务端写）。
+-- 本迁移只开 INSERT：事实日志不开客户端 UPDATE/DELETE；不恢复 anon INSERT。
+
+create policy device_status_insert_own
+  on public.device_status
+  for insert
+  to authenticated
+  with check (user_id = (select auth.uid()));
+
+comment on column public.device_status.source_app is
+  'expo_app = Expo App 直写（authenticated owner INSERT，V4.0 Phase 3 起）；为空 = 快捷指令经 device-report Edge Function 服务端写入的历史与降级通道。';


### PR DESCRIPTION
## 变更
- 新增 RLS 策略 `device_status_insert_own`：`for insert to authenticated with check (user_id = (select auth.uid()))`
- `source_app` 列注释更新：`expo_app` = App 直写；空 = 快捷指令经 device-report Edge Function

## 验证证据
- 生产库 BEGIN…ROLLBACK 演练：业主 JWT INSERT 成功（已回滚）；他人 JWT 冒写业主行被 42501 拒绝
- 已正式 apply 生产库（migration `v4_phase3_device_status_app_insert`）
- security advisors 复跑：零新增告警（device_status 无新条目）

## 风险与回滚
- 只开 INSERT，无 UPDATE/DELETE 策略，事实日志追加语义不变；anon 仍零策略
- 回滚：`drop policy device_status_insert_own on public.device_status;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)