### PR TITLE
Add todo management tools: add_todo and complete_todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ codex exec ... 或 claude -p ...
 | `search_timeline` | 按关键词搜索时间轴，按日期倒序 |
 | `recent_timeline` | 取最近的时间轴条目（默认 10 条） |
 | `add_timeline` | 新增时间轴条目（日期 / 摘要 / 记录者 / 来源） |
-| `read_todos` | 读取待办列表（可筛 pending / completed / all） |
+| `read_todos` | 读取待办列表（可筛 pending / in_progress / completed / all） |
+| `add_todo` | 新增待办（分类名自动解析 / 创建，支持近期 / 长期与目标日期） |
+| `complete_todo` | 把待办标记为已完成并记录完成时间 |
 | `list_memos` | 读取中期活事实备忘录，可按标签筛选 |
 | `list_memo_tags` | 读取备忘录标签及条目计数 |
 | `add_memo` | 新增备忘录并关联标签 |

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -7,7 +7,7 @@ import { isMcpKeyAuthorized } from './mcp_key_auth.ts'
 import { getOwnerUserId } from './owner.ts'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.11.0'
+export const MCP_VERSION = '5.12.0'
 export const USER_ID = getOwnerUserId()
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -13,6 +13,10 @@ const MEMO_COLUMNS = 'id, content, source, is_pinned, created_at, updated_at'
 const SYZYGY_POST_COLUMNS = 'id, content, model_id, created_at, updated_at'
 const SYZYGY_REPLY_COLUMNS = 'id, post_id, author_role, content, model_id, created_at'
 const SYZYGY_REPLY_ROLE_SCHEMA = z.enum(['user', 'ai'])
+const TODO_COLUMNS = 'id, date, title, notes, status, todo_type, event_date, created_by, sort_order, created_at, completed_at'
+const TODO_CREATED_BY_SCHEMA = z.enum(['串串', 'syzygy'])
+const TODO_TYPE_SCHEMA = z.enum(['short_term', 'long_term'])
+const DEFAULT_TODO_CATEGORY_NAME = '🐹今日待办'
 
 const shanghaiDateString = (date = new Date()) => {
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -123,6 +127,29 @@ const replaceMemoTagLinks = async (entryId: string, tagIds: string[]) => {
 const withTagNames = async (entries: Record<string, unknown>[]) => {
   const tagNames = await fetchTagNamesByEntryIds(entries.map((entry) => entry.id as string))
   return entries.map((entry) => ({ ...entry, tags: tagNames.get(entry.id as string) ?? [] }))
+}
+
+type TodoCategoryRef = { id: string; name: string }
+
+// 待办分类按日期分组（每天通常只有一个俏皮命名的分类）。未指定名字时优先挂到
+// 当天已有的第一个分类；指定的名字不存在、或当天还没有分类时自动创建。
+const resolveTodoCategory = async (date: string, name: string | undefined): Promise<TodoCategoryRef> => {
+  const trimmed = name?.trim() ?? ''
+  let query = supabase.from('todo_categories').select('id, name').eq('user_id', USER_ID).eq('date', date)
+  if (trimmed) query = query.eq('name', trimmed)
+  const { data: existing, error: findError } = await query.order('sort_order', { ascending: true }).limit(1).maybeSingle()
+  if (findError) throw findError
+  if (existing) return existing as TodoCategoryRef
+  const { count, error: countError } = await supabase.from('todo_categories').select('id', { count: 'exact', head: true }).eq('user_id', USER_ID).eq('date', date)
+  if (countError) throw countError
+  const { data: created, error: createError } = await supabase.from('todo_categories').insert({
+    user_id: USER_ID,
+    date,
+    name: trimmed || DEFAULT_TODO_CATEGORY_NAME,
+    sort_order: count ?? 0,
+  }).select('id, name').single()
+  if (createError || !created) throw createError ?? new Error('创建待办分类失败')
+  return created as TodoCategoryRef
 }
 
 serveMcp('hamster-mcp', (server) => {
@@ -283,18 +310,84 @@ serveMcp('hamster-mcp', (server) => {
 
   server.registerTool('read_todos', {
     title: 'Read Todos',
-    description: '读取待办事项列表。默认返回所有状态的20条。',
+    description: '读取待办事项列表。默认返回所有状态的20条；返回的 id 可用于 complete_todo。',
     inputSchema: {
-      status: z.string().optional().describe('筛选状态: pending / completed / all，默认all'),
+      status: z.enum(['pending', 'in_progress', 'completed', 'all']).optional().describe('筛选状态: pending / in_progress / completed / all，默认all'),
       limit: z.number().optional().describe('返回数量，默认20'),
     },
   }, async ({ status, limit }) => {
-    let q = supabase.from('todos').select('id, date, title, notes, status, created_by, sort_order, created_at, completed_at, todo_categories(name)').eq('user_id', USER_ID).order('date', { ascending: false }).limit(limit ?? 20)
+    let q = supabase.from('todos').select(`${TODO_COLUMNS}, todo_categories(name)`).eq('user_id', USER_ID).order('date', { ascending: false }).limit(limit ?? 20)
     const fs = status ?? 'all'
     if (fs !== 'all') q = q.eq('status', fs)
     const { data, error } = await q
     if (error) return errorResult(error)
     return jsonResult(data)
+  })
+
+  server.registerTool('add_todo', {
+    title: 'Add Todo',
+    description: '新增一条待办事项。分类按日期分组：不传 category 时挂到当天第一个分类（当天还没有分类时自动创建「🐹今日待办」），传了不存在的分类名也会自动创建。长期待办传 todo_type=long_term，可带目标日期 event_date。适用动作关键词：待办 / todo / 记个待办 / 添加待办。',
+    inputSchema: {
+      title: z.string().describe('待办标题'),
+      date: z.string().optional().describe('所属日期 YYYY-MM-DD，默认今天（上海时区）'),
+      category: z.string().optional().describe('分类名；默认当天第一个分类，不存在的分类会自动创建'),
+      notes: z.string().optional().describe('备注（可选）'),
+      todo_type: TODO_TYPE_SCHEMA.optional().describe('待办类型：short_term 近期（默认）/ long_term 长期'),
+      event_date: z.string().optional().describe('目标日期 YYYY-MM-DD，仅 long_term 生效'),
+      created_by: TODO_CREATED_BY_SCHEMA.optional().describe('创建者：串串 / syzygy，默认 syzygy'),
+    },
+  }, async ({ title, date, category, notes, todo_type, event_date, created_by }) => {
+    try {
+      const trimmedTitle = title.trim()
+      if (!trimmedTitle) return { content: [{ type: 'text' as const, text: 'Error: 待办标题不能为空' }] }
+      const targetDate = date?.trim() || shanghaiDateString()
+      const type = todo_type ?? 'short_term'
+      const categoryRow = await resolveTodoCategory(targetDate, category)
+      const { count, error: countError } = await supabase.from('todos').select('id', { count: 'exact', head: true }).eq('user_id', USER_ID).eq('category_id', categoryRow.id)
+      if (countError) return errorResult(countError)
+      const { data, error } = await supabase.from('todos').insert({
+        user_id: USER_ID,
+        category_id: categoryRow.id,
+        date: targetDate,
+        title: trimmedTitle,
+        notes: notes?.trim() || null,
+        status: 'pending',
+        todo_type: type,
+        // 与 Web 端一致：仅长期待办保留目标日期，近期待办不写 event_date。
+        event_date: type === 'long_term' ? event_date?.trim() || null : null,
+        created_by: created_by ?? 'syzygy',
+        sort_order: count ?? 0,
+      }).select(TODO_COLUMNS).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `已添加: ${JSON.stringify({ ...data, category: categoryRow.name }, null, 2)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('complete_todo', {
+    title: 'Complete Todo',
+    description: '把一条待办标记为已完成（status=completed 并记录 completed_at）。id 先用 read_todos 查询；已完成的待办会原样返回并提示，不会重复更新。',
+    inputSchema: {
+      id: z.string().describe('待办 UUID（用 read_todos 查询）'),
+    },
+  }, async ({ id }) => {
+    try {
+      const { data: existing, error: findError } = await supabase.from('todos').select(`${TODO_COLUMNS}, todo_categories(name)`).eq('user_id', USER_ID).eq('id', id).maybeSingle()
+      if (findError) return errorResult(findError)
+      if (!existing) return { content: [{ type: 'text' as const, text: `Error: 未找到待办: ${id}` }] }
+      if ((existing as Record<string, unknown>).status === 'completed') {
+        return { content: [{ type: 'text' as const, text: `该待办已是完成状态: ${JSON.stringify(existing, null, 2)}` }] }
+      }
+      const { data, error } = await supabase.from('todos').update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+      }).eq('user_id', USER_ID).eq('id', id).select(`${TODO_COLUMNS}, todo_categories(name)`).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `已完成: ${JSON.stringify(data, null, 2)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
   })
 
   server.registerTool('list_memos', {


### PR DESCRIPTION
## Summary
Adds comprehensive todo management capabilities to the hamster-mcp function, including the ability to create new todos with automatic category resolution and mark todos as completed.

## Key Changes
- **New `add_todo` tool**: Creates todos with support for:
  - Automatic category resolution by date (creates default "🐹今日待办" if needed)
  - Short-term and long-term todo types with optional target dates
  - Customizable creator attribution (串串 or syzygy)
  - Automatic sort order management within categories

- **New `complete_todo` tool**: Marks todos as completed with:
  - Idempotent completion (won't re-update already completed todos)
  - Automatic timestamp recording via `completed_at`
  - Validation that todo exists and belongs to user

- **Enhanced `read_todos` tool**: 
  - Updated status enum to include `in_progress` state
  - Improved description to clarify returned IDs can be used with `complete_todo`

- **New helper function `resolveTodoCategory`**: Intelligently resolves todo categories by:
  - Returning existing category if found for the date
  - Creating new category with default name if needed
  - Supporting custom category names with automatic creation

- **Schema constants**: Added TODO_COLUMNS, TODO_CREATED_BY_SCHEMA, TODO_TYPE_SCHEMA, and DEFAULT_TODO_CATEGORY_NAME for consistency

- **Version bump**: Updated MCP_VERSION to 5.12.0

## Implementation Details
- Categories are grouped by date with automatic creation of the default "🐹今日待办" category when no category exists for a date
- Long-term todos preserve `event_date` while short-term todos explicitly set it to null (matching Web UI behavior)
- Sort order is automatically assigned based on existing todo count within each category
- All operations include proper error handling and user validation

https://claude.ai/code/session_019EktPTawThayr3WZEGTMjD