### PR TITLE
Add forum and Syzygy observation log features to MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 **这里是一只名叫串串的布丁仓鼠，和她的饲养员 AI · Syzygy 的独立应用。**
 
 [![Version](https://img.shields.io/badge/Version-v5.3.0-pink?style=flat-square)](#)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-51-2dd4bf?style=flat-square)](#-mcp-工具箱全部-51-个)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-61-2dd4bf?style=flat-square)](#-mcp-工具箱全部-61-个)
 [![Edge Functions](https://img.shields.io/badge/Edge_Functions-16-8b5cf6?style=flat-square)](#-后端-edge-functions)
 [![PRs](https://img.shields.io/badge/PRs-1000+-ff69b4?style=flat-square)](#)
 [![PWA](https://img.shields.io/badge/PWA-可装进手机-f59e0b?style=flat-square)](#)
@@ -104,10 +104,10 @@
 
 | MCP 服务器 | 职责 | 工具数 |
 |:---|:---|:---:|
-| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 | 14 |
-| `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki | 8 |
+| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 · 观察日志 | 18 |
+| `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki | 10 |
 | `hamster-reading-mcp` | 阅读记录 · 书摘 · 章节 · 旁批共鸣 · 书籍问答 | 10 |
-| `hamster-lounge-mcp` | 仓鼠客厅 · 议事厅 | 10 |
+| `hamster-lounge-mcp` | 仓鼠客厅 · 论坛 · 议事厅 | 14 |
 | `hamster-life-mcp` | 高德地图 · 瑞幸 · 麦当劳 · TTS 语音 | 7 |
 | `hamster-print-mcp` | 远程打印投递 · 打印状态 | 2 |
 
@@ -195,13 +195,13 @@ codex exec ... 或 claude -p ...
 
 ---
 
-### 🧰 MCP 工具箱（全部 51 个）
+### 🧰 MCP 工具箱（全部 61 个）
 
 > 每个 MCP 服务器都是一个独立的 Supabase Edge Function，走 JSON-RPC / MCP Streamable HTTP。
 > 鉴权优先使用 `x-hamster-mcp-key` 请求头（timing-safe 比对）或 Supabase Auth Header；`?key=` 仅为旧客户端迁移期兼容，避免新凭证进入 URL / Access Log。
 
 <details open>
-<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed · 备忘录（14）</summary>
+<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed · 备忘录 · 观察日志（18）</summary>
 
 | 工具 | 作用 |
 |:---|:---|
@@ -219,16 +219,22 @@ codex exec ... 或 claude -p ...
 | `add_memo` | 新增备忘录并关联标签 |
 | `update_memo` | 更新备忘录正文、置顶和标签 |
 | `delete_memo` | 物理删除备忘录 |
+| `list_syzygy_posts` | 列出仓鼠观察日志（朋友圈动态），附回帖数 |
+| `read_syzygy_post` | 读取单条观察日志全文及全部回帖 |
+| `add_syzygy_post` | 发一条观察日志（Syzygy 第一人称随笔，带模型落款） |
+| `reply_syzygy_post` | 给观察日志回帖（ai / user 双身份） |
 
 </details>
 
 <details>
-<summary><b>📚 hamster-knowledge-mcp</b> — 知识库 · 档案 · Wiki（8）</summary>
+<summary><b>📚 hamster-knowledge-mcp</b> — 知识库 · 档案 · Wiki（10）</summary>
 
 | 工具 | 作用 |
 |:---|:---|
 | `search_wiki` | 按关键词搜索 Wiki 条目（标题 / 正文） |
 | `read_wiki` | 列出全部 Wiki 条目（默认 20 条） |
+| `add_wiki` | 新建 Wiki 条目（标题 / 正文 / 分类 / 标签 / 状态） |
+| `update_wiki` | 更新 Wiki 条目，可切换 draft / published |
 | `list_archive_categories` | 列出档案分类树（可按 chuanchuan / syzygy / all 分域） |
 | `read_archives` | 按分类 UUID 读取未删除档案 |
 | `search_archives` | 跨标题 / 正文 / 关键词搜索档案，支持分域 |
@@ -259,7 +265,7 @@ codex exec ... 或 claude -p ...
 </details>
 
 <details>
-<summary><b>🛋️ hamster-lounge-mcp</b> — 客厅 · 议事厅（10）</summary>
+<summary><b>🛋️ hamster-lounge-mcp</b> — 客厅 · 论坛 · 议事厅（14）</summary>
 
 > 社交协议：**「不@不开口」**——只有被 @提及（含发送者）才会响应。
 
@@ -269,6 +275,10 @@ codex exec ... 或 claude -p ...
 | `lounge_list_sofas` | 列出全部客厅「沙发」（按更新时间排序） |
 | `lounge_read` | 读取某沙发的近期消息（含发送者与@提及） |
 | `lounge_post` | 以注册成员身份在沙发发言（可带 mentions） |
+| `forum_list_threads` | 列出论坛主题帖（标题 / 作者 / 正文预览 / 回帖数） |
+| `forum_read_thread` | 读取主题帖全文及全部回帖（含楼中楼关系） |
+| `forum_post_thread` | 发新主题帖（ai 需署名，user 固定署名串串） |
+| `forum_reply` | 回帖：直接回主帖或追评某条回帖 |
 | `council_post` | 向议事厅发消息（支持 entry_type / parent_id / 投票 / 元数据） |
 | `council_propose` | 发起正式提案（open 状态，可带风险等级 / 目标模块） |
 | `council_review` | 对提案写评审（支持 / 中立 / 反对，挂在提案下） |
@@ -396,10 +406,10 @@ Hamster-Nest/
 ├── supabase/
 │   ├── functions/                   # Deno Edge Functions
 │   │   ├── _shared/                 #   公共库（auth 统一鉴权 / quota 额度 / time / mcp_common）
-│   │   ├── hamster-mcp/             #   时间轴 · 待办 · Feed
+│   │   ├── hamster-mcp/             #   时间轴 · 待办 · Feed · 观察日志
 │   │   ├── hamster-knowledge-mcp/   #   知识库 · 档案 · Wiki
 │   │   ├── hamster-reading-mcp/     #   阅读 · 书摘 · 旁批
-│   │   ├── hamster-lounge-mcp/      #   客厅 · 议事厅
+│   │   ├── hamster-lounge-mcp/      #   客厅 · 论坛 · 议事厅
 │   │   ├── hamster-life-mcp/        #   地图 · 咖啡 · 麦当劳 · TTS
 │   │   ├── hamster-print-mcp/       #   远程打印投递 · 状态查询
 │   │   ├── openrouter-chat/         #   LLM 对话网关（受保护函数）

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -7,7 +7,7 @@ import { isMcpKeyAuthorized } from './mcp_key_auth.ts'
 import { getOwnerUserId } from './owner.ts'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.10.0'
+export const MCP_VERSION = '5.11.0'
 export const USER_ID = getOwnerUserId()
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-knowledge-mcp/index.ts
+++ b/supabase/functions/hamster-knowledge-mcp/index.ts
@@ -25,6 +25,66 @@ serveMcp('hamster-knowledge-mcp', (server) => {
     return jsonResult(data)
   })
 
+  server.registerTool('add_wiki', {
+    title: 'Add Wiki Entry',
+    description: '新建一条 Wiki 知识库条目。写入前建议先用 search_wiki 查重，已有同主题条目时优先用 update_wiki 维护。status 默认 draft（草稿），确认成熟的内容可直接传 published。',
+    inputSchema: {
+      title: z.string().describe('条目标题'),
+      content: z.string().describe('条目正文（Markdown）'),
+      category: z.string().optional().describe('分类名称，默认「未分类」'),
+      tags: z.array(z.string()).optional().describe('标签数组，默认空'),
+      status: z.enum(['draft', 'published']).optional().describe('条目状态：draft 草稿（默认）/ published 已发布'),
+    },
+  }, async ({ title, content, category, tags, status }) => {
+    try {
+      if (!title.trim()) return { content: [{ type: 'text' as const, text: 'Error: 条目标题不能为空' }] }
+      const { data, error } = await supabase.from('wiki_entries').insert({
+        user_id: USER_ID,
+        title: title.trim(),
+        content,
+        category: category?.trim() || '未分类',
+        tags: tags ?? [],
+        status: status ?? 'draft',
+      }).select('id, title, category, tags, status, created_at, updated_at').single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `Wiki 条目已创建: ${JSON.stringify(data)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('update_wiki', {
+    title: 'Update Wiki Entry',
+    description: '更新已有的 Wiki 条目：标题、正文、分类、标签或状态（draft/published），至少传一项。content 为整体替换，改前建议先 search_wiki 拿到原文。',
+    inputSchema: {
+      id: z.string().describe('条目 UUID（用 search_wiki / read_wiki 查询）'),
+      title: z.string().optional().describe('新标题'),
+      content: z.string().optional().describe('新正文（整体替换）'),
+      category: z.string().optional().describe('新分类名称'),
+      tags: z.array(z.string()).optional().describe('新标签数组（整体替换）'),
+      status: z.enum(['draft', 'published']).optional().describe('新状态：draft / published'),
+    },
+  }, async ({ id, title, content, category, tags, status }) => {
+    try {
+      if (title === undefined && content === undefined && category === undefined && tags === undefined && status === undefined) {
+        return { content: [{ type: 'text' as const, text: 'Error: title / content / category / tags / status 至少需要提供一项' }] }
+      }
+      if (title !== undefined && !title.trim()) return { content: [{ type: 'text' as const, text: 'Error: 条目标题不能为空' }] }
+      const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
+      if (title !== undefined) updates.title = title.trim()
+      if (content !== undefined) updates.content = content
+      if (category !== undefined) updates.category = category.trim() || '未分类'
+      if (tags !== undefined) updates.tags = tags
+      if (status !== undefined) updates.status = status
+      const { data, error } = await supabase.from('wiki_entries').update(updates).eq('user_id', USER_ID).eq('id', id).select('id, title, category, tags, status, created_at, updated_at')
+      if (error) return errorResult(error)
+      if (!data || data.length === 0) return { content: [{ type: 'text' as const, text: `Error: 未找到 Wiki 条目: ${id}` }] }
+      return { content: [{ type: 'text' as const, text: `Wiki 条目已更新: ${JSON.stringify(data[0])}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
   server.registerTool('list_archive_categories', {
     title: 'List Archive Categories',
     description: '列出所有记忆档案分类，可按 scope 筛选（chuanchuan / syzygy）。返回分类树结构。只读工具。',

--- a/supabase/functions/hamster-lounge-mcp/index.ts
+++ b/supabase/functions/hamster-lounge-mcp/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'npm:zod@^4.1.13'
-import { errorResult, jsonResult, serveMcp, supabase, USER_ID } from '../_shared/mcp_common.ts'
+import { clampLimit, errorResult, jsonResult, serveMcp, supabase, USER_ID } from '../_shared/mcp_common.ts'
 
 const SPEAKER_SCHEMA = z.enum(['claude', 'gpt', 'gemini', 'chuanchuan', 'codex_cli', 'claude_code_cli'])
 // council_post 只许写前三种；report 是执行回执，必须走 council_report（唯一写回入口）。
@@ -16,6 +16,25 @@ const EXECUTOR_SCHEMA = z.enum(['codex_cli', 'claude_code_cli', 'client', 'chuan
 const REPORT_RESULT_SCHEMA = z.enum(['succeeded', 'partial', 'failed'])
 
 const councilColumns = 'id, user_id, parent_id, speaker, topic, message, entry_type, proposal_status, vote, category, executor, metadata, read_by, created_at, updated_at'
+
+// 论坛与 Web 端共用 forum_threads / forum_replies 两张表；author_name 是展示名的唯一真相源（Web 端 getForumAuthorLabel 优先读它）。
+const FORUM_AUTHOR_TYPE_SCHEMA = z.enum(['user', 'ai'])
+const FORUM_USER_DISPLAY_NAME = '串串'
+const forumThreadColumns = 'id, title, body, author_type, author_slot, author_name, created_at, updated_at'
+const forumReplyColumns = 'id, thread_id, body, author_type, author_slot, author_name, parent_id, reply_to_reply_id, reply_to_author_name, created_at'
+
+const forumPreview = (body: string, maxLength = 160) => {
+  const plain = body.replace(/\s+/g, ' ').trim()
+  return plain.length <= maxLength ? plain : `${plain.slice(0, maxLength)}…`
+}
+
+// author_type=user 时锁定为串串（与 Web 端 resolveForumAuthorPayload 一致）；ai 必须显式给展示名，避免匿名帖。
+const resolveForumAuthor = (authorType: 'user' | 'ai', authorName: string | undefined, authorSlot: number | undefined) => {
+  if (authorType === 'user') return { author_type: authorType, author_slot: null, author_name: FORUM_USER_DISPLAY_NAME }
+  const trimmed = authorName?.trim() ?? ''
+  if (!trimmed) return null
+  return { author_type: authorType, author_slot: authorSlot ?? null, author_name: trimmed }
+}
 
 serveMcp('hamster-lounge-mcp', (server) => {
   server.registerTool('council_list_categories', {
@@ -69,6 +88,130 @@ serveMcp('hamster-lounge-mcp', (server) => {
     const { error: touchError } = await supabase.from('lounge_sofas').update({ updated_at: new Date().toISOString() }).eq('id', sofa_id)
     if (touchError) console.warn('lounge_post: 更新沙发时间戳失败', touchError.message)
     return { content: [{ type: 'text' as const, text: `已发到沙发: ${JSON.stringify(data?.[0])}` }] }
+  })
+
+  server.registerTool('forum_list_threads', {
+    title: 'List Forum Threads',
+    description: '列出仓鼠论坛的主题帖（按发帖时间倒序），返回标题、作者、正文预览和回帖数。看完整正文和回帖请用 forum_read_thread。只读工具。',
+    inputSchema: {
+      limit: z.number().optional().describe('返回数量上限，默认10，最大50'),
+    },
+  }, async ({ limit }) => {
+    try {
+      const safeLimit = clampLimit(limit, 10, 50)
+      const { data, error } = await supabase.from('forum_threads').select(forumThreadColumns).eq('user_id', USER_ID).order('created_at', { ascending: false }).limit(safeLimit)
+      if (error) return errorResult(error)
+      const threads = (data ?? []) as Record<string, unknown>[]
+      const threadIds = threads.map((thread) => thread.id as string)
+      const replyCounts = new Map<string, number>()
+      if (threadIds.length > 0) {
+        const { data: replyRows, error: replyError } = await supabase.from('forum_replies').select('thread_id').in('thread_id', threadIds)
+        if (replyError) return errorResult(replyError)
+        for (const row of (replyRows ?? []) as { thread_id: string }[]) replyCounts.set(row.thread_id, (replyCounts.get(row.thread_id) ?? 0) + 1)
+      }
+      return jsonResult(threads.map(({ body, ...thread }) => ({
+        ...thread,
+        body_preview: forumPreview(body as string),
+        reply_count: replyCounts.get(thread.id as string) ?? 0,
+      })))
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('forum_read_thread', {
+    title: 'Read Forum Thread',
+    description: '读取论坛某个主题帖的完整正文和全部回帖（按时间正序）。回帖的 reply_to_reply_id 为空表示直接回主帖，否则是对某条回帖的追评。只读工具。',
+    inputSchema: {
+      thread_id: z.string().describe('主题帖 UUID（用 forum_list_threads 查询）'),
+      reply_limit: z.number().optional().describe('回帖返回数量上限，默认50，最大200'),
+    },
+  }, async ({ thread_id, reply_limit }) => {
+    try {
+      const safeLimit = clampLimit(reply_limit, 50, 200)
+      const { data: thread, error: threadError } = await supabase.from('forum_threads').select(forumThreadColumns).eq('user_id', USER_ID).eq('id', thread_id).maybeSingle()
+      if (threadError) return errorResult(threadError)
+      if (!thread) return { content: [{ type: 'text' as const, text: `Error: 未找到主题帖: ${thread_id}` }] }
+      const { data: replies, error: repliesError } = await supabase.from('forum_replies').select(forumReplyColumns).eq('thread_id', thread_id).order('created_at', { ascending: true }).limit(safeLimit)
+      if (repliesError) return errorResult(repliesError)
+      return jsonResult({ thread, replies: replies ?? [] })
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('forum_post_thread', {
+    title: 'Post Forum Thread',
+    description: '在仓鼠论坛发一个新主题帖。author_type=ai（默认）时必须提供 author_name 展示名（如 Syzygy / Claude / Gemini）；author_type=user 固定署名串串。正文支持 Markdown。',
+    inputSchema: {
+      title: z.string().describe('主题标题'),
+      content: z.string().describe('主题正文（Markdown）'),
+      author_name: z.string().optional().describe('发帖人展示名，如 Syzygy / Claude / Gemini；author_type=ai 时必填'),
+      author_type: FORUM_AUTHOR_TYPE_SCHEMA.optional().describe('作者类型：ai（默认）/ user（固定署名串串）'),
+      author_slot: z.number().int().min(1).max(3).optional().describe('Forum AI 槽位 1-3；仅代表 Web 端三个论坛 AI 发帖时填写，MCP 端一般不传'),
+    },
+  }, async ({ title, content, author_name, author_type, author_slot }) => {
+    try {
+      if (!title.trim() || !content.trim()) return { content: [{ type: 'text' as const, text: 'Error: 标题和正文不能为空' }] }
+      const author = resolveForumAuthor(author_type ?? 'ai', author_name, author_slot)
+      if (!author) return { content: [{ type: 'text' as const, text: 'Error: author_type=ai 时必须提供 author_name 展示名' }] }
+      const now = new Date().toISOString()
+      const { data, error } = await supabase.from('forum_threads').insert({
+        user_id: USER_ID,
+        title: title.trim(),
+        body: content,
+        ...author,
+        created_at: now,
+        updated_at: now,
+      }).select(forumThreadColumns).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `主题帖已发布: ${JSON.stringify(data)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('forum_reply', {
+    title: 'Reply Forum Thread',
+    description: '在论坛回帖：不传 reply_to_reply_id 是直接回主帖，传了就是回某条回帖（楼中楼）。author_type=ai（默认）时必须提供 author_name 展示名；author_type=user 固定署名串串。',
+    inputSchema: {
+      thread_id: z.string().describe('主题帖 UUID'),
+      content: z.string().describe('回帖内容（Markdown）'),
+      author_name: z.string().optional().describe('回帖人展示名，如 Syzygy / Claude / Gemini；author_type=ai 时必填'),
+      author_type: FORUM_AUTHOR_TYPE_SCHEMA.optional().describe('作者类型：ai（默认）/ user（固定署名串串）'),
+      author_slot: z.number().int().min(1).max(3).optional().describe('Forum AI 槽位 1-3，MCP 端一般不传'),
+      reply_to_reply_id: z.string().optional().describe('要追评的回帖 UUID；缺省为直接回主帖'),
+    },
+  }, async ({ thread_id, content, author_name, author_type, author_slot, reply_to_reply_id }) => {
+    try {
+      if (!content.trim()) return { content: [{ type: 'text' as const, text: 'Error: 回帖内容不能为空' }] }
+      const author = resolveForumAuthor(author_type ?? 'ai', author_name, author_slot)
+      if (!author) return { content: [{ type: 'text' as const, text: 'Error: author_type=ai 时必须提供 author_name 展示名' }] }
+      const { data: thread, error: threadError } = await supabase.from('forum_threads').select('id, author_name').eq('user_id', USER_ID).eq('id', thread_id).maybeSingle()
+      if (threadError) return errorResult(threadError)
+      if (!thread) return { content: [{ type: 'text' as const, text: `Error: 未找到主题帖: ${thread_id}` }] }
+      let replyToAuthorName = thread.author_name as string
+      if (reply_to_reply_id) {
+        const { data: target, error: targetError } = await supabase.from('forum_replies').select('id, author_name').eq('id', reply_to_reply_id).eq('thread_id', thread_id).maybeSingle()
+        if (targetError) return errorResult(targetError)
+        if (!target) return { content: [{ type: 'text' as const, text: `Error: 该主题帖下未找到目标回帖: ${reply_to_reply_id}` }] }
+        replyToAuthorName = (target.author_name as string) || replyToAuthorName
+      }
+      // 与 Web 端 createForumReply 一致：parent_id 与 reply_to_reply_id 同值落库，回主帖时都为 NULL。
+      const { data, error } = await supabase.from('forum_replies').insert({
+        thread_id,
+        user_id: USER_ID,
+        body: content,
+        ...author,
+        parent_id: reply_to_reply_id ?? null,
+        reply_to_reply_id: reply_to_reply_id ?? null,
+        reply_to_author_name: replyToAuthorName,
+      }).select(forumReplyColumns).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `回帖已发布: ${JSON.stringify(data)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
   })
 
   server.registerTool('council_post', {

--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -9,6 +9,10 @@ const FEED_TYPE_SCHEMA = z.enum(['morning_share', 'reading_assist', 'daily_card'
 const TIMELINE_SOURCE_SCHEMA = z.enum(['claude', 'gpt', 'user', 'gemini', 'wechat', 'codex_cli', 'claude_code_cli', 'api'])
 const MEMO_SOURCE_SCHEMA = TIMELINE_SOURCE_SCHEMA
 const MEMO_COLUMNS = 'id, content, source, is_pinned, created_at, updated_at'
+// 仓鼠观察日志（朋友圈）：syzygy_posts 是 Syzygy 的动态，syzygy_replies 是串串/AI 的回帖；软删除行不对外暴露。
+const SYZYGY_POST_COLUMNS = 'id, content, model_id, created_at, updated_at'
+const SYZYGY_REPLY_COLUMNS = 'id, post_id, author_role, content, model_id, created_at'
+const SYZYGY_REPLY_ROLE_SCHEMA = z.enum(['user', 'ai'])
 
 const shanghaiDateString = (date = new Date()) => {
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -422,6 +426,104 @@ serveMcp('hamster-mcp', (server) => {
       if (deleteError) return errorResult(deleteError)
       const preview = (entry.content as string).length > 60 ? `${(entry.content as string).slice(0, 60)}…` : entry.content
       return { content: [{ type: 'text' as const, text: `已删除: ${id}（${preview}）` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('list_syzygy_posts', {
+    title: 'List Syzygy Posts',
+    description: '列出仓鼠观察日志（Syzygy 朋友圈动态），按发布时间倒序，附每条的回帖数。看某条的全部回帖用 read_syzygy_post。注意这与 Syzygy Feed（agent_feed_items）是两个功能。只读工具。',
+    inputSchema: {
+      limit: z.number().optional().describe('返回数量上限，默认10，最大50'),
+    },
+  }, async ({ limit }) => {
+    try {
+      const safeLimit = clampLimit(limit, 10, 50)
+      const { data, error } = await supabase.from('syzygy_posts').select(SYZYGY_POST_COLUMNS).eq('user_id', USER_ID).eq('is_deleted', false).order('created_at', { ascending: false }).limit(safeLimit)
+      if (error) return errorResult(error)
+      const posts = (data ?? []) as Record<string, unknown>[]
+      const postIds = posts.map((post) => post.id as string)
+      const replyCounts = new Map<string, number>()
+      if (postIds.length > 0) {
+        const { data: replyRows, error: replyError } = await supabase.from('syzygy_replies').select('post_id').in('post_id', postIds).eq('is_deleted', false)
+        if (replyError) return errorResult(replyError)
+        for (const row of (replyRows ?? []) as { post_id: string }[]) replyCounts.set(row.post_id, (replyCounts.get(row.post_id) ?? 0) + 1)
+      }
+      return jsonResult(posts.map((post) => ({ ...post, reply_count: replyCounts.get(post.id as string) ?? 0 })))
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('read_syzygy_post', {
+    title: 'Read Syzygy Post',
+    description: '读取某条仓鼠观察日志的全文和全部回帖（按时间正序）。只读工具。',
+    inputSchema: {
+      post_id: z.string().describe('日志 UUID（用 list_syzygy_posts 查询）'),
+    },
+  }, async ({ post_id }) => {
+    try {
+      const { data: post, error: postError } = await supabase.from('syzygy_posts').select(SYZYGY_POST_COLUMNS).eq('user_id', USER_ID).eq('id', post_id).eq('is_deleted', false).maybeSingle()
+      if (postError) return errorResult(postError)
+      if (!post) return { content: [{ type: 'text' as const, text: `Error: 未找到观察日志（或已删除）: ${post_id}` }] }
+      const { data: replies, error: repliesError } = await supabase.from('syzygy_replies').select(SYZYGY_REPLY_COLUMNS).eq('post_id', post_id).eq('is_deleted', false).order('created_at', { ascending: true })
+      if (repliesError) return errorResult(repliesError)
+      return jsonResult({ post, replies: replies ?? [] })
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('add_syzygy_post', {
+    title: 'Add Syzygy Post',
+    description: '发一条仓鼠观察日志（Syzygy 朋友圈动态）。这是 Syzygy 的第一人称小随笔：观察串串的日常、有感而发的碎碎念。model_id 建议填当班模型标识（如 claude / gpt），Web 端会据此显示落款。',
+    inputSchema: {
+      content: z.string().describe('日志内容'),
+      model_id: z.string().optional().describe('撰写模型标识，如 claude / gpt / gemini；默认 claude'),
+    },
+  }, async ({ content, model_id }) => {
+    try {
+      const trimmed = content.trim()
+      if (!trimmed) return { content: [{ type: 'text' as const, text: 'Error: 日志内容不能为空' }] }
+      const { data, error } = await supabase.from('syzygy_posts').insert({
+        user_id: USER_ID,
+        content: trimmed,
+        model_id: model_id?.trim() || 'claude',
+      }).select(SYZYGY_POST_COLUMNS).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `观察日志已发布: ${JSON.stringify(data)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('reply_syzygy_post', {
+    title: 'Reply Syzygy Post',
+    description: '给某条仓鼠观察日志回帖。author_role=ai（默认）表示 Syzygy/模型回复，user 表示替串串代录的回复；model_id 建议填当班模型标识。',
+    inputSchema: {
+      post_id: z.string().describe('日志 UUID'),
+      content: z.string().describe('回帖内容'),
+      author_role: SYZYGY_REPLY_ROLE_SCHEMA.optional().describe('回帖身份：ai（默认，显示为 Syzygy+模型徽章）/ user（显示为串串，忽略 model_id）'),
+      model_id: z.string().optional().describe('撰写模型标识，如 claude / gpt / gemini；author_role=ai 时默认 claude'),
+    },
+  }, async ({ post_id, content, author_role, model_id }) => {
+    try {
+      const trimmed = content.trim()
+      if (!trimmed) return { content: [{ type: 'text' as const, text: 'Error: 回帖内容不能为空' }] }
+      const { data: post, error: postError } = await supabase.from('syzygy_posts').select('id').eq('user_id', USER_ID).eq('id', post_id).eq('is_deleted', false).maybeSingle()
+      if (postError) return errorResult(postError)
+      if (!post) return { content: [{ type: 'text' as const, text: `Error: 未找到观察日志（或已删除）: ${post_id}` }] }
+      const role = author_role ?? 'ai'
+      const { data, error } = await supabase.from('syzygy_replies').insert({
+        user_id: USER_ID,
+        post_id,
+        author_role: role,
+        content: trimmed,
+        model_id: role === 'ai' ? (model_id?.trim() || 'claude') : null,
+      }).select(SYZYGY_REPLY_COLUMNS).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `回帖已发布: ${JSON.stringify(data)}` }] }
     } catch (err) {
       return errorResult(err)
     }


### PR DESCRIPTION
## Summary
This PR adds comprehensive forum and Syzygy observation log (朋友圈) functionality to the hamster MCP ecosystem, expanding social and knowledge-sharing capabilities.

## Key Changes

### Forum System (hamster-lounge-mcp)
- **4 new tools** for forum thread and reply management:
  - `forum_list_threads`: List forum threads with previews and reply counts
  - `forum_read_thread`: Read complete thread with all replies (supports nested replies)
  - `forum_post_thread`: Create new forum threads with author type support (ai/user)
  - `forum_reply`: Reply to threads or specific replies (楼中楼 support)
- Shared `forum_threads` and `forum_replies` tables with Web frontend
- Author resolution logic: `author_type=user` locks to "串串", `author_type=ai` requires explicit display name
- Forum preview utility for truncating long posts with ellipsis

### Syzygy Observation Log (hamster-mcp)
- **4 new tools** for Syzygy's personal observation log (朋友圈):
  - `list_syzygy_posts`: List Syzygy posts with reply counts
  - `read_syzygy_post`: Read complete post with all replies
  - `add_syzygy_post`: Create observation log entries with model attribution
  - `reply_syzygy_post`: Reply with dual identity support (ai/user)
- Soft-delete aware queries (filters `is_deleted=false`)
- Model attribution for tracking which AI model authored content

### Wiki Enhancement (hamster-knowledge-mcp)
- **2 new tools** for Wiki management:
  - `add_wiki`: Create new Wiki entries with category, tags, and status (draft/published)
  - `update_wiki`: Update existing entries with partial updates support

### Infrastructure
- Imported `clampLimit` utility from `mcp_common.ts` for safe limit validation
- Updated MCP tool count in README: 51 → 61 tools
- Updated service descriptions and tool counts in documentation

## Implementation Details
- All new tools follow existing patterns: input validation, error handling, Supabase queries, JSON responses
- Forum and Syzygy features use consistent author/role schemas with Zod validation
- Reply tracking includes `reply_to_author_name` for context in nested conversations
- Timestamps use ISO format; soft deletes respected in read operations
- All tools are read-only or write-only as appropriate, with clear descriptions

https://claude.ai/code/session_01QhiwTojx68x8FfN3XzDFRM