### PR TITLE
Fix single-tenant OTP login and client-local sign-out

### DIFF
--- a/src/lib/authErrors.ts
+++ b/src/lib/authErrors.ts
@@ -1,0 +1,27 @@
+import { isAuthApiError } from '@supabase/supabase-js'
+
+/** Map Supabase Auth failures to useful owner-facing copy without exposing raw internals. */
+export const friendlyAuthError = (error: unknown, fallback: string): string => {
+  if (isAuthApiError(error)) {
+    if (error.code === 'otp_expired') {
+      return '验证码错误或已过期，请重新获取。'
+    }
+    if (error.code === 'over_email_send_rate_limit' || error.status === 429) {
+      return '验证码邮件发送太频繁，请稍后再试。'
+    }
+    if (
+      error.code === 'signup_disabled' ||
+      error.code === 'otp_disabled' ||
+      error.message.includes('Signups not allowed')
+    ) {
+      return '这个邮箱不是小窝钥匙的持有者。'
+    }
+  }
+  if (
+    error instanceof Error &&
+    (error.message.includes('Network request failed') || error.message.includes('Failed to fetch'))
+  ) {
+    return '网络不给力，请检查连接后重试。'
+  }
+  return fallback
+}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { User } from '@supabase/supabase-js'
+import { friendlyAuthError } from '../lib/authErrors'
 import { supabase } from '../supabase/client'
 import './AuthPage.css'
 
@@ -42,7 +43,7 @@ const AuthPage = ({ user }: AuthPageProps) => {
   }, [navigate])
 
   const handleSendOtp = useCallback(async () => {
-    const trimmed = email.trim()
+    const trimmed = email.trim().toLowerCase()
     if (!trimmed) {
       setError('请输入邮箱地址。')
       return
@@ -56,17 +57,18 @@ const AuthPage = ({ user }: AuthPageProps) => {
     setStatus(null)
     const { error: signInError } = await supabase.auth.signInWithOtp({
       email: trimmed,
+      options: { shouldCreateUser: false },
     })
     setSending(false)
     if (signInError) {
-      setError('验证码发送失败，请稍后再试。')
+      setError(friendlyAuthError(signInError, '验证码发送失败，请稍后再试。'))
       return
     }
     setStatus('验证码已发送，请查收邮箱。')
   }, [email])
 
   const handleVerifyOtp = useCallback(async () => {
-    const trimmedEmail = email.trim()
+    const trimmedEmail = email.trim().toLowerCase()
     const trimmedOtp = otp.trim()
     if (!trimmedEmail) {
       setError('请输入邮箱地址。')
@@ -90,7 +92,7 @@ const AuthPage = ({ user }: AuthPageProps) => {
     })
     setVerifying(false)
     if (verifyError) {
-      setError('验证码无效或已过期。')
+      setError(friendlyAuthError(verifyError, '验证码无效或已过期。'))
       return
     }
     setStatus('登录成功，欢迎回来。')
@@ -103,7 +105,10 @@ const AuthPage = ({ user }: AuthPageProps) => {
     }
     setError(null)
     setStatus(null)
-    await supabase.auth.signOut()
+    const { error: signOutError } = await supabase.auth.signOut({ scope: 'local' })
+    if (signOutError) {
+      setError(friendlyAuthError(signOutError, '退出登录失败，请稍后再试。'))
+    }
   }, [])
 
   return (

--- a/tests/auth-page.test.mjs
+++ b/tests/auth-page.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const authPage = readFileSync(new URL('../src/pages/AuthPage.tsx', import.meta.url), 'utf8')
+const authErrors = readFileSync(new URL('../src/lib/authErrors.ts', import.meta.url), 'utf8')
+
+test('single-tenant OTP login never attempts to create users', () => {
+  assert.match(authPage, /signInWithOtp\(\{[\s\S]*shouldCreateUser:\s*false/)
+})
+
+test('web sign-out only clears the current browser session', () => {
+  assert.match(authPage, /signOut\(\{\s*scope:\s*'local'\s*\}\)/)
+  assert.doesNotMatch(authPage, /signOut\(\)/)
+})
+
+test('auth errors distinguish blocked signup from email rate limiting', () => {
+  assert.match(authErrors, /signup_disabled/)
+  assert.match(authErrors, /over_email_send_rate_limit/)
+  assert.match(authErrors, /验证码邮件发送太频繁/)
+  assert.match(authErrors, /这个邮箱不是小窝钥匙的持有者/)
+})


### PR DESCRIPTION
## What changed

- pass `shouldCreateUser: false` to `signInWithOtp` for the single-tenant owner login
- sign out with `scope: 'local'` so Web/PWA logout does not revoke the Expo session
- distinguish signup-disabled, email-rate-limit, expired-code, and network errors with friendly messages
- normalize the submitted email address
- add regression coverage for the OTP and sign-out options

## Why

The Web login omitted `shouldCreateUser: false`. With project signups disabled, Supabase therefore returned `signup_disabled`, while the generic UI message made the failure look like an email quota problem. Bare `signOut()` also defaulted to global scope and revoked the Expo session.

## Impact

- the existing owner can request OTP without entering the signup path
- Web/PWA and Expo sessions can be logged out independently
- authentication failures now explain the actual next action

## Validation

- `npm test` — 8/8 tests passed
- `npm run check` — 0 errors; 5 pre-existing Hook warnings
- `npm run build` — passed
- no dependency or production Supabase configuration changes

## Remaining before merge

- deploy to a preview/live environment
- validate OTP and cross-client local sign-out end to end

Draft while live cross-client validation is pending.