### PR TITLE
hamster-mcp: 移除观察日志（syzygy_posts）四个工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Version](https://img.shields.io/badge/Version-v5.3.0-pink?style=flat-square)](#)
 [![License](https://img.shields.io/badge/License-MIT-a3e635?style=flat-square)](./LICENSE)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-88-2dd4bf?style=flat-square)](#-mcp-工具箱全部-88-个)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-84-2dd4bf?style=flat-square)](#-mcp-工具箱全部-84-个)
 [![Edge Functions](https://img.shields.io/badge/Edge_Functions-19-8b5cf6?style=flat-square)](#-后端-edge-functions)
 [![PRs](https://img.shields.io/badge/PRs-1000+-ff69b4?style=flat-square)](#)
 [![PWA](https://img.shields.io/badge/PWA-可装进手机-f59e0b?style=flat-square)](#)
@@ -106,7 +106,7 @@
 
 | MCP 服务器 | 职责 | 工具数 |
 |:---|:---|:---:|
-| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 · 事件集 · 观察日志 | 26 |
+| `hamster-mcp` | 时间轴 · 待办 · Syzygy Feed · 月度概览 · 备忘录 · 事件集 | 22 |
 | `hamster-knowledge-mcp` | 知识库 · 记忆档案 · Wiki · 学习库图谱 | 19 |
 | `hamster-reading-mcp` | 阅读记录 · 书摘 · 章节 · 旁批共鸣 · 书籍问答 · 导读/总结 | 18 |
 | `hamster-lounge-mcp` | 仓鼠客厅 · 论坛 · 议事厅 | 14 |
@@ -199,14 +199,14 @@ V4.1 起，两个 CLI 还各自收敛到一个持久的「正史会话」（dual
 
 ---
 
-### 🧰 MCP 工具箱（全部 88 个）
+### 🧰 MCP 工具箱（全部 84 个）
 
 > 每个 MCP 服务器都是一个独立的 Supabase Edge Function，走 JSON-RPC / MCP Streamable HTTP。
 > 鉴权优先使用 `x-hamster-mcp-key` 请求头（timing-safe 比对）或 Supabase Auth Header；`?key=` 仅为旧客户端迁移期兼容，避免新凭证进入 URL / Access Log。
 > 工具清单与计数以 `npm run mcp:inventory` 的输出为准（`--live` 模式直连已部署 server 拿精确清单）；跨工具的共性约定放在各 server 的 MCP `instructions` 里随握手下发，只读 / 危险操作标注在 `annotations`（readOnlyHint / destructiveHint）。
 
 <details open>
-<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed · 备忘录 · 事件集 · 观察日志（26）</summary>
+<summary><b>🐹 hamster-mcp</b> — 时间轴 · 待办 · Feed · 备忘录 · 事件集（22）</summary>
 
 | 工具 | 作用 |
 |:---|:---|
@@ -232,10 +232,6 @@ V4.1 起，两个 CLI 还各自收敛到一个持久的「正史会话」（dual
 | `update_event_thread` | 改标题 / 当前状态行 / 分组，或结项 / 重开 |
 | `add_event_entry` | 向事件线追加一条日期 + 事件，可顺手刷新当前状态行 |
 | `update_event_entry` | 修改条目正文 / 日期（仅改错字用） |
-| `list_syzygy_posts` | 列出仓鼠观察日志（朋友圈动态），附回帖数 |
-| `read_syzygy_post` | 读取单条观察日志全文及全部回帖 |
-| `add_syzygy_post` | 发一条观察日志（Syzygy 第一人称随笔，带模型落款） |
-| `reply_syzygy_post` | 给观察日志回帖（ai / user 双身份） |
 
 </details>
 
@@ -442,7 +438,7 @@ Hamster-Nest/
 ├── supabase/
 │   ├── functions/                   # Deno Edge Functions
 │   │   ├── _shared/                 #   公共库（auth 统一鉴权 / quota 额度 / time / mcp_common）
-│   │   ├── hamster-mcp/             #   时间轴 · 待办 · Feed · 观察日志
+│   │   ├── hamster-mcp/             #   时间轴 · 待办 · Feed · 备忘录 · 事件集
 │   │   ├── hamster-knowledge-mcp/   #   知识库 · 档案 · Wiki · 学习库
 │   │   ├── hamster-reading-mcp/     #   阅读 · 书摘 · 旁批
 │   │   ├── hamster-lounge-mcp/      #   客厅 · 论坛 · 议事厅

--- a/supabase/functions/_shared/mcp_common.ts
+++ b/supabase/functions/_shared/mcp_common.ts
@@ -7,7 +7,7 @@ import { isMcpKeyAuthorized } from './mcp_key_auth.ts'
 import { getOwnerUserId } from './owner.ts'
 import { getSupabaseAdminKey } from './supabase_secret.ts'
 
-export const MCP_VERSION = '5.15.0'
+export const MCP_VERSION = '5.16.0'
 export const USER_ID = getOwnerUserId()
 
 export const supabase = createClient(

--- a/supabase/functions/hamster-mcp/index.ts
+++ b/supabase/functions/hamster-mcp/index.ts
@@ -9,10 +9,6 @@ const FEED_TYPE_SCHEMA = z.enum(['morning_share', 'reading_assist', 'daily_card'
 const TIMELINE_SOURCE_SCHEMA = z.enum(['claude', 'gpt', 'user', 'gemini', 'wechat', 'codex_cli', 'claude_code_cli', 'api'])
 const MEMO_SOURCE_SCHEMA = TIMELINE_SOURCE_SCHEMA
 const MEMO_COLUMNS = 'id, content, source, is_pinned, created_at, updated_at'
-// 仓鼠观察日志（朋友圈）：syzygy_posts 是 Syzygy 的动态，syzygy_replies 是串串/AI 的回帖；软删除行不对外暴露。
-const SYZYGY_POST_COLUMNS = 'id, content, model_id, created_at, updated_at'
-const SYZYGY_REPLY_COLUMNS = 'id, post_id, author_role, content, model_id, created_at'
-const SYZYGY_REPLY_ROLE_SCHEMA = z.enum(['user', 'ai'])
 const TODO_COLUMNS = 'id, date, title, notes, status, todo_type, event_date, created_by, sort_order, created_at, completed_at'
 const TODO_CREATED_BY_SCHEMA = z.enum(['串串', 'syzygy'])
 const TODO_TYPE_SCHEMA = z.enum(['short_term', 'long_term'])
@@ -25,7 +21,7 @@ const EVENT_ENTRY_SOURCE_SCHEMA = z.enum(['claude', 'gpt', 'gemini', 'user', 'co
 
 // 服务器级使用说明：跨工具的共性约定统一放这里，工具描述只写"做什么"。
 const HAMSTER_MCP_INSTRUCTIONS = [
-  '仓鼠窝日常域：时间轴（长期事件记忆）、待办、Syzygy Feed（系统下发内容流）、备忘录 memo（中期活事实）、事件集 event_threads / event_entries（纪事本末体的线程记录层）、观察日志 syzygy_posts（Syzygy 的朋友圈动态，与 Feed 是两个功能）。',
+  '仓鼠窝日常域：时间轴（长期事件记忆）、待办、Syzygy Feed（系统下发内容流）、备忘录 memo（中期活事实）、事件集 event_threads / event_entries（纪事本末体的线程记录层）。',
   '裁决口诀：过去进时间轴，现在进 Memo，永远进档案，将来进 To do，线程进事件集；自己说的进 Wiki，世界说的进学习库；要许可的去议事厅。',
   '事件集：一件正在进行、有起止、频繁更新的事开一个大类（thread），进度按日期追加条目（entry）；开机默认只用 list_event_threads 读所有进行中大类的「当前状态」一行，对话碰到某件事再 read_event_thread 读条目；已结束大类默认不加载。同一件事允许同时进时间轴（意义与心情）和事件集（进度），不去重。追加条目时顺手用 current_status 刷新大类状态行。',
   '通用约定：日期按 Asia/Shanghai 时区；source / recorder / created_by 等枚举表示写入端身份，默认 claude / syzygy；Feed 读取默认只含 unread/read，不返回 archived/expired，摘要列表不含全文。',
@@ -773,106 +769,6 @@ serveMcp('hamster-mcp', (server) => {
       const entry = data?.[0]
       if (!entry) return { content: [{ type: 'text' as const, text: `Error: 未找到条目: ${entry_id}` }] }
       return { content: [{ type: 'text' as const, text: `已更新: ${JSON.stringify(entry, null, 2)}` }] }
-    } catch (err) {
-      return errorResult(err)
-    }
-  })
-
-  server.registerTool('list_syzygy_posts', {
-    title: 'List Syzygy Posts',
-    description: '列出仓鼠观察日志（Syzygy 动态），附回帖数。',
-    annotations: { readOnlyHint: true },
-    inputSchema: {
-      limit: z.number().optional().describe('返回数量上限，默认10，最大50'),
-    },
-  }, async ({ limit }) => {
-    try {
-      const safeLimit = clampLimit(limit, 10, 50)
-      const { data, error } = await supabase.from('syzygy_posts').select(SYZYGY_POST_COLUMNS).eq('user_id', USER_ID).eq('is_deleted', false).order('created_at', { ascending: false }).limit(safeLimit)
-      if (error) return errorResult(error)
-      const posts = (data ?? []) as Record<string, unknown>[]
-      const postIds = posts.map((post) => post.id as string)
-      const replyCounts = new Map<string, number>()
-      if (postIds.length > 0) {
-        const { data: replyRows, error: replyError } = await supabase.from('syzygy_replies').select('post_id').in('post_id', postIds).eq('is_deleted', false)
-        if (replyError) return errorResult(replyError)
-        for (const row of (replyRows ?? []) as { post_id: string }[]) replyCounts.set(row.post_id, (replyCounts.get(row.post_id) ?? 0) + 1)
-      }
-      return jsonResult(posts.map((post) => ({ ...post, reply_count: replyCounts.get(post.id as string) ?? 0 })))
-    } catch (err) {
-      return errorResult(err)
-    }
-  })
-
-  server.registerTool('read_syzygy_post', {
-    title: 'Read Syzygy Post',
-    description: '读取一条观察日志的全文和全部回帖。',
-    annotations: { readOnlyHint: true },
-    inputSchema: {
-      post_id: z.string().describe('日志 UUID（用 list_syzygy_posts 查询）'),
-    },
-  }, async ({ post_id }) => {
-    try {
-      const { data: post, error: postError } = await supabase.from('syzygy_posts').select(SYZYGY_POST_COLUMNS).eq('user_id', USER_ID).eq('id', post_id).eq('is_deleted', false).maybeSingle()
-      if (postError) return errorResult(postError)
-      if (!post) return { content: [{ type: 'text' as const, text: `Error: 未找到观察日志（或已删除）: ${post_id}` }] }
-      const { data: replies, error: repliesError } = await supabase.from('syzygy_replies').select(SYZYGY_REPLY_COLUMNS).eq('post_id', post_id).eq('is_deleted', false).order('created_at', { ascending: true })
-      if (repliesError) return errorResult(repliesError)
-      return jsonResult({ post, replies: replies ?? [] })
-    } catch (err) {
-      return errorResult(err)
-    }
-  })
-
-  server.registerTool('add_syzygy_post', {
-    title: 'Add Syzygy Post',
-    description: '发布一条仓鼠观察日志（Syzygy 第一人称动态）。',
-    inputSchema: {
-      content: z.string().describe('日志内容'),
-      model_id: z.string().optional().describe('撰写模型标识，如 claude / gpt / gemini；默认 claude'),
-    },
-  }, async ({ content, model_id }) => {
-    try {
-      const trimmed = content.trim()
-      if (!trimmed) return { content: [{ type: 'text' as const, text: 'Error: 日志内容不能为空' }] }
-      const { data, error } = await supabase.from('syzygy_posts').insert({
-        user_id: USER_ID,
-        content: trimmed,
-        model_id: model_id?.trim() || 'claude',
-      }).select(SYZYGY_POST_COLUMNS).single()
-      if (error) return errorResult(error)
-      return { content: [{ type: 'text' as const, text: `观察日志已发布: ${JSON.stringify(data)}` }] }
-    } catch (err) {
-      return errorResult(err)
-    }
-  })
-
-  server.registerTool('reply_syzygy_post', {
-    title: 'Reply Syzygy Post',
-    description: '给一条观察日志回帖。',
-    inputSchema: {
-      post_id: z.string().describe('日志 UUID'),
-      content: z.string().describe('回帖内容'),
-      author_role: SYZYGY_REPLY_ROLE_SCHEMA.optional().describe('回帖身份，默认 ai；user 表示替串串代录'),
-      model_id: z.string().optional().describe('撰写模型标识，如 claude / gpt / gemini；author_role=ai 时默认 claude'),
-    },
-  }, async ({ post_id, content, author_role, model_id }) => {
-    try {
-      const trimmed = content.trim()
-      if (!trimmed) return { content: [{ type: 'text' as const, text: 'Error: 回帖内容不能为空' }] }
-      const { data: post, error: postError } = await supabase.from('syzygy_posts').select('id').eq('user_id', USER_ID).eq('id', post_id).eq('is_deleted', false).maybeSingle()
-      if (postError) return errorResult(postError)
-      if (!post) return { content: [{ type: 'text' as const, text: `Error: 未找到观察日志（或已删除）: ${post_id}` }] }
-      const role = author_role ?? 'ai'
-      const { data, error } = await supabase.from('syzygy_replies').insert({
-        user_id: USER_ID,
-        post_id,
-        author_role: role,
-        content: trimmed,
-        model_id: role === 'ai' ? (model_id?.trim() || 'claude') : null,
-      }).select(SYZYGY_REPLY_COLUMNS).single()
-      if (error) return errorResult(error)
-      return { content: [{ type: 'text' as const, text: `回帖已发布: ${JSON.stringify(data)}` }] }
     } catch (err) {
       return errorResult(err)
     }


### PR DESCRIPTION
## 背景

串串 2026-09-04 决定：观察日志功能基本不用，从 hamster-mcp 工具面下线。

## 改动

- 删除 `list_syzygy_posts` / `read_syzygy_post` / `add_syzygy_post` / `reply_syzygy_post` 四个工具，连带列常量、回帖身份枚举与 server instructions 里的描述
- `MCP_VERSION` 5.15.0 → 5.16.0
- README：工具总数 88 → 84，hamster-mcp 26 → 22，删除对应四行

不动的部分：`syzygy_posts` / `syzygy_replies` 数据表与 App 内 `/syzygy` 页面保持原样，只是 MCP 不再暴露。

## 验证

- `npm run mcp:inventory`：hamster-mcp 22，总计 84（含 reading 8 个工厂工具）
- `npm test`：84 通过
- 源码里 `syzygy_post` / `SYZYGY_` 引用清零

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QX4TpaQNasrKodJUtP1cZB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QX4TpaQNasrKodJUtP1cZB)_