### PR TITLE
chore: 同步数据库类型文件到平台当前生成结果，修复 Pages 部署 #564

### DIFF
--- a/scripts/supabase-types.mjs
+++ b/scripts/supabase-types.mjs
@@ -56,6 +56,20 @@ if (checkOnly) {
 
   if (current !== generated) {
     console.error('Database types are stale. Run `npm run db:types:generate` and commit the result.')
+    // 把前几处差异打印出来：类型文件由平台管理 API 服务端生成，PostgREST 版本戳或
+    // 生成器格式变了也会触发这里，看一眼差异就知道是 schema 漂移还是平台升级。
+    const currentLines = current.split('\n')
+    const generatedLines = generated.split('\n')
+    const maxLines = Math.max(currentLines.length, generatedLines.length)
+    let shown = 0
+    for (let index = 0; index < maxLines && shown < 20; index += 1) {
+      if (currentLines[index] === generatedLines[index]) continue
+      console.error(`  line ${index + 1}:`)
+      console.error(`    committed: ${currentLines[index] ?? '<eof>'}`)
+      console.error(`    generated: ${generatedLines[index] ?? '<eof>'}`)
+      shown += 1
+    }
+    console.error(`  (committed ${currentLines.length} lines, generated ${generatedLines.length} lines)`)
     process.exit(1)
   }
 

--- a/src/supabase/database.types.ts
+++ b/src/supabase/database.types.ts
@@ -10,7 +10,7 @@ export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.17"
+    PostgrestVersion: "14.5"
   }
   public: {
     Tables: {
@@ -3910,12 +3910,12 @@ export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -3939,11 +3939,11 @@ export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -3964,11 +3964,11 @@ export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -3989,11 +3989,11 @@ export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+  EnumName extends (DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
@@ -4006,11 +4006,11 @@ export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+  CompositeTypeName extends (PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
+    : never) = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }


### PR DESCRIPTION
## 背景

#506 合并后，Deploy to GitHub Pages run #564 在 build 前置的 `npm run db:types:check` 失败（"Database types are stale"）。Deploy Edge Functions 同一提交已成功，MCP 新工具已上线，只有 Pages 未部署。

## 原因

`src/supabase/database.types.ts` 由 Supabase 管理 API 服务端生成。自上次同步（423f93c，PostgREST 14.1 → 14.17）之后，平台侧生成器输出又变了两处：

- `PostgrestVersion` 版本戳 `14.17` → `14.5`
- 泛型条件类型（`Tables` / `TablesInsert` / `TablesUpdate` / `Enums` / `CompositeTypes`）多了一层括号

public schema 本身没有漂移，#506 新增的 `event_threads` / `event_entries` 类型块与生成结果一字不差。

## 改动

- 整份替换 `database.types.ts` 为当前生成输出（22 行，全部是上述两类差异）
- `scripts/supabase-types.mjs --check` 不一致时打印前 20 处行级差异，后续能直接从 CI 日志分清是 schema 漂移还是平台升级

## 验证

- `npm run check`：0 errors（5 条 warning 为既有文件原有）
- `node --check scripts/supabase-types.mjs` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QX4TpaQNasrKodJUtP1cZB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QX4TpaQNasrKodJUtP1cZB)_