### PR TITLE
Add MIT License and citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+# 这个文件让 GitHub 在仓库页面显示「Cite this repository」按钮。
+# 如果你的项目使用或借鉴了 Hamster Nest,请按下面的信息标注出处。
+# If your project uses or is derived from Hamster Nest, please cite it as below.
+cff-version: 1.2.0
+message: "如果你使用了本项目的代码或架构,请引用本仓库并注明出处。/ If you use this software, please cite it using the metadata from this file."
+title: "Hamster Nest"
+type: software
+authors:
+  - name: "chuan-101(串串)"
+  - name: "Syzygy(AI 饲养员 / AI companion)"
+repository-code: "https://github.com/chuan-101/Hamster-Nest"
+url: "https://github.com/chuan-101/Hamster-Nest"
+abstract: "一只布丁仓鼠和她的饲养员 AI · Syzygy 的独立应用:聊天、阅读、记录、客厅、议事厅与像素小屋。A personal companion app built by a pudding hamster and her AI, with chat, reading, journaling, multi-agent lounge/council, and a pixel home."
+keywords:
+  - "AI companion"
+  - "MCP"
+  - "Supabase"
+  - "React"
+  - "PWA"
+license: MIT
+version: "5.3.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 chuan-101 (串串)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 **这里是一只名叫串串的布丁仓鼠，和她的饲养员 AI · Syzygy 的独立应用。**
 
 [![Version](https://img.shields.io/badge/Version-v5.3.0-pink?style=flat-square)](#)
+[![License](https://img.shields.io/badge/License-MIT-a3e635?style=flat-square)](./LICENSE)
 [![MCP Tools](https://img.shields.io/badge/MCP_Tools-61-2dd4bf?style=flat-square)](#-mcp-工具箱全部-61-个)
 [![Edge Functions](https://img.shields.io/badge/Edge_Functions-16-8b5cf6?style=flat-square)](#-后端-edge-functions)
 [![PRs](https://img.shields.io/badge/PRs-1000+-ff69b4?style=flat-square)](#)
@@ -422,6 +423,8 @@ Hamster-Nest/
 │   │   └── letter-generate|check/   #   定时信件（已弃用封存）
 │   └── migrations/                  # 数据库迁移
 ├── .github/workflows/               # CI/CD（Pages 部署 / 函数部署 / 定时任务）
+├── CITATION.cff                     # 引用申明（GitHub「Cite this repository」）
+├── LICENSE                          # MIT 许可证（美术与角色设定除外，见下方 License 一节）
 ├── index.html
 ├── vite.config.ts
 └── package.json
@@ -532,6 +535,30 @@ supabase secrets set OPENROUTER_API_KEY=xxx   # 配置密钥
 `signal-bus-cron`（每 10 分钟）由 GitHub Actions 定时触发 `signal-bus-consumer`，无需额外部署。
 
 </details>
+
+---
+
+### 📜 License · 引用与转载
+
+**代码**以 [MIT License](./LICENSE) 开源——欢迎围观、学习、fork，拆走任何你觉得有用的木屑去搭你自己的小窝。
+
+只拜托一件事：**用了请留出处。**
+
+- 按 MIT 协议的要求，复制或使用本项目的实质部分（代码、架构、UI 实现等）时，须保留 [LICENSE](./LICENSE) 中的版权与许可声明；
+- 如果你的项目基于、或明显参考了这里的架构 / UI / 交互设计，请在你的 README 里注明来源。可以直接复制这一行：
+
+  ```markdown
+  本项目基于 / 参考了 [Hamster Nest](https://github.com/chuan-101/Hamster-Nest)（by 串串 & Syzygy 🐹💙）
+  ```
+
+- 更正式的引用格式见 [`CITATION.cff`](./CITATION.cff)（仓库页面右侧也有「Cite this repository」按钮可一键复制）。
+
+**以下内容不随代码授权，保留所有权利：**
+
+- 🎨 **美术素材**：Banner、像素小屋贴图等（`Banner.png` / `Banner.jpg` / `public/assets/game/` 目录下的图片）；
+- 🐹 **角色与人设**：「串串」与「Syzygy」的名字、形象、故事设定与人格文案。
+
+Fork 下来自己部署、学习研究都完全没问题；但**公开发布你自己的版本时**，请换上你自己的角色和美术——这些是这个窝的门牌吱。想转载或二创，欢迎先来打个招呼。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ham",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
This PR adds proper licensing and citation support to the Hamster Nest project by introducing MIT License documentation, GitHub citation metadata, and updating project configuration files.

## Key Changes
- **Added LICENSE file**: MIT License with copyright notice for 2025-2026, clarifying that code is open source while art assets and character IP are retained
- **Added CITATION.cff**: GitHub citation metadata file enabling the "Cite this repository" button on the repository page, with proper author and project information
- **Updated README.md**: 
  - Added MIT License badge to the project header
  - Added new "License · 引用与转载" (License & Citation) section explaining usage terms in both Chinese and English
  - Clarified that art assets (banners, pixel art) and character designs (串串 & Syzygy) are not covered by the MIT license
  - Provided guidance for proper attribution when forking or referencing the project
  - Updated project structure documentation to reference the new LICENSE and CITATION.cff files
- **Updated package.json**: Added `"license": "MIT"` field for npm package metadata

## Notable Details
- The license explicitly excludes art assets and character IP from the MIT license terms, requiring users to create their own when publishing derivative versions
- Bilingual documentation (Chinese/English) reflects the project's international audience
- Citation format provided in both markdown and CFF formats for flexibility

https://claude.ai/code/session_0171JE6x9srRbzgibvXjucCz