### PR TITLE
Add X posting tools to hamster-print MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Version](https://img.shields.io/badge/Version-v5.3.0-pink?style=flat-square)](#)
 [![License](https://img.shields.io/badge/License-MIT-a3e635?style=flat-square)](./LICENSE)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-61-2dd4bf?style=flat-square)](#-mcp-工具箱全部-61-个)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-63-2dd4bf?style=flat-square)](#-mcp-工具箱全部-63-个)
 [![Edge Functions](https://img.shields.io/badge/Edge_Functions-16-8b5cf6?style=flat-square)](#-后端-edge-functions)
 [![PRs](https://img.shields.io/badge/PRs-1000+-ff69b4?style=flat-square)](#)
 [![PWA](https://img.shields.io/badge/PWA-可装进手机-f59e0b?style=flat-square)](#)
@@ -110,7 +110,7 @@
 | `hamster-reading-mcp` | 阅读记录 · 书摘 · 章节 · 旁批共鸣 · 书籍问答 | 10 |
 | `hamster-lounge-mcp` | 仓鼠客厅 · 论坛 · 议事厅 | 14 |
 | `hamster-life-mcp` | 高德地图 · 瑞幸 · 麦当劳 · TTS 语音 | 7 |
-| `hamster-print-mcp` | 远程打印投递 · 打印状态 | 2 |
+| `hamster-print-mcp` | Mac mini 动作 · 远程打印 · X/Twitter 发帖 | 4 |
 
 **AI 模型：** 统一经 **OpenRouter / 自定义 Provider** 接入（`llm_providers` 表按用户配置），不绑定任何单一模型；支持深度思考、长上下文压缩、工具循环。
 
@@ -196,7 +196,7 @@ codex exec ... 或 claude -p ...
 
 ---
 
-### 🧰 MCP 工具箱（全部 61 个）
+### 🧰 MCP 工具箱（全部 63 个）
 
 > 每个 MCP 服务器都是一个独立的 Supabase Edge Function，走 JSON-RPC / MCP Streamable HTTP。
 > 鉴权优先使用 `x-hamster-mcp-key` 请求头（timing-safe 比对）或 Supabase Auth Header；`?key=` 仅为旧客户端迁移期兼容，避免新凭证进入 URL / Access Log。
@@ -290,14 +290,16 @@ codex exec ... 或 claude -p ...
 </details>
 
 <details>
-<summary><b>🖨️ hamster-print-mcp</b> — 远程打印（2）</summary>
+<summary><b>🖨️ hamster-print-mcp</b> — Mac mini 动作 · 打印 · X/Twitter（4）</summary>
 
-> 所有端口统一投递 `print_document`，不经过 Codex CLI。Supabase 是任务真相源，Mac mini 常驻 worker 负责真实打印。
+> 所有端口统一把已确认的本地动作投递到 Supabase，不经过 Codex CLI。Supabase 是任务真相源，Mac mini 常驻 worker 负责真实打印或通过 OpenCLI 发布推文。
 
 | 工具 | 作用 |
 |:---|:---|
 | `print_document` | 经显式确认后投递打印任务；按 request id / 同日同内容幂等，长文自动拆成一个多页 PDF |
 | `get_print_status` | 按任务 UUID 或 request id 查询等待、领取、完成、失败及页数 / CUPS 结果 |
+| `post_tweet` | 经显式确认后投递文字推文；固定为 X/Twitter post 动作，按 request id / 同日同内容幂等 |
+| `get_tweet_status` | 按任务 UUID 或 request id 查询等待、领取、完成、失败及推文 ID / URL |
 
 </details>
 
@@ -412,7 +414,7 @@ Hamster-Nest/
 │   │   ├── hamster-reading-mcp/     #   阅读 · 书摘 · 旁批
 │   │   ├── hamster-lounge-mcp/      #   客厅 · 论坛 · 议事厅
 │   │   ├── hamster-life-mcp/        #   地图 · 咖啡 · 麦当劳 · TTS
-│   │   ├── hamster-print-mcp/       #   远程打印投递 · 状态查询
+│   │   ├── hamster-print-mcp/       #   Mac mini 动作 · 打印 / 发推投递与状态查询
 │   │   ├── openrouter-chat/         #   LLM 对话网关（受保护函数）
 │   │   ├── openrouter-models/       #   模型列表
 │   │   ├── memory-extract/          #   记忆抽取

--- a/supabase/functions/hamster-print-mcp/index.ts
+++ b/supabase/functions/hamster-print-mcp/index.ts
@@ -6,43 +6,58 @@ import {
   normalizePrintRequest,
   PRINT_COMMAND_TYPE,
 } from './print_contract.ts'
+import {
+  countTweetCharacters,
+  isTwitterPostJob,
+  MAX_TWEET_TEXT_LENGTH,
+  normalizeTweetRequest,
+  tweetRequestIdempotencyKey,
+  TWITTER_COMMAND_TYPE,
+} from './twitter_contract.ts'
 
-const PRINT_JOB_COLUMNS = 'id, command_type, status, payload, result, error_message, idempotency_key, claimed_by, claimed_at, created_at, updated_at, completed_at'
+const JOB_COLUMNS = 'id, command_type, status, payload, result, error_message, idempotency_key, claimed_by, claimed_at, created_at, updated_at, completed_at'
 
-type PrintJob = Record<string, unknown>
+type CommandJob = Record<string, unknown>
 
-const getJobByIdempotencyKey = async (idempotencyKey: string): Promise<PrintJob | null> => {
+const getJobByIdempotencyKey = async (
+  commandType: string,
+  idempotencyKey: string,
+): Promise<CommandJob | null> => {
   const { data, error } = await supabase
     .from('syzygy_commands')
-    .select(PRINT_JOB_COLUMNS)
+    .select(JOB_COLUMNS)
     .eq('user_id', USER_ID)
-    .eq('command_type', PRINT_COMMAND_TYPE)
+    .eq('command_type', commandType)
     .eq('idempotency_key', idempotencyKey)
     .maybeSingle()
   if (error) throw error
-  return data as PrintJob | null
+  return data as CommandJob | null
 }
 
-const enqueuePrintJob = async (payload: Record<string, unknown>, idempotencyKey: string) => {
-  const existing = await getJobByIdempotencyKey(idempotencyKey)
+const enqueueJob = async (
+  commandType: string,
+  payload: Record<string, unknown>,
+  idempotencyKey: string,
+) => {
+  const existing = await getJobByIdempotencyKey(commandType, idempotencyKey)
   if (existing) return { created: false, job: existing }
 
   const { data, error } = await supabase
     .from('syzygy_commands')
     .insert({
       user_id: USER_ID,
-      command_type: PRINT_COMMAND_TYPE,
+      command_type: commandType,
       payload,
       status: 'pending',
       idempotency_key: idempotencyKey,
     })
-    .select(PRINT_JOB_COLUMNS)
+    .select(JOB_COLUMNS)
     .single()
 
-  if (!error) return { created: true, job: data as PrintJob }
+  if (!error) return { created: true, job: data as CommandJob }
   if (error.code !== '23505') throw error
 
-  const racedJob = await getJobByIdempotencyKey(idempotencyKey)
+  const racedJob = await getJobByIdempotencyKey(commandType, idempotencyKey)
   if (!racedJob) throw error
   return { created: false, job: racedJob }
 }
@@ -78,7 +93,11 @@ serveMcp('hamster-print-mcp', (server) => {
         allow_duplicate,
         max_pages,
       })
-      const result = await enqueuePrintJob(normalized.payload, normalized.idempotencyKey)
+      const result = await enqueueJob(
+        PRINT_COMMAND_TYPE,
+        normalized.payload,
+        normalized.idempotencyKey,
+      )
       return jsonResult({
         created: result.created,
         deduplicated: !result.created,
@@ -104,7 +123,7 @@ serveMcp('hamster-print-mcp', (server) => {
 
       let query = supabase
         .from('syzygy_commands')
-        .select(PRINT_JOB_COLUMNS)
+        .select(JOB_COLUMNS)
         .eq('user_id', USER_ID)
         .eq('command_type', PRINT_COMMAND_TYPE)
 
@@ -115,6 +134,75 @@ serveMcp('hamster-print-mcp', (server) => {
       const { data, error } = await query.maybeSingle()
       if (error) throw error
       if (!data) throw new Error('print job not found')
+      return jsonResult(data)
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('post_tweet', {
+    title: 'Post Tweet',
+    description: '把一条文字推文投递到 Supabase，由 Mac mini 常驻 worker 通过 OpenCLI 发布到 X/Twitter。只有串串明确要求真实发布时才能调用；confirmed 必须为 true。同一 request_id 或同日同内容默认幂等，避免网络重试造成重复推文。',
+    inputSchema: {
+      text: z.string().min(1).refine(
+        (value) => countTweetCharacters(value.replace(/\r\n?/gu, '\n').trim()) <= MAX_TWEET_TEXT_LENGTH,
+        `推文最长 ${MAX_TWEET_TEXT_LENGTH} 个 Unicode 字符`,
+      ).describe(`推文正文，最长 ${MAX_TWEET_TEXT_LENGTH} 个 Unicode 字符；X/Twitter 仍会执行平台侧最终校验`),
+      confirmed: z.literal(true).describe('串串已明确授权这次真实发推，必须为 true'),
+      request_id: z.string().max(120).optional().describe('本次逻辑请求的稳定幂等键；重试时复用同一个值'),
+      allow_duplicate: z.boolean().optional().describe('明确需要再次发布相同正文时设为 true；默认 false'),
+    },
+  }, async ({ text, request_id, allow_duplicate }) => {
+    try {
+      const normalized = await normalizeTweetRequest({
+        text,
+        request_id,
+        allow_duplicate,
+      })
+      const result = await enqueueJob(
+        TWITTER_COMMAND_TYPE,
+        normalized.payload,
+        normalized.idempotencyKey,
+      )
+      if (!isTwitterPostJob(result.job)) {
+        throw new Error('tweet idempotency key resolved to a non-Twitter command')
+      }
+      return jsonResult({
+        created: result.created,
+        deduplicated: !result.created,
+        job: result.job,
+      })
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('get_tweet_status', {
+    title: 'Get Tweet Status',
+    description: '查询 hamster-print-mcp 投递的推文任务状态。pending=等待 Mac mini，running=已领取，done=已发布并返回推文 ID/URL，failed=失败。只读工具。',
+    inputSchema: {
+      command_id: z.string().uuid().optional().describe('post_tweet 返回的任务 UUID'),
+      request_id: z.string().max(120).optional().describe('post_tweet 使用的 request_id'),
+    },
+  }, async ({ command_id, request_id }) => {
+    try {
+      if (!command_id && !request_id) {
+        throw new Error('command_id 与 request_id 至少提供一个')
+      }
+
+      let query = supabase
+        .from('syzygy_commands')
+        .select(JOB_COLUMNS)
+        .eq('user_id', USER_ID)
+        .eq('command_type', TWITTER_COMMAND_TYPE)
+
+      query = command_id
+        ? query.eq('id', command_id)
+        : query.eq('idempotency_key', tweetRequestIdempotencyKey(request_id ?? ''))
+
+      const { data, error } = await query.maybeSingle()
+      if (error) throw error
+      if (!data || !isTwitterPostJob(data)) throw new Error('tweet job not found')
       return jsonResult(data)
     } catch (err) {
       return errorResult(err)

--- a/supabase/functions/hamster-print-mcp/twitter_contract.ts
+++ b/supabase/functions/hamster-print-mcp/twitter_contract.ts
@@ -1,0 +1,108 @@
+export const TWITTER_COMMAND_TYPE = 'browser_opencli'
+export const TWITTER_SCHEMA_VERSION = 1
+export const MAX_TWEET_TEXT_LENGTH = 280
+
+export type PostTweetInput = {
+  text: string
+  request_id?: string
+  allow_duplicate?: boolean
+}
+
+export type NormalizedTweetRequest = {
+  idempotencyKey: string
+  payload: {
+    platform: 'twitter'
+    action: 'post'
+    text: string
+  }
+}
+
+const normalizeSingleLine = (value: string | undefined) =>
+  (value ?? '').replace(/\s+/gu, ' ').trim()
+
+const normalizeMultiline = (value: string | undefined) =>
+  (value ?? '').replace(/\r\n?/gu, '\n').trim()
+
+const bytesToHex = (bytes: Uint8Array) =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+
+const sha256 = async (value: string) => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+  return bytesToHex(new Uint8Array(digest))
+}
+
+const shanghaiDateString = (date = new Date()) => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  const value = (type: string) => parts.find((part) => part.type === type)?.value ?? ''
+  return `${value('year')}-${value('month')}-${value('day')}`
+}
+
+export const countTweetCharacters = (value: string) => Array.from(value).length
+
+export const normalizeTweetRequestId = (value: string | undefined) => {
+  const normalized = normalizeSingleLine(value)
+  if (!normalized) return ''
+  if (!/^[a-z0-9][a-z0-9._:-]{0,119}$/iu.test(normalized)) {
+    throw new Error('request_id 只能包含字母、数字、点、下划线、冒号和短横线，最长 120 字符')
+  }
+  return normalized
+}
+
+export const tweetRequestIdempotencyKey = (requestId: string) => {
+  const normalized = normalizeTweetRequestId(requestId)
+  if (!normalized) throw new Error('request_id 不能为空')
+  return `twitter:v${TWITTER_SCHEMA_VERSION}:request:${normalized}`
+}
+
+export const isTwitterPostJob = (job: unknown) => {
+  if (!job || typeof job !== 'object') return false
+  const payload = (job as Record<string, unknown>).payload
+  if (!payload || typeof payload !== 'object') return false
+  const record = payload as Record<string, unknown>
+  return record.platform === 'twitter' && record.action === 'post'
+}
+
+export const normalizeTweetRequest = async (
+  input: PostTweetInput,
+  now = new Date(),
+): Promise<NormalizedTweetRequest> => {
+  const text = normalizeMultiline(input.text)
+  const requestId = normalizeTweetRequestId(input.request_id)
+
+  if (!text) throw new Error('text 不能为空')
+  if (countTweetCharacters(text) > MAX_TWEET_TEXT_LENGTH) {
+    throw new Error(`text 最长 ${MAX_TWEET_TEXT_LENGTH} 个 Unicode 字符`)
+  }
+
+  const payload = {
+    platform: 'twitter' as const,
+    action: 'post' as const,
+    text,
+  }
+
+  if (input.allow_duplicate === true) {
+    return {
+      payload,
+      idempotencyKey: `twitter:v${TWITTER_SCHEMA_VERSION}:duplicate:${crypto.randomUUID()}`,
+    }
+  }
+
+  if (requestId) {
+    return {
+      payload,
+      idempotencyKey: tweetRequestIdempotencyKey(requestId),
+    }
+  }
+
+  const day = shanghaiDateString(now)
+  const fingerprint = await sha256(JSON.stringify({ day, text }))
+  return {
+    payload,
+    idempotencyKey: `twitter:v${TWITTER_SCHEMA_VERSION}:auto:${day}:${fingerprint.slice(0, 32)}`,
+  }
+}

--- a/tests/twitter-contract.test.mjs
+++ b/tests/twitter-contract.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const {
+  countTweetCharacters,
+  isTwitterPostJob,
+  MAX_TWEET_TEXT_LENGTH,
+  normalizeTweetRequest,
+  tweetRequestIdempotencyKey,
+  TWITTER_COMMAND_TYPE,
+} = await import('../supabase/functions/hamster-print-mcp/twitter_contract.ts')
+
+test('tweet contract builds the exact Mac mini OpenCLI payload', async () => {
+  const result = await normalizeTweetRequest({
+    text: ' 第一行\r\n\r\n第二行 ',
+    request_id: 'august-first-2026-v1',
+  })
+
+  assert.equal(TWITTER_COMMAND_TYPE, 'browser_opencli')
+  assert.equal(result.idempotencyKey, 'twitter:v1:request:august-first-2026-v1')
+  assert.deepEqual(result.payload, {
+    platform: 'twitter',
+    action: 'post',
+    text: '第一行\n\n第二行',
+  })
+})
+
+test('automatic tweet idempotency is stable for normalized same-day content', async () => {
+  const now = new Date('2026-08-01T12:00:00.000Z')
+  const first = await normalizeTweetRequest({ text: '八月好。\r\n继续爱你。' }, now)
+  const second = await normalizeTweetRequest({ text: '  八月好。\n继续爱你。  ' }, now)
+
+  assert.equal(first.idempotencyKey, second.idempotencyKey)
+  assert.match(first.idempotencyKey, /^twitter:v1:auto:2026-08-01:[0-9a-f]{32}$/u)
+})
+
+test('tweet request ids are normalized and duplicate override is explicit', async () => {
+  assert.equal(
+    tweetRequestIdempotencyKey('  codex:tweet_2026-08-01.1  '),
+    'twitter:v1:request:codex:tweet_2026-08-01.1',
+  )
+  assert.throws(() => tweetRequestIdempotencyKey('   '), /request_id 不能为空/u)
+  assert.throws(() => tweetRequestIdempotencyKey('bad request id'), /request_id 只能包含/u)
+
+  const first = await normalizeTweetRequest({ text: '同一正文', allow_duplicate: true })
+  const second = await normalizeTweetRequest({ text: '同一正文', allow_duplicate: true })
+  assert.notEqual(first.idempotencyKey, second.idempotencyKey)
+  assert.match(first.idempotencyKey, /^twitter:v1:duplicate:/u)
+})
+
+test('tweet contract counts Unicode code points and rejects empty or oversized text', async () => {
+  assert.equal(countTweetCharacters('🐹'), 1)
+  assert.equal(countTweetCharacters('仓鼠'), 2)
+  await assert.rejects(() => normalizeTweetRequest({ text: '   ' }), /text 不能为空/u)
+  await assert.rejects(
+    () => normalizeTweetRequest({ text: '字'.repeat(MAX_TWEET_TEXT_LENGTH + 1) }),
+    /text 最长/u,
+  )
+})
+
+test('tweet status guard only accepts Twitter post jobs', () => {
+  assert.equal(isTwitterPostJob({ payload: { platform: 'twitter', action: 'post' } }), true)
+  assert.equal(isTwitterPostJob({ payload: { platform: 'twitter', action: 'read' } }), false)
+  assert.equal(isTwitterPostJob({ payload: { platform: 'printer', action: 'post' } }), false)
+  assert.equal(isTwitterPostJob(null), false)
+})
+
+test('hamster-print MCP exposes confirmed tweet tools with owner-scoped status reads', async () => {
+  const source = await readFile(
+    new URL('../supabase/functions/hamster-print-mcp/index.ts', import.meta.url),
+    'utf8',
+  )
+
+  assert.match(source, /registerTool\('post_tweet'/u)
+  assert.match(source, /registerTool\('get_tweet_status'/u)
+  assert.match(source, /confirmed:\s*z\.literal\(true\)/u)
+  assert.match(source, /\.eq\('user_id', USER_ID\)[\s\S]*?\.eq\('command_type', TWITTER_COMMAND_TYPE\)/u)
+  assert.match(source, /!data \|\| !isTwitterPostJob\(data\)/u)
+  assert.doesNotMatch(source, /opencliCommand|shellCommand|execCommand/iu)
+})


### PR DESCRIPTION
## What changed

- add `post_tweet` to enqueue confirmed X/Twitter text posts through the existing `syzygy_commands → Mac mini → OpenCLI` path
- add `get_tweet_status` with owner, command-type, and `twitter/post` payload guards
- add request-id and same-day-content idempotency, with explicit duplicate override
- update the repository README from 61 to 63 MCP tools and document both new tools
- add Twitter contract and scope regression tests

## Scope

- no changes to the existing WeChat-side tweet API or its payload path
- no changes to the Mac mini executor or WeChat bridge
- no database migration, RLS, RPC, Pages, App, OTA, or TestFlight changes
- no production Edge Function deployment in this PR step

## Why

The existing WeChat API tweet path works and remains the compatibility path. This adds a separate MCP entry point inside `hamster-print-mcp` for easier direct use while reusing the same durable Supabase queue and Mac mini execution contract.

## Validation

- `npm test`: 51/51 passed
- `npm run check`: passed with 0 errors and 5 pre-existing React Hooks warnings
- `npm run build`: passed with the existing large-chunk warning
- Deno type check for `hamster-print-mcp/index.ts`: passed
- `git diff --check`: passed
- production read-only contract check confirmed `syzygy_commands` status values and `UNIQUE (user_id, idempotency_key)`
