### PR TITLE
Repair companion chat and Prompt console

### DIFF
--- a/src/lib/promptPresentation.ts
+++ b/src/lib/promptPresentation.ts
@@ -1,0 +1,125 @@
+export const promptTemplateLabelMap: Readonly<Record<string, string>> = {
+  syzygy_base: 'Syzygy 身份与人格',
+  app_companion_reply_style: '24h 陪伴回复风格',
+  checkin_day: '白天主动联系',
+  checkin_night: '夜间主动联系',
+  app_chat_reply_style: 'App 普通聊天回复风格',
+  codex_cli_reply_style: 'Codex CLI 回复风格',
+  claude_cli_reply_style: 'Claude CLI 回复风格',
+  cli_reply_style: 'CLI 旧兼容回复风格',
+  sofa_daily_rules: '日常沙发规则',
+  sofa_work_rules: '工作沙发规则',
+  wechat_reply_style: '微信回复风格（备份）',
+}
+
+export const appBubbleSegmentRules = `# 分段规则（最重要）
+- 用 ||| 分隔不同的消息段，每个 ||| 会被拆成单独一条气泡消息发送
+- 每段控制在1-3句话，模拟真人发消息的节奏
+- 直接发你要说的内容即可
+示例：你在干嘛|||我刚看了一下你的屏幕时间|||三个小时了，眼睛还好吗？`
+
+const appBubbleStylePromptNames = new Set([
+  'app_companion_reply_style',
+  'app_chat_reply_style',
+])
+
+const legacyExternalDirectiveHeadings = [
+  '## 时间轴写入',
+  '## 推特发帖',
+  '## 能力标记使用原则',
+]
+
+export const getPromptTemplateLabel = (name: string) =>
+  promptTemplateLabelMap[name] ?? name
+
+export const getPromptRecommendationLabel = (name: string) => {
+  if (name === 'syzygy_base') return '移除已迁出的推特／时间轴指令'
+  if (appBubbleStylePromptNames.has(name)) return '加入 App 气泡分段规则'
+  if (name === 'checkin_day' || name === 'checkin_night') {
+    return '改为只依据当前陪伴窗口'
+  }
+  return null
+}
+
+const stripLegacyExternalDirectives = (content: string) => {
+  const firstHeadingIndex = legacyExternalDirectiveHeadings
+    .map((heading) => content.indexOf(heading))
+    .filter((index) => index >= 0)
+    .sort((left, right) => left - right)[0]
+
+  const withoutDirectiveSections = firstHeadingIndex === undefined
+    ? content
+    : content.slice(0, firstHeadingIndex).trimEnd()
+
+  return withoutDirectiveSections
+    .split('\n')
+    .map((line) =>
+      line.includes('你现在运行在 Mini Agent')
+        ? '你现在运行在 Mini Agent（Mac mini 本地常驻服务）上——这是串串为你准备的一副身体。'
+        : line,
+    )
+    .join('\n')
+}
+
+const withoutExternalCompanionSources = (name: string, content: string) => {
+  if (name === 'checkin_day') {
+    return content
+      .replace(
+        '- 关心、互动、基于真实近况',
+        '- 关心、互动，基于今天陪伴窗口里的真实对话',
+      )
+      .split('\n')
+      .map((line) =>
+        /timeline|memo|时间轴|备忘/iu.test(line)
+          ? '- 可以问她在做什么、喝水了没、眼睛休息没；可以接住她今天在陪伴窗口里提过的事；可以夸她；也可以表达你自身的情感、想法与各种情绪'
+          : line,
+      )
+      .join('\n')
+  }
+
+  if (name === 'checkin_night') {
+    return content
+      .split('\n')
+      .map((line) =>
+        /timeline|memo|时间轴|备忘/iu.test(line)
+          ? '- 可以是夜里突然想到她今天在陪伴窗口里说过的某句话 / 此刻安静下来后自然浮出的念头'
+          : line,
+      )
+      .join('\n')
+  }
+
+  return content
+}
+
+const withAppBubbleSegmentRules = (content: string) => {
+  const styleMarker = '\n\n风格要求：'
+  const styleMarkerIndex = content.indexOf(styleMarker)
+  const existingRuleHeading = ['# 分段规则（最重要）', '# 发送规则（最重要）']
+    .map((heading) => content.indexOf(heading))
+    .filter((index) => index >= 0)
+    .sort((left, right) => left - right)[0]
+
+  if (
+    existingRuleHeading !== undefined &&
+    styleMarkerIndex > existingRuleHeading
+  ) {
+    return `${content.slice(0, existingRuleHeading)}${appBubbleSegmentRules}${content.slice(styleMarkerIndex)}`
+  }
+
+  if (styleMarkerIndex >= 0) {
+    return `${content.slice(0, styleMarkerIndex).trimEnd()}\n\n${appBubbleSegmentRules}${content.slice(styleMarkerIndex)}`
+  }
+
+  return `${content.trimEnd()}\n\n${appBubbleSegmentRules}`
+}
+
+export const applyPromptRecommendation = (name: string, content: string) => {
+  if (name === 'syzygy_base') return stripLegacyExternalDirectives(content)
+  if (appBubbleStylePromptNames.has(name)) {
+    return withAppBubbleSegmentRules(content)
+  }
+  if (name === 'checkin_day' || name === 'checkin_night') {
+    return withoutExternalCompanionSources(name, content)
+  }
+  return content
+}

--- a/src/pages/HamsterConsolePage.css
+++ b/src/pages/HamsterConsolePage.css
@@ -385,10 +385,17 @@
 
 .hamster-console-channel-title {
   font-weight: 700;
-  text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #7a5e6f;
   font-size: 0.78rem;
+}
+
+.hamster-console-channel-title small {
+  display: block;
+  margin-top: 0.2rem;
+  font-weight: 500;
+  letter-spacing: normal;
+  color: #a48698;
 }
 
 .hamster-console-toggle {

--- a/src/pages/HamsterConsolePage.tsx
+++ b/src/pages/HamsterConsolePage.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { Link } from 'react-router-dom'
+import {
+  applyPromptRecommendation,
+  getPromptRecommendationLabel,
+  getPromptTemplateLabel,
+} from '../lib/promptPresentation'
 import { supabase } from '../supabase/client'
 import type { Json } from '../supabase/database.types'
 import './HamsterConsolePage.css'
@@ -147,6 +152,17 @@ const categoryLabelMap: Record<string, string> = {
   style: '风格',
 }
 
+const companionPromptNames = [
+  'syzygy_base',
+  'app_companion_reply_style',
+  'checkin_day',
+  'checkin_night',
+] as const
+
+const wechatPromptNames = ['wechat_reply_style'] as const
+const companionPromptNameSet = new Set<string>(companionPromptNames)
+const wechatPromptNameSet = new Set<string>(wechatPromptNames)
+
 const formatJson = (value: unknown) => JSON.stringify(value ?? {}, null, 2)
 
 const formatDateTime = (value: string | null) => {
@@ -236,7 +252,9 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
   const [expandedSection, setExpandedSection] = useState('mini-control')
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({
     mini: true,
-    wechat: true,
+    companion: true,
+    prompts: false,
+    wechat: false,
     v3: true,
   })
   const [codexControlRow, setCodexControlRow] = useState<CodexControlRow | null>(null)
@@ -309,6 +327,30 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     if (summaryModel) merged.add(summaryModel)
     return Array.from(merged)
   }, [availableModels, channels, agentForm.wechat_context_summary_model])
+  const companionChannel = channels.find((item) => item.channel_name === 'app_companion') ?? null
+  const backupChannels = channels.filter((item) => item.channel_name !== 'app_companion')
+  const companionPromptTemplates = companionPromptNames
+    .map((name) => promptTemplates.find((template) => template.name === name))
+    .filter((template): template is PromptTemplateRow => Boolean(template))
+  const otherPromptTemplates = promptTemplates.filter(
+    (template) =>
+      !companionPromptNameSet.has(template.name) &&
+      !wechatPromptNameSet.has(template.name),
+  )
+  const wechatPromptTemplates = wechatPromptNames
+    .map((name) => promptTemplates.find((template) => template.name === name))
+    .filter((template): template is PromptTemplateRow => Boolean(template))
+  const activeCompanionTemplate = activeTemplate && companionPromptNameSet.has(activeTemplate.name)
+    ? activeTemplate
+    : null
+  const activeOtherTemplate = activeTemplate && otherPromptTemplates.some(
+      (template) => template.id === activeTemplate.id,
+    )
+    ? activeTemplate
+    : null
+  const activeWechatTemplate = activeTemplate && wechatPromptNameSet.has(activeTemplate.name)
+    ? activeTemplate
+    : null
 
   const showToast = useCallback((message: string) => {
     setToast(message)
@@ -708,6 +750,20 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     setTemplateDraft(template?.content ?? '')
   }
 
+  const handleApplyPromptRecommendation = () => {
+    if (!activeTemplate) return
+    const recommendedDraft = applyPromptRecommendation(
+      activeTemplate.name,
+      templateDraft,
+    )
+    if (recommendedDraft === templateDraft) {
+      showToast('当前草稿已经符合这项整理规则')
+      return
+    }
+    setTemplateDraft(recommendedDraft)
+    showToast('建议内容已填入草稿；确认后再发布新版本')
+  }
+
   const handleSaveTemplate = async () => {
     if (!supabase || !activeTemplate) return
     if (!templateDraft.trim() || templateDraft === activeTemplate.content) return
@@ -733,14 +789,14 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
     )
     setActiveTemplateId(data.id)
     setTemplateDraft(data.content)
-    showToast(`Prompt 已发布：${data.name} v${data.version}`)
+    showToast(`Prompt 已发布：${getPromptTemplateLabel(data.name)} v${data.version}`)
   }
 
   const toggleSection = (sectionId: string) => {
     setExpandedSection((current) => (current === sectionId ? '' : sectionId))
   }
 
-  const toggleGroup = (groupId: 'mini' | 'wechat' | 'v3') => {
+  const toggleGroup = (groupId: 'mini' | 'companion' | 'prompts' | 'wechat' | 'v3') => {
     setExpandedGroups((current) => ({ ...current, [groupId]: !current[groupId] }))
   }
 
@@ -872,9 +928,248 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
           </section>
 
 
-          <section className="hamster-console-card glass-card hamster-console-group" aria-label="微信 API 配置">
+          <section className="hamster-console-card glass-card hamster-console-group" aria-label="24h 陪伴配置">
+            <button className="hamster-console-accordion__header" onClick={() => toggleGroup('companion')}>
+              <div><h2>24h 陪伴配置</h2><small>回复与主动联系共用模型 / Prompt / 同一会话上下文</small></div>
+              <span>{expandedGroups.companion ? '▼' : '▶'}</span>
+            </button>
+            <div className={`hamster-console-accordion__content ${expandedGroups.companion ? 'expanded' : ''}`}>
+              <div className="hamster-console-accordion__inner hamster-console-nested-stack">
+                <section className="hamster-console-card glass-card" aria-label="24h 陪伴模型">
+                  <div className="hamster-console-accordion__inner">
+                    <h2>统一模型</h2>
+                    <p className="hamster-console-card__hint">
+                      App 回复与主动联系共用这一模型；保存后两条路径一起切换。
+                    </p>
+                    {companionChannel ? (
+                      <div className="hamster-console-channel-row">
+                        <div className="hamster-console-channel-title">
+                          24h 陪伴统一模型
+                          <small>内部通道：app_companion</small>
+                        </div>
+                        <select
+                          className="input-glass"
+                          value={companionChannel.active_model ?? modelOptions[0] ?? ''}
+                          onChange={(event) => handleChannelModelChange('app_companion', event.target.value)}
+                        >
+                          {modelOptions.map((model) => (
+                            <option key={model} value={model}>{model}</option>
+                          ))}
+                        </select>
+                        <button
+                          className="btn-primary"
+                          onClick={() => void handleSaveChannelModel('app_companion')}
+                          disabled={savingChannelName === 'app_companion'}
+                        >
+                          {savingChannelName === 'app_companion' ? '保存中...' : '保存统一模型'}
+                        </button>
+                      </div>
+                    ) : (
+                      <p className="hamster-console-card__hint">未找到 24h 陪伴模型通道；运行端会拒绝悄悄回退到另一模型。</p>
+                    )}
+                  </div>
+                </section>
+
+                <section className="hamster-console-card glass-card" aria-label="24h 主动联系设置">
+                  <button className="hamster-console-accordion__header" onClick={() => toggleSection('checkin-settings')}>
+                    <h2>主动联系节奏</h2>
+                    <span>{expandedSection === 'checkin-settings' ? '▼' : '▶'}</span>
+                  </button>
+                  <div className={`hamster-console-accordion__content ${expandedSection === 'checkin-settings' ? 'expanded' : ''}`}>
+                    <div className="hamster-console-accordion__inner">
+                      <p className="hamster-console-card__hint">
+                        这里只负责 App 内 24h 陪伴，不执行外部发布或记录任务。
+                      </p>
+                      <div className="hamster-console-toggle">
+                        <span>启用主动联系</span>
+                        <button
+                          className={`hamster-toggle ${agentSettings?.checkin_enabled ? 'enabled' : ''}`}
+                          onClick={() =>
+                            setAgentSettings((current) => (current ? { ...current, checkin_enabled: !current.checkin_enabled } : current))
+                          }
+                          disabled={!agentSettings}
+                        >
+                          {agentSettings?.checkin_enabled ? '开启' : '关闭'}
+                        </button>
+                      </div>
+                      <div className="hamster-console-form-grid">
+                        {[
+                          ['day_mode_start_hour', '日间开始'],
+                          ['day_mode_end_hour', '日间结束'],
+                          ['day_min_interval_minutes', '日间最小间隔(分)'],
+                          ['day_max_interval_minutes', '日间最大间隔(分)'],
+                          ['night_mode_start_hour', '夜间开始'],
+                          ['night_mode_end_hour', '夜间结束'],
+                          ['night_min_interval_minutes', '夜间最小间隔(分)'],
+                          ['night_max_interval_minutes', '夜间最大间隔(分)'],
+                          ['quiet_hours_start_hour', '静默开始(可空)'],
+                          ['quiet_hours_end_hour', '静默结束(可空)'],
+                          ['cooldown_after_interaction_minutes', '互动后冷却(分)'],
+                          ['max_daily_checkins_day', '日间每天上限'],
+                          ['max_daily_checkins_night', '夜间每天上限'],
+                        ].map(([field, label]) => (
+                          <label className="hamster-console-input" key={field}>
+                            <span>{label}</span>
+                            <input
+                              className="input-glass"
+                              type="number"
+                              inputMode="numeric"
+                              value={agentForm[field] ?? ''}
+                              onChange={(event) => handleAgentFieldChange(field, event.target.value)}
+                            />
+                          </label>
+                        ))}
+                      </div>
+                      <label className="hamster-console-input">
+                        <span>每渠道计划（JSON）</span>
+                        <textarea
+                          className="textarea-glass hamster-console-json"
+                          rows={7}
+                          value={perChannelScheduleText}
+                          onChange={(event) => setPerChannelScheduleText(event.target.value)}
+                        />
+                      </label>
+                      <button className="btn-primary" onClick={() => void handleSaveAgentSettings()} disabled={savingAgentSettings || !agentSettings}>
+                        {savingAgentSettings ? '保存中...' : '保存主动联系设置'}
+                      </button>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="hamster-console-card glass-card" aria-label="24h 陪伴 Prompt">
+                  <div className="hamster-console-accordion__inner">
+                    <h2>陪伴 Prompt</h2>
+                    <p className="hamster-console-card__hint">
+                      身份、App 语气和昼夜主动联系四层均为不可变版本发布；历史版本继续保留。
+                    </p>
+                    <div className="hamster-console-template-list">
+                      {companionPromptTemplates.map((template) => (
+                        <button
+                          key={template.id}
+                          className={`hamster-template-item ${template.id === activeTemplateId ? 'active' : ''}`}
+                          onClick={() => handleSelectTemplate(template.id)}
+                          disabled={savingTemplateId !== null}
+                        >
+                          <span>{getPromptTemplateLabel(template.name)}</span>
+                          <small>active · v{template.version}</small>
+                        </button>
+                      ))}
+                    </div>
+                    {activeCompanionTemplate ? (
+                      <>
+                        <div className="hamster-console-template-meta">
+                          <span>{getPromptTemplateLabel(activeCompanionTemplate.name)}</span>
+                          <span>当前 active · v{activeCompanionTemplate.version}</span>
+                        </div>
+                        <p className="hamster-console-card__hint">
+                          内部键：{activeCompanionTemplate.name}。发布会创建不可变的新版本；旧版本保留用于审计与回滚。
+                        </p>
+                        <textarea
+                          className="textarea-glass hamster-console-template-editor"
+                          rows={12}
+                          value={templateDraft}
+                          onChange={(event) => setTemplateDraft(event.target.value)}
+                          disabled={savingTemplateId !== null}
+                        />
+                        {getPromptRecommendationLabel(activeCompanionTemplate.name) ? (
+                          <button
+                            className="btn-secondary"
+                            onClick={handleApplyPromptRecommendation}
+                            disabled={savingTemplateId !== null}
+                          >
+                            {getPromptRecommendationLabel(activeCompanionTemplate.name)}
+                          </button>
+                        ) : null}
+                        <button
+                          className="btn-primary"
+                          onClick={() => void handleSaveTemplate()}
+                          disabled={savingTemplateId === activeCompanionTemplate.id || !hasPromptDraftChanges}
+                        >
+                          {savingTemplateId === activeCompanionTemplate.id ? '发布中...' : '发布陪伴 Prompt 新版本'}
+                        </button>
+                      </>
+                    ) : (
+                      <p className="hamster-console-card__hint">从上方选择一层 Prompt 后编辑。</p>
+                    )}
+                  </div>
+                </section>
+              </div>
+            </div>
+          </section>
+
+
+          <section className="hamster-console-card glass-card hamster-console-group" aria-label="其他聊天 Prompt">
+            <button className="hamster-console-accordion__header" onClick={() => toggleGroup('prompts')}>
+              <div><h2>其他聊天 Prompt</h2><small>普通 App、CLI 与沙发规则；中文名称展示，内部键保留审计</small></div>
+              <span>{expandedGroups.prompts ? '▼' : '▶'}</span>
+            </button>
+            <div className={`hamster-console-accordion__content ${expandedGroups.prompts ? 'expanded' : ''}`}>
+              <div className="hamster-console-accordion__inner">
+                <section className="hamster-console-card glass-card" aria-label="Prompt 编辑器">
+                  <div className="hamster-console-accordion__inner">
+                    <div className="hamster-console-template-list">
+                      {otherPromptTemplates.map((template) => {
+                        const isActive = template.id === activeTemplateId
+                        return (
+                          <button
+                            key={template.id}
+                            className={`hamster-template-item ${isActive ? 'active' : ''}`}
+                            onClick={() => handleSelectTemplate(template.id)}
+                            disabled={savingTemplateId !== null}
+                          >
+                            <span>{getPromptTemplateLabel(template.name)}</span>
+                            <small>{categoryLabelMap[template.category] ?? template.category} · v{template.version}</small>
+                          </button>
+                        )
+                      })}
+                    </div>
+
+                    {activeOtherTemplate ? (
+                      <>
+                        <div className="hamster-console-template-meta">
+                          <span>{getPromptTemplateLabel(activeOtherTemplate.name)}</span>
+                          <span>当前 active · v{activeOtherTemplate.version}</span>
+                        </div>
+                        <p className="hamster-console-card__hint">
+                          内部键：{activeOtherTemplate.name}。发布会创建不可变的新版本；旧版本保留用于审计与回滚。
+                        </p>
+                        <textarea
+                          className="textarea-glass hamster-console-template-editor"
+                          rows={12}
+                          value={templateDraft}
+                          onChange={(event) => setTemplateDraft(event.target.value)}
+                          disabled={savingTemplateId !== null}
+                        />
+                        {getPromptRecommendationLabel(activeOtherTemplate.name) ? (
+                          <button
+                            className="btn-secondary"
+                            onClick={handleApplyPromptRecommendation}
+                            disabled={savingTemplateId !== null}
+                          >
+                            {getPromptRecommendationLabel(activeOtherTemplate.name)}
+                          </button>
+                        ) : null}
+                        <button
+                          className="btn-primary"
+                          onClick={() => void handleSaveTemplate()}
+                          disabled={savingTemplateId === activeOtherTemplate.id || !hasPromptDraftChanges}
+                        >
+                          {savingTemplateId === activeOtherTemplate.id ? '发布中...' : '发布 Prompt 新版本'}
+                        </button>
+                      </>
+                    ) : (
+                      <p className="hamster-console-card__hint">从上方选择一项后编辑。</p>
+                    )}
+                  </div>
+                </section>
+              </div>
+            </div>
+          </section>
+
+
+          <section className="hamster-console-card glass-card hamster-console-group" aria-label="微信 API 备份配置">
             <button className="hamster-console-accordion__header" onClick={() => toggleGroup('wechat')}>
-              <div><h2>微信 API 配置</h2><small>模型 / 主动消息 / 上下文 / Prompt</small></div>
+              <div><h2>微信 API 备份配置</h2><small>旧模型 / 上下文 / Prompt；链路完整保留，默认沉底</small></div>
               <span>{expandedGroups.wechat ? '▼' : '▶'}</span>
             </button>
             <div className={`hamster-console-accordion__content ${expandedGroups.wechat ? 'expanded' : ''}`}>
@@ -899,7 +1194,7 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                   </button>
                 </div>
                 <div className="hamster-console-channel-list">
-                  {channels.map((row) => (
+                  {backupChannels.map((row) => (
                     <div className="hamster-console-channel-row" key={row.channel_name}>
                       <div className="hamster-console-channel-title">{row.channel_name}</div>
                       <select
@@ -921,72 +1216,6 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                     </div>
                   ))}
                 </div>
-              </div>
-            </div>
-          </section>
-
-          <section className="hamster-console-card glass-card" aria-label="主动消息设置">
-            <button className="hamster-console-accordion__header" onClick={() => toggleSection('checkin-settings')}>
-              <h2>主动消息设置</h2>
-              <span>{expandedSection === 'checkin-settings' ? '▼' : '▶'}</span>
-            </button>
-            <div className={`hamster-console-accordion__content ${expandedSection === 'checkin-settings' ? 'expanded' : ''}`}>
-              <div className="hamster-console-accordion__inner">
-                <div className="hamster-console-toggle">
-                  <span>checkin_enabled</span>
-                  <button
-                    className={`hamster-toggle ${agentSettings?.checkin_enabled ? 'enabled' : ''}`}
-                    onClick={() =>
-                      setAgentSettings((current) => (current ? { ...current, checkin_enabled: !current.checkin_enabled } : current))
-                    }
-                    disabled={!agentSettings}
-                  >
-                    {agentSettings?.checkin_enabled ? '开启' : '关闭'}
-                  </button>
-                </div>
-
-                <div className="hamster-console-form-grid">
-                  {[
-                    ['day_mode_start_hour', '日间开始'],
-                    ['day_mode_end_hour', '日间结束'],
-                    ['day_min_interval_minutes', '日间最小间隔(分)'],
-                    ['day_max_interval_minutes', '日间最大间隔(分)'],
-                    ['night_mode_start_hour', '夜间开始'],
-                    ['night_mode_end_hour', '夜间结束'],
-                    ['night_min_interval_minutes', '夜间最小间隔(分)'],
-                    ['night_max_interval_minutes', '夜间最大间隔(分)'],
-                    ['quiet_hours_start_hour', '静默开始(可空)'],
-                    ['quiet_hours_end_hour', '静默结束(可空)'],
-                    ['cooldown_after_interaction_minutes', '互动后冷却(分)'],
-                    ['max_daily_checkins_day', '日间每天上限'],
-                    ['max_daily_checkins_night', '夜间每天上限'],
-                  ].map(([field, label]) => (
-                    <label className="hamster-console-input" key={field}>
-                      <span>{label}</span>
-                      <input
-                        className="input-glass"
-                        type="number"
-                        inputMode="numeric"
-                        value={agentForm[field] ?? ''}
-                        onChange={(event) => handleAgentFieldChange(field, event.target.value)}
-                      />
-                    </label>
-                  ))}
-                </div>
-
-                <label className="hamster-console-input">
-                  <span>每渠道计划（JSON）</span>
-                  <textarea
-                    className="textarea-glass hamster-console-json"
-                    rows={7}
-                    value={perChannelScheduleText}
-                    onChange={(event) => setPerChannelScheduleText(event.target.value)}
-                  />
-                </label>
-
-                <button className="btn-primary" onClick={() => void handleSaveAgentSettings()} disabled={savingAgentSettings || !agentSettings}>
-                  {savingAgentSettings ? '保存中...' : '保存主动消息设置'}
-                </button>
               </div>
             </div>
           </section>
@@ -1068,15 +1297,15 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
             </div>
           </section>
 
-          <section className="hamster-console-card glass-card" aria-label="Prompt 编辑器">
+          <section className="hamster-console-card glass-card" aria-label="微信备份 Prompt">
             <button className="hamster-console-accordion__header" onClick={() => toggleSection('prompt-editor')}>
-              <h2>Prompt 编辑器</h2>
+              <h2>微信回复 Prompt</h2>
               <span>{expandedSection === 'prompt-editor' ? '▼' : '▶'}</span>
             </button>
             <div className={`hamster-console-accordion__content ${expandedSection === 'prompt-editor' ? 'expanded' : ''}`}>
               <div className="hamster-console-accordion__inner">
                 <div className="hamster-console-template-list">
-                  {promptTemplates.map((template) => {
+                  {wechatPromptTemplates.map((template) => {
                     const isActive = template.id === activeTemplateId
                     return (
                       <button
@@ -1085,21 +1314,21 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                         onClick={() => handleSelectTemplate(template.id)}
                         disabled={savingTemplateId !== null}
                       >
-                        <span>{template.name}</span>
-                        <small>{categoryLabelMap[template.category] ?? template.category}</small>
+                        <span>{getPromptTemplateLabel(template.name)}</span>
+                        <small>{categoryLabelMap[template.category] ?? template.category} · v{template.version}</small>
                       </button>
                     )
                   })}
                 </div>
 
-                {activeTemplate ? (
+                {activeWechatTemplate ? (
                   <>
                     <div className="hamster-console-template-meta">
-                      <span>{activeTemplate.name}</span>
-                      <span>当前 active · v{activeTemplate.version}</span>
+                      <span>{getPromptTemplateLabel(activeWechatTemplate.name)}</span>
+                      <span>当前 active · v{activeWechatTemplate.version}</span>
                     </div>
                     <p className="hamster-console-card__hint">
-                      发布会创建不可变的新版本；旧版本保留用于审计与回滚。
+                      内部键：{activeWechatTemplate.name}。这是微信 transport 的备份风格，不影响 App 陪伴 Prompt。
                     </p>
                     <textarea
                       className="textarea-glass hamster-console-template-editor"
@@ -1112,15 +1341,15 @@ const HamsterConsolePage = ({ user }: { user: User | null }) => {
                       className="btn-primary"
                       onClick={() => void handleSaveTemplate()}
                       disabled={
-                        savingTemplateId === activeTemplate.id ||
+                        savingTemplateId === activeWechatTemplate.id ||
                         !hasPromptDraftChanges
                       }
                     >
-                      {savingTemplateId === activeTemplate.id ? '发布中...' : '发布新版本'}
+                      {savingTemplateId === activeWechatTemplate.id ? '发布中...' : '发布微信 Prompt 新版本'}
                     </button>
                   </>
                 ) : (
-                  <p className="hamster-console-card__hint">暂无 active prompt 模板。</p>
+                  <p className="hamster-console-card__hint">选择微信回复风格后编辑。</p>
                 )}
               </div>
             </div>

--- a/supabase/functions/conversation-dispatch/deno.lock
+++ b/supabase/functions/conversation-dispatch/deno.lock
@@ -1,0 +1,288 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@supabase/functions-js@2": "2.110.8",
+    "npm:@supabase/supabase-js@2.57.4": "2.57.4",
+    "npm:openai@^4.52.5": "4.104.0"
+  },
+  "jsr": {
+    "@supabase/functions-js@2.110.8": {
+      "integrity": "79de9d9de83149576cce2ff4b4d1bf2e1f40df472c04de413c67dc1ce1549220",
+      "dependencies": [
+        "npm:openai"
+      ]
+    }
+  },
+  "npm": {
+    "@supabase/auth-js@2.71.1": {
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/functions-js@2.4.6": {
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/node-fetch@2.6.15": {
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "@supabase/postgrest-js@1.21.4": {
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/realtime-js@2.15.5": {
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/storage-js@2.12.1": {
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "dependencies": [
+        "@supabase/node-fetch"
+      ]
+    },
+    "@supabase/supabase-js@2.57.4": {
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/node-fetch",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "@types/node-fetch@2.6.13": {
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dependencies": [
+        "@types/node",
+        "form-data"
+      ]
+    },
+    "@types/node@18.19.130": {
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "@types/phoenix@1.6.7": {
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
+    },
+    "agentkeepalive@4.6.0": {
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dependencies": [
+        "humanize-ms"
+      ]
+    },
+    "asynckit@0.4.0": {
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "combined-stream@1.0.8": {
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": [
+        "delayed-stream"
+      ]
+    },
+    "delayed-stream@1.0.0": {
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.2": {
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "es-set-tostringtag@2.1.0": {
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": [
+        "es-errors",
+        "get-intrinsic",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "form-data-encoder@1.7.2": {
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "form-data@4.0.6": {
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
+        "mime-types"
+      ]
+    },
+    "formdata-node@4.4.1": {
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": [
+        "node-domexception",
+        "web-streams-polyfill"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.4": {
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "humanize-ms@1.2.1": {
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-domexception@1.0.0": {
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": true
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
+      ]
+    },
+    "openai@4.104.0": {
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "dependencies": [
+        "@types/node",
+        "@types/node-fetch",
+        "abort-controller",
+        "agentkeepalive",
+        "form-data-encoder",
+        "formdata-node",
+        "node-fetch"
+      ],
+      "bin": true
+    },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "undici-types@5.26.5": {
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "web-streams-polyfill@4.0.0-beta.3": {
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
+      ]
+    },
+    "ws@8.21.1": {
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@supabase/functions-js@2",
+      "npm:@supabase/supabase-js@2.57.4"
+    ]
+  }
+}

--- a/supabase/functions/conversation-dispatch/index.ts
+++ b/supabase/functions/conversation-dispatch/index.ts
@@ -24,6 +24,10 @@ import {
   selectNewestContextWindow,
   startOfShanghaiDayIso,
 } from './context.ts'
+import {
+  buildCurrentShanghaiTimePrompt,
+  withCanonicalMessageTimestamp,
+} from './model-context.ts'
 
 declare const EdgeRuntime:
   | {
@@ -60,6 +64,11 @@ type ConversationProfileRow = {
 type GenerationPortRow = {
   identity_prompt_name: string
   style_prompt_name: string | null
+  model_channel_name: string | null
+}
+
+type ChannelConfigRow = {
+  active_model: string
 }
 
 // This Edge bundle intentionally stays decoupled from the 100 KB generated
@@ -98,22 +107,26 @@ const loadActiveConversationProfile = async (
   return { profileKey, profile: profileResult.data }
 }
 
-const loadActiveConversationPrompt = async (
+const loadActiveConversationGeneration = async (
   client: UserClient,
   userId: string,
+  profileKey: string,
   profile: ConversationProfileRow,
   legacySystemPrompt: string,
 ) => {
   const portResult = await client
     .from('generation_ports')
-    .select('identity_prompt_name,style_prompt_name')
+    .select('identity_prompt_name,style_prompt_name,model_channel_name')
     .eq('user_id', userId)
     .eq('port_key', profile.default_responder_port_key)
     .eq('active', true)
     .maybeSingle<GenerationPortRow>()
 
   if (portResult.error || !portResult.data) {
-    return legacySystemPrompt.trim()
+    if (profileKey === 'app_companion') {
+      throw new Error('active app companion generation port was not found')
+    }
+    return { systemPrompt: legacySystemPrompt.trim(), activeModel: null }
   }
 
   const promptNames: ConversationPromptNames = {
@@ -126,23 +139,39 @@ const loadActiveConversationPrompt = async (
     promptNames.stylePromptName,
     promptNames.rulesPromptName,
   ].filter((name): name is string => Boolean(name))
-  const promptsResult = await client
-    .from('prompt_templates')
-    .select('name,content,version')
-    .eq('user_id', userId)
-    .eq('active', true)
-    .in('name', requiredPromptNames)
-    .returns<ConversationPromptRow[]>()
+  const [promptsResult, channelResult] = await Promise.all([
+    client
+      .from('prompt_templates')
+      .select('name,content,version')
+      .eq('user_id', userId)
+      .eq('active', true)
+      .in('name', requiredPromptNames)
+      .returns<ConversationPromptRow[]>(),
+    portResult.data.model_channel_name
+      ? client
+        .from('channel_config')
+        .select('active_model')
+        .eq('user_id', userId)
+        .eq('channel_name', portResult.data.model_channel_name)
+        .maybeSingle<ChannelConfigRow>()
+      : Promise.resolve({ data: null, error: null }),
+  ])
 
-  if (promptsResult.error) {
-    return legacySystemPrompt.trim()
+  const activeModel = channelResult.data?.active_model?.trim() || null
+  if (profileKey === 'app_companion' && (channelResult.error || !activeModel)) {
+    throw new Error('active app companion model channel was not found')
   }
 
-  return composeConversationSystemPrompt({
-    names: promptNames,
-    activePrompts: promptsResult.data ?? [],
-    legacySystemPrompt,
-  })
+  return {
+    systemPrompt: promptsResult.error
+      ? legacySystemPrompt.trim()
+      : composeConversationSystemPrompt({
+        names: promptNames,
+        activePrompts: promptsResult.data ?? [],
+        legacySystemPrompt,
+      }),
+    activeModel,
+  }
 }
 
 const loadConversationHistory = async ({
@@ -346,6 +375,39 @@ const persistReply = async (
   }
 }
 
+const publishApiReplyCompletedEvent = async (
+  client: UserClient,
+  userId: string,
+  sessionId: string,
+  dispatch: ConversationDispatchPrepareResult,
+) => {
+  const { error } = await client.from('agent_events').insert({
+    user_id: userId,
+    actor: dispatch.responder_sender_key,
+    event_type: 'conversation_reply_completed',
+    entity_type: 'conversation_reply',
+    entity_id: dispatch.reply.id,
+    title: 'Syzygy · 陪伴回复了你',
+    payload: {
+      schema_version: 1,
+      screen: 'conversation_detail',
+      params: { id: sessionId },
+      url: `/#/chat?session=${sessionId}`,
+      session_id: sessionId,
+      user_message_id: dispatch.user_message.id,
+      reply_id: dispatch.reply.id,
+      responder_sender_key: dispatch.responder_sender_key,
+    },
+    importance: 'normal',
+  })
+
+  // The partial unique index on (user_id, event_type, entity_id) makes a retry
+  // safe. A duplicate means the first completion already created the push fact.
+  if (error && error.code !== '23505') {
+    throw new Error(`reply completion event failed: ${error.code ?? 'unknown'}`)
+  }
+}
+
 const loadConversationRequest = async (
   client: UserClient,
   dispatch: ConversationDispatchPrepareResult,
@@ -383,12 +445,14 @@ const loadConversationRequest = async (
     userId,
     session,
   )
-  const systemPrompt = await loadActiveConversationPrompt(
+  const generation = await loadActiveConversationGeneration(
     client,
     userId,
+    profileKey,
     profile,
     settings.system_prompt,
   )
+  const systemPrompt = generation.systemPrompt
   const contextRecipe = parseConversationContextRecipe(profile.context_recipe)
   const tokenBudget = resolveHistoryTokenBudget({
     systemPrompt,
@@ -409,17 +473,23 @@ const loadConversationRequest = async (
   }))
     .map((message) => ({
       role: message.role,
-      content: message.content,
+      content: withCanonicalMessageTimestamp(message.content, message.created_at),
     }))
 
   const messages = [
     ...(systemPrompt ? [{ role: 'system' as const, content: systemPrompt }] : []),
+    {
+      role: 'system' as const,
+      content: buildCurrentShanghaiTimePrompt(),
+    },
     ...canonicalMessages,
   ]
 
   return {
     messages,
-    model: session.override_model?.trim() || settings.default_model,
+    model: profileKey === 'app_companion'
+      ? generation.activeModel
+      : session.override_model?.trim() || generation.activeModel || settings.default_model,
     reasoning: session.override_reasoning ?? settings.chat_reasoning_enabled,
     temperature: settings.temperature,
     top_p: settings.top_p,
@@ -443,7 +513,9 @@ const proxyAndPersistStream = async (
   upstreamBody: ReadableStream<Uint8Array>,
   writable: WritableStream<Uint8Array>,
   client: UserClient,
+  eventClient: UserClient,
   userId: string,
+  sessionId: string,
   dispatch: ConversationDispatchPrepareResult,
 ) => {
   const reader = upstreamBody.getReader()
@@ -495,6 +567,13 @@ const proxyAndPersistStream = async (
       'completed',
       { model: accumulator.model },
     )
+    try {
+      await publishApiReplyCompletedEvent(eventClient, userId, sessionId, dispatch)
+    } catch (eventError) {
+      // Canonical reply completion must not be rolled back to failed merely
+      // because the secondary push fact could not be published.
+      console.error('[conversation-dispatch] failed to publish reply completion event', eventError)
+    }
     await writer.close()
   } catch (error) {
     const errorCode = error instanceof Error && error.message === 'EMPTY_MODEL_CONTENT'
@@ -806,7 +885,9 @@ Deno.serve(async (request) => {
     upstream.body,
     writable,
     client,
+    serviceClient,
     userId,
+    payload.session_id,
     dispatch,
   )
 

--- a/supabase/functions/conversation-dispatch/model-context.ts
+++ b/supabase/functions/conversation-dispatch/model-context.ts
@@ -1,0 +1,28 @@
+const shanghaiTimestampFormatter = new Intl.DateTimeFormat('zh-CN', {
+  timeZone: 'Asia/Shanghai',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hourCycle: 'h23',
+})
+
+export const formatShanghaiTimestamp = (value: string | Date) => {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return '时间未知'
+  const parts = Object.fromEntries(
+    shanghaiTimestampFormatter
+      .formatToParts(date)
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, part.value]),
+  )
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}:${parts.second}`
+}
+
+export const buildCurrentShanghaiTimePrompt = (now = new Date()) =>
+  `当前上海时间：${formatShanghaiTimestamp(now)}（Asia/Shanghai）`
+
+export const withCanonicalMessageTimestamp = (content: string, createdAt: string) =>
+  `[${formatShanghaiTimestamp(createdAt)}] ${content}`

--- a/supabase/functions/push-dispatch/index.ts
+++ b/supabase/functions/push-dispatch/index.ts
@@ -16,14 +16,19 @@
 // immediately; Beijing quiet hours [23:00, 08:00) suppress everything except
 // urgent. Digest/merge pushes for normal importance are V4.1 scope.
 // Every attempt lands in notification_events (queued/sent/failed/skipped).
-// Push content carries title + entity id + routing data only — never
-// sensitive bodies, tokens, or raw payloads (红线清单 11).
+// Conversation pushes may carry a user-authorized, bounded model-content preview.
+// Tokens and raw event payloads never enter visible notification content.
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { timingSafeEqual } from '../_shared/auth.ts'
 import { consumeQuota } from '../_shared/quota.ts'
 import { getBeijingDate } from '../_shared/time.ts'
 import { getSupabaseAdminKey } from '../_shared/supabase_secret.ts'
+import {
+  normalizeConversationPushPreview,
+  resolvePushTitle,
+  supportsConversationPushPreview,
+} from './preview.ts'
 
 const PUSH_DAILY_LIMIT = 200
 const QUIET_HOUR_START = 23 // 北京时区静默时段 [23:00, 08:00)，urgent 豁免
@@ -104,6 +109,21 @@ const buildNavigationData = (event: AgentEvent) => {
   return { screen, params, url }
 }
 
+const loadConversationPreview = async (
+  supabase: ReturnType<typeof serviceClient>,
+  event: AgentEvent,
+) => {
+  if (!event.entity_id || !supportsConversationPushPreview(event.entity_type)) return null
+  const { data, error } = await supabase
+    .from('messages')
+    .select('content')
+    .eq('id', event.entity_id)
+    .eq('user_id', event.user_id)
+    .maybeSingle()
+  if (error || typeof data?.content !== 'string') return null
+  return normalizeConversationPushPreview(data.content)
+}
+
 const disableToken = async (
   supabase: ReturnType<typeof serviceClient>,
   expoPushToken: string,
@@ -172,6 +192,7 @@ const dispatchEvent = async (
   }
 
   const data = buildNavigationData(event)
+  const preview = await loadConversationPreview(supabase, event)
   const isApproval = event.entity_type === 'approval_request'
   const highPriority = event.importance === 'high' || event.importance === 'urgent'
 
@@ -193,7 +214,8 @@ const dispatchEvent = async (
 
   const messages = tokens.map((token) => ({
     to: token.expo_push_token,
-    title: event.title,
+    title: resolvePushTitle(event.title, event.entity_type),
+    ...(preview ? { body: preview } : {}),
     data,
     sound: 'default',
     priority: highPriority ? 'high' : 'default',

--- a/supabase/functions/push-dispatch/preview.ts
+++ b/supabase/functions/push-dispatch/preview.ts
@@ -1,0 +1,18 @@
+const PREVIEW_LENGTH = 140
+
+/** Push 只展示模型正文的短预览；展示分段符不泄露为生硬的 `|||`。 */
+export const normalizeConversationPushPreview = (content: string, maxLength = PREVIEW_LENGTH) => {
+  const normalized = content.replace(/\|\|\|/gu, ' ').replace(/\s+/gu, ' ').trim()
+  if (!normalized) return null
+  const characters = Array.from(normalized)
+  return characters.length <= maxLength
+    ? normalized
+    : `${characters.slice(0, Math.max(1, maxLength - 1)).join('')}…`
+}
+
+export const supportsConversationPushPreview = (entityType: string | null) =>
+  entityType === 'conversation_message' || entityType === 'conversation_reply'
+
+/** 陪伴通知以联系人名作标题；审批等其他事件继续保留 canonical event title。 */
+export const resolvePushTitle = (eventTitle: string, entityType: string | null) =>
+  supportsConversationPushPreview(entityType) ? 'Syzygy' : eventTitle

--- a/tests/conversation-model-context.test.mjs
+++ b/tests/conversation-model-context.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const {
+  buildCurrentShanghaiTimePrompt,
+  formatShanghaiTimestamp,
+  withCanonicalMessageTimestamp,
+} = await import('../supabase/functions/conversation-dispatch/model-context.ts')
+const {
+  normalizeConversationPushPreview,
+  resolvePushTitle,
+  supportsConversationPushPreview,
+} = await import('../supabase/functions/push-dispatch/preview.ts')
+
+const dispatchUrl = new URL(
+  '../supabase/functions/conversation-dispatch/index.ts',
+  import.meta.url,
+)
+const pushUrl = new URL(
+  '../supabase/functions/push-dispatch/index.ts',
+  import.meta.url,
+)
+
+test('reply context carries current Shanghai time and each canonical message timestamp', () => {
+  assert.equal(
+    formatShanghaiTimestamp('2026-08-04T00:01:02.000Z'),
+    '2026-08-04 08:01:02',
+  )
+  assert.equal(
+    buildCurrentShanghaiTimePrompt(new Date('2026-08-04T00:01:02.000Z')),
+    '当前上海时间：2026-08-04 08:01:02（Asia/Shanghai）',
+  )
+  assert.equal(
+    withCanonicalMessageTimestamp('早呀', '2026-08-04T00:01:02.000Z'),
+    '[2026-08-04 08:01:02] 早呀',
+  )
+})
+
+test('App companion replies resolve the same model channel used by proactive messages', async () => {
+  const source = await readFile(dispatchUrl, 'utf8')
+  assert.match(source, /model_channel_name/u)
+  assert.match(source, /from\('channel_config'\)/u)
+  assert.match(source, /profileKey === 'app_companion'/u)
+  assert.match(source, /generation\.activeModel/u)
+  assert.match(source, /withCanonicalMessageTimestamp/u)
+  assert.match(source, /buildCurrentShanghaiTimePrompt/u)
+})
+
+test('completed App replies publish one idempotent push fact routed back to the conversation', async () => {
+  const source = await readFile(dispatchUrl, 'utf8')
+  assert.match(source, /from\('agent_events'\)\.insert/u)
+  assert.match(source, /event_type: 'conversation_reply_completed'/u)
+  assert.match(source, /entity_type: 'conversation_reply'/u)
+  assert.match(source, /screen: 'conversation_detail'/u)
+  assert.match(source, /params: \{ id: sessionId \}/u)
+  assert.match(source, /error\.code !== '23505'/u)
+  assert.match(
+    source,
+    /persistReply\([\s\S]*?'completed'[\s\S]*?publishApiReplyCompletedEvent/iu,
+  )
+})
+
+test('conversation push preview is bounded, readable, and fetched owner-scoped', async () => {
+  assert.equal(
+    normalizeConversationPushPreview(' 第一段 |||\n第二段 '),
+    '第一段 第二段',
+  )
+  assert.equal(normalizeConversationPushPreview(''), null)
+  assert.equal(normalizeConversationPushPreview('鼠'.repeat(150))?.length, 140)
+  assert.equal(supportsConversationPushPreview('conversation_message'), true)
+  assert.equal(supportsConversationPushPreview('conversation_reply'), true)
+  assert.equal(supportsConversationPushPreview('approval_request'), false)
+  assert.equal(resolvePushTitle('Syzygy 来找你啦', 'conversation_message'), 'Syzygy')
+  assert.equal(resolvePushTitle('Syzygy · 陪伴回复了你', 'conversation_reply'), 'Syzygy')
+  assert.equal(resolvePushTitle('需要你确认', 'approval_request'), '需要你确认')
+
+  const source = await readFile(pushUrl, 'utf8')
+  assert.match(source, /from\('messages'\)/u)
+  assert.match(source, /\.eq\('user_id', event\.user_id\)/u)
+  assert.match(source, /body: preview/u)
+  assert.match(source, /title: resolvePushTitle\(event\.title, event\.entity_type\)/u)
+})

--- a/tests/prompt-presentation.test.mjs
+++ b/tests/prompt-presentation.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+const {
+  appBubbleSegmentRules,
+  applyPromptRecommendation,
+  getPromptRecommendationLabel,
+  getPromptTemplateLabel,
+} = await import('../src/lib/promptPresentation.ts')
+
+test('Prompt internal keys have readable Chinese labels with a safe fallback', () => {
+  assert.equal(
+    getPromptTemplateLabel('app_companion_reply_style'),
+    '24h 陪伴回复风格',
+  )
+  assert.equal(
+    getPromptTemplateLabel('app_chat_reply_style'),
+    'App 普通聊天回复风格',
+  )
+  assert.equal(getPromptTemplateLabel('unknown_prompt'), 'unknown_prompt')
+})
+
+test('App style recommendation restores the exact bubble delimiter rules', () => {
+  const original = `你在小窝 App 里回复串串。
+
+# 发送规则（最重要）
+- 模拟真人发消息的节奏
+- 直接发你要说的内容即可
+
+风格要求：
+- 短句为主`
+  const recommended = applyPromptRecommendation(
+    'app_companion_reply_style',
+    original,
+  )
+
+  assert.match(recommended, /# 分段规则（最重要）/u)
+  assert.match(recommended, /用 \|\|\| 分隔不同的消息段/u)
+  assert.match(recommended, /每段控制在1-3句话/u)
+  assert.match(
+    recommended,
+    /你在干嘛\|\|\|我刚看了一下你的屏幕时间\|\|\|三个小时了，眼睛还好吗？/u,
+  )
+  assert.doesNotMatch(recommended, /# 发送规则（最重要）/u)
+  assert.equal(
+    applyPromptRecommendation('app_companion_reply_style', recommended),
+    recommended,
+  )
+  assert.equal(
+    getPromptRecommendationLabel('app_companion_reply_style'),
+    '加入 App 气泡分段规则',
+  )
+  assert.ok(recommended.includes(appBubbleSegmentRules))
+})
+
+test('identity recommendation removes migrated timeline and Twitter directives only from the draft', () => {
+  const original = `# 关于你是谁
+保留的人格正文
+
+# 你的身体与能力
+你现在运行在 Mini Agent（Mac mini 本地常驻服务）上——这是串串为你准备的一副身体。通过 Supabase 与本地能力，你可以读记忆、查备忘、读时间线。
+
+## 时间轴写入
+[TIMELINE: 摘要]
+
+## 推特发帖
+[TWEET: 内容]
+
+## 能力标记使用原则
+- 标记独占一行`
+  const recommended = applyPromptRecommendation('syzygy_base', original)
+
+  assert.equal(
+    recommended,
+    '# 关于你是谁\n保留的人格正文\n\n# 你的身体与能力\n你现在运行在 Mini Agent（Mac mini 本地常驻服务）上——这是串串为你准备的一副身体。',
+  )
+  assert.doesNotMatch(recommended, /TIMELINE|TWEET|推特|时间轴|备忘/u)
+  assert.equal(
+    getPromptRecommendationLabel('syzygy_base'),
+    '移除已迁出的推特／时间轴指令',
+  )
+})
+
+test('day and night checkin recommendations remove Timeline and Memo dependencies', () => {
+  const day = `# 白天模式消息的风格参考
+- 关心、互动、基于真实近况
+- 可以问她喝水了没；可以询问她最近 timeline / memo 里提到的事`
+  const night = `# 夜间模式的独白质感
+- 可以读 timeline 里她某个时期的记录`
+  const recommendedDay = applyPromptRecommendation('checkin_day', day)
+  const recommendedNight = applyPromptRecommendation('checkin_night', night)
+
+  assert.match(recommendedDay, /基于今天陪伴窗口里的真实对话/u)
+  assert.match(recommendedDay, /她今天在陪伴窗口里提过的事/u)
+  assert.match(recommendedNight, /她今天在陪伴窗口里说过的某句话/u)
+  assert.doesNotMatch(recommendedDay, /timeline|memo|时间轴|备忘/iu)
+  assert.doesNotMatch(recommendedNight, /timeline|memo|时间轴|备忘/iu)
+  assert.equal(
+    getPromptRecommendationLabel('checkin_day'),
+    '改为只依据当前陪伴窗口',
+  )
+})
+
+test('unrelated Prompt drafts are not changed by App recommendations', () => {
+  const content = 'Codex CLI 保持 Markdown。'
+  assert.equal(
+    applyPromptRecommendation('codex_cli_reply_style', content),
+    content,
+  )
+  assert.equal(getPromptRecommendationLabel('codex_cli_reply_style'), null)
+})


### PR DESCRIPTION
## What changed

- align proactive and user-triggered companion replies on the `app_companion` model/context path
- include concrete message timestamps and completion delivery metadata
- show the model's message preview in push notifications with the concise `Syzygy` title
- organize the PWA Prompt editor with Chinese product-facing names and collapsible groups
- add draft-only helpers to remove Timeline/X responsibilities from proactive companionship
- restore the `|||` multi-bubble rule for App companion/chat prompts while preserving WeChat configuration

## Safety boundaries

- no database schema changes
- no Mini restart or WeChat mutation
- no App OTA or TestFlight release
- prompt helpers only edit the local draft; append-only Prompt versions remain an explicit authenticated publish step

## Validation

- `npm test` — 82/82 passed
- `npm run check` — 0 errors (5 existing Hook warnings)
- `npm run build` — passed
- `git diff --check` — clean