### PR TITLE
fix: wait for conversation canary completion

### DIFF
--- a/src/lib/conversation-canary-runner.ts
+++ b/src/lib/conversation-canary-runner.ts
@@ -1,0 +1,123 @@
+export type ConversationCanaryRequest = {
+  sessionId: string
+  clientId: string
+  content: string
+  clientCreatedAt?: string
+  retryFailed?: boolean
+}
+
+export type ConversationCanaryResponse = {
+  status: number
+  userMessageId: string | null
+  replyId: string | null
+}
+
+export type ConversationCanaryAttempt = ConversationCanaryResponse
+
+type DispatchConversation = (
+  request: ConversationCanaryRequest,
+  options?: { timeoutMs?: number },
+) => Promise<ConversationCanaryResponse>
+
+type RunConversationCanaryOptions = {
+  dispatch: DispatchConversation
+  request: ConversationCanaryRequest
+  sleep: (milliseconds: number) => Promise<unknown>
+  initialTimeoutMs?: number
+  retryDelayMs?: number
+  roundDelayMs?: number
+  maxRounds?: number
+}
+
+export type ConversationCanaryResult = {
+  timeoutObserved: true
+  rounds: number
+  attempts: ConversationCanaryAttempt[]
+}
+
+const isClientTimeout = (error: unknown) =>
+  error instanceof Error &&
+  'code' in error &&
+  error.code === 'CLIENT_TIMEOUT'
+
+const summarize = (
+  response: ConversationCanaryResponse,
+): ConversationCanaryAttempt => ({
+  status: response.status,
+  userMessageId: response.userMessageId,
+  replyId: response.replyId,
+})
+
+export const runConversationCanary = async ({
+  dispatch,
+  request,
+  sleep,
+  initialTimeoutMs = 200,
+  retryDelayMs = 4_000,
+  roundDelayMs = 1_500,
+  maxRounds = 20,
+}: RunConversationCanaryOptions): Promise<ConversationCanaryResult> => {
+  let timeoutObserved = false
+  try {
+    await dispatch(request, { timeoutMs: initialTimeoutMs })
+  } catch (error) {
+    if (!isClientTimeout(error)) {
+      throw error
+    }
+    timeoutObserved = true
+  }
+
+  if (!timeoutObserved) {
+    throw new Error('未观察到真实客户端 timeout，请调整 canary 后重试')
+  }
+
+  await sleep(retryDelayMs)
+  const retryRequest = { ...request, retryFailed: true }
+  let canonicalPair: string | null = null
+  let lastStatuses = '无响应'
+
+  for (let round = 1; round <= maxRounds; round += 1) {
+    const settled = await Promise.allSettled([
+      dispatch(retryRequest),
+      dispatch(retryRequest),
+    ])
+    const attempts = settled.flatMap((attempt) =>
+      attempt.status === 'fulfilled' ? [summarize(attempt.value)] : [],
+    )
+
+    for (const attempt of attempts) {
+      if (!attempt.userMessageId || !attempt.replyId) {
+        throw new Error('补账响应缺少 canonical message IDs')
+      }
+      const pair = `${attempt.userMessageId}/${attempt.replyId}`
+      if (canonicalPair && pair !== canonicalPair) {
+        throw new Error('同一 client_id 返回了不同的 canonical message IDs')
+      }
+      canonicalPair = pair
+    }
+
+    lastStatuses =
+      attempts.length > 0
+        ? attempts.map((attempt) => String(attempt.status)).join(' / ')
+        : '全部失败'
+
+    if (
+      attempts.length === 2 &&
+      attempts.some((attempt) => attempt.status === 200)
+    ) {
+      return {
+        timeoutObserved: true,
+        rounds: round,
+        attempts,
+      }
+    }
+
+    if (round < maxRounds) {
+      await sleep(roundDelayMs)
+    }
+  }
+
+  throw new Error(
+    `补账未等到 completed 响应（最后状态：${lastStatuses}），请查数据库后再重试`,
+  )
+}

--- a/src/pages/ConversationCanaryPage.tsx
+++ b/src/pages/ConversationCanaryPage.tsx
@@ -1,40 +1,24 @@
 import { useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import {
-  ConversationDispatchTimeoutError,
-  type ConversationDispatchResponse,
-} from '../lib/conversation-dispatch-client'
+  runConversationCanary,
+  type ConversationCanaryResult,
+} from '../lib/conversation-canary-runner'
 import { dispatchConversation } from '../storage/conversationDispatch'
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
 const TIMEOUT_MS = 200
-const RETRY_DELAY_MS = 4_000
-
-type CanaryResult = {
-  timeoutObserved: boolean
-  attempts: Array<{
-    status: number
-    userMessageId: string | null
-    replyId: string | null
-  }>
-}
 
 const sleep = (milliseconds: number) =>
   new Promise((resolve) => window.setTimeout(resolve, milliseconds))
-
-const summarize = (response: ConversationDispatchResponse) => ({
-  status: response.status,
-  userMessageId: response.userMessageId,
-  replyId: response.replyId,
-})
 
 export default function ConversationCanaryPage() {
   const [searchParams] = useSearchParams()
   const [state, setState] = useState<
     | { status: 'idle' }
     | { status: 'running' }
-    | { status: 'completed'; result: CanaryResult }
+    | { status: 'completed'; result: ConversationCanaryResult }
     | { status: 'failed'; message: string }
   >({ status: 'idle' })
   const sessionId = searchParams.get('session_id') ?? ''
@@ -57,36 +41,14 @@ export default function ConversationCanaryPage() {
     }
 
     try {
-      let timeoutObserved = false
-      try {
-        await dispatchConversation(request, { timeoutMs: TIMEOUT_MS })
-      } catch (error) {
-        if (!(error instanceof ConversationDispatchTimeoutError)) {
-          throw error
-        }
-        timeoutObserved = true
-      }
-
-      await sleep(RETRY_DELAY_MS)
-      const retryRequest = { ...request, retryFailed: true }
-      const settled = await Promise.allSettled([
-        dispatchConversation(retryRequest),
-        dispatchConversation(retryRequest),
-      ])
-      const attempts = settled.flatMap((attempt) =>
-        attempt.status === 'fulfilled' ? [summarize(attempt.value)] : [],
-      )
-      if (attempts.length === 0) {
-        const firstFailure = settled.find(
-          (attempt): attempt is PromiseRejectedResult =>
-            attempt.status === 'rejected',
-        )
-        throw firstFailure?.reason
-      }
-
       setState({
         status: 'completed',
-        result: { timeoutObserved, attempts },
+        result: await runConversationCanary({
+          dispatch: dispatchConversation,
+          request,
+          sleep,
+          initialTimeoutMs: TIMEOUT_MS,
+        }),
       })
     } catch (error) {
       setState({
@@ -120,6 +82,7 @@ export default function ConversationCanaryPage() {
             真实客户端超时：{state.result.timeoutObserved ? '已观察' : '未观察'}
           </p>
           <p>后续响应数：{state.result.attempts.length}</p>
+          <p>补账轮次：{state.result.rounds}</p>
           <p>
             canonical IDs：
             {state.result.attempts

--- a/tests/conversation-dispatch-client.test.mjs
+++ b/tests/conversation-dispatch-client.test.mjs
@@ -7,6 +7,15 @@ const {
   ConversationDispatchError,
   ConversationDispatchTimeoutError,
 } = await import('../src/lib/conversation-dispatch-client.ts')
+const { runConversationCanary } = await import(
+  '../src/lib/conversation-canary-runner.ts'
+)
+
+const canonicalResponse = (status, suffix = '') => ({
+  status,
+  userMessageId: `00000000-0000-4000-8000-000000000003${suffix}`,
+  replyId: '00000000-0000-4000-8000-000000000004',
+})
 
 test('authenticated dispatch keeps the caller client id stable on concurrent requests', async () => {
   const bodies = []
@@ -124,6 +133,83 @@ test('HTTP failures preserve canonical ids for safe reconciliation', async () =>
   )
 })
 
+test('canary waits past duplicate 202 responses until one retry completes', async () => {
+  let callCount = 0
+  const dispatch = async () => {
+    callCount += 1
+    if (callCount === 1) {
+      throw Object.assign(new Error('timed out'), { code: 'CLIENT_TIMEOUT' })
+    }
+    return canonicalResponse(callCount === 4 ? 200 : 202)
+  }
+
+  const result = await runConversationCanary({
+    dispatch,
+    request: {
+      sessionId: '00000000-0000-4000-8000-000000000001',
+      clientId: '00000000-0000-4000-8000-000000000002',
+      content: 'timeout reconciliation',
+    },
+    sleep: async () => {},
+    maxRounds: 2,
+  })
+
+  assert.equal(callCount, 5)
+  assert.equal(result.rounds, 2)
+  assert.deepEqual(
+    result.attempts.map((attempt) => attempt.status),
+    [200, 202],
+  )
+})
+
+test('canary rejects mismatched canonical ids and 202-only false positives', async () => {
+  let mismatchCalls = 0
+  const mismatchDispatch = async () => {
+    mismatchCalls += 1
+    if (mismatchCalls === 1) {
+      throw Object.assign(new Error('timed out'), { code: 'CLIENT_TIMEOUT' })
+    }
+    return canonicalResponse(200, mismatchCalls === 3 ? '-mismatch' : '')
+  }
+
+  await assert.rejects(
+    runConversationCanary({
+      dispatch: mismatchDispatch,
+      request: {
+        sessionId: '00000000-0000-4000-8000-000000000001',
+        clientId: '00000000-0000-4000-8000-000000000002',
+        content: 'mismatch',
+      },
+      sleep: async () => {},
+      maxRounds: 1,
+    }),
+    /不同的 canonical message IDs/u,
+  )
+
+  let generatingCalls = 0
+  await assert.rejects(
+    runConversationCanary({
+      dispatch: async () => {
+        generatingCalls += 1
+        if (generatingCalls === 1) {
+          throw Object.assign(new Error('timed out'), {
+            code: 'CLIENT_TIMEOUT',
+          })
+        }
+        return canonicalResponse(202)
+      },
+      request: {
+        sessionId: '00000000-0000-4000-8000-000000000001',
+        clientId: '00000000-0000-4000-8000-000000000002',
+        content: 'still generating',
+      },
+      sleep: async () => {},
+      maxRounds: 2,
+    }),
+    /补账未等到 completed 响应/u,
+  )
+})
+
 test('Web wrapper uses the existing browser session and leaves legacy daily chat untouched', async () => {
   const [wrapper, app, canary] = await Promise.all([
     readFile(
@@ -143,8 +229,6 @@ test('Web wrapper uses the existing browser session and leaves legacy daily chat
   assert.match(app, /functions\/v1\/openrouter-chat/u)
   assert.doesNotMatch(app, /functions\/v1\/conversation-dispatch/u)
   assert.match(app, /path="\/conversation-canary"/u)
-  assert.match(canary, /timeoutMs: TIMEOUT_MS/u)
-  assert.match(canary, /Promise\.allSettled\(\[/u)
-  assert.match(canary, /dispatchConversation\(retryRequest\)/u)
-  assert.match(canary, /retryFailed: true/u)
+  assert.match(canary, /initialTimeoutMs: TIMEOUT_MS/u)
+  assert.match(canary, /runConversationCanary/u)
 })


### PR DESCRIPTION
## What changed

- move the hidden 2.3c timeout reconciliation flow into a tested runner
- keep retrying the same `client_id` while duplicate responses are still HTTP 202
- require two matching canonical ID pairs and at least one HTTP 200 before showing success
- reject mismatched IDs and 202-only false positives

## Why

The first production Web canary correctly reused one user/reply pair, but both follow-up responses were still `generating`. The page displayed success before the original aborted stream had settled to `failed`.

## Checks

- `npm test` (25/25)
- `npm run check` (0 errors; 5 existing hook warnings)
- `npm run build` (pass; existing chunk-size warning)