### PR TITLE
V4.1: add append-only Prompt publishing

### DIFF
--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -1083,6 +1083,7 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                         key={template.id}
                         className={`hamster-template-item ${isActive ? 'active' : ''}`}
                         onClick={() => handleSelectTemplate(template.id)}
+                        disabled={savingTemplateId !== null}
                       >
                         <span>{template.name}</span>
                         <small>{categoryLabelMap[template.category] ?? template.category}</small>
@@ -1105,6 +1106,7 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                       rows={12}
                       value={templateDraft}
                       onChange={(event) => setTemplateDraft(event.target.value)}
+                      disabled={savingTemplateId !== null}
                     />
                     <button
                       className="btn-primary"

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -42,7 +42,7 @@ type PromptTemplateRow = {
   name: string
   category: 'base' | 'scenario' | 'style' | string
   content: string
-  version: number | null
+  version: number
   active: boolean
 }
 
@@ -262,6 +262,11 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const activeTemplate = useMemo(
     () => promptTemplates.find((item) => item.id === activeTemplateId) ?? null,
     [promptTemplates, activeTemplateId],
+  )
+  const hasPromptDraftChanges = Boolean(
+    activeTemplate &&
+      templateDraft.trim() &&
+      templateDraft !== activeTemplate.content,
   )
   const codexControlState = useMemo(() => toCodexControlViewState(codexControlRow), [codexControlRow])
 
@@ -705,24 +710,30 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
 
   const handleSaveTemplate = async () => {
     if (!supabase || !activeTemplate) return
+    if (!templateDraft.trim() || templateDraft === activeTemplate.content) return
     setSavingTemplateId(activeTemplate.id)
 
-    const { error } = await supabase
-      .from('prompt_templates')
-      .update({ content: templateDraft })
-      .eq('id', activeTemplate.id)
-      .eq('user_id', scopedUserId)
+    const { data, error } = await supabase.rpc('prompt_template_publish', {
+      p_name: activeTemplate.name,
+      p_category: activeTemplate.category,
+      p_content: templateDraft,
+      p_expected_active_version: activeTemplate.version,
+    })
 
     setSavingTemplateId(null)
-    if (error) {
-      setErrorMessage(error.message)
+    if (error || !data) {
+      setErrorMessage(error?.message ?? 'Prompt 发布未返回新版本')
       return
     }
 
     setPromptTemplates((current) =>
-      current.map((item) => (item.id === activeTemplate.id ? { ...item, content: templateDraft } : item)),
+      current
+        .map((item) => (item.id === activeTemplate.id ? data : item))
+        .sort((left, right) => left.name.localeCompare(right.name)),
     )
-    showToast(`Prompt 已保存：${activeTemplate.name}`)
+    setActiveTemplateId(data.id)
+    setTemplateDraft(data.content)
+    showToast(`Prompt 已发布：${data.name} v${data.version}`)
   }
 
   const toggleSection = (sectionId: string) => {
@@ -1084,16 +1095,26 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                   <>
                     <div className="hamster-console-template-meta">
                       <span>{activeTemplate.name}</span>
-                      <span>v{activeTemplate.version ?? '-'}</span>
+                      <span>当前 active · v{activeTemplate.version}</span>
                     </div>
+                    <p className="hamster-console-card__hint">
+                      发布会创建不可变的新版本；旧版本保留用于审计与回滚。
+                    </p>
                     <textarea
                       className="textarea-glass hamster-console-template-editor"
                       rows={12}
                       value={templateDraft}
                       onChange={(event) => setTemplateDraft(event.target.value)}
                     />
-                    <button className="btn-primary" onClick={() => void handleSaveTemplate()} disabled={savingTemplateId === activeTemplate.id}>
-                      {savingTemplateId === activeTemplate.id ? '保存中...' : '保存 Prompt'}
+                    <button
+                      className="btn-primary"
+                      onClick={() => void handleSaveTemplate()}
+                      disabled={
+                        savingTemplateId === activeTemplate.id ||
+                        !hasPromptDraftChanges
+                      }
+                    >
+                      {savingTemplateId === activeTemplate.id ? '发布中...' : '发布新版本'}
                     </button>
                   </>
                 ) : (

--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -3688,6 +3688,31 @@ export type Database = {
         Args: { p_message_id: string; p_worker_id: string }
         Returns: boolean
       }
+      prompt_template_publish: {
+        Args: {
+          p_category: string
+          p_content: string
+          p_expected_active_version?: number
+          p_name: string
+        }
+        Returns: {
+          active: boolean
+          category: string
+          content: string
+          created_at: string
+          id: string
+          name: string
+          updated_at: string
+          user_id: string
+          version: number
+        }
+        SetofOptions: {
+          from: "*"
+          to: "prompt_templates"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       reset_stuck_wechat_messages: {
         Args: { p_max_retries?: number; p_timeout_minutes?: number }
         Returns: number

--- a/supabase/functions/conversation-dispatch/index.ts
+++ b/supabase/functions/conversation-dispatch/index.ts
@@ -11,6 +11,12 @@ import {
   OpenAiSseAccumulator,
   resolveConversationDispatchHttpStatus,
 } from './contract.ts'
+import {
+  composeConversationSystemPrompt,
+  type ConversationPromptNames,
+  type ConversationPromptRow,
+  resolveConversationProfileKey,
+} from './prompt.ts'
 
 declare const EdgeRuntime:
   | {
@@ -20,6 +26,8 @@ declare const EdgeRuntime:
 
 type SessionRow = {
   id: string
+  session_key: string | null
+  conversation_profile_key: string | null
   override_model: string | null
   override_reasoning: boolean | null
 }
@@ -41,6 +49,16 @@ type MessageRow = {
   created_at: string
 }
 
+type ConversationProfileRow = {
+  default_responder_port_key: string
+  rules_prompt_name: string | null
+}
+
+type GenerationPortRow = {
+  identity_prompt_name: string
+  style_prompt_name: string | null
+}
+
 // This Edge bundle intentionally stays decoupled from the 100 KB generated
 // browser type file; request/row contracts above provide the narrow boundary.
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -50,6 +68,69 @@ type UserClient = SupabaseClient<any, 'public', 'public', any, any>
 
 const HISTORY_LIMIT = 200
 const STREAM_PERSIST_INTERVAL_MS = 450
+
+const loadActiveConversationPrompt = async (
+  client: UserClient,
+  userId: string,
+  session: SessionRow,
+  legacySystemPrompt: string,
+) => {
+  const profileKey = resolveConversationProfileKey({
+    conversationProfileKey: session.conversation_profile_key,
+    sessionKey: session.session_key,
+  })
+  const profileResult = await client
+    .from('conversation_profiles')
+    .select('default_responder_port_key,rules_prompt_name')
+    .eq('user_id', userId)
+    .eq('profile_key', profileKey)
+    .eq('active', true)
+    .maybeSingle<ConversationProfileRow>()
+
+  if (profileResult.error || !profileResult.data) {
+    return legacySystemPrompt.trim()
+  }
+
+  const portResult = await client
+    .from('generation_ports')
+    .select('identity_prompt_name,style_prompt_name')
+    .eq('user_id', userId)
+    .eq('port_key', profileResult.data.default_responder_port_key)
+    .eq('active', true)
+    .maybeSingle<GenerationPortRow>()
+
+  if (portResult.error || !portResult.data) {
+    return legacySystemPrompt.trim()
+  }
+
+  const promptNames: ConversationPromptNames = {
+    identityPromptName: portResult.data.identity_prompt_name,
+    stylePromptName: portResult.data.style_prompt_name,
+    rulesPromptName: profileResult.data.rules_prompt_name,
+  }
+  const requiredPromptNames = [
+    promptNames.identityPromptName,
+    promptNames.stylePromptName,
+    promptNames.rulesPromptName,
+  ].filter((name): name is string => Boolean(name))
+  const promptsResult = await client
+    .from('prompt_templates')
+    .select('name,content,version')
+    .eq('user_id', userId)
+    .eq('active', true)
+    .in('name', requiredPromptNames)
+    .returns<ConversationPromptRow[]>()
+
+  if (promptsResult.error) {
+    return legacySystemPrompt.trim()
+  }
+
+  return composeConversationSystemPrompt({
+    names: promptNames,
+    activePrompts: promptsResult.data ?? [],
+    legacySystemPrompt,
+  })
+}
 
 const jsonResponse = (
   payload: Record<string, unknown>,
@@ -194,7 +275,9 @@ const loadConversationRequest = async (
   const [sessionResult, settingsResult, messagesResult] = await Promise.all([
     client
       .from('sessions')
-      .select('id,override_model,override_reasoning')
+      .select(
+        'id,session_key,conversation_profile_key,override_model,override_reasoning',
+      )
       .eq('id', sessionId)
       .eq('user_id', userId)
       .maybeSingle<SessionRow>(),
@@ -227,6 +310,12 @@ const loadConversationRequest = async (
 
   const session = sessionResult.data
   const settings = settingsResult.data
+  const systemPrompt = await loadActiveConversationPrompt(
+    client,
+    userId,
+    session,
+    settings.system_prompt,
+  )
   const canonicalMessages = [...(messagesResult.data ?? [])]
     .reverse()
     .filter((message) => {
@@ -246,7 +335,6 @@ const loadConversationRequest = async (
       content: message.content,
     }))
 
-  const systemPrompt = settings.system_prompt.trim()
   const messages = [
     ...(systemPrompt ? [{ role: 'system' as const, content: systemPrompt }] : []),
     ...canonicalMessages,

--- a/supabase/functions/conversation-dispatch/prompt.ts
+++ b/supabase/functions/conversation-dispatch/prompt.ts
@@ -1,0 +1,62 @@
+export type ConversationPromptRow = {
+  name: string
+  content: string
+  version: number
+}
+
+export type ConversationPromptNames = {
+  identityPromptName: string
+  stylePromptName: string | null
+  rulesPromptName: string | null
+}
+
+export const resolveConversationProfileKey = ({
+  conversationProfileKey,
+  sessionKey,
+}: {
+  conversationProfileKey: string | null
+  sessionKey: string | null
+}) => {
+  const explicitProfile = conversationProfileKey?.trim()
+  if (explicitProfile) {
+    return explicitProfile
+  }
+
+  return sessionKey === 'syzygy_instant' || sessionKey === 'syzygy_companion'
+    ? 'app_companion'
+    : 'app_chat'
+}
+
+export const composeConversationSystemPrompt = ({
+  names,
+  activePrompts,
+  legacySystemPrompt,
+}: {
+  names: ConversationPromptNames | null
+  activePrompts: ConversationPromptRow[]
+  legacySystemPrompt: string
+}) => {
+  const legacyPrompt = legacySystemPrompt.trim()
+  if (!names) {
+    return legacyPrompt
+  }
+
+  const promptByName = new Map(
+    activePrompts.map((prompt) => [prompt.name, prompt.content.trim()]),
+  )
+  const requiredNames = [
+    names.identityPromptName,
+    names.stylePromptName,
+    names.rulesPromptName,
+  ].filter((name): name is string => Boolean(name))
+
+  const resolvedLayers = requiredNames.map((name) => promptByName.get(name) ?? '')
+  if (
+    resolvedLayers.length !== requiredNames.length ||
+    resolvedLayers.some((content) => !content)
+  ) {
+    return legacyPrompt
+  }
+
+  return resolvedLayers.join('\n\n')
+}

--- a/supabase/migrations/20260730133228_v4_1_prompt_publishing.sql
+++ b/supabase/migrations/20260730133228_v4_1_prompt_publishing.sql
@@ -1,0 +1,452 @@
+-- Production migration history: 20260730133228.
+-- V4.1 W1 / 3.2: append-only Prompt publishing and chat Prompt seeds.
+--
+-- Local expand slice:
+-- - legacy user_settings Prompt columns remain available for fallback reads;
+-- - existing Prompt bodies are retained and never copied into source control;
+-- - runtime deployment and legacy-column contract remain separate gates.
+
+set lock_timeout = '5s';
+set statement_timeout = '2min';
+
+create schema if not exists private;
+revoke all on schema private from public, anon;
+grant usage on schema private to authenticated, service_role;
+
+-- ── Existing Prompt catalog hardening ────────────────────────────────────────
+
+alter table public.prompt_templates
+  add constraint prompt_templates_name_key_check
+    check (name ~ '^[a-z][a-z0-9_]*$') not valid;
+
+alter table public.prompt_templates
+  validate constraint prompt_templates_name_key_check;
+
+alter table public.prompt_templates
+  add constraint prompt_templates_content_nonempty_check
+    check (btrim(content) <> '') not valid;
+
+alter table public.prompt_templates
+  validate constraint prompt_templates_content_nonempty_check;
+
+create unique index prompt_templates_user_name_active_unique
+  on public.prompt_templates (user_id, name)
+  where active;
+
+comment on index public.prompt_templates_user_name_active_unique is
+  'Exactly one active version per owner Prompt name.';
+
+drop policy if exists prompt_templates_select_own
+  on public.prompt_templates;
+drop policy if exists prompt_templates_insert_own
+  on public.prompt_templates;
+drop policy if exists prompt_templates_update_own
+  on public.prompt_templates;
+drop policy if exists prompt_templates_delete_own
+  on public.prompt_templates;
+
+create policy prompt_templates_select_own
+  on public.prompt_templates
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+
+revoke all on public.prompt_templates from anon, authenticated;
+grant select on public.prompt_templates to authenticated;
+grant select, insert, update, delete
+  on public.prompt_templates
+  to service_role;
+
+-- ── Append-only version rows ─────────────────────────────────────────────────
+
+create or replace function private.enforce_prompt_template_immutable()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+begin
+  if tg_op = 'DELETE' then
+    raise exception
+      'prompt_templates rows are append-only and cannot be deleted';
+  end if;
+
+  if (
+    to_jsonb(new) - 'active' - 'updated_at'
+  ) is distinct from (
+    to_jsonb(old) - 'active' - 'updated_at'
+  ) then
+    raise exception
+      'prompt_templates rows are append-only; publish a new version instead';
+  end if;
+
+  if not old.active and new.active then
+    raise exception
+      'Inactive Prompt versions cannot be reactivated';
+  end if;
+
+  new.updated_at := now();
+  return new;
+end
+$function$;
+
+revoke all on function private.enforce_prompt_template_immutable()
+  from public, anon, authenticated;
+grant execute on function private.enforce_prompt_template_immutable()
+  to service_role;
+
+create trigger prompt_templates_immutable_version
+before update or delete on public.prompt_templates
+for each row execute function private.enforce_prompt_template_immutable();
+
+-- ── Owner-bound Prompt publishing ────────────────────────────────────────────
+
+create or replace function private.prompt_template_publish_core(
+  p_name text,
+  p_category text,
+  p_content text,
+  p_expected_active_version integer default null
+)
+returns public.prompt_templates
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_owner_id uuid := (select auth.uid());
+  v_name text := lower(btrim(p_name));
+  v_category text := lower(btrim(p_category));
+  v_content text := p_content;
+  v_active_version integer;
+  v_next_version integer;
+  v_result public.prompt_templates%rowtype;
+begin
+  if v_owner_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if v_name !~ '^[a-z][a-z0-9_]*$' then
+    raise exception 'Invalid Prompt name';
+  end if;
+
+  if v_category not in ('base', 'scenario', 'style') then
+    raise exception 'Invalid Prompt category';
+  end if;
+
+  if v_content is null or btrim(v_content) = '' then
+    raise exception 'Prompt content is required';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(
+      'v4.1:prompt-template:' || v_owner_id::text || ':' || v_name,
+      0
+    )
+  );
+
+  select version
+  into v_active_version
+  from public.prompt_templates
+  where user_id = v_owner_id
+    and name = v_name
+    and active
+  for update;
+
+  if v_active_version is null then
+    if p_expected_active_version is not null then
+      raise exception
+        'Prompt active version changed (expected %, actual none)',
+        p_expected_active_version;
+    end if;
+  elsif p_expected_active_version is null
+     or p_expected_active_version is distinct from v_active_version then
+    raise exception
+      'Prompt active version changed (expected %, actual %)',
+      p_expected_active_version,
+      v_active_version;
+  end if;
+
+  select coalesce(max(version), 0) + 1
+  into v_next_version
+  from public.prompt_templates
+  where user_id = v_owner_id
+    and name = v_name;
+
+  update public.prompt_templates
+  set active = false
+  where user_id = v_owner_id
+    and name = v_name
+    and active;
+
+  insert into public.prompt_templates (
+    user_id,
+    name,
+    category,
+    content,
+    version,
+    active
+  )
+  values (
+    v_owner_id,
+    v_name,
+    v_category,
+    v_content,
+    v_next_version,
+    true
+  )
+  returning * into v_result;
+
+  return v_result;
+end
+$function$;
+
+revoke all on function private.prompt_template_publish_core(
+  text, text, text, integer
+) from public, anon, authenticated, service_role;
+grant execute on function private.prompt_template_publish_core(
+  text, text, text, integer
+) to authenticated;
+
+create or replace function public.prompt_template_publish(
+  p_name text,
+  p_category text,
+  p_content text,
+  p_expected_active_version integer default null
+)
+returns public.prompt_templates
+language sql
+security invoker
+set search_path = ''
+as $function$
+  select private.prompt_template_publish_core(
+    p_name,
+    p_category,
+    p_content,
+    p_expected_active_version
+  )
+$function$;
+
+revoke all on function public.prompt_template_publish(
+  text, text, text, integer
+) from public, anon, service_role;
+grant execute on function public.prompt_template_publish(
+  text, text, text, integer
+) to authenticated;
+
+comment on function public.prompt_template_publish(
+  text, text, text, integer
+) is
+  'Publishes one immutable owner Prompt version and atomically deactivates its predecessor.';
+
+-- ── Owner chat Prompt seeds ──────────────────────────────────────────────────
+
+do $migration$
+declare
+  v_owner_id uuid;
+  v_owner_count bigint;
+  v_wechat_reply_style text;
+  v_cli_reply_style text;
+  v_sofa_rules text;
+begin
+  perform pg_advisory_xact_lock(
+    hashtextextended('v4.1:prompt-publishing-seed', 0)
+  );
+
+  select count(*), min(owner_id::text)::uuid
+  into v_owner_count, v_owner_id
+  from (
+    select distinct user_id as owner_id
+    from public.prompt_templates
+    where user_id is not null
+  ) owners;
+
+  if v_owner_count <> 1 or v_owner_id is null then
+    raise exception
+      'Expected exactly one Prompt owner before seeding chat Prompts; found %',
+      v_owner_count;
+  end if;
+
+  select content
+  into v_wechat_reply_style
+  from public.prompt_templates
+  where user_id = v_owner_id
+    and name = 'wechat_reply_style'
+    and active;
+
+  select content
+  into v_cli_reply_style
+  from public.prompt_templates
+  where user_id = v_owner_id
+    and name = 'cli_reply_style'
+    and active;
+
+  select lounge_scene_prompt
+  into v_sofa_rules
+  from public.user_settings
+  where user_id = v_owner_id;
+
+  if v_wechat_reply_style is null or btrim(v_wechat_reply_style) = '' then
+    raise exception 'Active wechat_reply_style is required as the App style seed';
+  end if;
+
+  if v_cli_reply_style is null or btrim(v_cli_reply_style) = '' then
+    raise exception 'Active cli_reply_style is required as the CLI style seed';
+  end if;
+
+  if v_sofa_rules is null or btrim(v_sofa_rules) = '' then
+    raise exception 'Legacy lounge_scene_prompt is required as the sofa rules seed';
+  end if;
+
+  insert into public.prompt_templates (
+    user_id,
+    name,
+    category,
+    content,
+    version,
+    active
+  )
+  select
+    v_owner_id,
+    seed.name,
+    seed.category,
+    seed.content,
+    1,
+    true
+  from (
+    values
+      ('app_companion_reply_style', 'style', v_wechat_reply_style),
+      ('app_chat_reply_style', 'style', v_wechat_reply_style),
+      ('codex_cli_reply_style', 'style', v_cli_reply_style),
+      ('claude_cli_reply_style', 'style', v_cli_reply_style),
+      ('sofa_daily_rules', 'scenario', v_sofa_rules),
+      ('sofa_work_rules', 'scenario', v_sofa_rules)
+  ) as seed(name, category, content)
+  where not exists (
+    select 1
+    from public.prompt_templates existing
+    where existing.user_id = v_owner_id
+      and existing.name = seed.name
+  );
+
+  if exists (
+    select 1
+    from public.generation_ports port
+    left join public.prompt_templates identity_prompt
+      on identity_prompt.user_id = port.user_id
+     and identity_prompt.name = port.identity_prompt_name
+     and identity_prompt.active
+    left join public.prompt_templates style_prompt
+      on style_prompt.user_id = port.user_id
+     and style_prompt.name = port.style_prompt_name
+     and style_prompt.active
+    where port.user_id = v_owner_id
+      and port.active
+      and (
+        identity_prompt.id is null
+        or (
+          port.style_prompt_name is not null
+          and style_prompt.id is null
+        )
+      )
+  ) then
+    raise exception 'Every active generation port must resolve to active Prompt versions';
+  end if;
+
+  if exists (
+    select 1
+    from public.conversation_profiles profile
+    left join public.prompt_templates rules_prompt
+      on rules_prompt.user_id = profile.user_id
+     and rules_prompt.name = profile.rules_prompt_name
+     and rules_prompt.active
+    where profile.user_id = v_owner_id
+      and profile.active
+      and profile.rules_prompt_name is not null
+      and rules_prompt.id is null
+  ) then
+    raise exception 'Every active sofa profile must resolve to an active rules Prompt';
+  end if;
+end
+$migration$;
+
+-- ── Migration assertions ─────────────────────────────────────────────────────
+
+do $assertions$
+declare
+  v_owner_id uuid;
+  v_missing_prompt_count bigint;
+begin
+  select min(user_id::text)::uuid
+  into v_owner_id
+  from public.prompt_templates;
+
+  if exists (
+    select 1
+    from public.prompt_templates
+    where active
+    group by user_id, name
+    having count(*) > 1
+  ) then
+    raise exception 'Prompt migration created duplicate active versions';
+  end if;
+
+  select count(*)
+  into v_missing_prompt_count
+  from unnest(array[
+    'syzygy_base',
+    'checkin_day',
+    'checkin_night',
+    'wechat_reply_style',
+    'app_companion_reply_style',
+    'app_chat_reply_style',
+    'codex_cli_reply_style',
+    'claude_cli_reply_style',
+    'sofa_daily_rules',
+    'sofa_work_rules'
+  ]) required_name
+  where not exists (
+    select 1
+    from public.prompt_templates prompt
+    where prompt.user_id = v_owner_id
+      and prompt.name = required_name
+      and prompt.active
+  );
+
+  if v_missing_prompt_count <> 0 then
+    raise exception
+      'Prompt migration is missing % required active chat Prompt(s)',
+      v_missing_prompt_count;
+  end if;
+
+  if has_table_privilege('anon', 'public.prompt_templates', 'SELECT')
+     or has_table_privilege('anon', 'public.prompt_templates', 'INSERT')
+     or has_table_privilege('anon', 'public.prompt_templates', 'UPDATE')
+     or has_table_privilege('anon', 'public.prompt_templates', 'DELETE') then
+    raise exception 'Anon must not have prompt_templates table privileges';
+  end if;
+
+  if not has_table_privilege(
+    'authenticated',
+    'public.prompt_templates',
+    'SELECT'
+  ) then
+    raise exception 'Authenticated must retain owner-readable Prompt access';
+  end if;
+
+  if has_table_privilege(
+    'authenticated',
+    'public.prompt_templates',
+    'INSERT'
+  ) or has_table_privilege(
+    'authenticated',
+    'public.prompt_templates',
+    'UPDATE'
+  ) or has_table_privilege(
+    'authenticated',
+    'public.prompt_templates',
+    'DELETE'
+  ) then
+    raise exception 'Authenticated Prompt writes must use the publish RPC';
+  end if;
+end
+$assertions$;

--- a/supabase/rollback-contracts/20260730133228_v4_1_prompt_publishing.sql
+++ b/supabase/rollback-contracts/20260730133228_v4_1_prompt_publishing.sql
@@ -1,0 +1,244 @@
+-- Production migration history: 20260730133228.
+-- Emergency contract rollback for V4.1 Prompt publishing.
+--
+-- This file deliberately lives outside supabase/migrations so normal forward
+-- migration tooling never applies it automatically. If production rollback is
+-- required, register this SQL as a new forward migration after confirming the
+-- guard below still passes. The guard fails closed once any seeded Prompt has
+-- been published beyond its original v1 row.
+
+set lock_timeout = '5s';
+set statement_timeout = '2min';
+
+do $rollback_guard$
+declare
+  v_seed_rows bigint;
+  v_seed_names bigint;
+begin
+  perform pg_advisory_xact_lock(
+    hashtextextended('v4.1:prompt-publishing-seed', 0)
+  );
+
+  if to_regprocedure(
+    'public.prompt_template_publish(text,text,text,integer)'
+  ) is null then
+    raise exception 'Prompt publishing contract is not installed';
+  end if;
+
+  select count(*), count(distinct name)
+  into v_seed_rows, v_seed_names
+  from public.prompt_templates
+  where name in (
+    'app_companion_reply_style',
+    'app_chat_reply_style',
+    'codex_cli_reply_style',
+    'claude_cli_reply_style',
+    'sofa_daily_rules',
+    'sofa_work_rules'
+  );
+
+  if v_seed_rows <> 6 or v_seed_names <> 6 then
+    raise exception
+      'Prompt rollback requires exactly six untouched seed rows; found % rows / % names',
+      v_seed_rows,
+      v_seed_names;
+  end if;
+
+  if exists (
+    select 1
+    from public.prompt_templates
+    where name in (
+      'app_companion_reply_style',
+      'app_chat_reply_style',
+      'codex_cli_reply_style',
+      'claude_cli_reply_style',
+      'sofa_daily_rules',
+      'sofa_work_rules'
+    )
+      and (version <> 1 or not active)
+  ) then
+    raise exception
+      'Prompt rollback refuses to delete a seed that has entered version history';
+  end if;
+end
+$rollback_guard$;
+
+drop function public.prompt_template_publish(
+  text, text, text, integer
+);
+drop function private.prompt_template_publish_core(
+  text, text, text, integer
+);
+
+drop trigger prompt_templates_immutable_version
+  on public.prompt_templates;
+drop function private.enforce_prompt_template_immutable();
+
+delete from public.prompt_templates
+where name in (
+  'app_companion_reply_style',
+  'app_chat_reply_style',
+  'codex_cli_reply_style',
+  'claude_cli_reply_style',
+  'sofa_daily_rules',
+  'sofa_work_rules'
+);
+
+drop index public.prompt_templates_user_name_active_unique;
+
+alter table public.prompt_templates
+  drop constraint prompt_templates_name_key_check,
+  drop constraint prompt_templates_content_nonempty_check;
+
+drop policy prompt_templates_select_own
+  on public.prompt_templates;
+
+create policy prompt_templates_select_own
+  on public.prompt_templates
+  for select
+  using ((select auth.uid()) = user_id);
+
+create policy prompt_templates_insert_own
+  on public.prompt_templates
+  for insert
+  with check ((select auth.uid()) = user_id);
+
+create policy prompt_templates_update_own
+  on public.prompt_templates
+  for update
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy prompt_templates_delete_own
+  on public.prompt_templates
+  for delete
+  using ((select auth.uid()) = user_id);
+
+revoke all on public.prompt_templates from anon, authenticated;
+grant all privileges on public.prompt_templates to anon, authenticated;
+
+do $rollback_assertions$
+begin
+  if to_regprocedure(
+    'public.prompt_template_publish(text,text,text,integer)'
+  ) is not null then
+    raise exception 'Prompt publish RPC survived contract rollback';
+  end if;
+
+  if to_regclass(
+    'public.prompt_templates_user_name_active_unique'
+  ) is not null then
+    raise exception 'Prompt active unique index survived contract rollback';
+  end if;
+
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.prompt_templates'::regclass
+      and tgname = 'prompt_templates_immutable_version'
+      and not tgisinternal
+  ) then
+    raise exception 'Prompt immutable trigger survived contract rollback';
+  end if;
+
+  if exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.prompt_templates'::regclass
+      and conname in (
+        'prompt_templates_name_key_check',
+        'prompt_templates_content_nonempty_check'
+      )
+  ) then
+    raise exception 'Prompt publishing constraints survived contract rollback';
+  end if;
+
+  if exists (
+    select 1
+    from public.prompt_templates
+    where name in (
+      'app_companion_reply_style',
+      'app_chat_reply_style',
+      'codex_cli_reply_style',
+      'claude_cli_reply_style',
+      'sofa_daily_rules',
+      'sofa_work_rules'
+    )
+  ) then
+    raise exception 'Prompt seed rows survived contract rollback';
+  end if;
+
+  if (
+    select count(*)
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'prompt_templates'
+      and policyname in (
+        'prompt_templates_select_own',
+        'prompt_templates_insert_own',
+        'prompt_templates_update_own',
+        'prompt_templates_delete_own'
+      )
+      and roles = array['public']::name[]
+  ) <> 4 then
+    raise exception 'Prompt owner policies were not restored';
+  end if;
+
+  if not (
+    has_table_privilege('anon', 'public.prompt_templates', 'SELECT')
+    and has_table_privilege('anon', 'public.prompt_templates', 'INSERT')
+    and has_table_privilege('anon', 'public.prompt_templates', 'UPDATE')
+    and has_table_privilege('anon', 'public.prompt_templates', 'DELETE')
+    and has_table_privilege('anon', 'public.prompt_templates', 'TRUNCATE')
+    and has_table_privilege('anon', 'public.prompt_templates', 'REFERENCES')
+    and has_table_privilege('anon', 'public.prompt_templates', 'TRIGGER')
+    and has_table_privilege(
+      'authenticated',
+      'public.prompt_templates',
+      'SELECT'
+    )
+    and has_table_privilege(
+      'authenticated',
+      'public.prompt_templates',
+      'INSERT'
+    )
+    and has_table_privilege(
+      'authenticated',
+      'public.prompt_templates',
+      'UPDATE'
+    )
+    and has_table_privilege(
+      'authenticated',
+      'public.prompt_templates',
+      'DELETE'
+    )
+    and has_table_privilege(
+      'authenticated',
+      'public.prompt_templates',
+      'TRUNCATE'
+    )
+    and has_table_privilege(
+      'authenticated',
+      'public.prompt_templates',
+      'REFERENCES'
+    )
+    and has_table_privilege(
+      'authenticated',
+      'public.prompt_templates',
+      'TRIGGER'
+    )
+  ) then
+    raise exception 'Prompt table grants were not restored';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.prompt_templates'::regclass
+      and tgname = 'prompt_templates_set_updated_at'
+      and not tgisinternal
+  ) then
+    raise exception 'Legacy Prompt updated_at trigger was not preserved';
+  end if;
+end
+$rollback_assertions$;

--- a/tests/prompt-publishing.test.mjs
+++ b/tests/prompt-publishing.test.mjs
@@ -194,6 +194,23 @@ test('Web editor publishes a new version instead of updating Prompt content', as
   assert.match(source, /旧版本保留用于审计与回滚/u)
 })
 
+test('Web editor locks Prompt selection and drafting while a publish is pending', async () => {
+  const source = await readFile(consoleUrl, 'utf8')
+  const editorStart = source.indexOf('aria-label="Prompt 编辑器"')
+  const editorEnd = source.indexOf('\n          <section', editorStart)
+  const editor = source.slice(editorStart, editorEnd)
+
+  assert.notEqual(editorStart, -1)
+  assert.match(
+    editor,
+    /onClick=\{\(\) => handleSelectTemplate\(template\.id\)\}[\s\S]*?disabled=\{savingTemplateId !== null\}/u,
+  )
+  assert.match(
+    editor,
+    /className="textarea-glass hamster-console-template-editor"[\s\S]*?disabled=\{savingTemplateId !== null\}/u,
+  )
+})
+
 test('API dispatch prefers active profile Prompt layers with legacy fallback', async () => {
   const source = await readFile(dispatchUrl, 'utf8')
 

--- a/tests/prompt-publishing.test.mjs
+++ b/tests/prompt-publishing.test.mjs
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const {
+  composeConversationSystemPrompt,
+  resolveConversationProfileKey,
+} = await import(
+  '../supabase/functions/conversation-dispatch/prompt.ts'
+)
+
+const migrationUrl = new URL(
+  '../supabase/migrations/20260730133228_v4_1_prompt_publishing.sql',
+  import.meta.url,
+)
+const rollbackUrl = new URL(
+  '../supabase/rollback-contracts/20260730133228_v4_1_prompt_publishing.sql',
+  import.meta.url,
+)
+const consoleUrl = new URL(
+  '../src/pages/HamsterConsolePage.tsx',
+  import.meta.url,
+)
+const dispatchUrl = new URL(
+  '../supabase/functions/conversation-dispatch/index.ts',
+  import.meta.url,
+)
+
+test('legacy direct API sessions resolve to the intended chat profiles', () => {
+  assert.equal(
+    resolveConversationProfileKey({
+      conversationProfileKey: null,
+      sessionKey: 'syzygy_instant',
+    }),
+    'app_companion',
+  )
+  assert.equal(
+    resolveConversationProfileKey({
+      conversationProfileKey: null,
+      sessionKey: null,
+    }),
+    'app_chat',
+  )
+  assert.equal(
+    resolveConversationProfileKey({
+      conversationProfileKey: ' app_companion ',
+      sessionKey: null,
+    }),
+    'app_companion',
+  )
+})
+
+test('active Prompt layers replace the legacy system Prompt in declared order', () => {
+  const result = composeConversationSystemPrompt({
+    names: {
+      identityPromptName: 'syzygy_base',
+      stylePromptName: 'app_companion_reply_style',
+      rulesPromptName: null,
+    },
+    activePrompts: [
+      { name: 'app_companion_reply_style', content: '温柔直接', version: 1 },
+      { name: 'syzygy_base', content: '你是 Syzygy', version: 3 },
+    ],
+    legacySystemPrompt: 'legacy',
+  })
+
+  assert.equal(result, '你是 Syzygy\n\n温柔直接')
+})
+
+test('missing active Prompt layers fail safely to the legacy system Prompt', () => {
+  const result = composeConversationSystemPrompt({
+    names: {
+      identityPromptName: 'syzygy_base',
+      stylePromptName: 'app_chat_reply_style',
+      rulesPromptName: null,
+    },
+    activePrompts: [
+      { name: 'syzygy_base', content: 'active base', version: 1 },
+    ],
+    legacySystemPrompt: ' legacy fallback ',
+  })
+
+  assert.equal(result, 'legacy fallback')
+})
+
+test('Prompt migration enforces one active immutable version and least privilege', async () => {
+  const sql = await readFile(migrationUrl, 'utf8')
+
+  assert.match(sql, /prompt_templates_user_name_active_unique/iu)
+  assert.match(sql, /where active/iu)
+  assert.match(
+    sql,
+    /prompt_templates_immutable_version[\s\S]*?before update or delete/iu,
+  )
+  assert.match(sql, /rows are append-only and cannot be deleted/iu)
+  assert.match(sql, /Inactive Prompt versions cannot be reactivated/iu)
+  assert.match(
+    sql,
+    /revoke all on public\.prompt_templates from anon, authenticated/iu,
+  )
+  assert.match(
+    sql,
+    /grant select on public\.prompt_templates to authenticated/iu,
+  )
+  assert.match(sql, /Authenticated Prompt writes must use the publish RPC/iu)
+})
+
+test('Prompt publish RPC is owner-bound, serialized, and version-checked', async () => {
+  const sql = await readFile(migrationUrl, 'utf8')
+  const publicStart = sql.indexOf(
+    'create or replace function public.prompt_template_publish(',
+  )
+  const publicEnd = sql.indexOf('$function$;', publicStart)
+  const publicFunction = sql.slice(
+    publicStart,
+    publicEnd + '$function$;'.length,
+  )
+  const privateStart = sql.indexOf(
+    'create or replace function private.prompt_template_publish_core(',
+  )
+  const privateEnd = sql.indexOf('$function$;', privateStart)
+  const privateFunction = sql.slice(
+    privateStart,
+    privateEnd + '$function$;'.length,
+  )
+
+  assert.notEqual(publicStart, -1)
+  assert.notEqual(privateStart, -1)
+  assert.match(publicFunction, /security invoker[\s\S]*?set search_path = ''/iu)
+  assert.match(privateFunction, /security definer[\s\S]*?set search_path = ''/iu)
+  assert.match(privateFunction, /v_owner_id uuid := \(select auth\.uid\(\)\)/iu)
+  assert.match(privateFunction, /pg_advisory_xact_lock/iu)
+  assert.match(privateFunction, /p_expected_active_version is null/iu)
+  assert.match(privateFunction, /Prompt active version changed/iu)
+  assert.match(
+    sql,
+    /revoke all on function public\.prompt_template_publish[\s\S]*?from public, anon, service_role/iu,
+  )
+  assert.match(
+    sql,
+    /grant execute on function public\.prompt_template_publish[\s\S]*?to authenticated/iu,
+  )
+})
+
+test('chat Prompt seeds copy server-side legacy sources without embedding bodies', async () => {
+  const sql = await readFile(migrationUrl, 'utf8')
+
+  for (const name of [
+    'app_companion_reply_style',
+    'app_chat_reply_style',
+    'codex_cli_reply_style',
+    'claude_cli_reply_style',
+    'sofa_daily_rules',
+    'sofa_work_rules',
+  ]) {
+    assert.match(sql, new RegExp(`'${name}'`, 'u'))
+  }
+
+  assert.match(sql, /v_wechat_reply_style/iu)
+  assert.match(sql, /v_cli_reply_style/iu)
+  assert.match(sql, /select lounge_scene_prompt[\s\S]*?from public\.user_settings/iu)
+  assert.match(
+    sql,
+    /Every active generation port must resolve to active Prompt versions/iu,
+  )
+})
+
+test('Prompt contract rollback is guarded and excluded from forward migrations', async () => {
+  const sql = await readFile(rollbackUrl, 'utf8')
+
+  assert.match(
+    rollbackUrl.pathname,
+    /\/supabase\/rollback-contracts\/20260730133228_v4_1_prompt_publishing\.sql$/u,
+  )
+  assert.doesNotMatch(rollbackUrl.pathname, /\/supabase\/migrations\//u)
+  assert.match(sql, /requires exactly six untouched seed rows/iu)
+  assert.match(sql, /refuses to delete a seed that has entered version history/iu)
+  assert.match(sql, /drop function public\.prompt_template_publish/iu)
+  assert.match(sql, /drop trigger prompt_templates_immutable_version/iu)
+  assert.match(sql, /grant all privileges on public\.prompt_templates/iu)
+  assert.match(sql, /Legacy Prompt updated_at trigger was not preserved/iu)
+})
+
+test('Web editor publishes a new version instead of updating Prompt content', async () => {
+  const source = await readFile(consoleUrl, 'utf8')
+  const saveStart = source.indexOf('const handleSaveTemplate = async')
+  const saveEnd = source.indexOf('\n  const toggleSection', saveStart)
+  const saveHandler = source.slice(saveStart, saveEnd)
+
+  assert.match(saveHandler, /\.rpc\('prompt_template_publish'/u)
+  assert.match(saveHandler, /p_expected_active_version: activeTemplate\.version/u)
+  assert.doesNotMatch(saveHandler, /\.from\('prompt_templates'\)[\s\S]*?\.update\(/u)
+  assert.match(source, /发布新版本/u)
+  assert.match(source, /旧版本保留用于审计与回滚/u)
+})
+
+test('API dispatch prefers active profile Prompt layers with legacy fallback', async () => {
+  const source = await readFile(dispatchUrl, 'utf8')
+
+  assert.match(source, /\.from\('conversation_profiles'\)/u)
+  assert.match(source, /\.from\('generation_ports'\)/u)
+  assert.match(source, /\.from\('prompt_templates'\)/u)
+  assert.match(source, /composeConversationSystemPrompt/u)
+  assert.match(source, /settings\.system_prompt/u)
+})


### PR DESCRIPTION
## What changed

- harden `prompt_templates` as an append-only version catalog with one active version per owner/name
- add an owner-bound, version-checked publish RPC plus immutable-row guard and a fail-closed rollback contract
- seed the six new chat Prompt keys by copying existing production sources server-side, without placing Prompt bodies in source control
- change the Web Prompt editor from in-place updates to publishing a new version
- make `conversation-dispatch` compose active identity, style, and optional rules layers, with a complete fallback to `user_settings.system_prompt`
- sync the generated production database types and add Prompt publishing contract tests

## Why

V4.1 needs a single auditable source of truth for chat identity, reply style, and sofa rules. Published Prompt bodies must remain immutable, concurrent edits must not silently overwrite each other, and the existing chat path must continue to work while the remaining runtime gates are rolled out separately.

## Impact and rollout state

The production migration is already applied as `20260730133228_v4_1_prompt_publishing` and was validated independently before this GitHub handoff. Current Pages still runs the legacy editor, so Prompt saving remains in a temporary maintenance window until a separately authorized Web merge/deploy. Chat reads retain the legacy fallback.

This Draft PR does not authorize or perform an Edge Function deployment, Pages deployment, merge, Mini change, OTA, or TestFlight release.

## Validation

- `npm test` — 54/54 passed
- `npm run check` — 0 errors; 5 pre-existing React Hooks warnings
- `npm run build` — passed; existing large-chunk warning only
- `npm run db:types:check` — production schema matched
- Deno check for `conversation-dispatch` and lint/fmt check for the Prompt resolver — passed
- `git diff --check` — passed
- production migration/rollback roundtrip, owner/cross-owner/anon/service-role smoke, Data API negatives, and advisor review — passed