### PR TITLE
feat: add authenticated conversation canary client

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ import WikiPage from './pages/WikiPage'
 import NovelPage from './pages/NovelPage'
 import LoungePage from './pages/LoungePage'
 import LoungeRoomPage, { type LoungeAiConfig } from './pages/LoungeRoomPage'
+import ConversationCanaryPage from './pages/ConversationCanaryPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1972,6 +1973,14 @@ const App = () => {
     >
       <Routes>
         <Route path="/auth" element={<AuthPage user={user} />} />
+        <Route
+          path="/conversation-canary"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <ConversationCanaryPage />
+            </RequireAuth>
+          }
+        />
         <Route
           path="/"
           element={

--- a/src/lib/conversation-dispatch-client.ts
+++ b/src/lib/conversation-dispatch-client.ts
@@ -1,0 +1,191 @@
+export type ConversationDispatchRequest = {
+  sessionId: string
+  clientId: string
+  content: string
+  clientCreatedAt?: string
+  targetSenderKeys?: string[]
+  retryFailed?: boolean
+}
+
+export type ConversationDispatchResponse = {
+  status: number
+  userMessageId: string | null
+  replyId: string | null
+  contentType: string
+  bodyText: string
+}
+
+export type ConversationDispatchOptions = {
+  timeoutMs?: number
+  signal?: AbortSignal
+}
+
+export type ConversationDispatchClientConfig = {
+  endpointUrl: string
+  publishableKey: string
+  getAccessToken: () => Promise<string | null>
+  fetchImpl?: typeof fetch
+}
+
+export class ConversationDispatchError extends Error {
+  readonly status: number | null
+  readonly code: string | null
+  readonly userMessageId: string | null
+  readonly replyId: string | null
+
+  constructor(
+    message: string,
+    options: {
+      status?: number | null
+      code?: string | null
+      userMessageId?: string | null
+      replyId?: string | null
+    } = {},
+  ) {
+    super(message)
+    this.name = 'ConversationDispatchError'
+    this.status = options.status ?? null
+    this.code = options.code ?? null
+    this.userMessageId = options.userMessageId ?? null
+    this.replyId = options.replyId ?? null
+  }
+}
+
+export class ConversationDispatchTimeoutError extends ConversationDispatchError {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super('会话请求超时；可使用原 clientId 对账或重试', {
+      code: 'CLIENT_TIMEOUT',
+    })
+    this.name = 'ConversationDispatchTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
+
+const parseErrorPayload = (bodyText: string) => {
+  if (!bodyText) {
+    return { message: '', code: null }
+  }
+  try {
+    const payload = JSON.parse(bodyText) as {
+      error?: unknown
+      code?: unknown
+    }
+    return {
+      message: typeof payload.error === 'string' ? payload.error : '',
+      code: typeof payload.code === 'string' ? payload.code : null,
+    }
+  } catch {
+    return { message: '', code: null }
+  }
+}
+
+const serializeRequest = (request: ConversationDispatchRequest) => ({
+  session_id: request.sessionId,
+  client_id: request.clientId,
+  content: request.content,
+  ...(request.clientCreatedAt
+    ? { client_created_at: request.clientCreatedAt }
+    : {}),
+  ...(request.targetSenderKeys
+    ? { target_sender_keys: request.targetSenderKeys }
+    : {}),
+  retry_failed: request.retryFailed === true,
+})
+
+export const createConversationDispatchClient = (
+  config: ConversationDispatchClientConfig,
+) => {
+  const fetchImpl = config.fetchImpl ?? fetch
+
+  return async (
+    request: ConversationDispatchRequest,
+    options: ConversationDispatchOptions = {},
+  ): Promise<ConversationDispatchResponse> => {
+    const timeoutMs = options.timeoutMs ?? 90_000
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new ConversationDispatchError('timeoutMs 必须是正数', {
+        code: 'INVALID_TIMEOUT',
+      })
+    }
+
+    const accessToken = await config.getAccessToken()
+    if (!accessToken) {
+      throw new ConversationDispatchError('登录状态异常，请重新登录', {
+        status: 401,
+        code: 'MISSING_SESSION',
+      })
+    }
+
+    const controller = new AbortController()
+    let didTimeout = false
+    const relayAbort = () => controller.abort()
+    options.signal?.addEventListener('abort', relayAbort, { once: true })
+    if (options.signal?.aborted) {
+      controller.abort()
+    }
+    const timeout = setTimeout(() => {
+      didTimeout = true
+      controller.abort()
+    }, timeoutMs)
+
+    try {
+      const response = await fetchImpl(config.endpointUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          apikey: config.publishableKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(serializeRequest(request)),
+        signal: controller.signal,
+      })
+      const bodyText = await response.text()
+      const userMessageId = response.headers.get(
+        'x-conversation-user-message-id',
+      )
+      const replyId = response.headers.get('x-conversation-reply-id')
+      const contentType = response.headers.get('content-type') ?? ''
+
+      if (!response.ok) {
+        const errorPayload = parseErrorPayload(bodyText)
+        throw new ConversationDispatchError(
+          errorPayload.message || `会话请求失败（HTTP ${response.status}）`,
+          {
+            status: response.status,
+            code: errorPayload.code,
+            userMessageId,
+            replyId,
+          },
+        )
+      }
+
+      return {
+        status: response.status,
+        userMessageId,
+        replyId,
+        contentType,
+        bodyText,
+      }
+    } catch (error) {
+      if (didTimeout) {
+        throw new ConversationDispatchTimeoutError(timeoutMs)
+      }
+      if (error instanceof ConversationDispatchError) {
+        throw error
+      }
+      if (controller.signal.aborted) {
+        throw new ConversationDispatchError('会话请求已取消', {
+          code: 'CLIENT_ABORTED',
+        })
+      }
+      throw new ConversationDispatchError('会话入口暂时无法连接', {
+        code: 'NETWORK_ERROR',
+      })
+    } finally {
+      clearTimeout(timeout)
+      options.signal?.removeEventListener('abort', relayAbort)
+    }
+  }
+}

--- a/src/pages/ConversationCanaryPage.tsx
+++ b/src/pages/ConversationCanaryPage.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import {
+  ConversationDispatchTimeoutError,
+  type ConversationDispatchResponse,
+} from '../lib/conversation-dispatch-client'
+import { dispatchConversation } from '../storage/conversationDispatch'
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
+const TIMEOUT_MS = 200
+const RETRY_DELAY_MS = 4_000
+
+type CanaryResult = {
+  timeoutObserved: boolean
+  attempts: Array<{
+    status: number
+    userMessageId: string | null
+    replyId: string | null
+  }>
+}
+
+const sleep = (milliseconds: number) =>
+  new Promise((resolve) => window.setTimeout(resolve, milliseconds))
+
+const summarize = (response: ConversationDispatchResponse) => ({
+  status: response.status,
+  userMessageId: response.userMessageId,
+  replyId: response.replyId,
+})
+
+export default function ConversationCanaryPage() {
+  const [searchParams] = useSearchParams()
+  const [state, setState] = useState<
+    | { status: 'idle' }
+    | { status: 'running' }
+    | { status: 'completed'; result: CanaryResult }
+    | { status: 'failed'; message: string }
+  >({ status: 'idle' })
+  const sessionId = searchParams.get('session_id') ?? ''
+  const clientId = searchParams.get('client_id') ?? ''
+  const parametersValid = useMemo(
+    () => UUID_PATTERN.test(sessionId) && UUID_PATTERN.test(clientId),
+    [clientId, sessionId],
+  )
+
+  const run = async () => {
+    if (!parametersValid || state.status === 'running') {
+      return
+    }
+    setState({ status: 'running' })
+    const request = {
+      sessionId,
+      clientId,
+      content: 'V4.1 2.3c authenticated canary，请只回复：2.3c OK',
+      clientCreatedAt: new Date().toISOString(),
+    }
+
+    try {
+      let timeoutObserved = false
+      try {
+        await dispatchConversation(request, { timeoutMs: TIMEOUT_MS })
+      } catch (error) {
+        if (!(error instanceof ConversationDispatchTimeoutError)) {
+          throw error
+        }
+        timeoutObserved = true
+      }
+
+      await sleep(RETRY_DELAY_MS)
+      const retryRequest = { ...request, retryFailed: true }
+      const settled = await Promise.allSettled([
+        dispatchConversation(retryRequest),
+        dispatchConversation(retryRequest),
+      ])
+      const attempts = settled.flatMap((attempt) =>
+        attempt.status === 'fulfilled' ? [summarize(attempt.value)] : [],
+      )
+      if (attempts.length === 0) {
+        const firstFailure = settled.find(
+          (attempt): attempt is PromiseRejectedResult =>
+            attempt.status === 'rejected',
+        )
+        throw firstFailure?.reason
+      }
+
+      setState({
+        status: 'completed',
+        result: { timeoutObserved, attempts },
+      })
+    } catch (error) {
+      setState({
+        status: 'failed',
+        message: error instanceof Error ? error.message : 'canary 失败',
+      })
+    }
+  }
+
+  return (
+    <main style={{ margin: '0 auto', maxWidth: 720, padding: 24 }}>
+      <Link to="/">‹ 返回小窝</Link>
+      <h1>2.3c 会话链路自检</h1>
+      <p>
+        使用当前登录态，对临时会话执行一次真实 timeout 与同 client_id 并发补账。
+      </p>
+      {!parametersValid ? (
+        <p role="alert">canary 参数无效，请使用施工记录中的专用链接。</p>
+      ) : null}
+      <button
+        type="button"
+        disabled={!parametersValid || state.status === 'running'}
+        onClick={() => void run()}
+      >
+        {state.status === 'running' ? '自检中…' : '运行 2.3c canary'}
+      </button>
+      {state.status === 'completed' ? (
+        <section aria-live="polite">
+          <h2>自检请求已完成</h2>
+          <p>
+            真实客户端超时：{state.result.timeoutObserved ? '已观察' : '未观察'}
+          </p>
+          <p>后续响应数：{state.result.attempts.length}</p>
+          <p>
+            canonical IDs：
+            {state.result.attempts
+              .map(
+                (attempt) =>
+                  `${attempt.userMessageId ?? '—'} / ${attempt.replyId ?? '—'}`,
+              )
+              .join('；')}
+          </p>
+        </section>
+      ) : null}
+      {state.status === 'failed' ? (
+        <p role="alert">自检失败：{state.message}</p>
+      ) : null}
+    </main>
+  )
+}

--- a/src/storage/conversationDispatch.ts
+++ b/src/storage/conversationDispatch.ts
@@ -1,0 +1,36 @@
+import {
+  createConversationDispatchClient,
+  type ConversationDispatchOptions,
+  type ConversationDispatchRequest,
+} from '../lib/conversation-dispatch-client'
+import { supabase, supabasePublicConfig } from '../supabase/client'
+
+export const dispatchConversation = async (
+  request: ConversationDispatchRequest,
+  options?: ConversationDispatchOptions,
+) => {
+  if (!supabase || !supabasePublicConfig) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const client = supabase
+
+  const dispatchAuthenticatedConversation = createConversationDispatchClient({
+    endpointUrl: `${supabasePublicConfig.url}/functions/v1/conversation-dispatch`,
+    publishableKey: supabasePublicConfig.publishableKey,
+    getAccessToken: async () => {
+      const { data, error } = await client.auth.getSession()
+      if (error) {
+        throw error
+      }
+      return data.session?.access_token ?? null
+    },
+  })
+
+  return dispatchAuthenticatedConversation(request, options)
+}
+
+export type {
+  ConversationDispatchOptions,
+  ConversationDispatchRequest,
+  ConversationDispatchResponse,
+} from '../lib/conversation-dispatch-client'

--- a/src/supabase/client.ts
+++ b/src/supabase/client.ts
@@ -4,6 +4,14 @@ import type { Database } from './database.types'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
 
+export const supabasePublicConfig =
+  supabaseUrl && supabaseAnonKey
+    ? {
+        url: supabaseUrl,
+        publishableKey: supabaseAnonKey,
+      }
+    : null
+
 export const supabase =
   supabaseUrl && supabaseAnonKey
     ? createClient<Database>(supabaseUrl, supabaseAnonKey, {

--- a/tests/conversation-dispatch-client.test.mjs
+++ b/tests/conversation-dispatch-client.test.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const {
+  createConversationDispatchClient,
+  ConversationDispatchError,
+  ConversationDispatchTimeoutError,
+} = await import('../src/lib/conversation-dispatch-client.ts')
+
+test('authenticated dispatch keeps the caller client id stable on concurrent requests', async () => {
+  const bodies = []
+  const dispatch = createConversationDispatchClient({
+    endpointUrl: 'https://example.test/functions/v1/conversation-dispatch',
+    publishableKey: 'publishable-test-key',
+    getAccessToken: async () => 'access-token',
+    fetchImpl: async (_url, init) => {
+      bodies.push(JSON.parse(init.body))
+      return new Response(
+        JSON.stringify({
+          schema_version: 1,
+          handler: 'api',
+          should_execute: false,
+          was_duplicate: true,
+        }),
+        {
+          status: 202,
+          headers: {
+            'content-type': 'application/json',
+            'x-conversation-user-message-id':
+              '00000000-0000-4000-8000-000000000003',
+            'x-conversation-reply-id': '00000000-0000-4000-8000-000000000004',
+          },
+        },
+      )
+    },
+  })
+  const request = {
+    sessionId: '00000000-0000-4000-8000-000000000001',
+    clientId: '00000000-0000-4000-8000-000000000002',
+    content: '并发幂等 canary',
+    clientCreatedAt: '2026-07-25T12:00:00.000Z',
+  }
+
+  const [first, second] = await Promise.all([
+    dispatch(request),
+    dispatch(request),
+  ])
+
+  assert.equal(bodies.length, 2)
+  assert.deepEqual(bodies[0], bodies[1])
+  assert.equal(bodies[0].client_id, request.clientId)
+  assert.equal(first.userMessageId, second.userMessageId)
+  assert.equal(first.replyId, second.replyId)
+})
+
+test('client timeout is explicit and preserves retry responsibility with the caller', async () => {
+  const dispatch = createConversationDispatchClient({
+    endpointUrl: 'https://example.test/functions/v1/conversation-dispatch',
+    publishableKey: 'publishable-test-key',
+    getAccessToken: async () => 'access-token',
+    fetchImpl: async (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener(
+          'abort',
+          () => reject(new DOMException('aborted', 'AbortError')),
+          { once: true },
+        )
+      }),
+  })
+
+  await assert.rejects(
+    dispatch(
+      {
+        sessionId: '00000000-0000-4000-8000-000000000001',
+        clientId: '00000000-0000-4000-8000-000000000002',
+        content: 'timeout canary',
+      },
+      { timeoutMs: 5 },
+    ),
+    (error) => {
+      assert.ok(error instanceof ConversationDispatchTimeoutError)
+      assert.equal(error.code, 'CLIENT_TIMEOUT')
+      assert.equal(error.timeoutMs, 5)
+      return true
+    },
+  )
+})
+
+test('HTTP failures preserve canonical ids for safe reconciliation', async () => {
+  const dispatch = createConversationDispatchClient({
+    endpointUrl: 'https://example.test/functions/v1/conversation-dispatch',
+    publishableKey: 'publishable-test-key',
+    getAccessToken: async () => 'access-token',
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({ error: '回复仍在生成', code: 'REPLY_GENERATING' }),
+        {
+          status: 409,
+          headers: {
+            'content-type': 'application/json',
+            'x-conversation-user-message-id':
+              '00000000-0000-4000-8000-000000000003',
+            'x-conversation-reply-id': '00000000-0000-4000-8000-000000000004',
+          },
+        },
+      ),
+  })
+
+  await assert.rejects(
+    dispatch({
+      sessionId: '00000000-0000-4000-8000-000000000001',
+      clientId: '00000000-0000-4000-8000-000000000002',
+      content: 'retry canary',
+    }),
+    (error) => {
+      assert.ok(error instanceof ConversationDispatchError)
+      assert.equal(error.status, 409)
+      assert.equal(error.code, 'REPLY_GENERATING')
+      assert.equal(error.userMessageId, '00000000-0000-4000-8000-000000000003')
+      assert.equal(error.replyId, '00000000-0000-4000-8000-000000000004')
+      return true
+    },
+  )
+})
+
+test('Web wrapper uses the existing browser session and leaves legacy daily chat untouched', async () => {
+  const [wrapper, app, canary] = await Promise.all([
+    readFile(
+      new URL('../src/storage/conversationDispatch.ts', import.meta.url),
+      'utf8',
+    ),
+    readFile(new URL('../src/App.tsx', import.meta.url), 'utf8'),
+    readFile(
+      new URL('../src/pages/ConversationCanaryPage.tsx', import.meta.url),
+      'utf8',
+    ),
+  ])
+
+  assert.match(wrapper, /client\.auth\.getSession\(\)/u)
+  assert.match(wrapper, /functions\/v1\/conversation-dispatch/u)
+  assert.doesNotMatch(wrapper, /service[_-]?role/iu)
+  assert.match(app, /functions\/v1\/openrouter-chat/u)
+  assert.doesNotMatch(app, /functions\/v1\/conversation-dispatch/u)
+  assert.match(app, /path="\/conversation-canary"/u)
+  assert.match(canary, /timeoutMs: TIMEOUT_MS/u)
+  assert.match(canary, /Promise\.allSettled\(\[/u)
+  assert.match(canary, /dispatchConversation\(retryRequest\)/u)
+  assert.match(canary, /retryFailed: true/u)
+})


### PR DESCRIPTION
## What changed

- add the Web-side typed `conversation-dispatch` client using the current browser Supabase session
- keep caller-owned `clientId` stable across timeout and concurrent retry attempts
- add an authenticated, unlinked `/conversation-canary` route for the controlled 2.3c PWA canary
- add behavioral tests for concurrent identity, timeout, HTTP reconciliation, and the legacy-chat boundary

## Why

V4.1 W0 / 2.3c needs a real authenticated PWA request through the canonical dispatch path before the daily chat UI is switched. The diagnostic route exercises a temporary session without replacing the existing `openrouter-chat` daily-chat flow.

## Impact and boundaries

- existing daily chat and its tool loop remain unchanged
- no schema, RLS, migration, Edge Function, auth policy, or mini/WeChat changes
- merging this PR triggers the repository's existing GitHub Pages deployment; no App OTA or TestFlight action

## Validation

- `npm run test` (23/23)
- `npm run check` (0 errors; 5 existing Hooks warnings)
- `npm run build` (successful; existing large-chunk warning only)