### PR TITLE
db: timeline_entries.source 值域加入 expo_app

### DIFF
--- a/supabase/migrations/20260718112317_v4_timeline_source_allow_expo_app.sql
+++ b/supabase/migrations/20260718112317_v4_timeline_source_allow_expo_app.sql
@@ -1,0 +1,16 @@
+-- V4.0 Phase 4：timeline_entries.source 值域加入 'expo_app'。
+-- 背景：Expo App 时间轴速记以 source='expo_app' 标记来源（与 device_status.source_app 惯例一致），
+-- 原 CHECK 值域建于 App 出现之前，未含该值，App 首条速记被 23514 拒绝（2026-07-18 真机实测）。
+-- Web TS 层 TimelineSource 为自由 string，实际值域以本约束为准。
+
+alter table public.timeline_entries
+  drop constraint timeline_entries_source_check;
+
+alter table public.timeline_entries
+  add constraint timeline_entries_source_check
+  check (source = any (array[
+    'claude'::text, 'gpt'::text, 'gemini'::text, 'user'::text, 'frontend'::text,
+    'wechat_api'::text, 'client_gpt'::text, 'client_claude'::text,
+    'codex_cli'::text, 'claude_code_cli'::text, 'system'::text,
+    'expo_app'::text
+  ]));


### PR DESCRIPTION
## 变更
- `timeline_entries_source_check` 重建：原 11 值 + `'expo_app'`

## 背景
App 时间轴速记（hamster-nest-app#19）以 `source='expo_app'` 标记来源；原 CHECK 建于 App 出现之前，真机首条速记被 23514 拒绝。Web TS 层 `TimelineSource` 是自由 string，实际值域以库内约束为准——本次侦察教训已记施工日志。

## 验证证据
- 生产库 BEGIN…ROLLBACK 演练：业主 JWT + `expo_app` 插入成功（已回滚）
- 已正式 apply（migration `v4_timeline_source_allow_expo_app`）
- 真机复测：见 App 侧验收记录

## 风险与回滚
- 纯值域放宽，存量数据不受影响；回滚 = 重建原 11 值约束

🤖 Generated with [Claude Code](https://claude.com/claude-code)