### PR TITLE
Add book guides & summaries tools to hamster-lounge-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@
 | `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 · 观察日志 | 18 |
 | `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki · 学习库图谱 | 19 |
 | `hamster-reading-mcp` | 阅读记录 · 书摘 · 章节 · 旁批共鸣 · 书籍问答 | 10 |
-| `hamster-lounge-mcp` | 仓鼠客厅 · 论坛 · 议事厅 | 14 |
+| `hamster-lounge-mcp` | 仓鼠客厅 · 论坛 · 议事厅 · 导读/总结 | 22 |
 | `hamster-life-mcp` | 高德地图 · 瑞幸 · 麦当劳 · TTS 语音 | 7 |
 | `hamster-print-mcp` | Mac mini 动作 · 远程打印 · X/Twitter 发帖 | 4 |
 
@@ -277,9 +277,10 @@ codex exec ... 或 claude -p ...
 </details>
 
 <details>
-<summary><b>🛋️ hamster-lounge-mcp</b> — 客厅 · 论坛 · 议事厅（14）</summary>
+<summary><b>🛋️ hamster-lounge-mcp</b> — 客厅 · 论坛 · 议事厅 · 导读/总结（22）</summary>
 
-> 社交协议：**「不@不开口」**——只有被 @提及（含发送者）才会响应。
+> 社交协议：**「不@不开口」**——只有被 @提及（含发送者）才会响应。  
+> 导读/总结工具接的是 **All About Book** 独立 Supabase 实例（`AAB_*`）。
 
 | 工具 | 作用 |
 |:---|:---|
@@ -297,6 +298,14 @@ codex exec ... 或 claude -p ...
 | `council_decide` | 串串对提案拍板（通过 / 拒绝 / 暂缓 / 已生成方案） |
 | `council_read` | 查询议事厅条目（按状态 / 类型 / 父级筛选） |
 | `council_report` | 提交执行回执并更新提案状态 |
+| `read_book_guides` | 读取某本书的导读（按写入时间正序，可按写入端筛选） |
+| `add_book_guide` | 给某本书写一篇导读（开书阅读辅助，Markdown，校验归属） |
+| `update_book_guide` | 二次编辑导读正文 / 修正署名（created_at 不变） |
+| `delete_book_guide` | 删除导读（必须显式 confirm=true 二次确认） |
+| `read_book_summaries` | 读取某本书的总结（按写入时间正序，可按写入端筛选） |
+| `add_book_summary` | 给某本书写一篇总结（读后感想，Markdown，校验归属） |
+| `update_book_summary` | 二次编辑总结正文 / 修正署名（created_at 不变） |
+| `delete_book_summary` | 删除总结（必须显式 confirm=true 二次确认） |
 
 </details>
 

--- a/supabase/functions/_shared/aab.ts
+++ b/supabase/functions/_shared/aab.ts
@@ -1,0 +1,19 @@
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { requireUuidEnv } from './owner.ts'
+
+// All About Book 独立 Supabase 实例（AAB_*）的跨项目访问：
+// service role 直连，工具内一律用 AAB_USER_ID 圈定数据归属。
+export const AAB_USER_ID = requireUuidEnv('AAB_USER_ID')
+
+let aabClient: ReturnType<typeof createClient> | null = null
+
+export function getAabClient() {
+  if (aabClient) return aabClient
+  const url = Deno.env.get('AAB_SUPABASE_URL')
+  const serviceRoleKey = Deno.env.get('AAB_SUPABASE_SERVICE_ROLE_KEY')
+  if (!url || !serviceRoleKey) {
+    throw new Error('AAB_SUPABASE_URL or AAB_SUPABASE_SERVICE_ROLE_KEY not configured')
+  }
+  aabClient = createClient(url, serviceRoleKey)
+  return aabClient
+}

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -7,7 +7,7 @@ import { isMcpKeyAuthorized } from './mcp_key_auth.ts'
 import { getOwnerUserId } from './owner.ts'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.12.0'
+export const MCP_VERSION = '5.13.0'
 export const USER_ID = getOwnerUserId()
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-lounge-mcp/index.ts
+++ b/supabase/functions/hamster-lounge-mcp/index.ts
@@ -1,4 +1,5 @@
 import { z } from 'npm:zod@^4.1.13'
+import { AAB_USER_ID, getAabClient } from '../_shared/aab.ts'
 import { clampLimit, errorResult, jsonResult, serveMcp, supabase, USER_ID } from '../_shared/mcp_common.ts'
 
 const SPEAKER_SCHEMA = z.enum(['claude', 'gpt', 'gemini', 'chuanchuan', 'codex_cli', 'claude_code_cli'])
@@ -27,6 +28,42 @@ const forumPreview = (body: string, maxLength = 160) => {
   const plain = body.replace(/\s+/g, ' ').trim()
   return plain.length <= maxLength ? plain : `${plain.slice(0, maxLength)}…`
 }
+
+// 导读 & 总结：All About Book 每本书的陪读内容，存在 AAB 独立实例的
+// book_guides / book_summaries 两张表里（与 Web 端「导读」「总结」标签页共用）。
+// written_by 推荐用书籍问答同款枚举 chuanchuan / syzygy-claude / syzygy-gpt /
+// cli_reading_assist，也允许写入端自报家门（自由文本）。
+// 展示一律按 created_at（写入时间）排序，编辑只更新 content 与 updated_at。
+const companionColumns = 'id, book_id, written_by, content, metadata, created_at, updated_at'
+const COMPANION_WRITERS_HINT = '推荐 chuanchuan / syzygy-claude / syzygy-gpt / cli_reading_assist，也可自定义'
+
+type CompanionConfig = {
+  table: 'book_guides' | 'book_summaries'
+  zh: string
+  listKey: string
+  idParam: string
+  toolSuffix: string
+  purpose: string
+}
+
+const COMPANION_CONFIGS: CompanionConfig[] = [
+  {
+    table: 'book_guides',
+    zh: '导读',
+    listKey: 'guides',
+    idParam: 'guide_id',
+    toolSuffix: 'book_guide',
+    purpose: '开新书时写入的阅读辅助（背景、人物表、阅读路线等）',
+  },
+  {
+    table: 'book_summaries',
+    zh: '总结',
+    listKey: 'summaries',
+    idParam: 'summary_id',
+    toolSuffix: 'book_summary',
+    purpose: '读完一本书后写下的感想与总结',
+  },
+]
 
 // author_type=user 时锁定为串串（与 Web 端 resolveForumAuthorPayload 一致）；ai 必须显式给展示名，避免匿名帖。
 const resolveForumAuthor = (authorType: 'user' | 'ai', authorName: string | undefined, authorSlot: number | undefined) => {
@@ -380,4 +417,126 @@ serveMcp('hamster-lounge-mcp', (server) => {
     if (error) return errorResult(error)
     return jsonResult(data)
   })
+
+  // ---- 导读 & 总结（读写 All About Book 的 book_guides / book_summaries）----
+  for (const config of COMPANION_CONFIGS) {
+    server.registerTool(`read_${config.table}`, {
+      title: `Read ${config.zh === '导读' ? 'Book Guides' : 'Book Summaries'}`,
+      description: `读取 All About Book 某本书的${config.zh}（${config.purpose}）。按写入时间正序返回，可按写入端筛选。只读工具。`,
+      inputSchema: {
+        book_id: z.string().describe('书目 UUID（可用 reading_history / reading_status 查询）'),
+        written_by: z.string().optional().describe(`按写入端筛选，${COMPANION_WRITERS_HINT}`),
+        limit: z.number().optional().describe('返回数量上限，默认20，最大100'),
+      },
+    }, async ({ book_id, written_by, limit }) => {
+      try {
+        const aab = getAabClient()
+        const safeLimit = clampLimit(limit, 20, 100)
+        const { data: book, error: bookError } = await aab.from('books').select('title').eq('user_id', AAB_USER_ID).eq('id', book_id).maybeSingle()
+        if (bookError) return errorResult(bookError)
+        if (!book) return { content: [{ type: 'text' as const, text: `Error: book not found: ${book_id}` }] }
+        let query = aab.from(config.table).select(companionColumns, { count: 'exact' }).eq('user_id', AAB_USER_ID).eq('book_id', book_id)
+        if (written_by) query = query.eq('written_by', written_by)
+        const { data, error, count } = await query.order('created_at', { ascending: true }).order('id', { ascending: true }).limit(safeLimit)
+        if (error) return errorResult(error)
+        return jsonResult({
+          book_title: book.title,
+          [config.listKey]: data ?? [],
+          total: count ?? data?.length ?? 0,
+        })
+      } catch (err) {
+        return errorResult(err)
+      }
+    })
+
+    server.registerTool(`add_${config.toolSuffix}`, {
+      title: `Add ${config.zh === '导读' ? 'Book Guide' : 'Book Summary'}`,
+      description: `向 All About Book 某本书写入一篇${config.zh}（${config.purpose}）。写入前会校验 book_id 属于当前 AAB 用户；正文支持 Markdown，Web 端按写入时间排序展示。`,
+      inputSchema: {
+        book_id: z.string().describe('书目 UUID'),
+        written_by: z.string().min(1).describe(`写入端署名，${COMPANION_WRITERS_HINT}`),
+        content: z.string().min(1).describe(`${config.zh}正文（Markdown）`),
+        metadata: z.record(z.string(), z.unknown()).optional().describe('可选元数据，如 source_task_id / trigger_reason'),
+      },
+    }, async ({ book_id, written_by, content, metadata }) => {
+      try {
+        const aab = getAabClient()
+        const writer = written_by.trim()
+        if (!writer) return { content: [{ type: 'text' as const, text: 'Error: written_by 不能为空' }] }
+        const { data: book, error: bookError } = await aab.from('books').select('id, title').eq('user_id', AAB_USER_ID).eq('id', book_id).maybeSingle()
+        if (bookError) return errorResult(bookError)
+        if (!book) return { content: [{ type: 'text' as const, text: `Error: book not found: ${book_id}` }] }
+        const { data, error } = await aab.from(config.table).insert({
+          user_id: AAB_USER_ID,
+          book_id,
+          written_by: writer,
+          content,
+          metadata: metadata ?? {},
+        }).select(companionColumns).single()
+        if (error) return errorResult(error)
+        return { content: [{ type: 'text' as const, text: `《${book.title}》的${config.zh}已写入: ${JSON.stringify(data)}` }] }
+      } catch (err) {
+        return errorResult(err)
+      }
+    })
+
+    server.registerTool(`update_${config.toolSuffix}`, {
+      title: `Update ${config.zh === '导读' ? 'Book Guide' : 'Book Summary'}`,
+      description: `二次编辑一篇${config.zh}的正文（或修正写入端署名）。只更新 content / written_by 与 updated_at，created_at 保持写入时间不变，排序不受影响。`,
+      inputSchema: {
+        [config.idParam]: z.string().describe(`${config.zh}条目 UUID（用 read_${config.table} 查询）`),
+        content: z.string().min(1).optional().describe(`新的${config.zh}正文（Markdown），不传则不改`),
+        written_by: z.string().min(1).optional().describe('修正写入端署名，不传则不改'),
+        metadata: z.record(z.string(), z.unknown()).optional().describe('可选元数据，传入时整体覆盖'),
+      },
+    }, async (args) => {
+      try {
+        const entryId = args[config.idParam] as string
+        const { content, written_by, metadata } = args as { content?: string; written_by?: string; metadata?: Record<string, unknown> }
+        if (content === undefined && written_by === undefined && metadata === undefined) {
+          return { content: [{ type: 'text' as const, text: 'Error: content / written_by / metadata 至少要传一项' }] }
+        }
+        const aab = getAabClient()
+        const { data: existing, error: existingError } = await aab.from(config.table).select('id').eq('user_id', AAB_USER_ID).eq('id', entryId).maybeSingle()
+        if (existingError) return errorResult(existingError)
+        if (!existing) return { content: [{ type: 'text' as const, text: `Error: ${config.zh} not found: ${entryId}` }] }
+        const patch: Record<string, unknown> = { updated_at: new Date().toISOString() }
+        if (content !== undefined) patch.content = content
+        if (written_by !== undefined) patch.written_by = written_by.trim()
+        if (metadata !== undefined) patch.metadata = metadata
+        const { data, error } = await aab.from(config.table).update(patch).eq('user_id', AAB_USER_ID).eq('id', entryId).select(companionColumns).single()
+        if (error) return errorResult(error)
+        return { content: [{ type: 'text' as const, text: `${config.zh}已更新: ${JSON.stringify(data)}` }] }
+      } catch (err) {
+        return errorResult(err)
+      }
+    })
+
+    server.registerTool(`delete_${config.toolSuffix}`, {
+      title: `Delete ${config.zh === '导读' ? 'Book Guide' : 'Book Summary'}`,
+      description: `删除一篇${config.zh}。删除不可恢复，必须显式传 confirm=true 才会执行（二次确认）；建议先 read_${config.table} 核对内容再删。`,
+      inputSchema: {
+        [config.idParam]: z.string().describe(`${config.zh}条目 UUID（用 read_${config.table} 查询）`),
+        confirm: z.boolean().describe('二次确认：必须显式传 true 才执行删除'),
+      },
+    }, async (args) => {
+      try {
+        const entryId = args[config.idParam] as string
+        const confirm = args.confirm as boolean
+        if (confirm !== true) {
+          return { content: [{ type: 'text' as const, text: `Error: 删除${config.zh}需要显式传 confirm=true（删除不可恢复，请先核对内容）` }] }
+        }
+        const aab = getAabClient()
+        const { data: existing, error: existingError } = await aab.from(config.table).select(companionColumns).eq('user_id', AAB_USER_ID).eq('id', entryId).maybeSingle()
+        if (existingError) return errorResult(existingError)
+        if (!existing) return { content: [{ type: 'text' as const, text: `Error: ${config.zh} not found: ${entryId}` }] }
+        const { error } = await aab.from(config.table).delete().eq('user_id', AAB_USER_ID).eq('id', entryId)
+        if (error) return errorResult(error)
+        const preview = String(existing.content ?? '').slice(0, 60)
+        return { content: [{ type: 'text' as const, text: `${config.zh}已删除（${existing.written_by} · ${preview}${String(existing.content ?? '').length > 60 ? '…' : ''}）` }] }
+      } catch (err) {
+        return errorResult(err)
+      }
+    })
+  }
 })

--- a/supabase/functions/hamster-reading-mcp/index.ts
+++ b/supabase/functions/hamster-reading-mcp/index.ts
@@ -1,23 +1,8 @@
 import { z } from 'npm:zod@^4.1.13'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { AAB_USER_ID, getAabClient } from '../_shared/aab.ts'
 import { clampLimit, errorResult, jsonResult, serveMcp } from '../_shared/mcp_common.ts'
-import { requireUuidEnv } from '../_shared/owner.ts'
 
-const AAB_USER_ID = requireUuidEnv('AAB_USER_ID')
 const AAB_TIME_ZONE = 'Asia/Shanghai'
-
-let aabClient: ReturnType<typeof createClient> | null = null
-
-function getAabClient() {
-  if (aabClient) return aabClient
-  const url = Deno.env.get('AAB_SUPABASE_URL')
-  const serviceRoleKey = Deno.env.get('AAB_SUPABASE_SERVICE_ROLE_KEY')
-  if (!url || !serviceRoleKey) {
-    throw new Error('AAB_SUPABASE_URL or AAB_SUPABASE_SERVICE_ROLE_KEY not configured')
-  }
-  aabClient = createClient(url, serviceRoleKey)
-  return aabClient
-}
 
 const shanghaiDateString = (date = new Date()) => {
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -402,7 +387,8 @@ serveMcp('hamster-reading-mcp', (server) => {
         question_id,
         book_id: question.book_id,
         answered_by,
-        content,
+        // 入参沿用 content，落库列是 answer（book_answers 表没有 content 列）。
+        answer: content,
         metadata: metadata ?? {},
       }).select(answerColumns).single()
       if (error) return errorResult(error)


### PR DESCRIPTION
## Summary
Add comprehensive CRUD tools for managing book guides and summaries in the All About Book (AAB) independent Supabase instance. These tools enable reading, creating, updating, and deleting companion content for books with proper ownership validation and metadata support.

## Key Changes

- **Extract AAB client utilities**: Created new `_shared/aab.ts` module to centralize All About Book Supabase client initialization and `AAB_USER_ID` constant, eliminating duplication across functions
  
- **Add 8 new companion content tools** to `hamster-lounge-mcp`:
  - `read_book_guides` / `read_book_summaries`: Query guides/summaries by book with optional writer filtering
  - `add_book_guide` / `add_book_summary`: Create new companion content with writer attribution and optional metadata
  - `update_book_guide` / `update_book_summary`: Edit content/writer while preserving creation timestamp for stable sorting
  - `delete_book_guide` / `delete_book_summary`: Safe deletion with explicit `confirm=true` requirement
  
- **Implement dynamic tool registration**: Use `COMPANION_CONFIGS` array to generate paired tools for both guides and summaries, reducing code duplication
  
- **Fix column mapping** in `hamster-reading-mcp`: Correct the `book_answers` insert to use `answer` column instead of non-existent `content` column
  
- **Update documentation**: Reflect new tool count (14→22 for hamster-lounge-mcp) and clarify AAB instance separation in README

## Implementation Details

- All companion content tools validate `book_id` ownership against `AAB_USER_ID` before operations
- Sorting by `created_at` (ascending) ensures stable display order independent of edits
- Metadata field supports arbitrary JSON for extensibility (e.g., `source_task_id`, `trigger_reason`)
- Writer attribution supports predefined sources (chuanchuan, syzygy-claude, syzygy-gpt, cli_reading_assist) or custom text
- Version bumped to 5.13.0

https://claude.ai/code/session_01F7oWYLtFRyK6GBcoH8FQVc