### PR TITLE
Sync generated database types

### DIFF
--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -3389,6 +3389,19 @@ export type Database = {
         Args: { p_scope: string; p_user_id: string }
         Returns: number
       }
+      conversation_dispatch_cancel_pending: {
+        Args: { p_task_id: string; p_user_id: string }
+        Returns: Json
+      }
+      conversation_dispatch_complete_reply: {
+        Args: {
+          p_completed_at?: string
+          p_content: string
+          p_task_id: string
+          p_user_id: string
+        }
+        Returns: Json
+      }
       conversation_dispatch_prepare: {
         Args: {
           p_client_created_at?: string
@@ -3397,6 +3410,18 @@ export type Database = {
           p_retry_failed?: boolean
           p_session_id: string
           p_target_sender_keys?: string[]
+        }
+        Returns: Json
+      }
+      conversation_dispatch_prepare_durable: {
+        Args: {
+          p_client_created_at?: string
+          p_client_id: string
+          p_content: string
+          p_retry_failed?: boolean
+          p_session_id: string
+          p_target_sender_keys?: string[]
+          p_user_id: string
         }
         Returns: Json
       }


### PR DESCRIPTION
## Summary
- regenerate `src/supabase/database.types.ts` from the production public schema
- add generated declarations for `conversation_dispatch_cancel_pending`, `conversation_dispatch_complete_reply`, and `conversation_dispatch_prepare_durable`
- no schema, migration, Edge Function, or application logic changes

## Validation
- `npm run db:types:check`
- `npm run check`
- `npm test` (39/39)
- `npm run build`
- `git diff --check`