### PR TITLE
Fix generated database type normalization

### DIFF
--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -3630,4 +3630,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-


### PR DESCRIPTION
## What changed

- remove one extra blank line at the end of the generated production database type file

## Root cause

The production types were generated through the management API, whose output ended with two newline characters. The repository CI regenerates them with the Supabase CLI, which ends with one newline, so the byte-for-byte freshness check failed even though the schema content was identical.

## Impact

No type, schema, runtime, or application behavior changes.

## Validation

- production Supabase CLI output now matches the committed type file byte-for-byte
- Web type/lint check passed with the existing five hook warnings and zero errors
- production build passed