### PR TITLE
feat: add Supabase remote print MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 **这里是一只名叫串串的布丁仓鼠，和她的饲养员 AI · Syzygy 的独立应用。**
 
 [![Version](https://img.shields.io/badge/Version-v5.3.0-pink?style=flat-square)](#)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-41-2dd4bf?style=flat-square)](#-mcp-工具箱全部-41-个)
-[![Edge Functions](https://img.shields.io/badge/Edge_Functions-14-8b5cf6?style=flat-square)](#-后端-edge-functions)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-51-2dd4bf?style=flat-square)](#-mcp-工具箱全部-51-个)
+[![Edge Functions](https://img.shields.io/badge/Edge_Functions-16-8b5cf6?style=flat-square)](#-后端-edge-functions)
 [![PRs](https://img.shields.io/badge/PRs-1000+-ff69b4?style=flat-square)](#)
 [![PWA](https://img.shields.io/badge/PWA-可装进手机-f59e0b?style=flat-square)](#)
 [![Syzygy](https://img.shields.io/badge/Syzygy-🩷_×_💙-2dd4bf?style=flat-square)](#)
@@ -100,15 +100,16 @@
 
 **前端：** React 19 + Vite 7 + TypeScript + Tailwind 风格自研样式，打包成 **PWA**，可以添加到手机主屏幕吱！游戏形态用 **Phaser 3** 渲染像素小屋。
 
-**后端：** 一组 **Supabase Edge Functions（Deno）**，其中 5 个是独立的 **MCP 服务器**，用 Hono + Streamable HTTP 传输，工具 schema 全部由服务端动态下发，前端零硬编码——
+**后端：** 一组 **Supabase Edge Functions（Deno）**，其中 6 个是独立的 **MCP 服务器**，用 Hono + Streamable HTTP 传输，工具 schema 全部由服务端动态下发，前端零硬编码——
 
 | MCP 服务器 | 职责 | 工具数 |
 |:---|:---|:---:|
-| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 | 9 |
+| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 | 14 |
 | `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki | 8 |
-| `hamster-reading-mcp` | 阅读记录 · 书摘 · 旁批共鸣 · 书籍问答 | 9 |
-| `hamster-lounge-mcp` | 仓鼠客厅 · 议事厅 | 8 |
+| `hamster-reading-mcp` | 阅读记录 · 书摘 · 章节 · 旁批共鸣 · 书籍问答 | 10 |
+| `hamster-lounge-mcp` | 仓鼠客厅 · 议事厅 | 10 |
 | `hamster-life-mcp` | 高德地图 · 瑞幸 · 麦当劳 · TTS 语音 | 7 |
+| `hamster-print-mcp` | 远程打印投递 · 打印状态 | 2 |
 
 **AI 模型：** 统一经 **OpenRouter / 自定义 Provider** 接入（`llm_providers` 表按用户配置），不绑定任何单一模型；支持深度思考、长上下文压缩、工具循环。
 
@@ -135,6 +136,7 @@ com.syzygy.mini-agent
 | 💬 WeChat Bridge | `src/cli/wechat.js` + `src/wechat/bridge.py` | 接收 / 发送 WeChat 消息，把微信上下文写回 Supabase |
 | 📮 WeChat 发送队列 | `src/wechat/bus-runner.js` | 监听 `pending_wechat_messages`，认领待发消息，成功 / 失败都写审计 |
 | 🧭 命令监听器 | `src/commands/listener.js` | 监听 `syzygy_commands`，把云端写入的任务交给本地执行器 |
+| 🖨️ 打印 worker | `src/commands/executors.js` + `tools/diary_printer.swift` | 领取 `print_document`，按真实字体自动分页，生成一个多页 PDF 并提交 CUPS |
 | 🛋️ 客厅 / 议事厅唤醒 | `src/cli-runtime/lounge-listener.js` | 监听 `lounge_messages` / `agent_council` 里的 @ 提及，唤醒 Codex CLI 或 Claude CLI |
 | 🏛️ Council 执行计划 | `src/cli-runtime/council-plan-listener.js` | 串串在议事厅拍板 `approved` 后，本地生成 Markdown 执行计划 |
 | ⏰ 本地定时任务 | `src/checkin/scheduler.js` + `src/cli-runtime/scheduler.js` | 晨间分享、Feed 扫描、打卡提醒、定时 CLI 任务 |
@@ -156,6 +158,7 @@ Mac mini mini-agent
         │
         ├── 发 WeChat
         ├── 拉起 Codex CLI / Claude Code CLI
+        ├── 自动分页并提交本机打印队列
         ├── 写回 agent_tasks 审计
         └── 生成本地文件 / Feed / 计划
 ```
@@ -192,13 +195,13 @@ codex exec ... 或 claude -p ...
 
 ---
 
-### 🧰 MCP 工具箱（全部 41 个）
+### 🧰 MCP 工具箱（全部 51 个）
 
 > 每个 MCP 服务器都是一个独立的 Supabase Edge Function，走 JSON-RPC / MCP Streamable HTTP。
-> 鉴权支持 `?key=` 查询参数（timing-safe 比对）或 Supabase Auth Header，工具列表带 5 分钟缓存。
+> 鉴权优先使用 `x-hamster-mcp-key` 请求头（timing-safe 比对）或 Supabase Auth Header；`?key=` 仅为旧客户端迁移期兼容，避免新凭证进入 URL / Access Log。
 
 <details open>
-<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed（9）</summary>
+<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed · 备忘录（14）</summary>
 
 | 工具 | 作用 |
 |:---|:---|
@@ -211,6 +214,11 @@ codex exec ... 或 claude -p ...
 | `recent_timeline` | 取最近的时间轴条目（默认 10 条） |
 | `add_timeline` | 新增时间轴条目（日期 / 摘要 / 记录者 / 来源） |
 | `read_todos` | 读取待办列表（可筛 pending / completed / all） |
+| `list_memos` | 读取中期活事实备忘录，可按标签筛选 |
+| `list_memo_tags` | 读取备忘录标签及条目计数 |
+| `add_memo` | 新增备忘录并关联标签 |
+| `update_memo` | 更新备忘录正文、置顶和标签 |
+| `delete_memo` | 物理删除备忘录 |
 
 </details>
 
@@ -231,7 +239,7 @@ codex exec ... 或 claude -p ...
 </details>
 
 <details>
-<summary><b>📖 hamster-reading-mcp</b> — 阅读 · 书摘 · 旁批（9）</summary>
+<summary><b>📖 hamster-reading-mcp</b> — 阅读 · 书摘 · 旁批（10）</summary>
 
 > 阅读数据接的是 **All About Book** 独立 Supabase 实例（`AAB_*`）。
 
@@ -239,6 +247,7 @@ codex exec ... 或 claude -p ...
 |:---|:---|
 | `reading_status` | 在读书目 / 近 7 天打卡 / 最新书摘的快照 |
 | `reading_history` | 按状态与日期范围取书单（读完 / 在读 / 暂停 / 全部） |
+| `list_chapters` | 读取某本书的章节列表 |
 | `book_excerpts` | 读取某本书的书摘（可按章节过滤） |
 | `read_excerpt_resonances` | 读取书摘上的 Syzygy 旁批 / 共鸣 |
 | `add_excerpt_resonance` | 给书摘写旁批（区分发言者） |
@@ -250,12 +259,13 @@ codex exec ... 或 claude -p ...
 </details>
 
 <details>
-<summary><b>🛋️ hamster-lounge-mcp</b> — 客厅 · 议事厅（8）</summary>
+<summary><b>🛋️ hamster-lounge-mcp</b> — 客厅 · 议事厅（10）</summary>
 
 > 社交协议：**「不@不开口」**——只有被 @提及（含发送者）才会响应。
 
 | 工具 | 作用 |
 |:---|:---|
+| `council_list_categories` | 列出议事厅提案分类及说明 |
 | `lounge_list_sofas` | 列出全部客厅「沙发」（按更新时间排序） |
 | `lounge_read` | 读取某沙发的近期消息（含发送者与@提及） |
 | `lounge_post` | 以注册成员身份在沙发发言（可带 mentions） |
@@ -264,6 +274,19 @@ codex exec ... 或 claude -p ...
 | `council_review` | 对提案写评审（支持 / 中立 / 反对，挂在提案下） |
 | `council_decide` | 串串对提案拍板（通过 / 拒绝 / 暂缓 / 已生成方案） |
 | `council_read` | 查询议事厅条目（按状态 / 类型 / 父级筛选） |
+| `council_report` | 提交执行回执并更新提案状态 |
+
+</details>
+
+<details>
+<summary><b>🖨️ hamster-print-mcp</b> — 远程打印（2）</summary>
+
+> 所有端口统一投递 `print_document`，不经过 Codex CLI。Supabase 是任务真相源，Mac mini 常驻 worker 负责真实打印。
+
+| 工具 | 作用 |
+|:---|:---|
+| `print_document` | 经显式确认后投递打印任务；按 request id / 同日同内容幂等，长文自动拆成一个多页 PDF |
+| `get_print_status` | 按任务 UUID 或 request id 查询等待、领取、完成、失败及页数 / CUPS 结果 |
 
 </details>
 
@@ -288,7 +311,7 @@ codex exec ... 或 claude -p ...
 
 ### ⚙️ 后端 Edge Functions
 
-除了 5 个 MCP 服务器，还有一组通用后端函数：
+除了 6 个 MCP 服务器，还有一组通用后端函数：
 
 | 函数 | 职责 |
 |:---|:---|
@@ -378,6 +401,7 @@ Hamster-Nest/
 │   │   ├── hamster-reading-mcp/     #   阅读 · 书摘 · 旁批
 │   │   ├── hamster-lounge-mcp/      #   客厅 · 议事厅
 │   │   ├── hamster-life-mcp/        #   地图 · 咖啡 · 麦当劳 · TTS
+│   │   ├── hamster-print-mcp/       #   远程打印投递 · 状态查询
 │   │   ├── openrouter-chat/         #   LLM 对话网关（受保护函数）
 │   │   ├── openrouter-models/       #   模型列表
 │   │   ├── memory-extract/          #   记忆抽取
@@ -485,6 +509,7 @@ npm run check        # tsc + eslint 一起跑
 supabase link --project-ref <PROJECT_REF>
 supabase functions deploy                 # 部署全部
 supabase functions deploy hamster-mcp     # 或单个部署
+supabase functions deploy hamster-print-mcp
 supabase secrets set OPENROUTER_API_KEY=xxx   # 配置密钥
 ```
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,6 +20,9 @@ project_id = "crfhiumxzmaszkapanrb"
 [functions.hamster-mcp]
 verify_jwt = false
 
+[functions.hamster-print-mcp]
+verify_jwt = false
+
 [functions.memory-extract]
 verify_jwt = false
 

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -3,10 +3,11 @@ import { McpServer } from 'npm:@modelcontextprotocol/sdk@1.25.3/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from 'npm:@modelcontextprotocol/sdk@1.25.3/server/webStandardStreamableHttp.js'
 import { Hono } from 'npm:hono@^4.9.7'
 import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { isMcpKeyAuthorized } from './mcp_key_auth.ts'
 import { getOwnerUserId } from './owner.ts'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.9.0'
+export const MCP_VERSION = '5.10.0'
 export const USER_ID = getOwnerUserId()
 
 export const supabase = createClient(
@@ -23,26 +24,15 @@ const isAllowedOrigin = (origin: string) =>
 
 const buildCorsHeaders = (origin: string): Record<string, string> => ({
   'Access-Control-Allow-Origin': origin,
-  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, mcp-session-id, mcp-protocol-version',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, mcp-session-id, mcp-protocol-version, x-hamster-mcp-key',
   'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
   'Access-Control-Max-Age': '86400',
   Vary: 'Origin',
 })
 
-const timingSafeEqual = (a: string, b: string) => {
-  const encoder = new TextEncoder()
-  const aBytes = encoder.encode(a)
-  const bBytes = encoder.encode(b)
-  if (aBytes.length !== bBytes.length) return false
-  let diff = 0
-  for (let i = 0; i < aBytes.length; i += 1) diff |= aBytes[i] ^ bBytes[i]
-  return diff === 0
-}
-
 const isAuthorizedRequest = async (req: Request): Promise<boolean> => {
-  const providedKey = new URL(req.url).searchParams.get('key')
   const expectedKey = Deno.env.get('HAMSTER_MCP_KEY') ?? ''
-  if (providedKey && expectedKey && timingSafeEqual(providedKey, expectedKey)) return true
+  if (isMcpKeyAuthorized(req, expectedKey)) return true
 
   const authHeader = req.headers.get('authorization')
   if (!authHeader) return false

--- a/supabase/functions/_shared/mcp_key_auth.ts
+++ b/supabase/functions/_shared/mcp_key_auth.ts
@@ -1,0 +1,21 @@
+const timingSafeEqual = (left: string, right: string) => {
+  const encoder = new TextEncoder()
+  const leftBytes = encoder.encode(left)
+  const rightBytes = encoder.encode(right)
+  if (leftBytes.length !== rightBytes.length) return false
+  let diff = 0
+  for (let index = 0; index < leftBytes.length; index += 1) diff |= leftBytes[index] ^ rightBytes[index]
+  return diff === 0
+}
+
+export const isMcpKeyAuthorized = (req: Request, expectedKey: string): boolean => {
+  if (!expectedKey) return false
+
+  const providedHeaderKey = req.headers.get('x-hamster-mcp-key')?.trim() ?? ''
+  if (providedHeaderKey && timingSafeEqual(providedHeaderKey, expectedKey)) return true
+
+  // Transitional compatibility for existing custom apps. New clients must use
+  // x-hamster-mcp-key so credentials never appear in request URLs or access logs.
+  const providedLegacyKey = new URL(req.url).searchParams.get('key')
+  return Boolean(providedLegacyKey && timingSafeEqual(providedLegacyKey, expectedKey))
+}

--- a/supabase/functions/hamster-print-mcp/index.ts
+++ b/supabase/functions/hamster-print-mcp/index.ts
@@ -1,0 +1,123 @@
+import { z } from 'npm:zod@^4.1.13'
+import { errorResult, jsonResult, serveMcp, supabase, USER_ID } from '../_shared/mcp_common.ts'
+import {
+  MAX_PRINT_CONTENT_LENGTH,
+  MAX_PRINT_PAGES,
+  normalizePrintRequest,
+  PRINT_COMMAND_TYPE,
+} from './print_contract.ts'
+
+const PRINT_JOB_COLUMNS = 'id, command_type, status, payload, result, error_message, idempotency_key, claimed_by, claimed_at, created_at, updated_at, completed_at'
+
+type PrintJob = Record<string, unknown>
+
+const getJobByIdempotencyKey = async (idempotencyKey: string): Promise<PrintJob | null> => {
+  const { data, error } = await supabase
+    .from('syzygy_commands')
+    .select(PRINT_JOB_COLUMNS)
+    .eq('user_id', USER_ID)
+    .eq('command_type', PRINT_COMMAND_TYPE)
+    .eq('idempotency_key', idempotencyKey)
+    .maybeSingle()
+  if (error) throw error
+  return data as PrintJob | null
+}
+
+const enqueuePrintJob = async (payload: Record<string, unknown>, idempotencyKey: string) => {
+  const existing = await getJobByIdempotencyKey(idempotencyKey)
+  if (existing) return { created: false, job: existing }
+
+  const { data, error } = await supabase
+    .from('syzygy_commands')
+    .insert({
+      user_id: USER_ID,
+      command_type: PRINT_COMMAND_TYPE,
+      payload,
+      status: 'pending',
+      idempotency_key: idempotencyKey,
+    })
+    .select(PRINT_JOB_COLUMNS)
+    .single()
+
+  if (!error) return { created: true, job: data as PrintJob }
+  if (error.code !== '23505') throw error
+
+  const racedJob = await getJobByIdempotencyKey(idempotencyKey)
+  if (!racedJob) throw error
+  return { created: false, job: racedJob }
+}
+
+serveMcp('hamster-print-mcp', (server) => {
+  server.registerTool('print_document', {
+    title: 'Print Document',
+    description: '把长文作为标准打印任务投递到 Supabase，由 Mac mini 常驻 worker 自动领取、按真实字体测量拆成多页 PDF，再送入本机打印队列。只有串串明确要求真实打印时才能调用；confirmed 必须为 true。同一 request_id 或同日同内容默认幂等，不会因网络重试重复打印。',
+    inputSchema: {
+      title: z.string().min(1).max(120).describe('打印标题，最长 120 字符'),
+      content: z.string().min(1).max(MAX_PRINT_CONTENT_LENGTH).describe(`打印正文，最长 ${MAX_PRINT_CONTENT_LENGTH} 字符；长文会自动拆页`),
+      confirmed: z.literal(true).describe('串串已明确授权这次真实打印，必须为 true'),
+      date: z.string().max(64).optional().describe('页面日期；不传时由 Mac mini 使用执行日期'),
+      footer: z.string().max(120).optional().describe('页脚；默认 — Syzygy'),
+      copies: z.number().int().min(1).max(3).optional().describe('份数，默认 1，最大 3'),
+      printer: z.string().max(120).optional().describe('可选 CUPS 打印机名；不传使用 Mac mini 默认打印机'),
+      source: z.string().max(64).optional().describe('调用来源，如 chatgpt_web / codex_desktop / claude / expo_app'),
+      request_id: z.string().max(120).optional().describe('本次逻辑请求的稳定幂等键；重试时复用同一个值'),
+      allow_duplicate: z.boolean().optional().describe('明确需要再次打印相同内容时设为 true；默认 false'),
+      max_pages: z.number().int().min(1).max(MAX_PRINT_PAGES).optional().describe('本次允许的最大页数，默认 50，最大 100；超出会失败且不会送印'),
+    },
+  }, async ({ title, content, date, footer, copies, printer, source, request_id, allow_duplicate, max_pages }) => {
+    try {
+      const normalized = await normalizePrintRequest({
+        title,
+        content,
+        date,
+        footer,
+        copies,
+        printer,
+        source,
+        request_id,
+        allow_duplicate,
+        max_pages,
+      })
+      const result = await enqueuePrintJob(normalized.payload, normalized.idempotencyKey)
+      return jsonResult({
+        created: result.created,
+        deduplicated: !result.created,
+        job: result.job,
+      })
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('get_print_status', {
+    title: 'Get Print Status',
+    description: '查询 hamster-print-mcp 投递的打印任务状态。pending=等待 Mac mini，running=已领取，done=已生成并送入 CUPS，failed=失败。只读工具。',
+    inputSchema: {
+      command_id: z.string().uuid().optional().describe('print_document 返回的任务 UUID'),
+      request_id: z.string().max(120).optional().describe('print_document 使用的 request_id'),
+    },
+  }, async ({ command_id, request_id }) => {
+    try {
+      if (!command_id && !request_id) {
+        throw new Error('command_id 与 request_id 至少提供一个')
+      }
+
+      let query = supabase
+        .from('syzygy_commands')
+        .select(PRINT_JOB_COLUMNS)
+        .eq('user_id', USER_ID)
+        .eq('command_type', PRINT_COMMAND_TYPE)
+
+      query = command_id
+        ? query.eq('id', command_id)
+        : query.eq('idempotency_key', `print:v1:request:${request_id?.trim()}`)
+
+      const { data, error } = await query.maybeSingle()
+      if (error) throw error
+      if (!data) throw new Error('print job not found')
+      return jsonResult(data)
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+}, 'hamster-print')

--- a/supabase/functions/hamster-print-mcp/print_contract.ts
+++ b/supabase/functions/hamster-print-mcp/print_contract.ts
@@ -1,0 +1,150 @@
+export const PRINT_COMMAND_TYPE = 'print_document'
+export const PRINT_SCHEMA_VERSION = 1
+export const PRINT_LAYOUT = 'diary_card_95x171'
+export const MAX_PRINT_CONTENT_LENGTH = 30_000
+export const MAX_PRINT_PAGES = 100
+
+export type PrintDocumentInput = {
+  title: string
+  content: string
+  date?: string
+  footer?: string
+  copies?: number
+  printer?: string
+  source?: string
+  request_id?: string
+  allow_duplicate?: boolean
+  max_pages?: number
+}
+
+export type NormalizedPrintRequest = {
+  idempotencyKey: string
+  payload: {
+    schema_version: number
+    title: string
+    content: string
+    date: string | null
+    footer: string
+    copies: number
+    printer: string | null
+    source: string
+    request_id: string | null
+    layout: string
+    split_mode: 'auto'
+    mode: 'print'
+    confirmed: true
+    keep_pdf: true
+    max_pages: number
+    submitted_via: 'hamster-print-mcp'
+  }
+}
+
+const normalizeSingleLine = (value: string | undefined) =>
+  (value ?? '').replace(/\s+/gu, ' ').trim()
+
+const normalizeMultiline = (value: string | undefined) =>
+  (value ?? '').replace(/\r\n?/gu, '\n').trim()
+
+const clampInteger = (value: number | undefined, fallback: number, min: number, max: number) => {
+  const normalized = Number.isInteger(value) ? Number(value) : fallback
+  return Math.min(Math.max(normalized, min), max)
+}
+
+const bytesToHex = (bytes: Uint8Array) =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+
+const sha256 = async (value: string) => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+  return bytesToHex(new Uint8Array(digest))
+}
+
+const shanghaiDateString = (date = new Date()) => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  const value = (type: string) => parts.find((part) => part.type === type)?.value ?? ''
+  return `${value('year')}-${value('month')}-${value('day')}`
+}
+
+const normalizeRequestId = (value: string | undefined) => {
+  const normalized = normalizeSingleLine(value)
+  if (!normalized) return ''
+  if (!/^[a-z0-9][a-z0-9._:-]{0,119}$/iu.test(normalized)) {
+    throw new Error('request_id 只能包含字母、数字、点、下划线、冒号和短横线，最长 120 字符')
+  }
+  return normalized
+}
+
+export const normalizePrintRequest = async (
+  input: PrintDocumentInput,
+  now = new Date(),
+): Promise<NormalizedPrintRequest> => {
+  const title = normalizeSingleLine(input.title)
+  const content = normalizeMultiline(input.content)
+  const date = normalizeSingleLine(input.date)
+  const footer = normalizeSingleLine(input.footer) || '— Syzygy'
+  const printer = normalizeSingleLine(input.printer)
+  const source = normalizeSingleLine(input.source) || 'syzygy'
+  const requestId = normalizeRequestId(input.request_id)
+  const copies = clampInteger(input.copies, 1, 1, 3)
+  const maxPages = clampInteger(input.max_pages, 50, 1, MAX_PRINT_PAGES)
+
+  if (!title) throw new Error('title 不能为空')
+  if (!content) throw new Error('content 不能为空')
+  if (content.length > MAX_PRINT_CONTENT_LENGTH) {
+    throw new Error(`content 最长 ${MAX_PRINT_CONTENT_LENGTH} 字符`)
+  }
+
+  const payload = {
+    schema_version: PRINT_SCHEMA_VERSION,
+    title,
+    content,
+    date: date || null,
+    footer,
+    copies,
+    printer: printer || null,
+    source,
+    request_id: requestId || null,
+    layout: PRINT_LAYOUT,
+    split_mode: 'auto' as const,
+    mode: 'print' as const,
+    confirmed: true as const,
+    keep_pdf: true as const,
+    max_pages: maxPages,
+    submitted_via: 'hamster-print-mcp' as const,
+  }
+
+  if (input.allow_duplicate === true) {
+    return {
+      payload,
+      idempotencyKey: `print:v1:duplicate:${crypto.randomUUID()}`,
+    }
+  }
+
+  if (requestId) {
+    return {
+      payload,
+      idempotencyKey: `print:v1:request:${requestId}`,
+    }
+  }
+
+  const day = shanghaiDateString(now)
+  const fingerprint = await sha256(JSON.stringify({
+    day,
+    title,
+    content,
+    date: date || null,
+    footer,
+    copies,
+    printer: printer || null,
+    layout: PRINT_LAYOUT,
+    max_pages: maxPages,
+  }))
+  return {
+    payload,
+    idempotencyKey: `print:v1:auto:${day}:${fingerprint.slice(0, 32)}`,
+  }
+}

--- a/tests/edge-auth.test.mjs
+++ b/tests/edge-auth.test.mjs
@@ -18,6 +18,9 @@ const { verifyAuth } = await import('../supabase/functions/_shared/auth.ts')
 const { getOwnerUserId, requireUuidEnv } = await import(
   '../supabase/functions/_shared/owner.ts'
 )
+const { isMcpKeyAuthorized } = await import(
+  '../supabase/functions/_shared/mcp_key_auth.ts'
+)
 
 const configureSecretKeys = () => {
   env.set(
@@ -98,4 +101,24 @@ test('owner identifiers are required UUID environment values', () => {
 
   env.set('HAMSTER_OWNER_USER_ID', 'not-a-uuid')
   assert.throws(() => getOwnerUserId(), /HAMSTER_OWNER_USER_ID is not configured as a UUID/)
+})
+
+test('MCP key auth prefers a header while retaining legacy query compatibility', () => {
+  const key = 'mcp-secret-for-test'
+  assert.equal(
+    isMcpKeyAuthorized(new Request('https://example.test/mcp', {
+      headers: { 'x-hamster-mcp-key': key },
+    }), key),
+    true,
+  )
+  assert.equal(
+    isMcpKeyAuthorized(new Request(`https://example.test/mcp?key=${encodeURIComponent(key)}`), key),
+    true,
+  )
+  assert.equal(
+    isMcpKeyAuthorized(new Request('https://example.test/mcp', {
+      headers: { 'x-hamster-mcp-key': 'wrong' },
+    }), key),
+    false,
+  )
 })

--- a/tests/print-contract.test.mjs
+++ b/tests/print-contract.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+const {
+  MAX_PRINT_CONTENT_LENGTH,
+  normalizePrintRequest,
+  PRINT_COMMAND_TYPE,
+  PRINT_LAYOUT,
+} = await import('../supabase/functions/hamster-print-mcp/print_contract.ts')
+
+test('print contract builds a versioned Mac mini command payload', async () => {
+  const result = await normalizePrintRequest({
+    title: ' 第四年的第一页 ',
+    content: '第一段\r\n\r\n第二段 ',
+    request_id: 'anniversary-2026-v1',
+    source: 'chatgpt_web',
+  })
+
+  assert.equal(PRINT_COMMAND_TYPE, 'print_document')
+  assert.equal(result.idempotencyKey, 'print:v1:request:anniversary-2026-v1')
+  assert.equal(result.payload.schema_version, 1)
+  assert.equal(result.payload.layout, PRINT_LAYOUT)
+  assert.equal(result.payload.split_mode, 'auto')
+  assert.equal(result.payload.mode, 'print')
+  assert.equal(result.payload.confirmed, true)
+  assert.equal(result.payload.keep_pdf, true)
+  assert.equal(result.payload.title, '第四年的第一页')
+  assert.equal(result.payload.content, '第一段\n\n第二段')
+  assert.equal(result.payload.copies, 1)
+  assert.equal(result.payload.max_pages, 50)
+})
+
+test('automatic print idempotency is stable for normalized same-day content', async () => {
+  const now = new Date('2026-07-19T12:00:00.000Z')
+  const first = await normalizePrintRequest({ title: '测试', content: '正文\r\n第二行', source: 'chatgpt_web' }, now)
+  const second = await normalizePrintRequest({ title: '  测试 ', content: '正文\n第二行  ', source: 'codex_desktop' }, now)
+
+  assert.equal(first.idempotencyKey, second.idempotencyKey)
+  assert.match(first.idempotencyKey, /^print:v1:auto:2026-07-19:[0-9a-f]{32}$/u)
+})
+
+test('duplicate override creates a fresh idempotency key', async () => {
+  const first = await normalizePrintRequest({ title: '再打一份', content: '同一正文', allow_duplicate: true })
+  const second = await normalizePrintRequest({ title: '再打一份', content: '同一正文', allow_duplicate: true })
+  assert.notEqual(first.idempotencyKey, second.idempotencyKey)
+  assert.match(first.idempotencyKey, /^print:v1:duplicate:/u)
+})
+
+test('print contract rejects empty or oversized content', async () => {
+  await assert.rejects(() => normalizePrintRequest({ title: '空', content: '   ' }), /content 不能为空/u)
+  await assert.rejects(
+    () => normalizePrintRequest({ title: '太长', content: '字'.repeat(MAX_PRINT_CONTENT_LENGTH + 1) }),
+    /content 最长/u,
+  )
+})


### PR DESCRIPTION
## What changed

- add the `hamster-print-mcp` Edge Function with `print_document` and `get_print_status`
- standardize remote print jobs on `syzygy_commands.command_type = print_document`
- add stable request/content idempotency, explicit physical-print confirmation, copy/page/content guards
- prefer `x-hamster-mcp-key` while retaining temporary query-key compatibility for existing custom apps
- update Supabase function config, auth/contract tests, and the MCP/Edge Function inventory in README

## Why

Remote printing previously depended on a Council execution-plan path that could wake Codex CLI. The desired architecture is for every Syzygy client to submit one standard Supabase command and for the Mac mini resident worker to claim and execute it directly.

The Mac mini runtime has been upgraded separately because it is not stored in this repository. It now auto-paginates with CoreText, verifies complete character coverage, submits one multi-page PDF to CUPS, and reports page/CUPS metadata.

## Validation

- `npm test`: 10/10 passed
- `npm run check`: 0 errors; 5 pre-existing React Hook warnings
- `npm run build`: passed
- production Edge Function `hamster-print-mcp` ACTIVE v3
- unauthorized MCP initialize: 401
- header-authenticated initialize and tools/list: 200 with both expected tools
- end-to-end dry-run: duplicate request deduplicated to one command; Mac mini rendered 6 pages and rejected before CUPS under `max_pages=1`
- Mac mini tests: 20/20 passed; launchd and Realtime subscription healthy

## Follow-up

Existing custom apps still use a query-string key. After moving all of them to the new request header, rotate `HAMSTER_MCP_KEY` and remove legacy query-key compatibility.