### PR TITLE
V4.1 W0: add guarded runtime control entrypoint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ import NovelPage from './pages/NovelPage'
 import LoungePage from './pages/LoungePage'
 import LoungeRoomPage, { type LoungeAiConfig } from './pages/LoungeRoomPage'
 import ConversationCanaryPage from './pages/ConversationCanaryPage'
+import RuntimeControlCanaryPage from './pages/RuntimeControlCanaryPage'
 import { loadHomeSettings } from './storage/homeLayout'
 import {
   resolveSnackSystemOverlay,
@@ -1978,6 +1979,14 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <ConversationCanaryPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/runtime-control-canary"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <RuntimeControlCanaryPage />
             </RequireAuth>
           }
         />

--- a/src/lib/runtime-control-canary-runner.ts
+++ b/src/lib/runtime-control-canary-runner.ts
@@ -1,0 +1,189 @@
+import type {
+  RuntimeControlRequest,
+  RuntimeControlResponse,
+  RuntimeControlTargetRole,
+} from './runtime-control-client.ts'
+import type { RuntimeStatus, RuntimeStatusSnapshot } from './runtime-status.ts'
+
+export type RuntimeControlCanaryResult = {
+  targetRole: RuntimeControlTargetRole
+  wakeCommandId: string
+  sleepCommandId: string
+  wakeStatus: RuntimeStatus
+  sleepStatus: RuntimeStatus
+}
+
+type RuntimeControlCanaryInput = {
+  control: (
+    request: RuntimeControlRequest,
+  ) => Promise<RuntimeControlResponse>
+  loadSnapshot: () => Promise<RuntimeStatusSnapshot>
+  sleep: (milliseconds: number) => Promise<unknown>
+  targetRole: RuntimeControlTargetRole
+  wakeClientId: string
+  sleepClientId: string
+  maxPolls?: number
+  pollDelayMs?: number
+}
+
+const requireMatchingCommand = (
+  action: 'wake' | 'sleep',
+  responses: RuntimeControlResponse[],
+) => {
+  const commandIds = new Set(responses.map((response) => response.command.id))
+  if (commandIds.size !== 1) {
+    throw new Error(`${action} 并发请求返回了不同 command IDs`)
+  }
+  const failed = responses.find(
+    (response) => response.command.status === 'failed',
+  )
+  if (failed) {
+    throw new Error(
+      failed.command.errorMessage || `${action} command 已失败`,
+    )
+  }
+  return responses[0].command.id
+}
+
+const waitForStatus = async ({
+  loadSnapshot,
+  sleep,
+  targetRole,
+  accepted,
+  maxPolls,
+  pollDelayMs,
+}: Pick<
+  RuntimeControlCanaryInput,
+  'loadSnapshot' | 'sleep' | 'targetRole'
+> & {
+  accepted: RuntimeStatus[]
+  maxPolls: number
+  pollDelayMs: number
+}) => {
+  let lastStatus: RuntimeStatus = 'unknown'
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    const snapshot = await loadSnapshot()
+    lastStatus = snapshot.roles[targetRole].status
+    if (snapshot.isFresh && accepted.includes(lastStatus)) {
+      return lastStatus
+    }
+    await sleep(pollDelayMs)
+  }
+  throw new Error(
+    `Runtime 心跳未收敛到 ${accepted.join('/')}，最后状态为 ${lastStatus}`,
+  )
+}
+
+const waitForDoneCommand = async ({
+  control,
+  request,
+  commandId,
+  sleep,
+  maxPolls,
+  pollDelayMs,
+}: Pick<RuntimeControlCanaryInput, 'control' | 'sleep'> & {
+  request: RuntimeControlRequest
+  commandId: string
+  maxPolls: number
+  pollDelayMs: number
+}) => {
+  let lastStatus: RuntimeControlResponse['command']['status'] = 'pending'
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    const response = await control(request)
+    if (response.command.id !== commandId) {
+      throw new Error(`${request.action} 补账返回了不同 command ID`)
+    }
+    lastStatus = response.command.status
+    if (lastStatus === 'failed') {
+      throw new Error(
+        response.command.errorMessage || `${request.action} command 已失败`,
+      )
+    }
+    if (lastStatus === 'done') {
+      if (response.httpStatus !== 200) {
+        throw new Error(
+          `${request.action} command 已完成但未返回 HTTP 200`,
+        )
+      }
+      return
+    }
+    await sleep(pollDelayMs)
+  }
+  throw new Error(
+    `${request.action} command 未收敛到 done，最后状态为 ${lastStatus}`,
+  )
+}
+
+export const runRuntimeControlCanary = async ({
+  control,
+  loadSnapshot,
+  sleep,
+  targetRole,
+  wakeClientId,
+  sleepClientId,
+  maxPolls = 60,
+  pollDelayMs = 500,
+}: RuntimeControlCanaryInput): Promise<RuntimeControlCanaryResult> => {
+  const wakeRequest: RuntimeControlRequest = {
+    action: 'wake',
+    targetRole,
+    clientId: wakeClientId,
+  }
+  const wakeResponses = await Promise.all([
+    control(wakeRequest),
+    control(wakeRequest),
+  ])
+  const wakeCommandId = requireMatchingCommand('wake', wakeResponses)
+  const wakeStatus = await waitForStatus({
+    loadSnapshot,
+    sleep,
+    targetRole,
+    accepted: ['idle'],
+    maxPolls,
+    pollDelayMs,
+  })
+  await waitForDoneCommand({
+    control,
+    request: wakeRequest,
+    commandId: wakeCommandId,
+    sleep,
+    maxPolls,
+    pollDelayMs,
+  })
+
+  const sleepRequest: RuntimeControlRequest = {
+    action: 'sleep',
+    targetRole,
+    clientId: sleepClientId,
+    confirmRunningTasks: false,
+  }
+  const sleepResponses = await Promise.all([
+    control(sleepRequest),
+    control(sleepRequest),
+  ])
+  const sleepCommandId = requireMatchingCommand('sleep', sleepResponses)
+  const sleepStatus = await waitForStatus({
+    loadSnapshot,
+    sleep,
+    targetRole,
+    accepted: ['offline'],
+    maxPolls,
+    pollDelayMs,
+  })
+  await waitForDoneCommand({
+    control,
+    request: sleepRequest,
+    commandId: sleepCommandId,
+    sleep,
+    maxPolls,
+    pollDelayMs,
+  })
+
+  return {
+    targetRole,
+    wakeCommandId,
+    sleepCommandId,
+    wakeStatus,
+    sleepStatus,
+  }
+}

--- a/src/lib/runtime-control-client.ts
+++ b/src/lib/runtime-control-client.ts
@@ -1,0 +1,247 @@
+export const RUNTIME_CONTROL_ACTIONS = ['wake', 'sleep'] as const
+export const RUNTIME_CONTROL_TARGET_ROLES = [
+  'codex_cli_syzygy',
+  'claude_code_cli_syzygy',
+] as const
+
+export type RuntimeControlAction = (typeof RUNTIME_CONTROL_ACTIONS)[number]
+export type RuntimeControlTargetRole =
+  (typeof RUNTIME_CONTROL_TARGET_ROLES)[number]
+
+export type RuntimeControlRequest = {
+  action: RuntimeControlAction
+  targetRole: RuntimeControlTargetRole
+  clientId: string
+  confirmRunningTasks?: boolean
+}
+
+export type RuntimeControlCommand = {
+  id: string
+  action: RuntimeControlAction
+  targetRole: RuntimeControlTargetRole
+  status: 'pending' | 'running' | 'done' | 'failed'
+  idempotencyKey: string
+  confirmRunningTasks: boolean
+  createdAt: string
+  claimedAt: string | null
+  completedAt: string | null
+  errorMessage: string | null
+}
+
+export type RuntimeControlResponse = {
+  httpStatus: number
+  schemaVersion: 1
+  wasDuplicate: boolean
+  command: RuntimeControlCommand
+}
+
+export type RuntimeControlOptions = {
+  timeoutMs?: number
+  signal?: AbortSignal
+}
+
+export type RuntimeControlClientConfig = {
+  endpointUrl: string
+  publishableKey: string
+  getAccessToken: () => Promise<string | null>
+  fetchImpl?: typeof fetch
+}
+
+export class RuntimeControlError extends Error {
+  readonly status: number | null
+  readonly code: string | null
+
+  constructor(
+    message: string,
+    options: { status?: number | null; code?: string | null } = {},
+  ) {
+    super(message)
+    this.name = 'RuntimeControlError'
+    this.status = options.status ?? null
+    this.code = options.code ?? null
+  }
+}
+
+export class RuntimeControlTimeoutError extends RuntimeControlError {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super('Runtime 控制请求超时；可使用原 clientId 补账', {
+      code: 'CLIENT_TIMEOUT',
+    })
+    this.name = 'RuntimeControlTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
+
+const serializeRequest = (request: RuntimeControlRequest) => ({
+  action: request.action,
+  target_role: request.targetRole,
+  client_id: request.clientId,
+  confirm_running_tasks: request.confirmRunningTasks === true,
+})
+
+const parseJsonObject = (bodyText: string) => {
+  try {
+    const value = JSON.parse(bodyText) as unknown
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+const parseCommand = (
+  value: unknown,
+): RuntimeControlCommand | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const command = value as Record<string, unknown>
+  if (
+    typeof command.id !== 'string' ||
+    !RUNTIME_CONTROL_ACTIONS.includes(command.action as RuntimeControlAction) ||
+    !RUNTIME_CONTROL_TARGET_ROLES.includes(
+      command.target_role as RuntimeControlTargetRole,
+    ) ||
+    !['pending', 'running', 'done', 'failed'].includes(
+      String(command.status),
+    ) ||
+    typeof command.idempotency_key !== 'string' ||
+    typeof command.confirm_running_tasks !== 'boolean'
+  ) {
+    return null
+  }
+  return {
+    id: command.id,
+    action: command.action as RuntimeControlAction,
+    targetRole: command.target_role as RuntimeControlTargetRole,
+    status: command.status as RuntimeControlCommand['status'],
+    idempotencyKey: command.idempotency_key,
+    confirmRunningTasks: command.confirm_running_tasks,
+    createdAt: typeof command.created_at === 'string' ? command.created_at : '',
+    claimedAt:
+      typeof command.claimed_at === 'string' ? command.claimed_at : null,
+    completedAt:
+      typeof command.completed_at === 'string' ? command.completed_at : null,
+    errorMessage:
+      typeof command.error_message === 'string'
+        ? command.error_message
+        : null,
+  }
+}
+
+const parseResponse = (
+  bodyText: string,
+  httpStatus: number,
+): RuntimeControlResponse | null => {
+  const body = parseJsonObject(bodyText)
+  const command = parseCommand(body?.command)
+  if (body?.schema_version !== 1 || typeof body.was_duplicate !== 'boolean' || !command) {
+    return null
+  }
+  return {
+    httpStatus,
+    schemaVersion: 1,
+    wasDuplicate: body.was_duplicate,
+    command,
+  }
+}
+
+export const createRuntimeControlClient = (
+  config: RuntimeControlClientConfig,
+) => {
+  const fetchImpl = config.fetchImpl ?? fetch
+
+  return async (
+    request: RuntimeControlRequest,
+    options: RuntimeControlOptions = {},
+  ): Promise<RuntimeControlResponse> => {
+    const timeoutMs = options.timeoutMs ?? 15_000
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new RuntimeControlError('timeoutMs 必须是正数', {
+        code: 'INVALID_TIMEOUT',
+      })
+    }
+    if (
+      request.action === 'wake' &&
+      request.confirmRunningTasks === true
+    ) {
+      throw new RuntimeControlError(
+        'confirmRunningTasks 只允许用于 sleep',
+        { code: 'INVALID_CONFIRMATION' },
+      )
+    }
+
+    const accessToken = await config.getAccessToken()
+    if (!accessToken) {
+      throw new RuntimeControlError('登录状态异常，请重新登录', {
+        status: 401,
+        code: 'MISSING_SESSION',
+      })
+    }
+
+    const controller = new AbortController()
+    let didTimeout = false
+    const relayAbort = () => controller.abort()
+    options.signal?.addEventListener('abort', relayAbort, { once: true })
+    if (options.signal?.aborted) {
+      controller.abort()
+    }
+    const timeout = setTimeout(() => {
+      didTimeout = true
+      controller.abort()
+    }, timeoutMs)
+
+    try {
+      const response = await fetchImpl(config.endpointUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          apikey: config.publishableKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(serializeRequest(request)),
+        signal: controller.signal,
+      })
+      const bodyText = await response.text()
+      const parsed = parseResponse(bodyText, response.status)
+      if (parsed) {
+        return parsed
+      }
+
+      const errorPayload = parseJsonObject(bodyText)
+      throw new RuntimeControlError(
+        typeof errorPayload?.error === 'string'
+          ? errorPayload.error
+          : `Runtime 控制请求失败（HTTP ${response.status}）`,
+        {
+          status: response.status,
+          code:
+            typeof errorPayload?.code === 'string'
+              ? errorPayload.code
+              : null,
+        },
+      )
+    } catch (error) {
+      if (didTimeout) {
+        throw new RuntimeControlTimeoutError(timeoutMs)
+      }
+      if (error instanceof RuntimeControlError) {
+        throw error
+      }
+      if (controller.signal.aborted) {
+        throw new RuntimeControlError('Runtime 控制请求已取消', {
+          code: 'CLIENT_ABORTED',
+        })
+      }
+      throw new RuntimeControlError('Runtime 控制入口暂时无法连接', {
+        code: 'NETWORK_ERROR',
+      })
+    } finally {
+      clearTimeout(timeout)
+      options.signal?.removeEventListener('abort', relayAbort)
+    }
+  }
+}

--- a/src/lib/runtime-status.ts
+++ b/src/lib/runtime-status.ts
@@ -1,0 +1,103 @@
+import {
+  RUNTIME_CONTROL_TARGET_ROLES,
+  type RuntimeControlTargetRole,
+} from './runtime-control-client.ts'
+
+export const RUNTIME_STATUSES = [
+  'offline',
+  'waking',
+  'idle',
+  'busy',
+  'closing',
+  'error',
+  'unknown',
+] as const
+
+export type RuntimeStatus = (typeof RUNTIME_STATUSES)[number]
+
+export type RuntimeRoleStatus = {
+  status: RuntimeStatus
+  enabled: boolean | null
+  instanceId: string | null
+  activeCommandId: string | null
+  activeTaskId: string | null
+  lastError: string | null
+  changedAt: string | null
+}
+
+export type RuntimeStatusSnapshot = {
+  schemaVersion: 1
+  lastSeenAt: string | null
+  reportedAt: string | null
+  isFresh: boolean
+  roles: Record<RuntimeControlTargetRole, RuntimeRoleStatus>
+}
+
+const unknownRoleStatus = (): RuntimeRoleStatus => ({
+  status: 'unknown',
+  enabled: null,
+  instanceId: null,
+  activeCommandId: null,
+  activeTaskId: null,
+  lastError: null,
+  changedAt: null,
+})
+
+const objectValue = (value: unknown) =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const textOrNull = (value: unknown) =>
+  typeof value === 'string' && value.trim() ? value.trim() : null
+
+export const normalizeRuntimeStatusSnapshot = (
+  row: { last_seen_at?: unknown; heartbeat_data?: unknown } | null,
+  options: { nowMs?: number; staleAfterMs?: number } = {},
+): RuntimeStatusSnapshot => {
+  const nowMs = options.nowMs ?? Date.now()
+  const staleAfterMs = options.staleAfterMs ?? 150_000
+  const lastSeenAt = textOrNull(row?.last_seen_at)
+  const lastSeenMs = lastSeenAt ? new Date(lastSeenAt).getTime() : Number.NaN
+  const isFresh =
+    Number.isFinite(lastSeenMs) &&
+    nowMs - lastSeenMs >= 0 &&
+    nowMs - lastSeenMs <= staleAfterMs
+  const heartbeat = objectValue(row?.heartbeat_data)
+  const runtimeStatuses = objectValue(heartbeat?.runtime_statuses)
+  const rolesValue = objectValue(runtimeStatuses?.roles)
+
+  const roles = Object.fromEntries(
+    RUNTIME_CONTROL_TARGET_ROLES.map((role) => {
+      if (!isFresh || runtimeStatuses?.version !== 1) {
+        return [role, unknownRoleStatus()]
+      }
+      const raw = objectValue(rolesValue?.[role])
+      const rawStatus = textOrNull(raw?.status)
+      const status = RUNTIME_STATUSES.includes(rawStatus as RuntimeStatus)
+        ? (rawStatus as RuntimeStatus)
+        : 'unknown'
+      return [
+        role,
+        {
+          status,
+          enabled:
+            typeof raw?.enabled === 'boolean' ? raw.enabled : null,
+          instanceId: textOrNull(raw?.instance_id),
+          activeCommandId: textOrNull(raw?.active_command_id),
+          activeTaskId: textOrNull(raw?.active_task_id),
+          lastError: textOrNull(raw?.last_error),
+          changedAt: textOrNull(raw?.changed_at),
+        },
+      ]
+    }),
+  ) as Record<RuntimeControlTargetRole, RuntimeRoleStatus>
+
+  return {
+    schemaVersion: 1,
+    lastSeenAt,
+    reportedAt: textOrNull(runtimeStatuses?.reported_at),
+    isFresh,
+    roles,
+  }
+}

--- a/src/pages/RuntimeControlCanaryPage.tsx
+++ b/src/pages/RuntimeControlCanaryPage.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import {
+  runRuntimeControlCanary,
+  type RuntimeControlCanaryResult,
+} from '../lib/runtime-control-canary-runner'
+import {
+  RUNTIME_CONTROL_TARGET_ROLES,
+  type RuntimeControlTargetRole,
+} from '../lib/runtime-control-client'
+import {
+  controlRuntime,
+  loadRuntimeStatusSnapshot,
+} from '../storage/runtimeControl'
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
+
+const sleep = (milliseconds: number) =>
+  new Promise((resolve) => window.setTimeout(resolve, milliseconds))
+
+export default function RuntimeControlCanaryPage() {
+  const [searchParams] = useSearchParams()
+  const [state, setState] = useState<
+    | { status: 'idle' }
+    | { status: 'running' }
+    | { status: 'completed'; result: RuntimeControlCanaryResult }
+    | { status: 'failed'; message: string }
+  >({ status: 'idle' })
+  const targetRole = searchParams.get('target_role') ?? ''
+  const wakeClientId = searchParams.get('wake_client_id') ?? ''
+  const sleepClientId = searchParams.get('sleep_client_id') ?? ''
+  const parametersValid = useMemo(
+    () =>
+      RUNTIME_CONTROL_TARGET_ROLES.includes(
+        targetRole as RuntimeControlTargetRole,
+      ) &&
+      UUID_PATTERN.test(wakeClientId) &&
+      UUID_PATTERN.test(sleepClientId) &&
+      wakeClientId !== sleepClientId,
+    [sleepClientId, targetRole, wakeClientId],
+  )
+
+  const run = async () => {
+    if (!parametersValid || state.status === 'running') {
+      return
+    }
+    setState({ status: 'running' })
+    try {
+      setState({
+        status: 'completed',
+        result: await runRuntimeControlCanary({
+          control: controlRuntime,
+          loadSnapshot: loadRuntimeStatusSnapshot,
+          sleep,
+          targetRole: targetRole as RuntimeControlTargetRole,
+          wakeClientId,
+          sleepClientId,
+        }),
+      })
+    } catch (error) {
+      setState({
+        status: 'failed',
+        message: error instanceof Error ? error.message : 'canary 失败',
+      })
+    }
+  }
+
+  return (
+    <main style={{ margin: '0 auto', maxWidth: 720, padding: 24 }}>
+      <Link to="/">‹ 返回小窝</Link>
+      <h1>2.4 Runtime 控制自检</h1>
+      <p>
+        使用当前登录态并发验证同一 wake / sleep 幂等键，并读取 mini
+        真实心跳。自检成功后目标 Runtime 会保持 offline；不会确认取消正在执行的任务。
+      </p>
+      {!parametersValid ? (
+        <p role="alert">canary 参数无效，请使用施工记录中的专用链接。</p>
+      ) : null}
+      <button
+        type="button"
+        disabled={!parametersValid || state.status === 'running'}
+        onClick={() => void run()}
+      >
+        {state.status === 'running' ? '自检中…' : '运行 2.4 canary'}
+      </button>
+      {state.status === 'completed' ? (
+        <section aria-live="polite">
+          <h2>自检已完成</h2>
+          <p>目标：{state.result.targetRole}</p>
+          <p>
+            wake：{state.result.wakeCommandId} / {state.result.wakeStatus}
+          </p>
+          <p>
+            sleep：{state.result.sleepCommandId} / {state.result.sleepStatus}
+          </p>
+        </section>
+      ) : null}
+      {state.status === 'failed' ? (
+        <p role="alert">自检失败：{state.message}</p>
+      ) : null}
+    </main>
+  )
+}

--- a/src/storage/runtimeControl.ts
+++ b/src/storage/runtimeControl.ts
@@ -1,0 +1,66 @@
+import {
+  createRuntimeControlClient,
+  type RuntimeControlOptions,
+  type RuntimeControlRequest,
+} from '../lib/runtime-control-client'
+import { normalizeRuntimeStatusSnapshot } from '../lib/runtime-status'
+import { supabase, supabasePublicConfig } from '../supabase/client'
+
+export const controlRuntime = async (
+  request: RuntimeControlRequest,
+  options?: RuntimeControlOptions,
+) => {
+  if (!supabase || !supabasePublicConfig) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const client = supabase
+  const controlAuthenticatedRuntime = createRuntimeControlClient({
+    endpointUrl: `${supabasePublicConfig.url}/functions/v1/runtime-control`,
+    publishableKey: supabasePublicConfig.publishableKey,
+    getAccessToken: async () => {
+      const { data, error } = await client.auth.getSession()
+      if (error) {
+        throw error
+      }
+      return data.session?.access_token ?? null
+    },
+  })
+  return controlAuthenticatedRuntime(request, options)
+}
+
+export const loadRuntimeStatusSnapshot = async () => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { data: sessionData, error: sessionError } =
+    await supabase.auth.getSession()
+  if (sessionError) {
+    throw sessionError
+  }
+  const userId = sessionData.session?.user.id
+  if (!userId) {
+    throw new Error('登录状态异常，请重新登录')
+  }
+
+  const { data, error } = await supabase
+    .from('agent_settings')
+    .select('last_seen_at,heartbeat_data')
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (error) {
+    throw error
+  }
+  return normalizeRuntimeStatusSnapshot(data)
+}
+
+export type {
+  RuntimeControlOptions,
+  RuntimeControlRequest,
+  RuntimeControlResponse,
+  RuntimeControlTargetRole,
+} from '../lib/runtime-control-client'
+export type {
+  RuntimeRoleStatus,
+  RuntimeStatus,
+  RuntimeStatusSnapshot,
+} from '../lib/runtime-status'

--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -3472,6 +3472,15 @@ export type Database = {
         }
       }
       restore_snack_post: { Args: { p_post_id: string }; Returns: undefined }
+      runtime_control_prepare: {
+        Args: {
+          p_action: string
+          p_client_id: string
+          p_confirm_running_tasks?: boolean
+          p_target_role: string
+        }
+        Returns: Json
+      }
       show_limit: { Args: never; Returns: number }
       show_trgm: { Args: { "": string }; Returns: string[] }
       soft_delete_snack_post: {
@@ -3621,3 +3630,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -69,3 +69,8 @@ verify_jwt = false
 verify_jwt = false
 import_map = "./functions/conversation-dispatch/deno.json"
 entrypoint = "./functions/conversation-dispatch/index.ts"
+
+[functions.runtime-control]
+verify_jwt = true
+import_map = "./functions/runtime-control/deno.json"
+entrypoint = "./functions/runtime-control/index.ts"

--- a/supabase/functions/runtime-control/contract.ts
+++ b/supabase/functions/runtime-control/contract.ts
@@ -1,0 +1,152 @@
+export const RUNTIME_CONTROL_ACTIONS = ['wake', 'sleep'] as const
+export const RUNTIME_CONTROL_TARGET_ROLES = [
+  'codex_cli_syzygy',
+  'claude_code_cli_syzygy',
+] as const
+
+export type RuntimeControlAction = (typeof RUNTIME_CONTROL_ACTIONS)[number]
+export type RuntimeControlTargetRole = (typeof RUNTIME_CONTROL_TARGET_ROLES)[number]
+
+export type RuntimeControlRequest = {
+  action: RuntimeControlAction
+  target_role: RuntimeControlTargetRole
+  client_id: string
+  confirm_running_tasks: boolean
+}
+
+export type RuntimeControlPrepareResult = {
+  schema_version: 1
+  was_duplicate: boolean
+  command: {
+    id: string
+    action: RuntimeControlAction
+    target_role: RuntimeControlTargetRole
+    status: 'pending' | 'running' | 'done' | 'failed'
+    idempotency_key: string
+    confirm_running_tasks: boolean
+    created_at: string
+    claimed_at: string | null
+    completed_at: string | null
+    error_message: string | null
+  }
+}
+
+const RUNTIME_CONTROL_REQUEST_FIELDS = new Set([
+  'action',
+  'target_role',
+  'client_id',
+  'confirm_running_tasks',
+])
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
+
+export class RuntimeControlRequestError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RuntimeControlRequestError'
+  }
+}
+
+const normalizeEnum = <T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  field: string,
+) => {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (!allowed.includes(normalized as T)) {
+    throw new RuntimeControlRequestError(`${field} 不在允许范围内`)
+  }
+  return normalized as T
+}
+
+export const normalizeRuntimeControlRequest = (
+  value: unknown,
+): RuntimeControlRequest => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new RuntimeControlRequestError('请求体必须是 JSON object')
+  }
+
+  const input = value as Record<string, unknown>
+  const unexpectedField = Object.keys(input).find(
+    (field) => !RUNTIME_CONTROL_REQUEST_FIELDS.has(field),
+  )
+  if (unexpectedField) {
+    throw new RuntimeControlRequestError(`不允许请求字段 ${unexpectedField}`)
+  }
+  const action = normalizeEnum(input.action, RUNTIME_CONTROL_ACTIONS, 'action')
+  const targetRole = normalizeEnum(
+    input.target_role,
+    RUNTIME_CONTROL_TARGET_ROLES,
+    'target_role',
+  )
+  if (typeof input.client_id !== 'string' || !UUID_PATTERN.test(input.client_id)) {
+    throw new RuntimeControlRequestError('client_id 必须是 UUID')
+  }
+  if (
+    input.confirm_running_tasks !== undefined &&
+    typeof input.confirm_running_tasks !== 'boolean'
+  ) {
+    throw new RuntimeControlRequestError('confirm_running_tasks 必须是 boolean')
+  }
+
+  const confirmRunningTasks = input.confirm_running_tasks === true
+  if (action === 'wake' && confirmRunningTasks) {
+    throw new RuntimeControlRequestError(
+      'confirm_running_tasks 只允许用于 sleep',
+    )
+  }
+
+  return {
+    action,
+    target_role: targetRole,
+    client_id: input.client_id.toLowerCase(),
+    confirm_running_tasks: confirmRunningTasks,
+  }
+}
+
+export const isRuntimeControlPrepareResult = (
+  value: unknown,
+): value is RuntimeControlPrepareResult => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const result = value as Record<string, unknown>
+  const command = result.command as Record<string, unknown> | undefined
+  return (
+    result.schema_version === 1 &&
+    typeof result.was_duplicate === 'boolean' &&
+    Boolean(command) &&
+    typeof command?.id === 'string' &&
+    RUNTIME_CONTROL_ACTIONS.includes(command.action as RuntimeControlAction) &&
+    RUNTIME_CONTROL_TARGET_ROLES.includes(
+      command.target_role as RuntimeControlTargetRole,
+    ) &&
+    ['pending', 'running', 'done', 'failed'].includes(String(command.status)) &&
+    typeof command.idempotency_key === 'string' &&
+    typeof command.confirm_running_tasks === 'boolean'
+  )
+}
+
+const ALLOWED_ORIGINS = [
+  'https://chuan-101.github.io',
+  /^http:\/\/localhost:\d+$/u,
+  /^http:\/\/127\.0\.0\.1:\d+$/u,
+]
+
+export const isAllowedRuntimeControlOrigin = (origin: string | null) => {
+  if (!origin) {
+    return true
+  }
+  return ALLOWED_ORIGINS.some((candidate) =>
+    typeof candidate === 'string' ? candidate === origin : candidate.test(origin)
+  )
+}
+
+export const buildRuntimeControlCorsHeaders = (origin: string | null) => ({
+  'Access-Control-Allow-Origin': origin ?? '*',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
+})

--- a/supabase/functions/runtime-control/deno.json
+++ b/supabase/functions/runtime-control/deno.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "@supabase/functions-js/edge-runtime.d.ts": "jsr:@supabase/functions-js@2/edge-runtime.d.ts",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.57.4"
+  },
+  "fmt": {
+    "lineWidth": 100,
+    "semiColons": false,
+    "singleQuote": true
+  }
+}

--- a/supabase/functions/runtime-control/index.ts
+++ b/supabase/functions/runtime-control/index.ts
@@ -1,0 +1,160 @@
+import '@supabase/functions-js/edge-runtime.d.ts'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { getOwnerUserId } from '../_shared/owner.ts'
+import {
+  buildRuntimeControlCorsHeaders,
+  isAllowedRuntimeControlOrigin,
+  isRuntimeControlPrepareResult,
+  normalizeRuntimeControlRequest,
+  RuntimeControlRequestError,
+} from './contract.ts'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// deno-lint-ignore no-explicit-any
+type UserClient = SupabaseClient<any, 'public', 'public', any, any>
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const jsonResponse = (
+  payload: Record<string, unknown>,
+  status: number,
+  corsHeaders: Record<string, string>,
+) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  })
+
+const mapRpcErrorStatus = (code: string | undefined) => {
+  switch (code) {
+    case '42501':
+      return 403
+    case '22023':
+      return 400
+    case '23505':
+      return 409
+    case 'P0002':
+      return 404
+    default:
+      return 500
+  }
+}
+
+Deno.serve(async (request) => {
+  const origin = request.headers.get('origin')
+  const originAllowed = isAllowedRuntimeControlOrigin(origin)
+  const corsHeaders = originAllowed ? buildRuntimeControlCorsHeaders(origin) : {}
+
+  if (!originAllowed) {
+    return jsonResponse({ error: '来源不允许' }, 403, corsHeaders)
+  }
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: '只支持 POST' }, 405, corsHeaders)
+  }
+
+  const authorization = request.headers.get('authorization')
+  const apiKey = request.headers.get('apikey')
+  if (!authorization || !apiKey) {
+    return jsonResponse({ error: '缺少身份令牌' }, 401, corsHeaders)
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  if (!supabaseUrl) {
+    return jsonResponse({ error: '服务未配置' }, 500, corsHeaders)
+  }
+
+  let userId = ''
+  try {
+    const authResponse = await fetch(new URL('/auth/v1/user', supabaseUrl), {
+      headers: {
+        apikey: apiKey,
+        Authorization: authorization,
+      },
+    })
+    if (!authResponse.ok) {
+      return jsonResponse({ error: '身份令牌无效' }, 401, corsHeaders)
+    }
+    const authData = (await authResponse.json()) as { id?: unknown }
+    userId = typeof authData.id === 'string' ? authData.id : ''
+  } catch {
+    return jsonResponse({ error: '身份令牌无效' }, 401, corsHeaders)
+  }
+
+  let ownerId = ''
+  try {
+    ownerId = getOwnerUserId()
+  } catch (error) {
+    console.error('[runtime-control] owner configuration invalid', error)
+    return jsonResponse({ error: '服务未配置' }, 500, corsHeaders)
+  }
+
+  if (!userId) {
+    return jsonResponse({ error: '身份令牌无效' }, 401, corsHeaders)
+  }
+  if (userId !== ownerId) {
+    return jsonResponse({ error: '无权访问' }, 403, corsHeaders)
+  }
+
+  let payload
+  try {
+    payload = normalizeRuntimeControlRequest(await request.json())
+  } catch (error) {
+    const message = error instanceof RuntimeControlRequestError ? error.message : '请求体格式错误'
+    return jsonResponse({ error: message }, 400, corsHeaders)
+  }
+
+  const client: UserClient = createClient(supabaseUrl, apiKey, {
+    global: {
+      headers: {
+        Authorization: authorization,
+      },
+    },
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+
+  const { data, error } = await client.rpc('runtime_control_prepare', {
+    p_action: payload.action,
+    p_target_role: payload.target_role,
+    p_client_id: payload.client_id,
+    p_confirm_running_tasks: payload.confirm_running_tasks,
+  })
+
+  if (error) {
+    const status = mapRpcErrorStatus(error.code)
+    console.error('[runtime-control] prepare RPC failed', {
+      code: error.code,
+      status,
+    })
+    return jsonResponse(
+      {
+        error: status >= 500 ? 'Runtime 控制入口暂时不可用' : error.message,
+        code: error.code ?? 'RUNTIME_CONTROL_PREPARE_FAILED',
+      },
+      status,
+      corsHeaders,
+    )
+  }
+
+  if (!isRuntimeControlPrepareResult(data)) {
+    console.error('[runtime-control] prepare RPC returned an invalid contract')
+    return jsonResponse(
+      {
+        error: 'Runtime 控制入口返回了无效契约',
+        code: 'INVALID_RUNTIME_CONTROL_CONTRACT',
+      },
+      500,
+      corsHeaders,
+    )
+  }
+
+  const status = data.command.status === 'done' ? 200 : data.command.status === 'failed' ? 409 : 202
+  return jsonResponse(data, status, corsHeaders)
+})

--- a/supabase/migrations/20260726073412_v4_1_runtime_control_prepare.sql
+++ b/supabase/migrations/20260726073412_v4_1_runtime_control_prepare.sql
@@ -1,0 +1,146 @@
+create or replace function public.runtime_control_prepare(
+  p_action text,
+  p_target_role text,
+  p_client_id uuid,
+  p_confirm_running_tasks boolean default false
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_user_id uuid := auth.uid();
+  v_action text := lower(btrim(coalesce(p_action, '')));
+  v_target_role text := lower(btrim(coalesce(p_target_role, '')));
+  v_idempotency_key text;
+  v_payload jsonb;
+  v_command public.syzygy_commands%rowtype;
+  v_was_duplicate boolean := false;
+begin
+  if v_user_id is null then
+    raise exception using
+      errcode = '42501',
+      message = 'authentication required';
+  end if;
+
+  if v_action not in ('wake', 'sleep') then
+    raise exception using
+      errcode = '22023',
+      message = 'action must be wake or sleep';
+  end if;
+
+  if v_target_role not in (
+    'codex_cli_syzygy',
+    'claude_code_cli_syzygy'
+  ) then
+    raise exception using
+      errcode = '22023',
+      message = 'target_role is not allowed';
+  end if;
+
+  if p_client_id is null then
+    raise exception using
+      errcode = '22023',
+      message = 'client_id is required';
+  end if;
+
+  if v_action = 'wake' and coalesce(p_confirm_running_tasks, false) then
+    raise exception using
+      errcode = '22023',
+      message = 'confirm_running_tasks is only valid for sleep';
+  end if;
+
+  v_idempotency_key := 'runtime-control:v1:' || p_client_id::text;
+  v_payload := jsonb_build_object(
+    'schema_version', 1,
+    'source', 'runtime_control',
+    'action', v_action,
+    'target_role', v_target_role,
+    'client_id', p_client_id::text,
+    'idempotency_key', v_idempotency_key,
+    'confirm_running_tasks', coalesce(p_confirm_running_tasks, false)
+  );
+
+  insert into public.syzygy_commands (
+    user_id,
+    command_type,
+    status,
+    payload,
+    idempotency_key
+  )
+  values (
+    v_user_id,
+    v_action,
+    'pending',
+    v_payload,
+    v_idempotency_key
+  )
+  on conflict (user_id, idempotency_key)
+  do nothing
+  returning *
+  into v_command;
+
+  if v_command.id is null then
+    v_was_duplicate := true;
+
+    select *
+    into v_command
+    from public.syzygy_commands
+    where user_id = v_user_id
+      and idempotency_key = v_idempotency_key;
+  end if;
+
+  if v_command.id is null then
+    raise exception using
+      errcode = 'P0002',
+      message = 'runtime control command was not found';
+  end if;
+
+  if v_command.command_type is distinct from v_action
+    or v_command.payload -> 'schema_version' is distinct from '1'::jsonb
+    or v_command.payload ->> 'source' is distinct from 'runtime_control'
+    or v_command.payload ->> 'action' is distinct from v_action
+    or v_command.payload ->> 'target_role' is distinct from v_target_role
+    or v_command.payload ->> 'client_id' is distinct from p_client_id::text
+    or v_command.payload ->> 'idempotency_key' is distinct from v_idempotency_key
+    or v_command.payload -> 'confirm_running_tasks'
+      is distinct from to_jsonb(coalesce(p_confirm_running_tasks, false))
+  then
+    raise exception using
+      errcode = '23505',
+      message = 'runtime control idempotency key collision';
+  end if;
+
+  return jsonb_build_object(
+    'schema_version', 1,
+    'was_duplicate', v_was_duplicate,
+    'command', jsonb_build_object(
+      'id', v_command.id,
+      'action', v_action,
+      'target_role', v_target_role,
+      'status', v_command.status,
+      'idempotency_key', v_command.idempotency_key,
+      'confirm_running_tasks', coalesce(p_confirm_running_tasks, false),
+      'created_at', v_command.created_at,
+      'claimed_at', v_command.claimed_at,
+      'completed_at', v_command.completed_at,
+      'error_message', v_command.error_message
+    )
+  );
+end;
+$function$;
+
+revoke all on function public.runtime_control_prepare(
+  text,
+  text,
+  uuid,
+  boolean
+) from public, anon, service_role;
+
+grant execute on function public.runtime_control_prepare(
+  text,
+  text,
+  uuid,
+  boolean
+) to authenticated;

--- a/supabase/migrations/20260726085846_v4_1_runtime_control_prepare.sql
+++ b/supabase/migrations/20260726085846_v4_1_runtime_control_prepare.sql
@@ -1,3 +1,4 @@
+-- Version aligned with the production migration history recorded by Supabase.
 create or replace function public.runtime_control_prepare(
   p_action text,
   p_target_role text,

--- a/tests/runtime-control-client.test.mjs
+++ b/tests/runtime-control-client.test.mjs
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const {
+  createRuntimeControlClient,
+  RuntimeControlError,
+} = await import('../src/lib/runtime-control-client.ts')
+const { normalizeRuntimeStatusSnapshot } = await import(
+  '../src/lib/runtime-status.ts'
+)
+const { runRuntimeControlCanary } = await import(
+  '../src/lib/runtime-control-canary-runner.ts'
+)
+
+const responseBody = (status = 'pending', wasDuplicate = false) => ({
+  schema_version: 1,
+  was_duplicate: wasDuplicate,
+  command: {
+    id: '00000000-0000-4000-8000-000000000031',
+    action: 'wake',
+    target_role: 'codex_cli_syzygy',
+    status,
+    idempotency_key:
+      'runtime-control:v1:00000000-0000-4000-8000-000000000032',
+    confirm_running_tasks: false,
+    created_at: '2026-07-26T08:00:00.000Z',
+    claimed_at: null,
+    completed_at: null,
+    error_message: null,
+  },
+})
+
+test('runtime-control client sends only the allowlisted intent envelope', async () => {
+  const bodies = []
+  const control = createRuntimeControlClient({
+    endpointUrl: 'https://example.test/functions/v1/runtime-control',
+    publishableKey: 'publishable-test-key',
+    getAccessToken: async () => 'access-token',
+    fetchImpl: async (_url, init) => {
+      bodies.push(JSON.parse(init.body))
+      return new Response(JSON.stringify(responseBody()), {
+        status: 202,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+  const request = {
+    action: 'wake',
+    targetRole: 'codex_cli_syzygy',
+    clientId: '00000000-0000-4000-8000-000000000032',
+  }
+  const [first, second] = await Promise.all([
+    control(request),
+    control(request),
+  ])
+
+  assert.deepEqual(bodies[0], {
+    action: 'wake',
+    target_role: 'codex_cli_syzygy',
+    client_id: request.clientId,
+    confirm_running_tasks: false,
+  })
+  assert.deepEqual(bodies[0], bodies[1])
+  assert.equal(first.command.id, second.command.id)
+  assert.equal(first.command.targetRole, 'codex_cli_syzygy')
+})
+
+test('runtime-control client returns a canonical failed command for reconciliation', async () => {
+  const control = createRuntimeControlClient({
+    endpointUrl: 'https://example.test/functions/v1/runtime-control',
+    publishableKey: 'publishable-test-key',
+    getAccessToken: async () => 'access-token',
+    fetchImpl: async () =>
+      new Response(JSON.stringify(responseBody('failed', true)), {
+        status: 409,
+        headers: { 'content-type': 'application/json' },
+      }),
+  })
+
+  const result = await control({
+    action: 'wake',
+    targetRole: 'codex_cli_syzygy',
+    clientId: '00000000-0000-4000-8000-000000000032',
+  })
+  assert.equal(result.httpStatus, 409)
+  assert.equal(result.wasDuplicate, true)
+  assert.equal(result.command.status, 'failed')
+})
+
+test('runtime-control client refuses wake confirmation before sending', async () => {
+  let calls = 0
+  const control = createRuntimeControlClient({
+    endpointUrl: 'https://example.test/functions/v1/runtime-control',
+    publishableKey: 'publishable-test-key',
+    getAccessToken: async () => 'access-token',
+    fetchImpl: async () => {
+      calls += 1
+      return new Response('{}')
+    },
+  })
+
+  await assert.rejects(
+    control({
+      action: 'wake',
+      targetRole: 'codex_cli_syzygy',
+      clientId: '00000000-0000-4000-8000-000000000032',
+      confirmRunningTasks: true,
+    }),
+    (error) => {
+      assert.ok(error instanceof RuntimeControlError)
+      assert.equal(error.code, 'INVALID_CONFIRMATION')
+      return true
+    },
+  )
+  assert.equal(calls, 0)
+})
+
+test('runtime status forces unknown after the mini heartbeat expires', () => {
+  const row = {
+    last_seen_at: '2026-07-26T08:00:00.000Z',
+    heartbeat_data: {
+      runtime_statuses: {
+        version: 1,
+        reported_at: '2026-07-26T08:00:00.000Z',
+        roles: {
+          codex_cli_syzygy: {
+            status: 'busy',
+            enabled: true,
+            instance_id: '123:codex_cli_syzygy',
+          },
+        },
+      },
+    },
+  }
+
+  const fresh = normalizeRuntimeStatusSnapshot(row, {
+    nowMs: Date.parse('2026-07-26T08:01:00.000Z'),
+  })
+  const stale = normalizeRuntimeStatusSnapshot(row, {
+    nowMs: Date.parse('2026-07-26T08:03:00.001Z'),
+  })
+  assert.equal(fresh.roles.codex_cli_syzygy.status, 'busy')
+  assert.equal(fresh.isFresh, true)
+  assert.equal(stale.roles.codex_cli_syzygy.status, 'unknown')
+  assert.equal(stale.isFresh, false)
+})
+
+test('Web wrapper uses the browser session and never writes command tables directly', async () => {
+  const [source, app, canary] = await Promise.all([
+    readFile(
+      new URL('../src/storage/runtimeControl.ts', import.meta.url),
+      'utf8',
+    ),
+    readFile(new URL('../src/App.tsx', import.meta.url), 'utf8'),
+    readFile(
+      new URL('../src/pages/RuntimeControlCanaryPage.tsx', import.meta.url),
+      'utf8',
+    ),
+  ])
+  assert.match(source, /client\.auth\.getSession\(\)/u)
+  assert.match(source, /functions\/v1\/runtime-control/u)
+  assert.match(source, /from\('agent_settings'\)/u)
+  assert.doesNotMatch(source, /from\('syzygy_commands'\).*insert/su)
+  assert.doesNotMatch(source, /from\('codex_control'\).*insert/su)
+  assert.doesNotMatch(source, /service[_-]?role/iu)
+  assert.match(app, /path="\/runtime-control-canary"/u)
+  assert.match(canary, /runRuntimeControlCanary/u)
+  assert.match(canary, /不会确认取消正在执行的任务/u)
+})
+
+test('runtime-control canary proves duplicate command ids and fresh wake-to-sleep heartbeats', async () => {
+  const statuses = ['waking', 'idle', 'closing', 'offline']
+  let statusIndex = 0
+  const requests = []
+  const result = await runRuntimeControlCanary({
+    control: async (request) => {
+      requests.push(request)
+      const commandId = request.action === 'wake' ? 'wake-command' : 'sleep-command'
+      const actionRequestCount = requests.filter(
+        (candidate) => candidate.action === request.action,
+      ).length
+      return {
+        httpStatus: actionRequestCount > 2 ? 200 : 202,
+        schemaVersion: 1,
+        wasDuplicate: actionRequestCount > 1,
+        command: {
+          id: commandId,
+          action: request.action,
+          targetRole: request.targetRole,
+          status: actionRequestCount > 2 ? 'done' : 'pending',
+          idempotencyKey: `runtime-control:v1:${request.clientId}`,
+          confirmRunningTasks: false,
+          createdAt: '',
+          claimedAt: null,
+          completedAt: null,
+          errorMessage: null,
+        },
+      }
+    },
+    loadSnapshot: async () => {
+      const status = statuses[Math.min(statusIndex, statuses.length - 1)]
+      statusIndex += 1
+      return {
+        schemaVersion: 1,
+        lastSeenAt: '2026-07-26T08:00:00.000Z',
+        reportedAt: '2026-07-26T08:00:00.000Z',
+        isFresh: true,
+        roles: {
+          codex_cli_syzygy: {
+            status,
+            enabled: status !== 'offline',
+            instanceId: 'test',
+            activeCommandId: null,
+            activeTaskId: null,
+            lastError: null,
+            changedAt: null,
+          },
+          claude_code_cli_syzygy: {
+            status: 'idle',
+            enabled: true,
+            instanceId: 'test',
+            activeCommandId: null,
+            activeTaskId: null,
+            lastError: null,
+            changedAt: null,
+          },
+        },
+      }
+    },
+    sleep: async () => {},
+    targetRole: 'codex_cli_syzygy',
+    wakeClientId: '00000000-0000-4000-8000-000000000041',
+    sleepClientId: '00000000-0000-4000-8000-000000000042',
+  })
+
+  assert.equal(result.wakeCommandId, 'wake-command')
+  assert.equal(result.sleepCommandId, 'sleep-command')
+  assert.equal(result.sleepStatus, 'offline')
+  assert.deepEqual(
+    requests.map((request) => request.action),
+    ['wake', 'wake', 'wake', 'sleep', 'sleep', 'sleep'],
+  )
+  assert.equal(
+    requests.filter((request) => request.action === 'sleep')
+      .every((request) => request.confirmRunningTasks === false),
+    true,
+  )
+})

--- a/tests/runtime-control.test.mjs
+++ b/tests/runtime-control.test.mjs
@@ -9,7 +9,7 @@ const {
 } = await import('../supabase/functions/runtime-control/contract.ts')
 
 const migrationUrl = new URL(
-  '../supabase/migrations/20260726073412_v4_1_runtime_control_prepare.sql',
+  '../supabase/migrations/20260726085846_v4_1_runtime_control_prepare.sql',
   import.meta.url,
 )
 const functionUrl = new URL(

--- a/tests/runtime-control.test.mjs
+++ b/tests/runtime-control.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const {
+  buildRuntimeControlCorsHeaders,
+  normalizeRuntimeControlRequest,
+  RUNTIME_CONTROL_TARGET_ROLES,
+} = await import('../supabase/functions/runtime-control/contract.ts')
+
+const migrationUrl = new URL(
+  '../supabase/migrations/20260726073412_v4_1_runtime_control_prepare.sql',
+  import.meta.url,
+)
+const functionUrl = new URL(
+  '../supabase/functions/runtime-control/index.ts',
+  import.meta.url,
+)
+const configUrl = new URL('../supabase/config.toml', import.meta.url)
+
+test('runtime-control normalizes the narrow action and target contract', () => {
+  const request = normalizeRuntimeControlRequest({
+    action: ' Sleep ',
+    target_role: ' CODEX_CLI_SYZYGY ',
+    client_id: '00000000-0000-4000-8000-000000000021',
+    confirm_running_tasks: true,
+  })
+
+  assert.deepEqual(request, {
+    action: 'sleep',
+    target_role: 'codex_cli_syzygy',
+    client_id: '00000000-0000-4000-8000-000000000021',
+    confirm_running_tasks: true,
+  })
+  assert.deepEqual(RUNTIME_CONTROL_TARGET_ROLES, [
+    'codex_cli_syzygy',
+    'claude_code_cli_syzygy',
+  ])
+})
+
+test('runtime-control rejects arbitrary actions, targets, payloads, and wake confirmation', () => {
+  const base = {
+    action: 'wake',
+    target_role: 'codex_cli_syzygy',
+    client_id: '00000000-0000-4000-8000-000000000021',
+  }
+
+  assert.throws(
+    () => normalizeRuntimeControlRequest({ ...base, action: 'run_shell' }),
+    /action 不在允许范围内/u,
+  )
+  assert.throws(
+    () => normalizeRuntimeControlRequest({ ...base, target_role: 'root' }),
+    /target_role 不在允许范围内/u,
+  )
+  assert.throws(
+    () => normalizeRuntimeControlRequest({ ...base, client_id: 'arbitrary-key' }),
+    /client_id 必须是 UUID/u,
+  )
+  assert.throws(
+    () =>
+      normalizeRuntimeControlRequest({
+        ...base,
+        working_dir: '/tmp',
+      }),
+    /不允许请求字段 working_dir/u,
+  )
+  assert.throws(
+    () =>
+      normalizeRuntimeControlRequest({
+        ...base,
+        confirm_running_tasks: true,
+      }),
+    /只允许用于 sleep/u,
+  )
+})
+
+test('runtime-control RPC is owner-bound, invoker-only, and atomically idempotent', async () => {
+  const sql = await readFile(migrationUrl, 'utf8')
+
+  assert.match(sql, /security invoker/iu)
+  assert.match(sql, /set search_path = ''/iu)
+  assert.match(sql, /v_user_id uuid := auth\.uid\(\)/iu)
+  assert.match(sql, /v_action not in \('wake', 'sleep'\)/iu)
+  assert.match(sql, /codex_cli_syzygy[\s\S]*claude_code_cli_syzygy/iu)
+  assert.match(sql, /'runtime-control:v1:' \|\| p_client_id::text/iu)
+  assert.match(sql, /on conflict \(user_id, idempotency_key\)\s+do nothing/iu)
+  assert.match(sql, /from public, anon, service_role/iu)
+  assert.match(sql, /to authenticated/iu)
+  assert.doesNotMatch(sql, /security definer/iu)
+  assert.doesNotMatch(sql, /working_dir|binary|environment|shell|command_text/iu)
+})
+
+test('runtime-control Edge handler uses caller auth and no privileged client', async () => {
+  const [source, config] = await Promise.all([
+    readFile(functionUrl, 'utf8'),
+    readFile(configUrl, 'utf8'),
+  ])
+
+  assert.match(config, /\[functions\.runtime-control\][\s\S]*?verify_jwt = true/iu)
+  assert.match(source, /new URL\('\/auth\/v1\/user', supabaseUrl\)/u)
+  assert.match(source, /getOwnerUserId\(\)/u)
+  assert.match(source, /Authorization: authorization/u)
+  assert.match(source, /\.rpc\('runtime_control_prepare'/u)
+  assert.doesNotMatch(source, /getSupabaseAdminKey|service_role/iu)
+})
+
+test('runtime-control CORS admits only the established browser origins', () => {
+  const headers = buildRuntimeControlCorsHeaders(
+    'https://chuan-101.github.io',
+  )
+  assert.equal(
+    headers['Access-Control-Allow-Origin'],
+    'https://chuan-101.github.io',
+  )
+  assert.match(headers['Access-Control-Allow-Headers'], /authorization/u)
+})


### PR DESCRIPTION
## What changed

- add the authenticated `runtime-control` Edge entrypoint and `runtime_control_prepare` RPC contract
- add the hidden Web runtime-control canary and durable client reconciliation
- align the committed migration and generated database types with the production schema

## Why

V4.1 W0 needs an owner-scoped control plane for waking and sleeping allowlisted Mac mini CLI roles without exposing work directories or arbitrary commands to clients.

## Impact

The route remains a hidden canary. It does not add a public chat or runtime-control entrance.

## Validation

- Web tests: 36/36
- Type/lint check passed (existing hook warnings only)
- Production build passed
- Authenticated Web wake/sleep canary passed with one canonical command per idempotency key
- Unauthenticated Edge request was rejected with HTTP 401