### PR TITLE
Add V4.1 fixed companion context contract

### DIFF
--- a/supabase/functions/conversation-dispatch/context.ts
+++ b/supabase/functions/conversation-dispatch/context.ts
@@ -1,0 +1,165 @@
+export type ConversationContextRecipe = {
+  version: number
+  history_scope: 'current_session'
+  epoch: 'asia_shanghai_day' | 'session'
+  selection: 'newest_within_token_budget'
+  external_sources: string[]
+}
+
+export type ContextMessageRow = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  meta: Record<string, unknown> | null
+  created_at: string
+}
+
+const SHANGHAI_OFFSET_MS = 8 * 60 * 60 * 1000
+const DEFAULT_CONTEXT_LIMIT = 32_000
+const DEFAULT_TRIGGER_RATIO = 0.65
+const MAX_TRIGGER_RATIO = 0.9
+const MIN_TRIGGER_RATIO = 0.2
+const CONTEXT_SAFETY_TOKENS = 1_024
+const TOKEN_OVERHEAD_PER_MESSAGE = 8
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+export const parseConversationContextRecipe = (
+  value: unknown,
+): ConversationContextRecipe => {
+  const recipe = asRecord(value)
+  const externalSources = recipe?.external_sources
+  if (
+    typeof recipe?.version !== 'number' ||
+    !Number.isInteger(recipe.version) ||
+    recipe.version < 1 ||
+    recipe.history_scope !== 'current_session' ||
+    (recipe.epoch !== 'asia_shanghai_day' && recipe.epoch !== 'session') ||
+    recipe.selection !== 'newest_within_token_budget' ||
+    !Array.isArray(externalSources) ||
+    externalSources.some(
+      (source) => typeof source !== 'string' || !source.trim(),
+    )
+  ) {
+    throw new Error(
+      'active conversation profile has an invalid context recipe',
+    )
+  }
+
+  return {
+    version: recipe.version,
+    history_scope: 'current_session',
+    epoch: recipe.epoch,
+    selection: 'newest_within_token_budget',
+    external_sources: externalSources.map((source) => source.trim()),
+  }
+}
+
+export const startOfShanghaiDayIso = (value: string | Date): string => {
+  const instant = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(instant.getTime())) {
+    throw new Error('canonical user message has an invalid created_at')
+  }
+  const shifted = new Date(instant.getTime() + SHANGHAI_OFFSET_MS)
+  return new Date(
+    Date.UTC(
+      shifted.getUTCFullYear(),
+      shifted.getUTCMonth(),
+      shifted.getUTCDate(),
+    ) - SHANGHAI_OFFSET_MS,
+  ).toISOString()
+}
+
+export const estimateTextTokens = (content: string): number => {
+  const trimmed = content.trim()
+  if (!trimmed) {
+    return TOKEN_OVERHEAD_PER_MESSAGE
+  }
+  const chineseChars = (trimmed.match(/[\u4e00-\u9fff]/g) ?? []).length
+  const englishWords = (trimmed.match(/[A-Za-z0-9_]+/g) ?? []).length
+  const otherChars = Math.max(trimmed.length - chineseChars, 0)
+  return Math.ceil(
+    chineseChars * 1.7 +
+      englishWords * 1.1 +
+      otherChars * 0.3 +
+      TOKEN_OVERHEAD_PER_MESSAGE,
+  )
+}
+
+export const resolveHistoryTokenBudget = ({
+  systemPrompt,
+  maxOutputTokens,
+  triggerRatio,
+}: {
+  systemPrompt: string
+  maxOutputTokens: number
+  triggerRatio: number | null
+}): number => {
+  const normalizedRatio = typeof triggerRatio === 'number' && Number.isFinite(triggerRatio)
+    ? Math.min(Math.max(triggerRatio, MIN_TRIGGER_RATIO), MAX_TRIGGER_RATIO)
+    : DEFAULT_TRIGGER_RATIO
+  const targetTokens = Math.floor(DEFAULT_CONTEXT_LIMIT * normalizedRatio)
+  const reservedTokens = estimateTextTokens(systemPrompt) +
+    Math.max(0, Math.floor(maxOutputTokens)) +
+    CONTEXT_SAFETY_TOKENS
+  return Math.max(0, targetTokens - reservedTokens)
+}
+
+const isEligibleContextMessage = (
+  message: ContextMessageRow,
+  excludedMessageIds: Set<string>,
+) => {
+  if (excludedMessageIds.has(message.id)) {
+    return false
+  }
+  if (message.role !== 'assistant') {
+    return true
+  }
+  const state = typeof message.meta?.delivery_state === 'string'
+    ? message.meta.delivery_state
+    : null
+  return state !== 'generating' && state !== 'failed'
+}
+
+export const selectNewestContextWindow = ({
+  newestFirst,
+  tokenBudget,
+  requiredMessageId,
+  excludedMessageIds = [],
+}: {
+  newestFirst: ContextMessageRow[]
+  tokenBudget: number
+  requiredMessageId: string
+  excludedMessageIds?: string[]
+}) => {
+  const excluded = new Set(excludedMessageIds)
+  const selected: ContextMessageRow[] = []
+  let usedTokens = 0
+  let reachedBudget = false
+
+  for (const message of newestFirst) {
+    if (!isEligibleContextMessage(message, excluded)) {
+      continue
+    }
+    const messageTokens = estimateTextTokens(message.content)
+    const required = message.id === requiredMessageId
+    if (!required && usedTokens + messageTokens > tokenBudget) {
+      reachedBudget = true
+      break
+    }
+    selected.push(message)
+    usedTokens += messageTokens
+  }
+
+  return {
+    newestFirst: selected,
+    usedTokens,
+    reachedBudget,
+    containsRequiredMessage: selected.some(
+      (message) => message.id === requiredMessageId,
+    ),
+  }
+}

--- a/supabase/functions/conversation-dispatch/index.ts
+++ b/supabase/functions/conversation-dispatch/index.ts
@@ -17,6 +17,13 @@ import {
   type ConversationPromptRow,
   resolveConversationProfileKey,
 } from './prompt.ts'
+import {
+  type ContextMessageRow,
+  parseConversationContextRecipe,
+  resolveHistoryTokenBudget,
+  selectNewestContextWindow,
+  startOfShanghaiDayIso,
+} from './context.ts'
 
 declare const EdgeRuntime:
   | {
@@ -39,19 +46,15 @@ type UserSettingsRow = {
   top_p: number
   max_tokens: number
   chat_reasoning_enabled: boolean
+  compression_trigger_ratio: number | null
 }
 
-type MessageRow = {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  meta: Record<string, unknown> | null
-  created_at: string
-}
+type MessageRow = ContextMessageRow
 
 type ConversationProfileRow = {
   default_responder_port_key: string
   rules_prompt_name: string | null
+  context_recipe: unknown
 }
 
 type GenerationPortRow = {
@@ -66,14 +69,13 @@ type GenerationPortRow = {
 type UserClient = SupabaseClient<any, 'public', 'public', any, any>
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-const HISTORY_LIMIT = 200
+const HISTORY_PAGE_SIZE = 100
 const STREAM_PERSIST_INTERVAL_MS = 450
 
-const loadActiveConversationPrompt = async (
+const loadActiveConversationProfile = async (
   client: UserClient,
   userId: string,
   session: SessionRow,
-  legacySystemPrompt: string,
 ) => {
   const profileKey = resolveConversationProfileKey({
     conversationProfileKey: session.conversation_profile_key,
@@ -81,21 +83,32 @@ const loadActiveConversationPrompt = async (
   })
   const profileResult = await client
     .from('conversation_profiles')
-    .select('default_responder_port_key,rules_prompt_name')
+    .select('default_responder_port_key,rules_prompt_name,context_recipe')
     .eq('user_id', userId)
     .eq('profile_key', profileKey)
     .eq('active', true)
     .maybeSingle<ConversationProfileRow>()
 
   if (profileResult.error || !profileResult.data) {
-    return legacySystemPrompt.trim()
+    throw new Error(
+      `active conversation profile load failed: ${profileResult.error?.code ?? 'not_found'}`,
+    )
   }
 
+  return { profileKey, profile: profileResult.data }
+}
+
+const loadActiveConversationPrompt = async (
+  client: UserClient,
+  userId: string,
+  profile: ConversationProfileRow,
+  legacySystemPrompt: string,
+) => {
   const portResult = await client
     .from('generation_ports')
     .select('identity_prompt_name,style_prompt_name')
     .eq('user_id', userId)
-    .eq('port_key', profileResult.data.default_responder_port_key)
+    .eq('port_key', profile.default_responder_port_key)
     .eq('active', true)
     .maybeSingle<GenerationPortRow>()
 
@@ -106,7 +119,7 @@ const loadActiveConversationPrompt = async (
   const promptNames: ConversationPromptNames = {
     identityPromptName: portResult.data.identity_prompt_name,
     stylePromptName: portResult.data.style_prompt_name,
-    rulesPromptName: profileResult.data.rules_prompt_name,
+    rulesPromptName: profile.rules_prompt_name,
   }
   const requiredPromptNames = [
     promptNames.identityPromptName,
@@ -130,6 +143,73 @@ const loadActiveConversationPrompt = async (
     activePrompts: promptsResult.data ?? [],
     legacySystemPrompt,
   })
+}
+
+const loadConversationHistory = async ({
+  client,
+  userId,
+  sessionId,
+  epochStart,
+  tokenBudget,
+  requiredMessageId,
+  excludedMessageId,
+}: {
+  client: UserClient
+  userId: string
+  sessionId: string
+  epochStart: string | null
+  tokenBudget: number
+  requiredMessageId: string
+  excludedMessageId: string
+}) => {
+  const candidates: MessageRow[] = []
+  let cursor: { createdAt: string; id: string } | null = null
+
+  while (true) {
+    let query = client
+      .from('messages')
+      .select('id,role,content,meta,created_at')
+      .eq('session_id', sessionId)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .order('id', { ascending: false })
+      .limit(HISTORY_PAGE_SIZE)
+
+    if (epochStart) {
+      query = query.gte('created_at', epochStart)
+    }
+    if (cursor) {
+      query = query.or(
+        `created_at.lt.${cursor.createdAt},and(created_at.eq.${cursor.createdAt},id.lt.${cursor.id})`,
+      )
+    }
+
+    const result = await query.returns<MessageRow[]>()
+    if (result.error) {
+      throw new Error(`message history load failed: ${result.error.code ?? 'unknown'}`)
+    }
+
+    const page = result.data ?? []
+    candidates.push(...page)
+    const selection = selectNewestContextWindow({
+      newestFirst: candidates,
+      tokenBudget,
+      requiredMessageId,
+      excludedMessageIds: [excludedMessageId],
+    })
+    if (selection.reachedBudget || page.length < HISTORY_PAGE_SIZE) {
+      if (!selection.containsRequiredMessage) {
+        throw new Error('canonical user message was not found inside its context boundary')
+      }
+      return [...selection.newestFirst].reverse()
+    }
+
+    const last = page.at(-1)
+    if (!last) {
+      throw new Error('message history pagination stopped before the canonical user message')
+    }
+    cursor = { createdAt: last.created_at, id: last.id }
+  }
 }
 
 const jsonResponse = (
@@ -272,7 +352,7 @@ const loadConversationRequest = async (
   sessionId: string,
   userId: string,
 ) => {
-  const [sessionResult, settingsResult, messagesResult] = await Promise.all([
+  const [sessionResult, settingsResult] = await Promise.all([
     client
       .from('sessions')
       .select(
@@ -284,18 +364,10 @@ const loadConversationRequest = async (
     client
       .from('user_settings')
       .select(
-        'default_model,system_prompt,temperature,top_p,max_tokens,chat_reasoning_enabled',
+        'default_model,system_prompt,temperature,top_p,max_tokens,chat_reasoning_enabled,compression_trigger_ratio',
       )
       .eq('user_id', userId)
       .maybeSingle<UserSettingsRow>(),
-    client
-      .from('messages')
-      .select('id,role,content,meta,created_at')
-      .eq('session_id', sessionId)
-      .eq('user_id', userId)
-      .order('created_at', { ascending: false })
-      .limit(HISTORY_LIMIT)
-      .returns<MessageRow[]>(),
   ])
 
   if (sessionResult.error || !sessionResult.data) {
@@ -304,32 +376,37 @@ const loadConversationRequest = async (
   if (settingsResult.error || !settingsResult.data) {
     throw new Error(`settings load failed: ${settingsResult.error?.code ?? 'not_found'}`)
   }
-  if (messagesResult.error) {
-    throw new Error(`message history load failed: ${messagesResult.error.code ?? 'unknown'}`)
-  }
-
   const session = sessionResult.data
   const settings = settingsResult.data
-  const systemPrompt = await loadActiveConversationPrompt(
+  const { profileKey, profile } = await loadActiveConversationProfile(
     client,
     userId,
     session,
+  )
+  const systemPrompt = await loadActiveConversationPrompt(
+    client,
+    userId,
+    profile,
     settings.system_prompt,
   )
-  const canonicalMessages = [...(messagesResult.data ?? [])]
-    .reverse()
-    .filter((message) => {
-      if (message.id === dispatch.reply.id) {
-        return false
-      }
-      if (message.role !== 'assistant') {
-        return true
-      }
-      const state = message.meta && typeof message.meta.delivery_state === 'string'
-        ? message.meta.delivery_state
-        : null
-      return state !== 'generating' && state !== 'failed'
-    })
+  const contextRecipe = parseConversationContextRecipe(profile.context_recipe)
+  const tokenBudget = resolveHistoryTokenBudget({
+    systemPrompt,
+    maxOutputTokens: settings.max_tokens,
+    triggerRatio: settings.compression_trigger_ratio,
+  })
+  const epochStart = contextRecipe.epoch === 'asia_shanghai_day'
+    ? startOfShanghaiDayIso(dispatch.user_message.created_at)
+    : null
+  const canonicalMessages = (await loadConversationHistory({
+    client,
+    userId,
+    sessionId,
+    epochStart,
+    tokenBudget,
+    requiredMessageId: dispatch.user_message.id,
+    excludedMessageId: dispatch.reply.id,
+  }))
     .map((message) => ({
       role: message.role,
       content: message.content,
@@ -347,6 +424,18 @@ const loadConversationRequest = async (
     temperature: settings.temperature,
     top_p: settings.top_p,
     max_tokens: settings.max_tokens,
+    extra: {
+      canonical_context: {
+        version: 1,
+        managed_by: 'conversation-dispatch',
+        profile_key: profileKey,
+        recipe_version: contextRecipe.version,
+        history_scope: contextRecipe.history_scope,
+        epoch: contextRecipe.epoch,
+        selection: contextRecipe.selection,
+        external_sources: contextRecipe.external_sources,
+      },
+    },
   }
 }
 

--- a/supabase/functions/openrouter-chat/context-contract.ts
+++ b/supabase/functions/openrouter-chat/context-contract.ts
@@ -1,0 +1,57 @@
+type ContextAwarePayload = {
+  module?: string
+  extra?: Record<string, unknown>
+}
+
+type CanonicalContextContract = {
+  version: 1
+  managed_by: 'conversation-dispatch'
+  external_sources: string[]
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+export const readCanonicalContextContract = (
+  payload: ContextAwarePayload,
+): CanonicalContextContract | null => {
+  const contract = asRecord(payload.extra?.canonical_context)
+  if (
+    contract?.version !== 1 ||
+    contract.managed_by !== 'conversation-dispatch' ||
+    !Array.isArray(contract.external_sources) ||
+    contract.external_sources.some((source) => typeof source !== 'string')
+  ) {
+    return null
+  }
+  return {
+    version: 1,
+    managed_by: 'conversation-dispatch',
+    external_sources: contract.external_sources,
+  }
+}
+
+export const shouldInjectChitchatMemory = (payload: ContextAwarePayload) => {
+  const contract = readCanonicalContextContract(payload)
+  if (contract) {
+    return contract.external_sources.includes('memory_entries')
+  }
+  return !payload.module || payload.module === 'chitchat'
+}
+
+export const resolveCompressionModule = (
+  payload: ContextAwarePayload,
+): 'chat' | 'rp' | null => {
+  if (readCanonicalContextContract(payload)) {
+    return null
+  }
+  if (!payload.module || payload.module === 'chitchat') {
+    return 'chat'
+  }
+  if (payload.module === 'rp-room') {
+    return 'rp'
+  }
+  return null
+}

--- a/supabase/functions/openrouter-chat/index.ts
+++ b/supabase/functions/openrouter-chat/index.ts
@@ -2,6 +2,10 @@ import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { consumeQuota } from '../_shared/quota.ts'
 import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
+import {
+  resolveCompressionModule,
+  shouldInjectChitchatMemory,
+} from './context-contract.ts'
 
 const DAILY_QUOTA = 1000
 
@@ -427,20 +431,7 @@ const buildUpstreamHeaders = (
 }
 
 const shouldInjectSyzygyFeedMemory = (payload: OpenRouterPayload) => payload.module === 'syzygy-feed'
-
-const shouldInjectChitchatMemory = (payload: OpenRouterPayload) =>
-  !payload.module || payload.module === 'chitchat'
-
 const shouldInjectBubbleChatMemory = (payload: OpenRouterPayload) => payload.module === 'bubble-chat'
-const resolveCompressionModule = (payload: OpenRouterPayload): 'chat' | 'rp' | null => {
-  if (!payload.module || payload.module === 'chitchat') {
-    return 'chat'
-  }
-  if (payload.module === 'rp-room') {
-    return 'rp'
-  }
-  return null
-}
 
 const DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_CHAT = 20
 const DEFAULT_RECENT_UNCOMPRESSED_MESSAGES_RP = 10

--- a/supabase/migrations/20260801123513_v4_1_companion_session_migrate.sql
+++ b/supabase/migrations/20260801123513_v4_1_companion_session_migrate.sql
@@ -1,0 +1,231 @@
+-- V4.1 W1 / 3.2: migrate the fixed API companion in place.
+--
+-- This is deliberately data-only:
+-- - the sessions.id remains stable;
+-- - canonical messages are never moved or rewritten;
+-- - no grants, RLS policies, functions, or schema objects are changed.
+
+set lock_timeout = '5s';
+set statement_timeout = '2min';
+
+do $migration$
+declare
+  v_owner_id uuid;
+  v_owner_count bigint;
+  v_legacy_session_id uuid;
+  v_companion_session_id uuid;
+  v_session_id uuid;
+  v_profile_count bigint;
+  v_message_count_before bigint;
+  v_message_count_after bigint;
+  v_message_ids_before text;
+  v_message_ids_after text;
+  v_existing_routing jsonb;
+  v_display_name text;
+  v_source_label text;
+  v_avatar text;
+  v_required_routing jsonb;
+begin
+  perform pg_advisory_xact_lock(
+    hashtextextended('v4.1:companion-session-migrate', 0)
+  );
+
+  select count(*), min(owner_id::text)::uuid
+  into v_owner_count, v_owner_id
+  from (
+    select distinct user_id as owner_id
+    from public.sessions
+    where user_id is not null
+  ) owners;
+
+  if v_owner_count <> 1 or v_owner_id is null then
+    raise exception
+      'Expected exactly one sessions owner before companion migration; found %',
+      v_owner_count;
+  end if;
+
+  select count(*)
+  into v_profile_count
+  from public.conversation_profiles
+  where user_id = v_owner_id
+    and profile_key = 'app_companion'
+    and active
+    and conversation_kind = 'direct'
+    and handler = 'api'
+    and session_policy = 'singleton'
+    and singleton_session_key = 'syzygy_companion'
+    and participant_port_keys = array['app_companion']::text[]
+    and default_responder_port_key = 'app_companion'
+    and context_recipe @> '{
+      "version": 1,
+      "history_scope": "current_session",
+      "epoch": "asia_shanghai_day",
+      "selection": "newest_within_token_budget",
+      "external_sources": []
+    }'::jsonb;
+
+  if v_profile_count <> 1 then
+    raise exception
+      'Companion migration requires exactly one active app_companion singleton profile; found %',
+      v_profile_count;
+  end if;
+
+  select id
+  into v_legacy_session_id
+  from public.sessions
+  where user_id = v_owner_id
+    and session_key = 'syzygy_instant';
+
+  select id
+  into v_companion_session_id
+  from public.sessions
+  where user_id = v_owner_id
+    and session_key = 'syzygy_companion';
+
+  if v_legacy_session_id is not null
+     and v_companion_session_id is not null
+     and v_legacy_session_id <> v_companion_session_id then
+    raise exception
+      'Companion migration refuses to merge two different session ids (% and %)',
+      v_legacy_session_id,
+      v_companion_session_id;
+  end if;
+
+  v_session_id := coalesce(v_companion_session_id, v_legacy_session_id);
+  if v_session_id is null then
+    raise exception
+      'Companion migration requires syzygy_instant or the already-migrated syzygy_companion session';
+  end if;
+
+  select routing_config
+  into v_existing_routing
+  from public.sessions
+  where id = v_session_id
+    and user_id = v_owner_id
+    and conversation_kind = 'direct'
+    and handler = 'api'
+  for update;
+
+  if not found then
+    raise exception
+      'Companion migration target must remain an owner direct API session';
+  end if;
+
+  v_existing_routing := coalesce(v_existing_routing, '{}'::jsonb);
+  v_display_name := case
+    when nullif(btrim(v_existing_routing ->> 'display_name'), '') is null
+      or v_existing_routing ->> 'display_name' = 'Syzygy·即时'
+      then 'Syzygy·陪伴'
+    else v_existing_routing ->> 'display_name'
+  end;
+  v_source_label := case
+    when nullif(btrim(v_existing_routing ->> 'source_label'), '') is null
+      or v_existing_routing ->> 'source_label' = '云端 · 即时'
+      then '云端 · 陪伴'
+    else v_existing_routing ->> 'source_label'
+  end;
+  v_avatar := coalesce(
+    nullif(btrim(v_existing_routing ->> 'avatar'), ''),
+    '✨'
+  );
+  v_required_routing := jsonb_build_object(
+    'version', 2,
+    'display_name', v_display_name,
+    'avatar', v_avatar,
+    'source_label', v_source_label,
+    'participants', jsonb_build_array(
+      'chuanchuan',
+      'app_companion',
+      'syzygy_proactive'
+    ),
+    'default_responder', 'app_companion'
+  );
+
+  select
+    count(*),
+    md5(coalesce(string_agg(id::text, ',' order by id), ''))
+  into v_message_count_before, v_message_ids_before
+  from public.messages
+  where session_id = v_session_id;
+
+  update public.sessions
+  set
+    title = case
+      when btrim(title) in ('', '新会话', 'Syzygy·即时') then 'Syzygy·陪伴'
+      else title
+    end,
+    session_key = 'syzygy_companion',
+    conversation_profile_key = 'app_companion',
+    conversation_kind = 'direct',
+    handler = 'api',
+    routing_config = v_existing_routing || v_required_routing,
+    is_archived = false,
+    archived_at = null
+  where id = v_session_id
+    and user_id = v_owner_id
+    and (
+      title,
+      session_key,
+      conversation_profile_key,
+      conversation_kind,
+      handler,
+      routing_config,
+      is_archived,
+      archived_at
+    ) is distinct from (
+      case
+        when btrim(title) in ('', '新会话', 'Syzygy·即时') then 'Syzygy·陪伴'
+        else title
+      end,
+      'syzygy_companion',
+      'app_companion',
+      'direct',
+      'api',
+      v_existing_routing || v_required_routing,
+      false,
+      null::timestamptz
+    );
+
+  select
+    count(*),
+    md5(coalesce(string_agg(id::text, ',' order by id), ''))
+  into v_message_count_after, v_message_ids_after
+  from public.messages
+  where session_id = v_session_id;
+
+  if v_message_count_after <> v_message_count_before
+     or v_message_ids_after is distinct from v_message_ids_before then
+    raise exception
+      'Companion migration must preserve every canonical message id';
+  end if;
+
+  if (
+    select count(*)
+    from public.sessions
+    where user_id = v_owner_id
+      and id = v_session_id
+      and session_key = 'syzygy_companion'
+      and conversation_profile_key = 'app_companion'
+      and conversation_kind = 'direct'
+      and handler = 'api'
+      and not is_archived
+      and routing_config ->> 'default_responder' = 'app_companion'
+      and routing_config -> 'participants' = '[
+        "chuanchuan",
+        "app_companion",
+        "syzygy_proactive"
+      ]'::jsonb
+  ) <> 1 then
+    raise exception 'Companion migration did not converge to the fixed window contract';
+  end if;
+
+  if exists (
+    select 1
+    from public.sessions
+    where user_id = v_owner_id
+      and session_key = 'syzygy_instant'
+  ) then
+    raise exception 'Legacy syzygy_instant key remained after companion migration';
+  end if;
+end
+$migration$;

--- a/supabase/rollback-contracts/20260801123513_v4_1_companion_session_migrate.sql
+++ b/supabase/rollback-contracts/20260801123513_v4_1_companion_session_migrate.sql
@@ -1,0 +1,94 @@
+-- Manual rollback contract for 20260801123513_v4_1_companion_session_migrate.
+--
+-- This rollback restores the legacy address and display metadata on the same
+-- sessions.id. It never deletes or rewrites canonical messages, including any
+-- messages created after the forward migration.
+
+set lock_timeout = '5s';
+set statement_timeout = '2min';
+
+do $rollback$
+declare
+  v_owner_id uuid;
+  v_owner_count bigint;
+  v_session_id uuid;
+  v_existing_routing jsonb;
+begin
+  perform pg_advisory_xact_lock(
+    hashtextextended('v4.1:companion-session-migrate', 0)
+  );
+
+  select count(*), min(owner_id::text)::uuid
+  into v_owner_count, v_owner_id
+  from (
+    select distinct user_id as owner_id
+    from public.sessions
+    where user_id is not null
+  ) owners;
+
+  if v_owner_count <> 1 or v_owner_id is null then
+    raise exception
+      'Companion rollback expected exactly one sessions owner; found %',
+      v_owner_count;
+  end if;
+
+  if exists (
+    select 1
+    from public.sessions
+    where user_id = v_owner_id
+      and session_key = 'syzygy_instant'
+  ) then
+    raise exception 'Companion rollback refuses to overwrite an existing syzygy_instant key';
+  end if;
+
+  select id, routing_config
+  into v_session_id, v_existing_routing
+  from public.sessions
+  where user_id = v_owner_id
+    and session_key = 'syzygy_companion'
+    and conversation_profile_key = 'app_companion'
+    and conversation_kind = 'direct'
+    and handler = 'api'
+  for update;
+
+  if v_session_id is null then
+    raise exception 'Companion rollback requires exactly the migrated companion session';
+  end if;
+
+  update public.sessions
+  set
+    title = case
+      when btrim(title) in ('', '新会话', 'Syzygy·陪伴') then 'Syzygy·即时'
+      else title
+    end,
+    session_key = 'syzygy_instant',
+    conversation_profile_key = null,
+    routing_config = coalesce(v_existing_routing, '{}'::jsonb) || jsonb_build_object(
+      'version', 1,
+      'display_name', case
+        when nullif(btrim(v_existing_routing ->> 'display_name'), '') is null
+          or v_existing_routing ->> 'display_name' = 'Syzygy·陪伴'
+          then 'Syzygy·即时'
+        else v_existing_routing ->> 'display_name'
+      end,
+      'avatar', coalesce(
+        nullif(btrim(v_existing_routing ->> 'avatar'), ''),
+        '✨'
+      ),
+      'source_label', case
+        when nullif(btrim(v_existing_routing ->> 'source_label'), '') is null
+          or v_existing_routing ->> 'source_label' = '云端 · 陪伴'
+          then '云端 · 即时'
+        else v_existing_routing ->> 'source_label'
+      end,
+      'participants', jsonb_build_array('chuanchuan', 'syzygy_instant'),
+      'default_responder', 'syzygy_instant'
+    )
+  where id = v_session_id
+    and user_id = v_owner_id;
+
+  if not found then
+    raise exception 'Companion rollback did not update the target session';
+  end if;
+end
+$rollback$;

--- a/tests/companion-context.test.mjs
+++ b/tests/companion-context.test.mjs
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const {
+  estimateTextTokens,
+  parseConversationContextRecipe,
+  resolveHistoryTokenBudget,
+  selectNewestContextWindow,
+  startOfShanghaiDayIso,
+} = await import('../supabase/functions/conversation-dispatch/context.ts')
+const {
+  readCanonicalContextContract,
+  resolveCompressionModule,
+  shouldInjectChitchatMemory,
+} = await import('../supabase/functions/openrouter-chat/context-contract.ts')
+
+const migrationUrl = new URL(
+  '../supabase/migrations/20260801123513_v4_1_companion_session_migrate.sql',
+  import.meta.url,
+)
+const rollbackUrl = new URL(
+  '../supabase/rollback-contracts/20260801123513_v4_1_companion_session_migrate.sql',
+  import.meta.url,
+)
+const dispatchUrl = new URL(
+  '../supabase/functions/conversation-dispatch/index.ts',
+  import.meta.url,
+)
+
+const message = ({ id, role = 'user', content, state = null, createdAt }) => ({
+  id,
+  role,
+  content,
+  meta: state ? { delivery_state: state } : null,
+  created_at: createdAt,
+})
+
+test('companion migration changes only the stable session address and preserves message ids', async () => {
+  const sql = await readFile(migrationUrl, 'utf8')
+  const rollback = await readFile(rollbackUrl, 'utf8')
+
+  assert.match(sql, /pg_advisory_xact_lock/iu)
+  assert.match(sql, /session_key = 'syzygy_companion'/iu)
+  assert.match(sql, /conversation_profile_key = 'app_companion'/iu)
+  assert.match(sql, /default_responder', 'app_companion'/iu)
+  assert.match(
+    sql,
+    /Companion migration must preserve every canonical message id/iu,
+  )
+  assert.match(sql, /md5\(coalesce\(string_agg\(id::text/iu)
+  assert.doesNotMatch(sql, /update public\.messages/iu)
+  assert.doesNotMatch(sql, /insert into public\.messages/iu)
+  assert.doesNotMatch(sql, /delete from public\.messages/iu)
+
+  assert.match(
+    rollbackUrl.pathname,
+    /\/supabase\/rollback-contracts\/20260801123513_v4_1_companion_session_migrate\.sql$/u,
+  )
+  assert.doesNotMatch(rollbackUrl.pathname, /\/supabase\/migrations\//u)
+  assert.match(rollback, /same[\s\S]*?sessions\.id/iu)
+  assert.match(rollback, /never deletes or rewrites canonical messages/iu)
+  assert.match(rollback, /session_key = 'syzygy_instant'/iu)
+  assert.match(rollback, /'version', 1/iu)
+})
+
+test('Shanghai epoch changes exactly at local midnight', () => {
+  assert.equal(
+    startOfShanghaiDayIso('2026-08-01T15:59:59.999Z'),
+    '2026-07-31T16:00:00.000Z',
+  )
+  assert.equal(
+    startOfShanghaiDayIso('2026-08-01T16:00:00.000Z'),
+    '2026-08-01T16:00:00.000Z',
+  )
+  assert.throws(
+    () => startOfShanghaiDayIso('not-a-date'),
+    /invalid created_at/u,
+  )
+})
+
+test('context recipe is explicit and fails closed when its boundary is malformed', () => {
+  const recipe = parseConversationContextRecipe({
+    version: 1,
+    history_scope: 'current_session',
+    epoch: 'asia_shanghai_day',
+    selection: 'newest_within_token_budget',
+    external_sources: [],
+  })
+  assert.equal(recipe.epoch, 'asia_shanghai_day')
+  assert.deepEqual(recipe.external_sources, [])
+  assert.throws(
+    () =>
+      parseConversationContextRecipe({
+        ...recipe,
+        history_scope: 'all_sessions',
+      }),
+    /invalid context recipe/u,
+  )
+})
+
+test('newest-first token selection excludes placeholders and always keeps the triggering user message', () => {
+  const replyId = '00000000-0000-4000-8000-000000000004'
+  const userId = '00000000-0000-4000-8000-000000000003'
+  const olderId = '00000000-0000-4000-8000-000000000002'
+  const oldestId = '00000000-0000-4000-8000-000000000001'
+  const current = message({
+    id: userId,
+    content: '今天继续',
+    createdAt: '2026-08-01T16:00:01.000Z',
+  })
+  const older = message({
+    id: olderId,
+    role: 'assistant',
+    content: '好',
+    state: 'completed',
+    createdAt: '2026-08-01T16:00:00.500Z',
+  })
+  const result = selectNewestContextWindow({
+    newestFirst: [
+      message({
+        id: replyId,
+        role: 'assistant',
+        content: '',
+        state: 'generating',
+        createdAt: '2026-08-01T16:00:01.100Z',
+      }),
+      current,
+      older,
+      message({
+        id: oldestId,
+        content: '太长了'.repeat(2_000),
+        createdAt: '2026-08-01T16:00:00.000Z',
+      }),
+    ],
+    tokenBudget: estimateTextTokens(current.content) + estimateTextTokens(older.content),
+    requiredMessageId: userId,
+    excludedMessageIds: [replyId],
+  })
+
+  assert.deepEqual(
+    result.newestFirst.map((row) => row.id),
+    [userId, olderId],
+  )
+  assert.equal(result.containsRequiredMessage, true)
+  assert.equal(result.reachedBudget, true)
+
+  const zeroBudget = selectNewestContextWindow({
+    newestFirst: [current, older],
+    tokenBudget: 0,
+    requiredMessageId: userId,
+  })
+  assert.deepEqual(
+    zeroBudget.newestFirst.map((row) => row.id),
+    [userId],
+  )
+})
+
+test('history budget reserves system, completion, and safety capacity', () => {
+  const withoutPrompt = resolveHistoryTokenBudget({
+    systemPrompt: '',
+    maxOutputTokens: 1_000,
+    triggerRatio: 0.65,
+  })
+  const withPrompt = resolveHistoryTokenBudget({
+    systemPrompt: '规则'.repeat(1_000),
+    maxOutputTokens: 1_000,
+    triggerRatio: 0.65,
+  })
+  assert.ok(withoutPrompt > 0)
+  assert.ok(withPrompt < withoutPrompt)
+})
+
+test('managed canonical context prevents a second history read and honors external sources', () => {
+  const managed = {
+    module: 'chitchat',
+    extra: {
+      canonical_context: {
+        version: 1,
+        managed_by: 'conversation-dispatch',
+        external_sources: [],
+      },
+    },
+  }
+  assert.deepEqual(readCanonicalContextContract(managed)?.external_sources, [])
+  assert.equal(resolveCompressionModule(managed), null)
+  assert.equal(shouldInjectChitchatMemory(managed), false)
+  assert.equal(
+    shouldInjectChitchatMemory({
+      ...managed,
+      extra: {
+        canonical_context: {
+          version: 1,
+          managed_by: 'conversation-dispatch',
+          external_sources: ['memory_entries'],
+        },
+      },
+    }),
+    true,
+  )
+  assert.equal(resolveCompressionModule({ module: 'chitchat' }), 'chat')
+  assert.equal(shouldInjectChitchatMemory({ module: 'chitchat' }), true)
+})
+
+test('dispatch applies profile boundary before keyset token selection', async () => {
+  const source = await readFile(dispatchUrl, 'utf8')
+
+  assert.match(source, /parseConversationContextRecipe/iu)
+  assert.match(
+    source,
+    /startOfShanghaiDayIso\(dispatch\.user_message\.created_at\)/iu,
+  )
+  assert.match(source, /query = query\.gte\('created_at', epochStart\)/iu)
+  assert.match(source, /order\('id', \{ ascending: false \}\)/iu)
+  assert.match(source, /selectNewestContextWindow/iu)
+  assert.match(source, /managed_by: 'conversation-dispatch'/iu)
+  assert.match(source, /external_sources: contextRecipe\.external_sources/iu)
+  assert.doesNotMatch(source, /HISTORY_LIMIT/iu)
+})


### PR DESCRIPTION
## What changed

- Migrate the existing fixed API session in place from `syzygy_instant` to `syzygy_companion / app_companion` while preserving the session and message IDs.
- Resolve the active conversation profile before dispatch, enforce the Shanghai-day context epoch, and select newest messages within a token budget.
- Pass a versioned canonical-context contract to `openrouter-chat` so managed requests do not re-read full-session compression history or inject undeclared memory sources.
- Add a guarded rollback contract and regression coverage for migration safety, day boundaries, token budgeting, and downstream context behavior.

## Why

The fixed companion window must remain one durable conversation while its model context rolls over by Asia/Shanghai calendar day. The previous runtime used a broad recent-message limit and downstream legacy memory behavior, which did not encode those boundaries.

## Impact

This establishes the database and Edge contract for the V4.1 fixed companion window. GitHub merge, Pages/Edge workflow execution, and any further production release remain separate gates.

## Validation

- `npm test`: 68/68
- `npm run check`: 0 errors; 5 existing React Hooks warnings
- `npm run build`: passed with the existing large-chunk warning
- Deno 2.9.4 check: dispatch entry and new context helpers passed with the function import map
- Deno lint: new context helpers passed
- `git diff --check`: passed
- Production migration, authenticated `app_companion` canary, guarded cleanup, and zero-residue reconciliation were completed separately before this handoff
