### PR TITLE
Add Event Collection feature (纪事本末体 thread-based event tracking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Version](https://img.shields.io/badge/Version-v5.3.0-pink?style=flat-square)](#)
 [![License](https://img.shields.io/badge/License-MIT-a3e635?style=flat-square)](./LICENSE)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-82-2dd4bf?style=flat-square)](#-mcp-工具箱全部-82-个)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-88-2dd4bf?style=flat-square)](#-mcp-工具箱全部-88-个)
 [![Edge Functions](https://img.shields.io/badge/Edge_Functions-19-8b5cf6?style=flat-square)](#-后端-edge-functions)
 [![PRs](https://img.shields.io/badge/PRs-1000+-ff69b4?style=flat-square)](#)
 [![PWA](https://img.shields.io/badge/PWA-可装进手机-f59e0b?style=flat-square)](#)
@@ -35,7 +35,7 @@
 |:---:|:---|:---:|
 | 💬 聊天 | 多模型对话 · 角色扮演（RP）· 动态广场 · 悬浮气泡聊天 | ✅ |
 | 📖 阅读 | All About Book 阅读追踪 · 书摘 · Syzygy 旁批共鸣 · 书籍问答 | ✅ |
-| 📝 记录 | 笔记 · 待办 · 时间轴 · 打卡 · 记忆库 · Wiki · 档案 · 知识图谱 | ✅ |
+| 📝 记录 | 笔记 · 待办 · 时间轴 · 事件集 · 打卡 · 记忆库 · Wiki · 档案 · 知识图谱 | ✅ |
 | 🎤 语音 | Syzygy 的声音（ElevenLabs TTS） | ✅ |
 | 🏠 客厅 | 仓鼠客厅 · 异步多 AI 群聊沙发（不@不开口） | ✅ |
 | 🏛️ 议事厅 | Agent Council · 提案 → 评审 → 拍板 → 执行 | ✅ |
@@ -75,6 +75,7 @@
 | `/memo` | 备忘录 | 快速记事、标签过滤、置顶 |
 | `/todo` | 待办 | 日历 + 仪表板双视图，未完成→进行中→完成 |
 | `/timeline` | 时间轴 | 按月记录生活事件，多来源标签 |
+| `/events` `/events/:id` | 事件集 | 纪事本末体：一事一线，当前状态一行 + 按日期追加的条目年表，结项归档 |
 | `/checkin` | 打卡 | 月历视图，统计连续打卡 |
 | `/memory-vault` | 记忆库 | 确认 / 待确认记忆，自动抽取 + 合并 |
 | `/wiki` | 个人 Wiki | 分类、标签、发布状态 |
@@ -105,7 +106,7 @@
 
 | MCP 服务器 | 职责 | 工具数 |
 |:---|:---|:---:|
-| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 · 观察日志 | 20 |
+| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 · 事件集 · 观察日志 | 26 |
 | `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki · 学习库图谱 | 19 |
 | `hamster-reading-mcp` | 阅读记录 · 书摘 · 章节 · 旁批共鸣 · 书籍问答 · 导读/总结 | 18 |
 | `hamster-lounge-mcp` | 仓鼠客厅 · 论坛 · 议事厅 | 14 |
@@ -198,14 +199,14 @@ V4.1 起，两个 CLI 还各自收敛到一个持久的「正史会话」（dual
 
 ---
 
-### 🧰 MCP 工具箱（全部 82 个）
+### 🧰 MCP 工具箱（全部 88 个）
 
 > 每个 MCP 服务器都是一个独立的 Supabase Edge Function，走 JSON-RPC / MCP Streamable HTTP。
 > 鉴权优先使用 `x-hamster-mcp-key` 请求头（timing-safe 比对）或 Supabase Auth Header；`?key=` 仅为旧客户端迁移期兼容，避免新凭证进入 URL / Access Log。
 > 工具清单与计数以 `npm run mcp:inventory` 的输出为准（`--live` 模式直连已部署 server 拿精确清单）；跨工具的共性约定放在各 server 的 MCP `instructions` 里随握手下发，只读 / 危险操作标注在 `annotations`（readOnlyHint / destructiveHint）。
 
 <details open>
-<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed · 备忘录 · 观察日志（20）</summary>
+<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed · 备忘录 · 事件集 · 观察日志（26）</summary>
 
 | 工具 | 作用 |
 |:---|:---|
@@ -225,6 +226,12 @@ V4.1 起，两个 CLI 还各自收敛到一个持久的「正史会话」（dual
 | `add_memo` | 新增备忘录并关联标签 |
 | `update_memo` | 更新备忘录正文、置顶和标签 |
 | `delete_memo` | 物理删除备忘录（需 confirm=true 二次确认） |
+| `list_event_threads` | 读取事件集大类列表（标题 + 一行当前状态），默认只列进行中，开机必读 |
+| `read_event_thread` | 按大类读条目年表（日期正序，可限时间范围），附大类信息 |
+| `add_event_thread` | 新开一条事件线（标题 / 当前状态 / 分组 / 开始日） |
+| `update_event_thread` | 改标题 / 当前状态行 / 分组，或结项 / 重开 |
+| `add_event_entry` | 向事件线追加一条日期 + 事件，可顺手刷新当前状态行 |
+| `update_event_entry` | 修改条目正文 / 日期（仅改错字用） |
 | `list_syzygy_posts` | 列出仓鼠观察日志（朋友圈动态），附回帖数 |
 | `read_syzygy_post` | 读取单条观察日志全文及全部回帖 |
 | `add_syzygy_post` | 发一条观察日志（Syzygy 第一人称随笔，带模型落款） |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,8 @@ import LettersPage from './pages/LettersPage'
 import StoryGroupPage from './pages/StoryGroupPage'
 import MemoPage from './pages/MemoPage'
 import TimelinePage from './pages/TimelinePage'
+import EventCollectionPage from './pages/EventCollectionPage'
+import EventThreadPage from './pages/EventThreadPage'
 import TodoPage from './pages/TodoPage'
 import HamsterConsolePage from './pages/HamsterConsolePage'
 import AgentCouncilPage from './pages/AgentCouncilPage'
@@ -2284,6 +2286,22 @@ const App = () => {
           element={
             <RequireAuth ready={authReady} user={user}>
               <TimelinePage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/events"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <EventCollectionPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/events/:threadId"
+          element={
+            <RequireAuth ready={authReady} user={user}>
+              <EventThreadPage />
             </RequireAuth>
           }
         />

--- a/src/constants/recordSources.ts
+++ b/src/constants/recordSources.ts
@@ -1,0 +1,32 @@
+// 写入端（source）标签：时间轴与事件集共用。source 表示"哪个端写的"，
+// 和 recorder（记录者：串串 / Syzygy）是两个维度。
+
+export const RECORD_SOURCE_META: Record<string, { label: string }> = {
+  frontend: { label: '仓鼠窝前端' },
+  wechat_api: { label: '微信' },
+  client_gpt: { label: '客户端 GPT' },
+  client_claude: { label: '客户端 Claude' },
+  codex_cli: { label: 'Codex CLI' },
+  claude_code_cli: { label: 'Claude Code CLI' },
+  system: { label: '系统' },
+  expo_app: { label: '鼠窝 App' },
+  api: { label: 'API' },
+  // 历史数据里已存在的旧来源值，保留可读标签。
+  claude: { label: 'Claude' },
+  gpt: { label: 'GPT' },
+  gemini: { label: 'Gemini' },
+  user: { label: '手动' },
+}
+
+// 新建 / 编辑表单可选来源（前端约定的来源端）。
+export const RECORD_SOURCE_OPTIONS: string[] = [
+  'frontend',
+  'wechat_api',
+  'client_gpt',
+  'client_claude',
+  'codex_cli',
+  'claude_code_cli',
+  'system',
+]
+
+export const getRecordSourceLabel = (source: string) => RECORD_SOURCE_META[source]?.label ?? source

--- a/src/pages/EventCollection.css
+++ b/src/pages/EventCollection.css
@@ -1,0 +1,747 @@
+/* 事件集：大类列表页 + 大类详情页共用样式，风格对齐备忘录 / 时间轴。 */
+
+.event-page {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 14px 14px 20px;
+  min-height: 100dvh;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  color: #1f2937;
+  position: relative;
+  isolation: isolate;
+  box-sizing: border-box;
+}
+
+.event-page::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(255, 214, 231, 0.34), transparent 42%),
+    radial-gradient(circle at 90% 0%, rgba(255, 239, 246, 0.82), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 254, 0.96) 0%, rgba(253, 245, 249, 0.96) 100%);
+}
+
+/* ── Header ───────────────────────────────────── */
+
+.event-header {
+  position: relative;
+  min-height: 72px;
+  padding: 12px 92px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8px 18px rgba(255, 214, 231, 0.24);
+}
+
+.event-title-wrap {
+  display: grid;
+  gap: 2px;
+  text-align: center;
+  min-width: 0;
+}
+
+.event-kicker {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #b27f98;
+}
+
+.event-header .ui-title {
+  margin: 0;
+  color: #5c5c5c;
+}
+
+.event-detail-title {
+  font-size: 18px;
+  overflow-wrap: anywhere;
+}
+
+.event-header-btn,
+.event-create-btn {
+  position: absolute;
+  top: 14px;
+  border-radius: 999px;
+  border: 1px solid #ffd6e7;
+  background: #fff;
+  color: #7d5d70;
+  padding: 7px 12px;
+  font-size: 13px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.event-header-btn--left { left: 12px; }
+.event-create-btn { right: 12px; }
+
+.event-create-btn {
+  background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%);
+  font-weight: 600;
+}
+
+/* ── Intro / filter card ──────────────────────── */
+
+.event-intro-card {
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 18px;
+  background: #fff;
+  padding: 12px;
+  box-shadow: 0 10px 20px rgba(255, 214, 231, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+.event-intro-dot {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.62) 1.2px, transparent 1.2px);
+  background-size: 16px 16px;
+  opacity: 0.38;
+}
+
+.event-intro-top,
+.event-intro-card .event-chip-list {
+  position: relative;
+  z-index: 1;
+}
+
+.event-intro-top {
+  display: grid;
+  gap: 4px;
+}
+
+.event-intro-top strong {
+  color: #76556c;
+  font-size: 14px;
+}
+
+.event-count {
+  margin-left: 8px;
+  font-size: 12px;
+  font-weight: 400;
+  color: #b28ba1;
+}
+
+.event-intro-hint {
+  margin: 0;
+  font-size: 12px;
+  color: #9a8793;
+}
+
+.event-chip-list {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.event-chip {
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #7c5a70;
+  padding: 6px 11px;
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.event-chip.selected {
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  color: #59354b;
+  border-color: #f8bed9;
+  box-shadow: 0 3px 7px rgba(255, 185, 216, 0.38);
+}
+
+/* ── Notice / Error / Empty ───────────────────── */
+
+.event-notice,
+.event-error {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid;
+  background: #fff;
+  font-size: 12px;
+}
+
+.event-notice {
+  color: #2f7a56;
+  border-color: rgba(126, 211, 167, 0.5);
+}
+
+.event-error {
+  color: #b13f4d;
+  border-color: rgba(255, 181, 192, 0.7);
+}
+
+.event-empty {
+  border: 1px dashed rgba(255, 214, 231, 0.85);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.75);
+  padding: 16px;
+  margin: 0;
+  color: #8f7285;
+  text-align: center;
+}
+
+.event-footnote {
+  margin: 0;
+  font-size: 11px;
+  color: #b28ba1;
+  text-align: center;
+}
+
+/* ── Thread list ──────────────────────────────── */
+
+.event-thread-list {
+  display: grid;
+  gap: 10px;
+}
+
+.event-section-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: #76556c;
+  padding-left: 6px;
+  border-left: 3px solid #ffd6e7;
+}
+
+.event-archive-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  border: 1px dashed rgba(255, 214, 231, 0.9);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 10px 12px;
+  color: #9a7a8c;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.event-thread-list--archive .event-thread-card {
+  opacity: 0.88;
+}
+
+.event-thread-card {
+  border: 1px solid rgba(255, 214, 231, 0.8);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.94);
+  padding: 12px;
+  display: grid;
+  gap: 9px;
+  box-shadow: 0 8px 14px rgba(255, 214, 231, 0.18);
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+  text-align: left;
+}
+
+.event-thread-card:hover,
+.event-thread-card:focus-visible {
+  background: #fffafc;
+  border-color: #f8bed9;
+  outline: none;
+}
+
+.event-thread-card--closed {
+  border-left: 4px solid #d9c4cf;
+  background: rgba(252, 248, 250, 0.94);
+}
+
+.event-thread-card__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.event-thread-card__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: #5a3c4f;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.event-thread-card__emoji {
+  font-size: 15px;
+  flex-shrink: 0;
+}
+
+.event-status-badge {
+  flex-shrink: 0;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid #f2a9cb;
+  background: linear-gradient(180deg, #ffe4f1 0%, #ffd4e8 100%);
+  color: #86335d;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.event-status-badge--closed {
+  border-color: #e4d2db;
+  background: #f5eef2;
+  color: #8c7180;
+}
+
+.event-thread-card__status-wrap {
+  display: grid;
+  gap: 4px;
+}
+
+.event-thread-card__status-label {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: #b27f98;
+}
+
+.event-thread-card__status {
+  margin: 0;
+  color: #4f3f4a;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.event-thread-card__status.clamped,
+.event-entry-card__content.clamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.event-expand-btn {
+  justify-self: start;
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 12px;
+  color: #c06e97;
+  cursor: pointer;
+}
+
+.event-expand-btn:hover {
+  color: #9a4b72;
+  text-decoration: underline;
+}
+
+.event-thread-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 12px;
+  font-size: 12px;
+  color: #9a8793;
+}
+
+.event-thread-card__meta .event-inline-btn {
+  margin-left: auto;
+}
+
+.event-inline-btn {
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 999px;
+  background: #fff;
+  color: #7d5d70;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.event-inline-btn:hover {
+  background: #fff5f9;
+}
+
+.event-inline-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.event-inline-btn--accent {
+  background: linear-gradient(180deg, #ffeef6 0%, #ffe1ef 100%);
+  font-weight: 600;
+}
+
+.event-inline-btn--danger {
+  background: #ffe8ee;
+  color: #9d3e53;
+  border-color: rgba(255, 181, 192, 0.8);
+}
+
+/* ── Thread summary (detail page) ─────────────── */
+
+.event-summary-card {
+  border: 1px solid #f6b6d4;
+  border-left: 4px solid #ef9cc4;
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at 100% 0%, rgba(255, 226, 240, 0.55), transparent 46%),
+    rgba(255, 255, 255, 0.96);
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+  box-shadow: 0 8px 14px rgba(255, 214, 231, 0.18);
+}
+
+.event-summary-card--closed {
+  border-color: #e4d2db;
+  border-left-color: #d9c4cf;
+  background: rgba(252, 248, 250, 0.96);
+}
+
+.event-summary-card__top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  font-size: 12px;
+  color: #8f7285;
+}
+
+.event-summary-card__count {
+  margin-left: auto;
+}
+
+.event-summary-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* ── Entry rail (detail page) ─────────────────── */
+
+.event-entry-list {
+  border: 1px solid rgba(255, 214, 231, 0.88);
+  border-radius: 18px;
+  background: #fff;
+  padding: 14px;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 10px 20px rgba(255, 214, 231, 0.16);
+}
+
+.event-entry-list__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.event-order-toggle {
+  display: inline-flex;
+  padding: 3px;
+  gap: 3px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 231, 0.8);
+  background: rgba(255, 248, 252, 0.95);
+}
+
+.event-order-toggle button {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: #7c5a70;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.event-order-toggle button.active {
+  background: linear-gradient(180deg, #ffdeec 0%, #ffcfe5 100%);
+  color: #59354b;
+  border-color: #f8bed9;
+}
+
+.event-rail {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0;
+}
+
+.event-rail__item {
+  display: grid;
+  grid-template-columns: 104px 1fr;
+  gap: 10px;
+  align-items: start;
+  position: relative;
+  padding-bottom: 12px;
+}
+
+.event-rail__item::before {
+  content: '';
+  position: absolute;
+  left: 95px;
+  top: 14px;
+  bottom: -2px;
+  width: 2px;
+  background: rgba(255, 214, 231, 0.9);
+}
+
+.event-rail__item:last-child::before {
+  display: none;
+}
+
+.event-rail__date {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #76556c;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.event-rail__date--muted {
+  color: #c2a9b7;
+  font-weight: 500;
+}
+
+.event-rail__dot {
+  order: 2;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #f29cc3;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.9);
+  flex-shrink: 0;
+  margin-right: -4px;
+}
+
+.event-rail__date--muted .event-rail__dot {
+  background: #ffd6e7;
+}
+
+.event-entry-card {
+  border: 1px solid rgba(255, 214, 231, 0.8);
+  background: #fff;
+  border-radius: 14px;
+  padding: 10px 12px;
+  display: grid;
+  gap: 6px;
+  box-shadow: 0 2px 8px rgba(255, 214, 231, 0.16);
+  min-width: 0;
+}
+
+.event-entry-card__content {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #4f3f4a;
+  line-height: 1.5;
+}
+
+.event-entry-card__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.event-entry-card__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.event-source-chip {
+  font-size: 11px;
+  font-weight: 600;
+  color: #8a6b7d;
+  background: #fff3f8;
+  border: 1px solid rgba(255, 214, 231, 0.85);
+  border-radius: 999px;
+  padding: 2px 9px;
+  line-height: 1.4;
+}
+
+/* ── Editor modal ─────────────────────────────── */
+
+.event-editor-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(78, 56, 73, 0.34);
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  z-index: 60;
+}
+
+.event-editor {
+  width: min(560px, 100%);
+  max-height: calc(100dvh - 36px);
+  overflow: auto;
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 233, 244, 0.6), transparent 30%),
+    #fff;
+  border: 1px solid rgba(255, 214, 231, 0.9);
+  border-radius: 20px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 14px 28px rgba(255, 214, 231, 0.24);
+  box-sizing: border-box;
+}
+
+.event-editor h2 {
+  margin: 0;
+  color: #68485e;
+  font-size: 18px;
+}
+
+.event-editor label {
+  display: grid;
+  gap: 5px;
+  font-size: 13px;
+  color: #76556c;
+  font-weight: 600;
+}
+
+.event-editor__group strong {
+  font-size: 13px;
+  color: #76556c;
+}
+
+.event-editor__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.event-editor input,
+.event-editor textarea,
+.event-editor select {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  box-sizing: border-box;
+  border-radius: 12px;
+  border: 1px solid #f7c6dd;
+  padding: 10px;
+  font: inherit;
+  font-weight: 400;
+  color: #4f3f4a;
+  background: #fffafd;
+}
+
+.event-editor input[type='date'] {
+  min-height: 42px;
+}
+
+.event-editor textarea {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 28px,
+    rgba(255, 214, 231, 0.35) 28px,
+    rgba(255, 214, 231, 0.35) 30px
+  );
+}
+
+.event-editor input:focus,
+.event-editor textarea:focus,
+.event-editor select:focus {
+  outline: none;
+  border-color: #f5b3d2;
+  box-shadow: 0 0 0 2px rgba(255, 214, 231, 0.35);
+}
+
+.event-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.event-editor__actions button {
+  border-radius: 10px;
+  border: 1px solid #ffd6e7;
+  padding: 7px 12px;
+  cursor: pointer;
+}
+
+.event-editor__actions .secondary {
+  background: #fff;
+  color: #7d5d70;
+}
+
+.event-editor__actions .danger {
+  background: #ffe8ee;
+  color: #9d3e53;
+}
+
+.event-editor__actions .primary {
+  background: linear-gradient(180deg, #ffdcec 0%, #ffcfe5 100%);
+  color: #5a3448;
+  font-weight: 600;
+}
+
+.event-editor__actions button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* ── Responsive ───────────────────────────────── */
+
+@media (max-width: 560px) {
+  .event-page {
+    padding: 12px;
+  }
+
+  .event-header {
+    min-height: 72px;
+    padding: 12px 76px;
+  }
+
+  .event-header-btn,
+  .event-create-btn {
+    top: 14px;
+    padding: 6px 10px;
+    font-size: 12px;
+  }
+
+  .event-rail__item {
+    grid-template-columns: 92px 1fr;
+    gap: 8px;
+  }
+
+  .event-rail__item::before {
+    left: 83px;
+  }
+
+  .event-rail__date {
+    font-size: 11px;
+  }
+
+  .event-entry-list__top {
+    flex-wrap: wrap;
+  }
+}

--- a/src/pages/EventCollectionPage.tsx
+++ b/src/pages/EventCollectionPage.tsx
@@ -1,0 +1,422 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent, type MouseEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { EventThread, EventThreadStatus } from '../types'
+import {
+  createEventThread,
+  deleteEventThread,
+  listEventEntryCounts,
+  listEventThreads,
+  updateEventThread,
+} from '../storage/supabaseSync'
+import ConfirmDialog from '../components/ConfirmDialog'
+import { formatLocalTimestamp } from '../utils/time'
+import {
+  EVENT_GROUP_OPTIONS,
+  formatDateRange,
+  getTodayDateKey,
+  isLongText,
+} from './eventCollectionShared'
+import './EventCollection.css'
+
+type ThreadEditorState = {
+  mode: 'create' | 'edit'
+  threadId?: string
+  title: string
+  currentStatus: string
+  emojiGroup: string | null
+  status: EventThreadStatus
+  startedOn: string
+  endedOn: string
+}
+
+type ThreadStats = Map<string, { count: number; lastEntryDate: string | null }>
+
+const buildEditorState = (thread?: EventThread): ThreadEditorState => ({
+  mode: thread ? 'edit' : 'create',
+  threadId: thread?.id,
+  title: thread?.title ?? '',
+  currentStatus: thread?.currentStatus ?? '',
+  emojiGroup: thread?.emojiGroup ?? null,
+  status: thread?.status ?? 'active',
+  startedOn: thread?.startedOn ?? getTodayDateKey(),
+  endedOn: thread?.endedOn ?? '',
+})
+
+const EventCollectionPage = () => {
+  const navigate = useNavigate()
+  const [threads, setThreads] = useState<EventThread[]>([])
+  const [stats, setStats] = useState<ThreadStats>(new Map())
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [editor, setEditor] = useState<ThreadEditorState | null>(null)
+  const [groupFilter, setGroupFilter] = useState<string | null>(null)
+  const [archiveOpen, setArchiveOpen] = useState(false)
+  const [expandedIds, setExpandedIds] = useState<string[]>([])
+  const [pendingDelete, setPendingDelete] = useState<EventThread | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [nextThreads, nextStats] = await Promise.all([listEventThreads(), listEventEntryCounts()])
+      setThreads(nextThreads)
+      setStats(nextStats)
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载事件集失败', loadError)
+      setError('加载事件集失败，请稍后重试')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const filteredThreads = useMemo(
+    () => (groupFilter ? threads.filter((thread) => thread.emojiGroup === groupFilter) : threads),
+    [groupFilter, threads],
+  )
+  const activeThreads = useMemo(() => filteredThreads.filter((thread) => thread.status === 'active'), [filteredThreads])
+  const closedThreads = useMemo(() => filteredThreads.filter((thread) => thread.status === 'closed'), [filteredThreads])
+  const activeCount = useMemo(() => threads.filter((thread) => thread.status === 'active').length, [threads])
+  const closedCount = threads.length - activeCount
+
+  const toggleExpanded = (event: MouseEvent, threadId: string) => {
+    event.stopPropagation()
+    setExpandedIds((current) =>
+      current.includes(threadId) ? current.filter((id) => id !== threadId) : [...current, threadId],
+    )
+  }
+
+  const openEditor = (event: MouseEvent, thread: EventThread) => {
+    event.stopPropagation()
+    setEditor(buildEditorState(thread))
+  }
+
+  const handleSave = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!editor) {
+      return
+    }
+    const title = editor.title.trim()
+    if (!title) {
+      setError('标题不能为空')
+      return
+    }
+    if (!editor.startedOn) {
+      setError('请选择开始日期')
+      return
+    }
+    setSaving(true)
+    try {
+      if (editor.mode === 'create') {
+        await createEventThread({
+          title,
+          currentStatus: editor.currentStatus.trim(),
+          emojiGroup: editor.emojiGroup,
+          startedOn: editor.startedOn,
+        })
+        setNotice('事件线已开')
+      } else if (editor.threadId) {
+        const closed = editor.status === 'closed'
+        await updateEventThread(editor.threadId, {
+          title,
+          currentStatus: editor.currentStatus.trim(),
+          emojiGroup: editor.emojiGroup,
+          status: editor.status,
+          startedOn: editor.startedOn,
+          endedOn: closed ? editor.endedOn || getTodayDateKey() : null,
+        })
+        setNotice('事件线已更新')
+      }
+      setEditor(null)
+      setError(null)
+      await refresh()
+    } catch (saveError) {
+      console.warn('保存事件线失败', saveError)
+      setError('保存失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const requestDelete = () => {
+    if (!editor?.threadId) {
+      return
+    }
+    const target = threads.find((thread) => thread.id === editor.threadId)
+    if (target) {
+      setPendingDelete(target)
+    }
+  }
+
+  const confirmDelete = async () => {
+    if (!pendingDelete || saving) {
+      return
+    }
+    setSaving(true)
+    try {
+      await deleteEventThread(pendingDelete.id)
+      setPendingDelete(null)
+      setEditor(null)
+      setNotice('事件线已删除')
+      setError(null)
+      await refresh()
+    } catch (deleteError) {
+      console.warn('删除事件线失败', deleteError)
+      setError('删除失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const renderThreadCard = (thread: EventThread) => {
+    const stat = stats.get(thread.id)
+    const expanded = expandedIds.includes(thread.id)
+    const hasStatus = thread.currentStatus.trim().length > 0
+    const clampable = hasStatus && isLongText(thread.currentStatus)
+    const closed = thread.status === 'closed'
+    return (
+      <article
+        key={thread.id}
+        className={closed ? 'event-thread-card event-thread-card--closed' : 'event-thread-card'}
+        onClick={() => navigate(`/events/${thread.id}`)}
+        role="link"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            navigate(`/events/${thread.id}`)
+          }
+        }}
+      >
+        <div className="event-thread-card__top">
+          <h3 className="event-thread-card__title">
+            {thread.emojiGroup ? <span className="event-thread-card__emoji">{thread.emojiGroup}</span> : null}
+            {thread.title}
+          </h3>
+          <span className={closed ? 'event-status-badge event-status-badge--closed' : 'event-status-badge'}>
+            {closed ? '已结束' : '进行中'}
+          </span>
+        </div>
+        <div className="event-thread-card__status-wrap">
+          <span className="event-thread-card__status-label">当前状态</span>
+          <p className={clampable && !expanded ? 'event-thread-card__status clamped' : 'event-thread-card__status'}>
+            {hasStatus ? thread.currentStatus : '（还没写当前状态）'}
+          </p>
+          {clampable ? (
+            <button type="button" className="event-expand-btn" onClick={(event) => toggleExpanded(event, thread.id)}>
+              {expanded ? '收起 ▲' : '展开全文 ▼'}
+            </button>
+          ) : null}
+        </div>
+        <div className="event-thread-card__meta">
+          <span>{formatDateRange(thread)}</span>
+          <span>{stat?.count ?? 0} 条</span>
+          {stat?.lastEntryDate ? <span>最近 {stat.lastEntryDate}</span> : null}
+          <button type="button" className="event-inline-btn" onClick={(event) => openEditor(event, thread)}>
+            编辑
+          </button>
+        </div>
+      </article>
+    )
+  }
+
+  return (
+    <div className="event-page">
+      <header className="event-header">
+        <button type="button" className="ghost event-header-btn event-header-btn--left" onClick={() => navigate(-1)}>
+          ← 返回
+        </button>
+        <div className="event-title-wrap">
+          <p className="event-kicker">Event Chronicle</p>
+          <h1 className="ui-title">事件集</h1>
+        </div>
+        <button type="button" className="event-create-btn" onClick={() => setEditor(buildEditorState())}>
+          + 新建
+        </button>
+      </header>
+
+      <section className="event-intro-card" aria-label="事件集说明与筛选">
+        <div className="event-intro-dot" aria-hidden="true" />
+        <div className="event-intro-top">
+          <strong>
+            线程进事件集
+            <span className="event-count">
+              进行中 {activeCount} · 已结束 {closedCount}
+            </span>
+          </strong>
+          <p className="event-intro-hint">一件正在进行的事开一条线，进度按日期追加；结项归档，不删。</p>
+        </div>
+        <div className="event-chip-list">
+          <button
+            type="button"
+            className={groupFilter === null ? 'event-chip selected' : 'event-chip'}
+            onClick={() => setGroupFilter(null)}
+          >
+            全部
+          </button>
+          {EVENT_GROUP_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={groupFilter === option.value ? 'event-chip selected' : 'event-chip'}
+              onClick={() => setGroupFilter((current) => (current === option.value ? null : option.value))}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {notice ? <p className="event-notice">{notice}</p> : null}
+      {error ? <p className="event-error">{error}</p> : null}
+
+      <section className="event-thread-list" aria-label="进行中的事件线">
+        <h2 className="event-section-title">进行中</h2>
+        {loading ? <p className="tips">加载中…</p> : null}
+        {!loading && activeThreads.length === 0 ? (
+          <p className="tips event-empty">
+            {threads.length === 0 ? '还没有事件线，点击右上角开第一条吧。' : '当前筛选下没有进行中的事件线。'}
+          </p>
+        ) : null}
+        {activeThreads.map(renderThreadCard)}
+      </section>
+
+      {!loading && closedThreads.length > 0 ? (
+        <section className="event-thread-list event-thread-list--archive" aria-label="已结束的事件线">
+          <button
+            type="button"
+            className="event-archive-toggle"
+            onClick={() => setArchiveOpen((current) => !current)}
+            aria-expanded={archiveOpen}
+          >
+            <span className="event-section-title">已结束 · {closedThreads.length}</span>
+            <span>{archiveOpen ? '收起 ▲' : '展开 ▼'}</span>
+          </button>
+          {archiveOpen ? closedThreads.map(renderThreadCard) : null}
+        </section>
+      ) : null}
+
+      {editor ? (
+        <div className="event-editor-backdrop" role="dialog" aria-modal="true" aria-label="事件线编辑">
+          <form className="event-editor" onSubmit={handleSave}>
+            <h2>{editor.mode === 'create' ? '新开事件线' : '编辑事件线'}</h2>
+            <label>
+              标题
+              <input
+                type="text"
+                value={editor.title}
+                onChange={(event) => setEditor({ ...editor, title: event.target.value })}
+                placeholder="一件正在进行的事，如「荣格阶段」"
+                required
+              />
+            </label>
+            <label>
+              当前状态（一行）
+              <textarea
+                rows={3}
+                value={editor.currentStatus}
+                onChange={(event) => setEditor({ ...editor, currentStatus: event.target.value })}
+                placeholder="各端开机只读这一行，写成能一眼看懂的现状"
+              />
+            </label>
+            <div className="event-editor__group">
+              <strong>分组</strong>
+              <div className="event-chip-list">
+                <button
+                  type="button"
+                  className={editor.emojiGroup === null ? 'event-chip selected' : 'event-chip'}
+                  onClick={() => setEditor({ ...editor, emojiGroup: null })}
+                >
+                  无
+                </button>
+                {EVENT_GROUP_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={editor.emojiGroup === option.value ? 'event-chip selected' : 'event-chip'}
+                    onClick={() => setEditor({ ...editor, emojiGroup: option.value })}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="event-editor__row">
+              <label>
+                开始日期
+                <input
+                  type="date"
+                  value={editor.startedOn}
+                  onChange={(event) => setEditor({ ...editor, startedOn: event.target.value })}
+                  required
+                />
+              </label>
+              {editor.mode === 'edit' ? (
+                <label>
+                  状态
+                  <select
+                    value={editor.status}
+                    onChange={(event) => setEditor({ ...editor, status: event.target.value as EventThreadStatus })}
+                  >
+                    <option value="active">进行中</option>
+                    <option value="closed">已结束</option>
+                  </select>
+                </label>
+              ) : null}
+            </div>
+            {editor.mode === 'edit' && editor.status === 'closed' ? (
+              <label>
+                结束日期
+                <input
+                  type="date"
+                  value={editor.endedOn}
+                  onChange={(event) => setEditor({ ...editor, endedOn: event.target.value })}
+                />
+              </label>
+            ) : null}
+
+            <div className="event-editor__actions">
+              <button type="button" className="secondary" onClick={() => setEditor(null)} disabled={saving}>
+                取消
+              </button>
+              {editor.mode === 'edit' ? (
+                <button type="button" className="danger" onClick={requestDelete} disabled={saving}>
+                  删除
+                </button>
+              ) : null}
+              <button type="submit" className="primary" disabled={saving || !editor.title.trim()}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="删除这条事件线？"
+        description={
+          pendingDelete
+            ? `「${pendingDelete.title}」及其全部 ${stats.get(pendingDelete.id)?.count ?? 0} 条条目将被彻底删除，无法恢复。结项归档不需要删除，只需把状态改为已结束。`
+            : undefined
+        }
+        confirmLabel="彻底删除"
+        confirmDisabled={saving}
+        cancelDisabled={saving}
+        onConfirm={() => void confirmDelete()}
+        onCancel={() => setPendingDelete(null)}
+      />
+
+      {!loading && threads.length > 0 ? (
+        <p className="event-footnote">最近活动：{formatLocalTimestamp(threads[0].updatedAt)}</p>
+      ) : null}
+    </div>
+  )
+}
+
+export default EventCollectionPage

--- a/src/pages/EventThreadPage.tsx
+++ b/src/pages/EventThreadPage.tsx
@@ -1,0 +1,531 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import type { EventEntry, EventThread } from '../types'
+import {
+  createEventEntry,
+  deleteEventEntry,
+  deleteEventThread,
+  fetchEventThread,
+  listEventEntries,
+  updateEventEntry,
+  updateEventThread,
+} from '../storage/supabaseSync'
+import ConfirmDialog from '../components/ConfirmDialog'
+import { RECORD_SOURCE_OPTIONS, getRecordSourceLabel } from '../constants/recordSources'
+import {
+  EVENT_GROUP_OPTIONS,
+  formatDateRange,
+  getTodayDateKey,
+  isLongText,
+  readStoredEntryOrder,
+  storeEntryOrder,
+  type EntryOrder,
+} from './eventCollectionShared'
+import './EventCollection.css'
+
+type EntryEditorState = {
+  mode: 'create' | 'edit'
+  entryId?: string
+  entryDate: string
+  content: string
+  source: string
+}
+
+type ThreadEditorState = {
+  title: string
+  currentStatus: string
+  emojiGroup: string | null
+  startedOn: string
+  endedOn: string
+}
+
+const DEFAULT_SOURCE = 'frontend'
+
+const buildEntryEditor = (entry?: EventEntry): EntryEditorState => ({
+  mode: entry ? 'edit' : 'create',
+  entryId: entry?.id,
+  entryDate: entry?.entryDate ?? getTodayDateKey(),
+  content: entry?.content ?? '',
+  source: entry?.source ?? DEFAULT_SOURCE,
+})
+
+const buildThreadEditor = (thread: EventThread): ThreadEditorState => ({
+  title: thread.title,
+  currentStatus: thread.currentStatus,
+  emojiGroup: thread.emojiGroup,
+  startedOn: thread.startedOn,
+  endedOn: thread.endedOn ?? '',
+})
+
+type PendingDelete = { kind: 'entry'; entry: EventEntry } | { kind: 'thread' } | null
+
+const EventThreadPage = () => {
+  const navigate = useNavigate()
+  const { threadId } = useParams<{ threadId: string }>()
+  const [thread, setThread] = useState<EventThread | null>(null)
+  const [entries, setEntries] = useState<EventEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [missing, setMissing] = useState(false)
+  const [order, setOrder] = useState<EntryOrder>(() => readStoredEntryOrder())
+  const [statusExpanded, setStatusExpanded] = useState(false)
+  const [expandedEntryIds, setExpandedEntryIds] = useState<string[]>([])
+  const [entryEditor, setEntryEditor] = useState<EntryEditorState | null>(null)
+  const [threadEditor, setThreadEditor] = useState<ThreadEditorState | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete>(null)
+
+  const refresh = useCallback(async () => {
+    if (!threadId) {
+      setMissing(true)
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    try {
+      const [nextThread, nextEntries] = await Promise.all([fetchEventThread(threadId), listEventEntries(threadId)])
+      if (!nextThread) {
+        setMissing(true)
+        setThread(null)
+        setEntries([])
+      } else {
+        setMissing(false)
+        setThread(nextThread)
+        setEntries(nextEntries)
+      }
+      setError(null)
+    } catch (loadError) {
+      console.warn('加载事件线失败', loadError)
+      setError('加载事件线失败，请稍后重试')
+    } finally {
+      setLoading(false)
+    }
+  }, [threadId])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const orderedEntries = useMemo(() => (order === 'asc' ? entries : [...entries].reverse()), [entries, order])
+
+  const changeOrder = (next: EntryOrder) => {
+    setOrder(next)
+    storeEntryOrder(next)
+  }
+
+  const toggleEntryExpanded = (entryId: string) => {
+    setExpandedEntryIds((current) =>
+      current.includes(entryId) ? current.filter((id) => id !== entryId) : [...current, entryId],
+    )
+  }
+
+  const handleSaveEntry = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!entryEditor || !threadId) {
+      return
+    }
+    const content = entryEditor.content.trim()
+    if (!entryEditor.entryDate) {
+      setError('请选择日期')
+      return
+    }
+    if (!content) {
+      setError('事件正文不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      if (entryEditor.mode === 'create') {
+        await createEventEntry({
+          threadId,
+          entryDate: entryEditor.entryDate,
+          content,
+          source: entryEditor.source,
+        })
+        setNotice('条目已追加')
+      } else if (entryEditor.entryId) {
+        await updateEventEntry(entryEditor.entryId, {
+          entryDate: entryEditor.entryDate,
+          content,
+          source: entryEditor.source,
+        })
+        setNotice('条目已更新')
+      }
+      setEntryEditor(null)
+      setError(null)
+      await refresh()
+    } catch (saveError) {
+      console.warn('保存条目失败', saveError)
+      setError('保存失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSaveThread = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!threadEditor || !thread) {
+      return
+    }
+    const title = threadEditor.title.trim()
+    if (!title) {
+      setError('标题不能为空')
+      return
+    }
+    setSaving(true)
+    try {
+      await updateEventThread(thread.id, {
+        title,
+        currentStatus: threadEditor.currentStatus.trim(),
+        emojiGroup: threadEditor.emojiGroup,
+        startedOn: threadEditor.startedOn,
+        endedOn: thread.status === 'closed' ? threadEditor.endedOn || getTodayDateKey() : null,
+      })
+      setThreadEditor(null)
+      setNotice('事件线已更新')
+      setError(null)
+      await refresh()
+    } catch (saveError) {
+      console.warn('保存事件线失败', saveError)
+      setError('保存失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const toggleClosed = async () => {
+    if (!thread || saving) {
+      return
+    }
+    setSaving(true)
+    try {
+      if (thread.status === 'closed') {
+        await updateEventThread(thread.id, { status: 'active', endedOn: null })
+        setNotice('事件线已重开')
+      } else {
+        await updateEventThread(thread.id, { status: 'closed', endedOn: getTodayDateKey() })
+        setNotice('事件线已结项，归档可见')
+      }
+      setError(null)
+      await refresh()
+    } catch (toggleError) {
+      console.warn('切换事件线状态失败', toggleError)
+      setError('操作失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const confirmDelete = async () => {
+    if (!pendingDelete || !thread || saving) {
+      return
+    }
+    setSaving(true)
+    try {
+      if (pendingDelete.kind === 'entry') {
+        await deleteEventEntry(pendingDelete.entry.id)
+        setPendingDelete(null)
+        setEntryEditor(null)
+        setNotice('条目已删除')
+        setError(null)
+        await refresh()
+      } else {
+        await deleteEventThread(thread.id)
+        setPendingDelete(null)
+        navigate('/events', { replace: true })
+      }
+    } catch (deleteError) {
+      console.warn('删除失败', deleteError)
+      setError('删除失败，请稍后重试')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const closed = thread?.status === 'closed'
+  const statusText = thread?.currentStatus.trim() ?? ''
+  const statusClampable = statusText.length > 0 && isLongText(statusText)
+
+  return (
+    <div className="event-page">
+      <header className="event-header">
+        <button type="button" className="ghost event-header-btn event-header-btn--left" onClick={() => navigate('/events')}>
+          ← 事件集
+        </button>
+        <div className="event-title-wrap">
+          <p className="event-kicker">Event Thread</p>
+          <h1 className="ui-title event-detail-title">
+            {thread?.emojiGroup ? <span className="event-thread-card__emoji">{thread.emojiGroup}</span> : null}
+            {thread?.title ?? (loading ? '加载中…' : '事件线')}
+          </h1>
+        </div>
+        {thread ? (
+          <button type="button" className="event-create-btn" onClick={() => setEntryEditor(buildEntryEditor())}>
+            + 记一条
+          </button>
+        ) : null}
+      </header>
+
+      {notice ? <p className="event-notice">{notice}</p> : null}
+      {error ? <p className="event-error">{error}</p> : null}
+
+      {loading ? <p className="tips">加载中…</p> : null}
+      {!loading && missing ? <p className="tips event-empty">找不到这条事件线，可能已被删除。</p> : null}
+
+      {thread ? (
+        <section className={closed ? 'event-summary-card event-summary-card--closed' : 'event-summary-card'} aria-label="事件线概览">
+          <div className="event-summary-card__top">
+            <span className={closed ? 'event-status-badge event-status-badge--closed' : 'event-status-badge'}>
+              {closed ? '已结束' : '进行中'}
+            </span>
+            <span className="event-summary-card__range">{formatDateRange(thread)}</span>
+            <span className="event-summary-card__count">{entries.length} 条</span>
+          </div>
+          <div className="event-thread-card__status-wrap">
+            <span className="event-thread-card__status-label">当前状态</span>
+            <p className={statusClampable && !statusExpanded ? 'event-thread-card__status clamped' : 'event-thread-card__status'}>
+              {statusText || '（还没写当前状态，点「编辑」补一行）'}
+            </p>
+            {statusClampable ? (
+              <button type="button" className="event-expand-btn" onClick={() => setStatusExpanded((current) => !current)}>
+                {statusExpanded ? '收起 ▲' : '展开全文 ▼'}
+              </button>
+            ) : null}
+          </div>
+          <div className="event-summary-card__actions">
+            <button type="button" className="event-inline-btn" onClick={() => setThreadEditor(buildThreadEditor(thread))} disabled={saving}>
+              编辑
+            </button>
+            <button type="button" className="event-inline-btn event-inline-btn--accent" onClick={() => void toggleClosed()} disabled={saving}>
+              {closed ? '重开' : '结项'}
+            </button>
+            <button type="button" className="event-inline-btn event-inline-btn--danger" onClick={() => setPendingDelete({ kind: 'thread' })} disabled={saving}>
+              删除
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {thread ? (
+        <section className="event-entry-list" aria-label="条目时间轴">
+          <div className="event-entry-list__top">
+            <h2 className="event-section-title">条目</h2>
+            <div className="event-order-toggle" role="group" aria-label="排序">
+              <button type="button" className={order === 'asc' ? 'active' : ''} onClick={() => changeOrder('asc')}>
+                从起到结
+              </button>
+              <button type="button" className={order === 'desc' ? 'active' : ''} onClick={() => changeOrder('desc')}>
+                最新在上
+              </button>
+            </div>
+          </div>
+          {entries.length === 0 ? (
+            <p className="tips event-empty">还没有条目，点右上角「记一条」写下第一笔。</p>
+          ) : (
+            <ol className="event-rail">
+              {orderedEntries.map((entry, index) => {
+                const previous = orderedEntries[index - 1]
+                const sameDateAsPrevious = previous?.entryDate === entry.entryDate
+                const expanded = expandedEntryIds.includes(entry.id)
+                const clampable = isLongText(entry.content)
+                return (
+                  <li key={entry.id} className="event-rail__item">
+                    <div className={sameDateAsPrevious ? 'event-rail__date event-rail__date--muted' : 'event-rail__date'}>
+                      <span className="event-rail__dot" aria-hidden="true" />
+                      <time dateTime={entry.entryDate}>{sameDateAsPrevious ? '同日' : entry.entryDate}</time>
+                    </div>
+                    <article className="event-entry-card">
+                      <p className={clampable && !expanded ? 'event-entry-card__content clamped' : 'event-entry-card__content'}>
+                        {entry.content}
+                      </p>
+                      <div className="event-entry-card__foot">
+                        {clampable ? (
+                          <button type="button" className="event-expand-btn" onClick={() => toggleEntryExpanded(entry.id)}>
+                            {expanded ? '收起 ▲' : '展开全文 ▼'}
+                          </button>
+                        ) : (
+                          <span />
+                        )}
+                        <span className="event-entry-card__meta">
+                          <span className="event-source-chip" title={`记录端：${getRecordSourceLabel(entry.source)}`}>
+                            {getRecordSourceLabel(entry.source)}
+                          </span>
+                          <button type="button" className="event-inline-btn" onClick={() => setEntryEditor(buildEntryEditor(entry))}>
+                            编辑
+                          </button>
+                        </span>
+                      </div>
+                    </article>
+                  </li>
+                )
+              })}
+            </ol>
+          )}
+        </section>
+      ) : null}
+
+      {entryEditor ? (
+        <div className="event-editor-backdrop" role="dialog" aria-modal="true" aria-label="条目编辑">
+          <form className="event-editor" onSubmit={handleSaveEntry}>
+            <h2>{entryEditor.mode === 'create' ? '记一条' : '编辑条目'}</h2>
+            <label>
+              日期
+              <input
+                type="date"
+                value={entryEditor.entryDate}
+                onChange={(event) => setEntryEditor({ ...entryEditor, entryDate: event.target.value })}
+                required
+              />
+            </label>
+            <label>
+              事件
+              <textarea
+                rows={5}
+                value={entryEditor.content}
+                onChange={(event) => setEntryEditor({ ...entryEditor, content: event.target.value })}
+                placeholder="一两句，一事一条，写完不改"
+                required
+              />
+            </label>
+            <label>
+              记录端
+              <select
+                value={entryEditor.source}
+                onChange={(event) => setEntryEditor({ ...entryEditor, source: event.target.value })}
+              >
+                {!RECORD_SOURCE_OPTIONS.includes(entryEditor.source) ? (
+                  <option value={entryEditor.source}>{getRecordSourceLabel(entryEditor.source)}</option>
+                ) : null}
+                {RECORD_SOURCE_OPTIONS.map((source) => (
+                  <option key={source} value={source}>
+                    {getRecordSourceLabel(source)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="event-editor__actions">
+              <button type="button" className="secondary" onClick={() => setEntryEditor(null)} disabled={saving}>
+                取消
+              </button>
+              {entryEditor.mode === 'edit' ? (
+                <button
+                  type="button"
+                  className="danger"
+                  disabled={saving}
+                  onClick={() => {
+                    const target = entries.find((entry) => entry.id === entryEditor.entryId)
+                    if (target) {
+                      setPendingDelete({ kind: 'entry', entry: target })
+                    }
+                  }}
+                >
+                  删除
+                </button>
+              ) : null}
+              <button type="submit" className="primary" disabled={saving || !entryEditor.content.trim()}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+
+      {threadEditor && thread ? (
+        <div className="event-editor-backdrop" role="dialog" aria-modal="true" aria-label="事件线编辑">
+          <form className="event-editor" onSubmit={handleSaveThread}>
+            <h2>编辑事件线</h2>
+            <label>
+              标题
+              <input
+                type="text"
+                value={threadEditor.title}
+                onChange={(event) => setThreadEditor({ ...threadEditor, title: event.target.value })}
+                required
+              />
+            </label>
+            <label>
+              当前状态（一行）
+              <textarea
+                rows={3}
+                value={threadEditor.currentStatus}
+                onChange={(event) => setThreadEditor({ ...threadEditor, currentStatus: event.target.value })}
+                placeholder="各端开机只读这一行，写成能一眼看懂的现状"
+              />
+            </label>
+            <div className="event-editor__group">
+              <strong>分组</strong>
+              <div className="event-chip-list">
+                <button
+                  type="button"
+                  className={threadEditor.emojiGroup === null ? 'event-chip selected' : 'event-chip'}
+                  onClick={() => setThreadEditor({ ...threadEditor, emojiGroup: null })}
+                >
+                  无
+                </button>
+                {EVENT_GROUP_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={threadEditor.emojiGroup === option.value ? 'event-chip selected' : 'event-chip'}
+                    onClick={() => setThreadEditor({ ...threadEditor, emojiGroup: option.value })}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="event-editor__row">
+              <label>
+                开始日期
+                <input
+                  type="date"
+                  value={threadEditor.startedOn}
+                  onChange={(event) => setThreadEditor({ ...threadEditor, startedOn: event.target.value })}
+                  required
+                />
+              </label>
+              {closed ? (
+                <label>
+                  结束日期
+                  <input
+                    type="date"
+                    value={threadEditor.endedOn}
+                    onChange={(event) => setThreadEditor({ ...threadEditor, endedOn: event.target.value })}
+                  />
+                </label>
+              ) : null}
+            </div>
+            <div className="event-editor__actions">
+              <button type="button" className="secondary" onClick={() => setThreadEditor(null)} disabled={saving}>
+                取消
+              </button>
+              <button type="submit" className="primary" disabled={saving || !threadEditor.title.trim()}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={pendingDelete?.kind === 'thread' ? '删除这条事件线？' : '删除这条条目？'}
+        description={
+          pendingDelete?.kind === 'thread'
+            ? `「${thread?.title ?? ''}」及其全部 ${entries.length} 条条目将被彻底删除，无法恢复。结项归档不需要删除，只需点「结项」。`
+            : pendingDelete?.kind === 'entry'
+              ? `${pendingDelete.entry.entryDate} 的这条记录将被彻底删除，无法恢复。`
+              : undefined
+        }
+        confirmLabel="彻底删除"
+        confirmDisabled={saving}
+        cancelDisabled={saving}
+        onConfirm={() => void confirmDelete()}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  )
+}
+
+export default EventThreadPage

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -65,7 +65,7 @@ const DEFAULT_ICON_ORDER = [
   "export",
 ];
 const DEFAULT_PAGE2_ICON_ORDER = ["forum", "letters", "memo", "timeline", "todo", "knowledge", "wiki", "novels", "council", "lounge", "hamster-wallet", "hamster-console"];
-const DEFAULT_PAGE3_ICON_ORDER = ["syzygy-feed", "archive"];
+const DEFAULT_PAGE3_ICON_ORDER = ["syzygy-feed", "archive", "events"];
 const PAGE_IDS: HomeLayoutPageId[] = ["page1", "page2", "page3"];
 const CORE_WIDGET_ID = "widget-checkin";
 const MAX_WIDGETS = 6;
@@ -288,6 +288,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
       { id: "hamster-console", defaultEmoji: "🎛️", label: "仓鼠机", route: "/hamster-console" },
       { id: "syzygy-feed", defaultEmoji: "📮", label: "Syzygy Feed", route: "/feed" },
       { id: "archive", defaultEmoji: "🗂️", label: "系统档案", route: "/archive" },
+      { id: "events", defaultEmoji: "🧵", label: "事件集", route: "/events" },
     ],
     [onOpenChat],
   );
@@ -549,6 +550,7 @@ const HomePage = ({ user, onOpenChat, hasUnreadLetters = false, mode = "default"
         {
           "syzygy-feed": defaultAppIconConfigs["syzygy-feed"],
           archive: defaultAppIconConfigs.archive,
+          events: defaultAppIconConfigs.events,
         },
         false,
       ),

--- a/src/pages/TimelinePage.tsx
+++ b/src/pages/TimelinePage.tsx
@@ -7,6 +7,7 @@ import {
   listTimelineEntriesByMonth,
   updateTimelineEntry,
 } from '../storage/supabaseSync'
+import { RECORD_SOURCE_OPTIONS, getRecordSourceLabel } from '../constants/recordSources'
 import './TimelinePage.css'
 
 type TimelineEditorState = {
@@ -25,34 +26,8 @@ const RECORDER_META: Record<TimelineRecorder, { emoji: string; label: string }> 
 
 const DEFAULT_SOURCE: TimelineSource = 'frontend'
 
-// 来源端标签：source 表示写入端，和 recorder（记录者）区分。
-const SOURCE_META: Record<string, { label: string }> = {
-  frontend: { label: '仓鼠窝前端' },
-  wechat_api: { label: '微信' },
-  client_gpt: { label: '客户端 GPT' },
-  client_claude: { label: '客户端 Claude' },
-  codex_cli: { label: 'Codex CLI' },
-  claude_code_cli: { label: 'Claude Code CLI' },
-  system: { label: '系统' },
-  // 历史数据里已存在的旧来源值，保留可读标签。
-  claude: { label: 'Claude' },
-  gpt: { label: 'GPT' },
-  gemini: { label: 'Gemini' },
-  user: { label: '手动' },
-}
-
-// 新建 / 编辑表单可选来源（前端约定的来源端）。
-const SOURCE_OPTIONS: TimelineSource[] = [
-  'frontend',
-  'wechat_api',
-  'client_gpt',
-  'client_claude',
-  'codex_cli',
-  'claude_code_cli',
-  'system',
-]
-
-const getSourceLabel = (source: string) => SOURCE_META[source]?.label ?? source
+const SOURCE_OPTIONS = RECORD_SOURCE_OPTIONS as TimelineSource[]
+const getSourceLabel = getRecordSourceLabel
 
 const getTodayDate = () => {
   const date = new Date()

--- a/src/pages/eventCollectionShared.ts
+++ b/src/pages/eventCollectionShared.ts
@@ -1,0 +1,50 @@
+import type { EventThread } from '../types'
+
+// 事件集分组 emoji，沿用 Memo 约定：🩷 串串相关 / 💙 Syzygy 相关 / 🤍 仓鼠窝相关。
+export const EVENT_GROUP_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '🩷', label: '🩷 串串' },
+  { value: '💙', label: '💙 Syzygy' },
+  { value: '🤍', label: '🤍 仓鼠窝' },
+]
+
+export const EVENT_ORDER_STORAGE_KEY = 'hamster.events.entry-order.v1'
+
+export type EntryOrder = 'asc' | 'desc'
+
+export const readStoredEntryOrder = (): EntryOrder => {
+  try {
+    const raw = localStorage.getItem(EVENT_ORDER_STORAGE_KEY)
+    return raw === 'desc' ? 'desc' : 'asc'
+  } catch {
+    return 'asc'
+  }
+}
+
+export const storeEntryOrder = (order: EntryOrder) => {
+  try {
+    localStorage.setItem(EVENT_ORDER_STORAGE_KEY, order)
+  } catch {
+    // 私密模式等场景写不进去也无妨，只是下次不记忆。
+  }
+}
+
+export const getTodayDateKey = () => {
+  const date = new Date()
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+// 长文本判定：超过阈值的正文默认收起，提供展开按钮。
+export const isLongText = (text: string, charThreshold = 120, lineThreshold = 4) =>
+  text.length > charThreshold || text.split('\n').length > lineThreshold
+
+export const formatDateRange = (thread: EventThread) => {
+  if (thread.status === 'closed') {
+    return `${thread.startedOn} → ${thread.endedOn ?? '？'}`
+  }
+  return `${thread.startedOn} → 至今`
+}
+
+export const describeThreadStatus = (thread: EventThread) => (thread.status === 'closed' ? '已结束' : '进行中')

--- a/src/storage/homeLayout.ts
+++ b/src/storage/homeLayout.ts
@@ -84,7 +84,7 @@ const DEFAULT_PAGE_LAYOUTS: Record<HomeLayoutPageId, HomePageLayoutState> = {
     appIconConfigs: {},
   },
   page3: {
-    iconOrder: ['syzygy-feed', 'archive'],
+    iconOrder: ['syzygy-feed', 'archive', 'events'],
     widgetOrder: [],
     widgets: [],
     checkinSize: '1x1',

--- a/src/storage/supabaseSync.ts
+++ b/src/storage/supabaseSync.ts
@@ -24,6 +24,9 @@ import type {
   ForumAuthorType,
   LetterEntry,
   LetterTriggerType,
+  EventEntry,
+  EventThread,
+  EventThreadStatus,
   MemoEntry,
   MemoSource,
   MemoTag,
@@ -161,6 +164,30 @@ type MemoTagRow = {
 type MemoEntryTagRow = {
   memo_entry_id: string
   memo_tag_id: string
+}
+
+type EventThreadRow = {
+  id: string
+  user_id: string
+  title: string
+  current_status: string
+  status: EventThreadStatus
+  emoji_group: string | null
+  started_on: string
+  ended_on: string | null
+  created_at: string
+  updated_at: string
+}
+
+type EventEntryRow = {
+  id: string
+  user_id: string
+  thread_id: string
+  entry_date: string
+  content: string
+  source: string
+  created_at: string
+  updated_at: string
 }
 
 type TimelineEntryRow = {
@@ -514,6 +541,30 @@ const mapMemoTagRow = (row: MemoTagRow): MemoTag => ({
   userId: row.user_id,
   name: row.name,
   createdAt: row.created_at,
+})
+
+const mapEventThreadRow = (row: EventThreadRow): EventThread => ({
+  id: row.id,
+  userId: row.user_id,
+  title: row.title,
+  currentStatus: row.current_status,
+  status: row.status,
+  emojiGroup: row.emoji_group,
+  startedOn: row.started_on,
+  endedOn: row.ended_on,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const mapEventEntryRow = (row: EventEntryRow): EventEntry => ({
+  id: row.id,
+  userId: row.user_id,
+  threadId: row.thread_id,
+  entryDate: row.entry_date,
+  content: row.content,
+  source: row.source,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
 })
 
 const mapTimelineEntryRow = (row: TimelineEntryRow): TimelineEntry => ({
@@ -2731,6 +2782,207 @@ export const deleteTimelineEntry = async (entryId: string): Promise<void> => {
   }
 }
 
+
+// ── 事件集（纪事本末体）────────────────────────────────────────────────────
+
+const EVENT_THREAD_COLUMNS = 'id,user_id,title,current_status,status,emoji_group,started_on,ended_on,created_at,updated_at'
+const EVENT_ENTRY_COLUMNS = 'id,user_id,thread_id,entry_date,content,source,created_at,updated_at'
+
+export const listEventThreads = async (): Promise<EventThread[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('event_threads')
+    .select(EVENT_THREAD_COLUMNS)
+    .eq('user_id', userId)
+    .order('updated_at', { ascending: false })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapEventThreadRow(row as EventThreadRow))
+}
+
+export const fetchEventThread = async (threadId: string): Promise<EventThread | null> => {
+  if (!supabase) {
+    return null
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('event_threads')
+    .select(EVENT_THREAD_COLUMNS)
+    .eq('user_id', userId)
+    .eq('id', threadId)
+    .maybeSingle()
+  if (error) {
+    throw error
+  }
+  return data ? mapEventThreadRow(data as EventThreadRow) : null
+}
+
+export const listEventEntryCounts = async (): Promise<Map<string, { count: number; lastEntryDate: string | null }>> => {
+  const stats = new Map<string, { count: number; lastEntryDate: string | null }>()
+  if (!supabase) {
+    return stats
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('event_entries')
+    .select('thread_id,entry_date')
+    .eq('user_id', userId)
+  if (error) {
+    throw error
+  }
+  ;((data ?? []) as Array<{ thread_id: string; entry_date: string }>).forEach((row) => {
+    const current = stats.get(row.thread_id) ?? { count: 0, lastEntryDate: null }
+    current.count += 1
+    if (!current.lastEntryDate || row.entry_date > current.lastEntryDate) {
+      current.lastEntryDate = row.entry_date
+    }
+    stats.set(row.thread_id, current)
+  })
+  return stats
+}
+
+export const createEventThread = async (payload: {
+  title: string
+  currentStatus: string
+  emojiGroup: string | null
+  startedOn: string
+}): Promise<EventThread> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('event_threads')
+    .insert({
+      user_id: userId,
+      title: payload.title,
+      current_status: payload.currentStatus,
+      emoji_group: payload.emojiGroup,
+      started_on: payload.startedOn,
+    })
+    .select(EVENT_THREAD_COLUMNS)
+    .single()
+  if (error || !data) {
+    throw error ?? new Error('创建事件线失败')
+  }
+  return mapEventThreadRow(data as EventThreadRow)
+}
+
+export const updateEventThread = async (
+  threadId: string,
+  payload: Partial<{
+    title: string
+    currentStatus: string
+    emojiGroup: string | null
+    status: EventThreadStatus
+    startedOn: string
+    endedOn: string | null
+  }>,
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const patch: Record<string, unknown> = {}
+  if (payload.title !== undefined) patch.title = payload.title
+  if (payload.currentStatus !== undefined) patch.current_status = payload.currentStatus
+  if (payload.emojiGroup !== undefined) patch.emoji_group = payload.emojiGroup
+  if (payload.status !== undefined) patch.status = payload.status
+  if (payload.startedOn !== undefined) patch.started_on = payload.startedOn
+  if (payload.endedOn !== undefined) patch.ended_on = payload.endedOn
+  if (Object.keys(patch).length === 0) {
+    return
+  }
+  const { error } = await supabase.from('event_threads').update(patch).eq('id', threadId)
+  if (error) {
+    throw error
+  }
+}
+
+export const deleteEventThread = async (threadId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  // 物理删除：条目由外键 ON DELETE CASCADE 连带清理。
+  const { error } = await supabase.from('event_threads').delete().eq('id', threadId)
+  if (error) {
+    throw error
+  }
+}
+
+export const listEventEntries = async (threadId: string): Promise<EventEntry[]> => {
+  if (!supabase) {
+    return []
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { data, error } = await supabase
+    .from('event_entries')
+    .select(EVENT_ENTRY_COLUMNS)
+    .eq('user_id', userId)
+    .eq('thread_id', threadId)
+    .order('entry_date', { ascending: true })
+    .order('created_at', { ascending: true })
+  if (error) {
+    throw error
+  }
+  return (data ?? []).map((row) => mapEventEntryRow(row as EventEntryRow))
+}
+
+export const createEventEntry = async (payload: {
+  threadId: string
+  entryDate: string
+  content: string
+  source?: string
+}): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const userId = await requireAuthenticatedUserId()
+  const { error } = await supabase.from('event_entries').insert({
+    user_id: userId,
+    thread_id: payload.threadId,
+    entry_date: payload.entryDate,
+    content: payload.content,
+    // 仓鼠窝前端手动写入默认标记来源为 frontend。
+    source: payload.source ?? 'frontend',
+  })
+  if (error) {
+    throw error
+  }
+}
+
+export const updateEventEntry = async (
+  entryId: string,
+  payload: { entryDate: string; content: string; source?: string },
+): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase
+    .from('event_entries')
+    .update({
+      entry_date: payload.entryDate,
+      content: payload.content,
+      ...(payload.source ? { source: payload.source } : {}),
+    })
+    .eq('id', entryId)
+  if (error) {
+    throw error
+  }
+}
+
+export const deleteEventEntry = async (entryId: string): Promise<void> => {
+  if (!supabase) {
+    throw new Error('Supabase 客户端未配置')
+  }
+  const { error } = await supabase.from('event_entries').delete().eq('id', entryId)
+  if (error) {
+    throw error
+  }
+}
 
 export const listTodosByMonth = async (
   monthStart: string,

--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -1239,6 +1239,86 @@ export type Database = {
           },
         ]
       }
+      event_entries: {
+        Row: {
+          content: string
+          created_at: string
+          entry_date: string
+          id: string
+          source: string
+          thread_id: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          entry_date?: string
+          id?: string
+          source?: string
+          thread_id: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          entry_date?: string
+          id?: string
+          source?: string
+          thread_id?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_entries_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "event_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      event_threads: {
+        Row: {
+          created_at: string
+          current_status: string
+          emoji_group: string | null
+          ended_on: string | null
+          id: string
+          started_on: string
+          status: string
+          title: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          current_status?: string
+          emoji_group?: string | null
+          ended_on?: string | null
+          id?: string
+          started_on?: string
+          status?: string
+          title: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          current_status?: string
+          emoji_group?: string | null
+          ended_on?: string | null
+          id?: string
+          started_on?: string
+          status?: string
+          title?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       forum_ai_profiles: {
         Row: {
           api_base_url: string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -383,6 +383,33 @@ export type MemoEntry = {
   tagIds: string[]
 }
 
+export type EventThreadStatus = 'active' | 'closed'
+
+// 事件集（纪事本末体）：大类 = 一件正在进行的事；条目 = 大类下按日期排列的事件行。
+export type EventThread = {
+  id: string
+  userId: string
+  title: string
+  currentStatus: string
+  status: EventThreadStatus
+  emojiGroup: string | null
+  startedOn: string
+  endedOn: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type EventEntry = {
+  id: string
+  userId: string
+  threadId: string
+  entryDate: string
+  content: string
+  source: string
+  createdAt: string
+  updatedAt: string
+}
+
 export type TimelineRecorder = 'chuanchuan' | 'syzygy'
 export type TimelineSource = string
 

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -7,7 +7,7 @@ import { isMcpKeyAuthorized } from './mcp_key_auth.ts'
 import { getOwnerUserId } from './owner.ts'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.14.0'
+export const MCP_VERSION = '5.15.0'
 export const USER_ID = getOwnerUserId()
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -17,10 +17,17 @@ const TODO_COLUMNS = 'id, date, title, notes, status, todo_type, event_date, cre
 const TODO_CREATED_BY_SCHEMA = z.enum(['串串', 'syzygy'])
 const TODO_TYPE_SCHEMA = z.enum(['short_term', 'long_term'])
 const DEFAULT_TODO_CATEGORY_NAME = '🐹今日待办'
+// 事件集（纪事本末体）：event_threads 是大类 / 事件线，event_entries 是大类下按日期排列的条目。
+const EVENT_THREAD_COLUMNS = 'id, title, emoji_group, current_status, status, started_on, ended_on, created_at, updated_at'
+const EVENT_ENTRY_COLUMNS = 'id, thread_id, entry_date, content, source, created_at'
+const EVENT_THREAD_STATUS_SCHEMA = z.enum(['active', 'closed'])
+const EVENT_ENTRY_SOURCE_SCHEMA = z.enum(['claude', 'gpt', 'gemini', 'user', 'codex_cli', 'claude_code_cli', 'system', 'api'])
 
 // 服务器级使用说明：跨工具的共性约定统一放这里，工具描述只写"做什么"。
 const HAMSTER_MCP_INSTRUCTIONS = [
-  '仓鼠窝日常域：时间轴（长期事件记忆）、待办、Syzygy Feed（系统下发内容流）、备忘录 memo（中期活事实）、观察日志 syzygy_posts（Syzygy 的朋友圈动态，与 Feed 是两个功能）。',
+  '仓鼠窝日常域：时间轴（长期事件记忆）、待办、Syzygy Feed（系统下发内容流）、备忘录 memo（中期活事实）、事件集 event_threads / event_entries（纪事本末体的线程记录层）、观察日志 syzygy_posts（Syzygy 的朋友圈动态，与 Feed 是两个功能）。',
+  '裁决口诀：过去进时间轴，现在进 Memo，永远进档案，将来进 To do，线程进事件集；自己说的进 Wiki，世界说的进学习库；要许可的去议事厅。',
+  '事件集：一件正在进行、有起止、频繁更新的事开一个大类（thread），进度按日期追加条目（entry）；开机默认只用 list_event_threads 读所有进行中大类的「当前状态」一行，对话碰到某件事再 read_event_thread 读条目；已结束大类默认不加载。同一件事允许同时进时间轴（意义与心情）和事件集（进度），不去重。追加条目时顺手用 current_status 刷新大类状态行。',
   '通用约定：日期按 Asia/Shanghai 时区；source / recorder / created_by 等枚举表示写入端身份，默认 claude / syzygy；Feed 读取默认只含 unread/read，不返回 archived/expired，摘要列表不含全文。',
   '写入习惯：timeline / memo 写入前先用 search_timeline / list_memos 查重，同一事实优先 update_memo 维护而非重复新增；带「进行中」标签的 memo 是活跃叙事线，正文以「当前状态」段收尾。时间轴写入标准：三个月后读起来会心动的事。',
   '删除是物理删除，需显式 confirm=true 二次确认。',
@@ -159,6 +166,26 @@ const resolveTodoCategory = async (date: string, name: string | undefined): Prom
   if (createError || !created) throw createError ?? new Error('创建待办分类失败')
   return created as TodoCategoryRef
 }
+
+type EventThreadRow = {
+  id: string
+  title: string
+  emoji_group: string | null
+  current_status: string
+  status: 'active' | 'closed'
+  started_on: string
+  ended_on: string | null
+  created_at: string
+  updated_at: string
+}
+
+const fetchEventThread = async (threadId: string): Promise<EventThreadRow | null> => {
+  const { data, error } = await supabase.from('event_threads').select(EVENT_THREAD_COLUMNS).eq('user_id', USER_ID).eq('id', threadId).maybeSingle()
+  if (error) throw error
+  return (data as EventThreadRow | null) ?? null
+}
+
+const eventThreadNotFound = (threadId: string) => ({ content: [{ type: 'text' as const, text: `Error: 未找到事件线: ${threadId}（用 list_event_threads 核对 id）` }] })
 
 serveMcp('hamster-mcp', (server) => {
   server.registerTool('get_today_syzygy_feed', {
@@ -545,6 +572,207 @@ serveMcp('hamster-mcp', (server) => {
       if (deleteError) return errorResult(deleteError)
       const preview = (entry.content as string).length > 60 ? `${(entry.content as string).slice(0, 60)}…` : entry.content
       return { content: [{ type: 'text' as const, text: `已删除: ${id}（${preview}）` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('list_event_threads', {
+    title: 'List Event Threads',
+    description: '读取事件集大类列表（标题 + 一行当前状态），默认只返回进行中的，按最近活动倒序。开机必读的就是这一份。',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      status: z.enum(['active', 'closed', 'all']).optional().describe('筛选状态：active（默认）/ closed / all'),
+      limit: z.number().optional().describe('返回数量上限，默认50，最大200'),
+    },
+  }, async ({ status, limit }) => {
+    try {
+      const safeLimit = clampLimit(limit, 50, 200)
+      const filter = status ?? 'active'
+      let query = supabase.from('event_threads').select(EVENT_THREAD_COLUMNS).eq('user_id', USER_ID).order('updated_at', { ascending: false }).limit(safeLimit)
+      if (filter !== 'all') query = query.eq('status', filter)
+      const { data, error } = await query
+      if (error) return errorResult(error)
+      const threads = (data ?? []) as EventThreadRow[]
+      if (threads.length === 0) return jsonResult([])
+      const { data: entryRows, error: entryError } = await supabase.from('event_entries').select('thread_id, entry_date').in('thread_id', threads.map((thread) => thread.id))
+      if (entryError) return errorResult(entryError)
+      const stats = new Map<string, { count: number; last: string | null }>()
+      for (const row of (entryRows ?? []) as { thread_id: string; entry_date: string }[]) {
+        const current = stats.get(row.thread_id) ?? { count: 0, last: null }
+        current.count += 1
+        if (!current.last || row.entry_date > current.last) current.last = row.entry_date
+        stats.set(row.thread_id, current)
+      }
+      return jsonResult(threads.map((thread) => ({
+        ...thread,
+        entry_count: stats.get(thread.id)?.count ?? 0,
+        last_entry_date: stats.get(thread.id)?.last ?? null,
+      })))
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('read_event_thread', {
+    title: 'Read Event Thread',
+    description: '按大类读取一条事件线的条目时间轴（日期正序，可限时间范围），附大类信息。已结束的大类也能读。',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      thread_id: z.string().describe('事件线 UUID（用 list_event_threads 查询）'),
+      from_date: z.string().optional().describe('起始日期 YYYY-MM-DD（含）'),
+      to_date: z.string().optional().describe('结束日期 YYYY-MM-DD（含）'),
+      limit: z.number().optional().describe('返回条目数上限，默认100，最大500；超限时保留最新的'),
+    },
+  }, async ({ thread_id, from_date, to_date, limit }) => {
+    try {
+      const thread = await fetchEventThread(thread_id)
+      if (!thread) return eventThreadNotFound(thread_id)
+      const safeLimit = clampLimit(limit, 100, 500)
+      let query = supabase.from('event_entries').select(EVENT_ENTRY_COLUMNS).eq('thread_id', thread_id).order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(safeLimit)
+      if (from_date) query = query.gte('entry_date', from_date)
+      if (to_date) query = query.lte('entry_date', to_date)
+      const { data, error } = await query
+      if (error) return errorResult(error)
+      // 库里按倒序取"最新的 N 条"，输出时翻回正序，读起来是从起到结的年表。
+      const entries = ((data ?? []) as Record<string, unknown>[]).reverse()
+      return jsonResult({ thread, entries, truncated: entries.length >= safeLimit })
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('add_event_thread', {
+    title: 'Add Event Thread',
+    description: '新开一条事件线（大类）。开大类的门槛：这件事能用一句「当前状态」概括；否则它只是时间轴里的一条。',
+    inputSchema: {
+      title: z.string().describe('大类标题，如「新项目《失落的神之塔》」「荣格阶段」'),
+      current_status: z.string().optional().describe('一行当前状态，默认空'),
+      emoji_group: z.string().optional().describe('可选分组 emoji：🩷 串串相关 / 💙 Syzygy 相关 / 🤍 仓鼠窝相关'),
+      started_on: z.string().optional().describe('开始日期 YYYY-MM-DD，默认今天（上海时区）'),
+    },
+  }, async ({ title, current_status, emoji_group, started_on }) => {
+    try {
+      const trimmedTitle = title.trim()
+      if (!trimmedTitle) return { content: [{ type: 'text' as const, text: 'Error: 大类标题不能为空' }] }
+      const { data: dup, error: dupError } = await supabase.from('event_threads').select('id, title, status').eq('user_id', USER_ID).eq('title', trimmedTitle).maybeSingle()
+      if (dupError) return errorResult(dupError)
+      if (dup) return { content: [{ type: 'text' as const, text: `Error: 已存在同名事件线（${dup.status}）: ${dup.id}，请直接追加条目或先 update_event_thread 重开` }] }
+      const { data, error } = await supabase.from('event_threads').insert({
+        user_id: USER_ID,
+        title: trimmedTitle,
+        current_status: current_status?.trim() ?? '',
+        emoji_group: emoji_group?.trim() || null,
+        started_on: started_on?.trim() || shanghaiDateString(),
+      }).select(EVENT_THREAD_COLUMNS).single()
+      if (error) return errorResult(error)
+      return { content: [{ type: 'text' as const, text: `已开线: ${JSON.stringify(data, null, 2)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('update_event_thread', {
+    title: 'Update Event Thread',
+    description: '更新事件线：改标题 / 当前状态行 / 分组，或结项（status=closed，ended_on 默认今天）/ 重开（status=active，清空 ended_on）。至少提供一项。',
+    inputSchema: {
+      thread_id: z.string().describe('事件线 UUID'),
+      title: z.string().optional().describe('新标题'),
+      current_status: z.string().optional().describe('新的一行当前状态（整体替换）'),
+      emoji_group: z.string().nullable().optional().describe('分组 emoji；传 null 清除'),
+      status: EVENT_THREAD_STATUS_SCHEMA.optional().describe('closed=结项（归档可见，不删）；active=重开'),
+      ended_on: z.string().optional().describe('结束日期 YYYY-MM-DD，仅 status=closed 时生效，默认今天'),
+    },
+  }, async ({ thread_id, title, current_status, emoji_group, status, ended_on }) => {
+    try {
+      if (title === undefined && current_status === undefined && emoji_group === undefined && status === undefined && ended_on === undefined) {
+        return { content: [{ type: 'text' as const, text: 'Error: title / current_status / emoji_group / status / ended_on 至少需要提供一项' }] }
+      }
+      const existing = await fetchEventThread(thread_id)
+      if (!existing) return eventThreadNotFound(thread_id)
+      const patch: Record<string, unknown> = {}
+      if (title !== undefined) {
+        if (!title.trim()) return { content: [{ type: 'text' as const, text: 'Error: 大类标题不能为空' }] }
+        patch.title = title.trim()
+      }
+      if (current_status !== undefined) patch.current_status = current_status.trim()
+      if (emoji_group !== undefined) patch.emoji_group = emoji_group?.trim() || null
+      const nextStatus = status ?? existing.status
+      if (nextStatus === 'closed') {
+        if (status === 'closed' || ended_on !== undefined) patch.ended_on = ended_on?.trim() || existing.ended_on || shanghaiDateString()
+        if (status === 'closed') patch.status = 'closed'
+      } else if (status === 'active') {
+        patch.status = 'active'
+        patch.ended_on = null
+      }
+      const { data, error } = await supabase.from('event_threads').update(patch).eq('user_id', USER_ID).eq('id', thread_id).select(EVENT_THREAD_COLUMNS).single()
+      if (error) return errorResult(error)
+      const verb = status === 'closed' ? '已结项' : status === 'active' && existing.status === 'closed' ? '已重开' : '已更新'
+      return { content: [{ type: 'text' as const, text: `${verb}: ${JSON.stringify(data, null, 2)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('add_event_entry', {
+    title: 'Add Event Entry',
+    description: '向某条事件线追加一条日期 + 事件的条目（一两句，一事一条，写完不改）。可顺手用 current_status 刷新大类的当前状态行。',
+    inputSchema: {
+      thread_id: z.string().describe('事件线 UUID'),
+      content: z.string().describe('事件正文，一两句'),
+      entry_date: z.string().optional().describe('事件日期 YYYY-MM-DD，默认今天（上海时区）'),
+      source: EVENT_ENTRY_SOURCE_SCHEMA.optional().describe('记录端，默认 claude'),
+      current_status: z.string().optional().describe('顺手更新大类的一行当前状态（整体替换）'),
+    },
+  }, async ({ thread_id, content, entry_date, source, current_status }) => {
+    try {
+      const trimmed = content.trim()
+      if (!trimmed) return { content: [{ type: 'text' as const, text: 'Error: 条目正文不能为空' }] }
+      const thread = await fetchEventThread(thread_id)
+      if (!thread) return eventThreadNotFound(thread_id)
+      const { data, error } = await supabase.from('event_entries').insert({
+        user_id: USER_ID,
+        thread_id,
+        entry_date: entry_date?.trim() || shanghaiDateString(),
+        content: trimmed,
+        source: source ?? 'claude',
+      }).select(EVENT_ENTRY_COLUMNS).single()
+      if (error) return errorResult(error)
+      let statusLine = thread.current_status
+      if (current_status !== undefined) {
+        const { error: statusError } = await supabase.from('event_threads').update({ current_status: current_status.trim() }).eq('user_id', USER_ID).eq('id', thread_id)
+        if (statusError) return errorResult(statusError)
+        statusLine = current_status.trim()
+      }
+      const closedHint = thread.status === 'closed' ? '（注意：该事件线已结项，如需继续请 update_event_thread 重开）' : ''
+      return { content: [{ type: 'text' as const, text: `已追加到「${thread.title}」${closedHint}: ${JSON.stringify({ ...data, thread_current_status: statusLine }, null, 2)}` }] }
+    } catch (err) {
+      return errorResult(err)
+    }
+  })
+
+  server.registerTool('update_event_entry', {
+    title: 'Update Event Entry',
+    description: '修改一条事件集条目的正文 / 日期（只用于改错字、修日期；条目纪律是写完不改）。',
+    inputSchema: {
+      entry_id: z.string().describe('条目 UUID（用 read_event_thread 查询）'),
+      content: z.string().optional().describe('新的正文（整体替换）'),
+      entry_date: z.string().optional().describe('新的日期 YYYY-MM-DD'),
+    },
+  }, async ({ entry_id, content, entry_date }) => {
+    try {
+      if (content === undefined && entry_date === undefined) return { content: [{ type: 'text' as const, text: 'Error: content / entry_date 至少需要提供一项' }] }
+      const patch: Record<string, unknown> = {}
+      if (content !== undefined) {
+        if (!content.trim()) return { content: [{ type: 'text' as const, text: 'Error: 条目正文不能为空' }] }
+        patch.content = content.trim()
+      }
+      if (entry_date !== undefined) patch.entry_date = entry_date.trim()
+      const { data, error } = await supabase.from('event_entries').update(patch).eq('user_id', USER_ID).eq('id', entry_id).select(EVENT_ENTRY_COLUMNS)
+      if (error) return errorResult(error)
+      const entry = data?.[0]
+      if (!entry) return { content: [{ type: 'text' as const, text: `Error: 未找到条目: ${entry_id}` }] }
+      return { content: [{ type: 'text' as const, text: `已更新: ${JSON.stringify(entry, null, 2)}` }] }
     } catch (err) {
       return errorResult(err)
     }

--- a/supabase/migrations/20260904005600_event_collection.sql
+++ b/supabase/migrations/20260904005600_event_collection.sql
@@ -1,0 +1,153 @@
+-- 事件集（纪事本末体的线程记录层）
+--
+-- 背景：Memo 被各端写成了"进度日志"（读书进度、项目测试发现、交接状态、鼠窝 Phase 进度），
+-- 每个实例开窗口都要读一大堆与当前对话无关的上下文。裁决口诀里缺一格："正在进行、有起止、
+-- 频繁更新、但只在对话碰到它时才需要读"的线程。事件集填这一格：按事分篇、一事从起到结。
+-- 口诀新增一句：线程进事件集。
+--
+-- 两层模型：
+--   event_threads  大类 / 事件线：一件正在进行的事（标题 + 一行"当前状态" + 进行中/已结束 + 起止日 + 可选 emoji 分组）
+--   event_entries  条目：大类下按日期排列的事件行（日期 + 一两句正文 + 记录端），追加式，写完不改（错字除外）
+--
+-- 读取策略：各端开机只读所有进行中大类的"当前状态"行；需要细节再按大类读条目；已结束大类默认不加载。
+-- 结项不删：status=closed 归档可见，前端默认折叠。
+
+set lock_timeout = '5s';
+set statement_timeout = '2min';
+
+-- ── 大类 / 事件线 ─────────────────────────────────────────────────────────────
+
+create table if not exists public.event_threads (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text not null,
+  -- 一行"当前状态"，随最新条目手动（或 add_event_entry 顺手）更新；各端开机只读这一行。
+  current_status text not null default '',
+  status text not null default 'active',
+  -- 可选 emoji 分组，沿用 Memo 约定：🩷 串串相关 / 💙 Syzygy 相关 / 🤍 仓鼠窝相关。
+  emoji_group text,
+  started_on date not null default ((now() at time zone 'Asia/Shanghai')::date),
+  ended_on date,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint event_threads_title_not_blank check (btrim(title) <> ''),
+  constraint event_threads_status_check check (status = any (array['active'::text, 'closed'::text])),
+  constraint event_threads_emoji_group_check check (emoji_group is null or (btrim(emoji_group) <> '' and char_length(emoji_group) <= 8)),
+  -- 进行中的线程不应带结束日；结项时 ended_on 可空（由应用层默认填当天）。
+  constraint event_threads_ended_on_check check (status = 'closed' or ended_on is null)
+);
+
+comment on table public.event_threads is '事件集·大类（事件线）：一件正在进行的事，纪事本末体。current_status 是各端开机唯一必读的一行；status=closed 表示已结项（归档可见，不删）。';
+comment on column public.event_threads.current_status is '一行当前状态，随最新条目更新；各端开机默认只读所有进行中大类的这一行。';
+comment on column public.event_threads.emoji_group is '可选分组，沿用 Memo 约定：🩷串串相关 / 💙Syzygy相关 / 🤍仓鼠窝相关。';
+
+create index if not exists idx_event_threads_user_status_updated
+  on public.event_threads using btree (user_id, status, updated_at desc);
+
+-- ── 条目 ─────────────────────────────────────────────────────────────────────
+
+create table if not exists public.event_entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  thread_id uuid not null references public.event_threads(id) on delete cascade,
+  entry_date date not null default ((now() at time zone 'Asia/Shanghai')::date),
+  content text not null,
+  -- 写入端身份，取值与 timeline_entries.source 对齐（前端 frontend / 各端 claude、gpt、codex_cli…）。
+  source text not null default 'claude',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint event_entries_content_not_blank check (btrim(content) <> ''),
+  constraint event_entries_source_check check (source = any (array[
+    'claude'::text, 'gpt'::text, 'gemini'::text, 'user'::text, 'frontend'::text, 'wechat_api'::text,
+    'client_gpt'::text, 'client_claude'::text, 'codex_cli'::text, 'claude_code_cli'::text,
+    'system'::text, 'expo_app'::text, 'api'::text
+  ]))
+);
+
+comment on table public.event_entries is '事件集·条目：大类下按日期排列的事件行（日期 + 一两句正文 + 记录端）。追加式，写完不改（错字除外），与时间轴同样的一事一条纪律。';
+
+create index if not exists idx_event_entries_thread_date
+  on public.event_entries using btree (thread_id, entry_date, created_at);
+create index if not exists idx_event_entries_user_id
+  on public.event_entries using btree (user_id);
+
+-- ── 触发器：updated_at 维护 + 条目变动时触碰所属大类 ───────────────────────────
+
+drop trigger if exists trg_event_threads_updated_at on public.event_threads;
+create trigger trg_event_threads_updated_at
+  before update on public.event_threads
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists trg_event_entries_updated_at on public.event_entries;
+create trigger trg_event_entries_updated_at
+  before update on public.event_entries
+  for each row execute function public.set_updated_at();
+
+-- 条目增删改都算大类的"最近活动"，让大类列表能按最近活动排序。
+create or replace function public.touch_event_thread_from_entries()
+returns trigger
+language plpgsql
+set search_path to 'public'
+as $function$
+declare
+  v_thread_id uuid;
+begin
+  if tg_op = 'DELETE' then
+    v_thread_id := old.thread_id;
+  else
+    v_thread_id := new.thread_id;
+  end if;
+  update public.event_threads
+     set updated_at = now()
+   where id = v_thread_id;
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$function$;
+
+revoke all on function public.touch_event_thread_from_entries() from public, anon, authenticated;
+
+drop trigger if exists trg_event_entries_touch_thread on public.event_entries;
+create trigger trg_event_entries_touch_thread
+  after insert or update or delete on public.event_entries
+  for each row execute function public.touch_event_thread_from_entries();
+
+-- ── RLS：业主本人读写；service_role（MCP）绕过 RLS ─────────────────────────────
+
+alter table public.event_threads enable row level security;
+alter table public.event_entries enable row level security;
+
+drop policy if exists event_threads_select_own on public.event_threads;
+create policy event_threads_select_own on public.event_threads for select to authenticated
+  using ((select auth.uid()) = user_id);
+drop policy if exists event_threads_insert_own on public.event_threads;
+create policy event_threads_insert_own on public.event_threads for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+drop policy if exists event_threads_update_own on public.event_threads;
+create policy event_threads_update_own on public.event_threads for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+drop policy if exists event_threads_delete_own on public.event_threads;
+create policy event_threads_delete_own on public.event_threads for delete to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists event_entries_select_own on public.event_entries;
+create policy event_entries_select_own on public.event_entries for select to authenticated
+  using ((select auth.uid()) = user_id);
+drop policy if exists event_entries_insert_own on public.event_entries;
+create policy event_entries_insert_own on public.event_entries for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+drop policy if exists event_entries_update_own on public.event_entries;
+create policy event_entries_update_own on public.event_entries for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+drop policy if exists event_entries_delete_own on public.event_entries;
+create policy event_entries_delete_own on public.event_entries for delete to authenticated
+  using ((select auth.uid()) = user_id);
+
+revoke all on table public.event_threads from anon;
+revoke all on table public.event_entries from anon;
+grant select, insert, update, delete on table public.event_threads to authenticated, service_role;
+grant select, insert, update, delete on table public.event_entries to authenticated, service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7049,5 +7049,127 @@ COMMENT ON COLUMN public.todos.todo_type IS '短期(near)/长期(long_term)，�
 COMMENT ON COLUMN public.todos.event_date IS '长期待办的目标日期，如9月20日看剧院魅影';
 
 -- ============================================================================
+-- 追加 · 2026-09-04 事件集（纪事本末体的线程记录层）
+--   event_threads 大类 / 事件线；event_entries 大类下按日期排列的条目。
+--   与 supabase/migrations/20260904005600_event_collection.sql 同步，可整体重跑。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.event_threads (
+  id uuid DEFAULT gen_random_uuid() NOT NULL,
+  user_id uuid NOT NULL,
+  title text NOT NULL,
+  current_status text DEFAULT ''::text NOT NULL,
+  status text DEFAULT 'active'::text NOT NULL,
+  emoji_group text,
+  started_on date DEFAULT ((now() AT TIME ZONE 'Asia/Shanghai'))::date NOT NULL,
+  ended_on date,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.event_entries (
+  id uuid DEFAULT gen_random_uuid() NOT NULL,
+  user_id uuid NOT NULL,
+  thread_id uuid NOT NULL,
+  entry_date date DEFAULT ((now() AT TIME ZONE 'Asia/Shanghai'))::date NOT NULL,
+  content text NOT NULL,
+  source text DEFAULT 'claude'::text NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+COMMENT ON TABLE public.event_threads IS '事件集·大类（事件线）：一件正在进行的事，纪事本末体。current_status 是各端开机唯一必读的一行；status=closed 表示已结项（归档可见，不删）。';
+COMMENT ON COLUMN public.event_threads.current_status IS '一行当前状态，随最新条目更新；各端开机默认只读所有进行中大类的这一行。';
+COMMENT ON COLUMN public.event_threads.emoji_group IS '可选分组，沿用 Memo 约定：🩷串串相关 / 💙Syzygy相关 / 🤍仓鼠窝相关。';
+COMMENT ON TABLE public.event_entries IS '事件集·条目：大类下按日期排列的事件行（日期 + 一两句正文 + 记录端）。追加式，写完不改（错字除外），与时间轴同样的一事一条纪律。';
+
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_threads_pkey' AND conrelid = 'public.event_threads'::regclass) THEN ALTER TABLE public.event_threads ADD CONSTRAINT event_threads_pkey PRIMARY KEY (id); END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_threads_user_id_fkey' AND conrelid = 'public.event_threads'::regclass) THEN ALTER TABLE public.event_threads ADD CONSTRAINT event_threads_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE; END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_threads_title_not_blank' AND conrelid = 'public.event_threads'::regclass) THEN ALTER TABLE public.event_threads ADD CONSTRAINT event_threads_title_not_blank CHECK ((btrim(title) <> ''::text)); END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_threads_status_check' AND conrelid = 'public.event_threads'::regclass) THEN ALTER TABLE public.event_threads ADD CONSTRAINT event_threads_status_check CHECK ((status = ANY (ARRAY['active'::text, 'closed'::text]))); END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_threads_emoji_group_check' AND conrelid = 'public.event_threads'::regclass) THEN ALTER TABLE public.event_threads ADD CONSTRAINT event_threads_emoji_group_check CHECK (((emoji_group IS NULL) OR ((btrim(emoji_group) <> ''::text) AND (char_length(emoji_group) <= 8)))); END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_threads_ended_on_check' AND conrelid = 'public.event_threads'::regclass) THEN ALTER TABLE public.event_threads ADD CONSTRAINT event_threads_ended_on_check CHECK (((status = 'closed'::text) OR (ended_on IS NULL))); END IF; END $c$;
+
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_entries_pkey' AND conrelid = 'public.event_entries'::regclass) THEN ALTER TABLE public.event_entries ADD CONSTRAINT event_entries_pkey PRIMARY KEY (id); END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_entries_user_id_fkey' AND conrelid = 'public.event_entries'::regclass) THEN ALTER TABLE public.event_entries ADD CONSTRAINT event_entries_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE; END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_entries_thread_id_fkey' AND conrelid = 'public.event_entries'::regclass) THEN ALTER TABLE public.event_entries ADD CONSTRAINT event_entries_thread_id_fkey FOREIGN KEY (thread_id) REFERENCES public.event_threads(id) ON DELETE CASCADE; END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_entries_content_not_blank' AND conrelid = 'public.event_entries'::regclass) THEN ALTER TABLE public.event_entries ADD CONSTRAINT event_entries_content_not_blank CHECK ((btrim(content) <> ''::text)); END IF; END $c$;
+DO $c$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'event_entries_source_check' AND conrelid = 'public.event_entries'::regclass) THEN ALTER TABLE public.event_entries ADD CONSTRAINT event_entries_source_check CHECK ((source = ANY (ARRAY['claude'::text, 'gpt'::text, 'gemini'::text, 'user'::text, 'frontend'::text, 'wechat_api'::text, 'client_gpt'::text, 'client_claude'::text, 'codex_cli'::text, 'claude_code_cli'::text, 'system'::text, 'expo_app'::text, 'api'::text]))); END IF; END $c$;
+
+CREATE INDEX IF NOT EXISTS idx_event_threads_user_status_updated ON public.event_threads USING btree (user_id, status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_event_entries_thread_date ON public.event_entries USING btree (thread_id, entry_date, created_at);
+CREATE INDEX IF NOT EXISTS idx_event_entries_user_id ON public.event_entries USING btree (user_id);
+
+CREATE OR REPLACE FUNCTION public.touch_event_thread_from_entries()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_thread_id uuid;
+begin
+  if tg_op = 'DELETE' then
+    v_thread_id := old.thread_id;
+  else
+    v_thread_id := new.thread_id;
+  end if;
+  update public.event_threads
+     set updated_at = now()
+   where id = v_thread_id;
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$function$;
+
+REVOKE ALL ON FUNCTION public.touch_event_thread_from_entries() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS trg_event_threads_updated_at ON public.event_threads;
+CREATE TRIGGER trg_event_threads_updated_at BEFORE UPDATE ON public.event_threads FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+DROP TRIGGER IF EXISTS trg_event_entries_updated_at ON public.event_entries;
+CREATE TRIGGER trg_event_entries_updated_at BEFORE UPDATE ON public.event_entries FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+DROP TRIGGER IF EXISTS trg_event_entries_touch_thread ON public.event_entries;
+CREATE TRIGGER trg_event_entries_touch_thread AFTER INSERT OR DELETE OR UPDATE ON public.event_entries FOR EACH ROW EXECUTE FUNCTION touch_event_thread_from_entries();
+
+ALTER TABLE public.event_threads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_entries ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS event_threads_select_own ON public.event_threads;
+CREATE POLICY event_threads_select_own ON public.event_threads FOR SELECT TO authenticated
+  USING ((( SELECT auth.uid() AS uid) = user_id));
+DROP POLICY IF EXISTS event_threads_insert_own ON public.event_threads;
+CREATE POLICY event_threads_insert_own ON public.event_threads FOR INSERT TO authenticated
+  WITH CHECK ((( SELECT auth.uid() AS uid) = user_id));
+DROP POLICY IF EXISTS event_threads_update_own ON public.event_threads;
+CREATE POLICY event_threads_update_own ON public.event_threads FOR UPDATE TO authenticated
+  USING ((( SELECT auth.uid() AS uid) = user_id))
+  WITH CHECK ((( SELECT auth.uid() AS uid) = user_id));
+DROP POLICY IF EXISTS event_threads_delete_own ON public.event_threads;
+CREATE POLICY event_threads_delete_own ON public.event_threads FOR DELETE TO authenticated
+  USING ((( SELECT auth.uid() AS uid) = user_id));
+
+DROP POLICY IF EXISTS event_entries_select_own ON public.event_entries;
+CREATE POLICY event_entries_select_own ON public.event_entries FOR SELECT TO authenticated
+  USING ((( SELECT auth.uid() AS uid) = user_id));
+DROP POLICY IF EXISTS event_entries_insert_own ON public.event_entries;
+CREATE POLICY event_entries_insert_own ON public.event_entries FOR INSERT TO authenticated
+  WITH CHECK ((( SELECT auth.uid() AS uid) = user_id));
+DROP POLICY IF EXISTS event_entries_update_own ON public.event_entries;
+CREATE POLICY event_entries_update_own ON public.event_entries FOR UPDATE TO authenticated
+  USING ((( SELECT auth.uid() AS uid) = user_id))
+  WITH CHECK ((( SELECT auth.uid() AS uid) = user_id));
+DROP POLICY IF EXISTS event_entries_delete_own ON public.event_entries;
+CREATE POLICY event_entries_delete_own ON public.event_entries FOR DELETE TO authenticated
+  USING ((( SELECT auth.uid() AS uid) = user_id));
+
+REVOKE ALL ON TABLE public.event_threads FROM anon;
+REVOKE ALL ON TABLE public.event_entries FROM anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.event_threads TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.event_threads TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.event_entries TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.event_entries TO service_role;
+
+-- ============================================================================
 -- 完 · Hamster-Nest schema 到此结束
 -- ============================================================================


### PR DESCRIPTION
## Summary

Introduces a new **Event Collection** (事件集) feature for tracking ongoing events using a thread-based model. This implements a "纪事本末体" (chronicle narrative) pattern where each event thread contains dated entries, filling a gap in the existing data model for "frequently updated, ongoing events with clear start/end dates."

## Key Changes

### Database & Types
- **New tables**: `event_threads` (event categories/threads) and `event_entries` (dated entries within threads)
  - `event_threads`: title, current_status (one-liner summary), status (active/closed), emoji_group, started_on, ended_on
  - `event_entries`: entry_date, content, source (write endpoint), thread_id reference
- Added `EventThread` and `EventEntry` types to `src/types.ts`
- Updated Supabase schema and generated TypeScript types

### Frontend Pages
- **EventCollectionPage** (`src/pages/EventCollectionPage.tsx`): List view of all event threads
  - Filter by emoji group (🩷串串 / 💙Syzygy / 🤍仓鼠窝)
  - Toggle between active/closed threads
  - Create/edit/delete threads
  - Display entry counts and last update dates
  
- **EventThreadPage** (`src/pages/EventThreadPage.tsx`): Detail view of a single thread
  - Timeline-style entry rail with date grouping
  - Toggle entry sort order (asc/desc) with localStorage persistence
  - Create/edit/delete entries
  - Thread status management (active/closed)
  - Expandable long-form content

### Styling
- **EventCollection.css** (747 lines): Comprehensive styling aligned with Memo/Timeline aesthetic
  - Pink/rose color palette (matching existing design system)
  - Card-based layout with subtle gradients and shadows
  - Timeline rail visualization for entries
  - Modal editor for threads and entries
  - Responsive design (max-width 720px)

### Storage & Sync
- Extended `supabaseSync.ts` with event collection operations:
  - `listEventThreads()`, `fetchEventThread()`, `createEventThread()`, `updateEventThread()`, `deleteEventThread()`
  - `listEventEntries()`, `createEventEntry()`, `updateEventEntry()`, `deleteEventEntry()`
  - `listEventEntryCounts()` for stats aggregation
  
### MCP Integration
- Added 8 new MCP tools to `hamster-mcp` function:
  - `list_event_threads`, `read_event_thread`, `add_event_entry`, `update_event_entry`, `delete_event_entry`, `create_event_thread`, `update_event_thread`, `delete_event_thread`
- Updated system instructions with event collection semantics and decision rules

### Shared Utilities
- **eventCollectionShared.ts**: Shared constants and helpers
  - Emoji group options, date formatting, text clamping logic
  - Entry order persistence (localStorage)
  
- **recordSources.ts**: Unified source/endpoint labels (shared with Timeline)
  - Supports frontend, API, CLI, and AI endpoints

### Navigation & Layout
- Integrated into App.tsx routing (`/events` and `/events/:threadId`)
- Added "events" icon to home page layout (page 3)
- Updated MCP version to 5.14.0

## Implementation Details

- **Design philosophy**: Follows existing Memo/Timeline patterns with consistent pink aesthetic and card-based UI
- **Data model**: Two-level hierarchy (threads → entries) enables efficient querying of "current status" summaries without loading full entry history
- **Deletion strategy**: Soft-close via `status='closed'` rather than hard delete; archived threads remain queryable
- **Source tracking**: Reuses timeline's source enum to track which endpoint wrote each entry
- **Responsive**: Mobile-first design with max-width constraint, suitable for both web and mobile clients

https://claude.ai/code/session_01QX4TpaQNasrKodJUtP1cZB