### PR TITLE
Fix settled HTTP status for CLI conversation dispatch

### DIFF
--- a/supabase/functions/conversation-dispatch/contract.ts
+++ b/supabase/functions/conversation-dispatch/contract.ts
@@ -16,6 +16,8 @@ export type ConversationDispatchRequest = {
   retry_failed: boolean
 }
 
+export type ConversationDeliveryState = 'generating' | 'completed' | 'failed'
+
 export type ConversationDispatchPrepareResult = {
   schema_version: 1
   handler: 'api' | 'cli'
@@ -27,7 +29,7 @@ export type ConversationDispatchPrepareResult = {
   }
   reply: {
     id: string
-    delivery_state: 'generating' | 'completed' | 'failed'
+    delivery_state: ConversationDeliveryState
     delivery_attempt: number
   }
   command: null | {
@@ -43,6 +45,11 @@ export type ConversationDispatchPrepareResult = {
   should_execute: boolean
   was_duplicate: boolean
 }
+
+export const resolveConversationDispatchHttpStatus = (
+  deliveryState: ConversationDeliveryState,
+): 200 | 202 | 409 =>
+  deliveryState === 'completed' ? 200 : deliveryState === 'generating' ? 202 : 409
 
 export class ConversationDispatchRequestError extends Error {
   constructor(message: string) {

--- a/supabase/functions/conversation-dispatch/index.ts
+++ b/supabase/functions/conversation-dispatch/index.ts
@@ -9,6 +9,7 @@ import {
   isAllowedConversationOrigin,
   normalizeConversationDispatchRequest,
   OpenAiSseAccumulator,
+  resolveConversationDispatchHttpStatus,
 } from './contract.ts'
 
 declare const EdgeRuntime:
@@ -510,16 +511,21 @@ Deno.serve(async (request) => {
   }
 
   if (dispatch.handler === 'cli') {
-    return jsonResponse(basePayload, 202, corsHeaders, dispatch)
+    return jsonResponse(
+      basePayload,
+      resolveConversationDispatchHttpStatus(dispatch.reply.delivery_state),
+      corsHeaders,
+      dispatch,
+    )
   }
 
   if (!dispatch.should_execute) {
-    const status = dispatch.reply.delivery_state === 'completed'
-      ? 200
-      : dispatch.reply.delivery_state === 'generating'
-      ? 202
-      : 409
-    return jsonResponse(basePayload, status, corsHeaders, dispatch)
+    return jsonResponse(
+      basePayload,
+      resolveConversationDispatchHttpStatus(dispatch.reply.delivery_state),
+      corsHeaders,
+      dispatch,
+    )
   }
 
   let modelRequest

--- a/tests/conversation-dispatch.test.mjs
+++ b/tests/conversation-dispatch.test.mjs
@@ -7,6 +7,7 @@ const {
   MAX_CONVERSATION_CONTENT_LENGTH,
   normalizeConversationDispatchRequest,
   OpenAiSseAccumulator,
+  resolveConversationDispatchHttpStatus,
 } = await import('../supabase/functions/conversation-dispatch/contract.ts')
 const {
   isConversationTaskCancelResult,
@@ -98,6 +99,12 @@ test('CORS contract exposes canonical message identifiers', () => {
   assert.match(headers['Access-Control-Allow-Headers'], /authorization/u)
 })
 
+test('settled dispatch HTTP status distinguishes queued, completed, and failed replies', () => {
+  assert.equal(resolveConversationDispatchHttpStatus('generating'), 202)
+  assert.equal(resolveConversationDispatchHttpStatus('completed'), 200)
+  assert.equal(resolveConversationDispatchHttpStatus('failed'), 409)
+})
+
 test('RPC remains an authenticated SECURITY INVOKER atomic claim', async () => {
   const sql = await readFile(migrationUrl, 'utf8')
 
@@ -164,6 +171,10 @@ test('Edge handler re-verifies the owner before using the service-only durable R
   assert.match(source, /getSupabaseAdminKey\(\)/u)
   assert.match(source, /\.rpc\('conversation_dispatch_prepare_durable'/u)
   assert.match(source, /p_user_id: userId/u)
+  assert.match(
+    source,
+    /dispatch\.handler === 'cli'[\s\S]*?resolveConversationDispatchHttpStatus\(dispatch\.reply\.delivery_state\)/u,
+  )
   assert.match(source, /EdgeRuntime\.waitUntil\(streamWork\)/u)
   assert.ok(source.indexOf('getOwnerUserId()') < source.indexOf('getSupabaseAdminKey()'))
   assert.equal(source.match(/new URL\('\/functions\/v1\/openrouter-chat'/gu)?.length, 1)


### PR DESCRIPTION
## Summary
- return HTTP 200 when a durable CLI reply is already completed
- keep HTTP 202 for generating work and HTTP 409 for failed replies
- share the settled-status mapping with the API reconciliation path

## Validation
- `npm test` — 39/39
- `npm run check` — 0 errors, 5 existing warnings
- `npm run build` — passed
- `npx --yes deno@2.9.4 check --config supabase/functions/conversation-dispatch/deno.json supabase/functions/conversation-dispatch/index.ts` — passed
- `git diff --check` — passed

The production canary exposed the previous unconditional CLI 202. Repeated owner-bound reconciliation reused the same canonical user/reply, one command, one completed task, and one completion event; no duplicate CLI execution occurred.