### PR TITLE
事件集：修复列表页说明卡片在内容超过一屏时被压成一行

### DIFF
--- a/src/pages/EventCollection.css
+++ b/src/pages/EventCollection.css
@@ -6,6 +6,9 @@
   margin: 0 auto;
   padding: 14px 14px 20px;
   min-height: 100dvh;
+  /* .app-shell 是固定高度的纵向 flex，不设 flex-shrink: 0 页面会被压到一屏高，
+     网格里带 overflow: hidden 的行会被压成 0（只剩 padding），表现为卡片只露一行。 */
+  flex-shrink: 0;
   display: grid;
   gap: 12px;
   align-content: start;
@@ -98,12 +101,12 @@
   padding: 12px;
   box-shadow: 0 10px 20px rgba(255, 214, 231, 0.2);
   position: relative;
-  overflow: hidden;
 }
 
 .event-intro-dot {
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   pointer-events: none;
   background-image: radial-gradient(circle at 1px 1px, rgba(255, 214, 231, 0.62) 1.2px, transparent 1.2px);
   background-size: 16px 16px;


### PR DESCRIPTION
## 问题

串串反馈 /events 列表页顶部说明卡片只露出"线程进事件集 进行中 4 · 已结束 0"一行，下面的提示文字和 🩷💙🤍 分组按钮被裁掉。

## 原因

`.app-shell` 是固定高度（100dvh）的纵向 flex 容器，`.event-page` 没设 `flex-shrink: 0`，内容超过一屏时整页被压到一屏高。网格里唯一带 `overflow: hidden` 的说明卡片自动最小高度为 0，行被压成 0，只剩内边距露出第一行文字。本地用假数据在 380px 高视口下复现，与截图一致；内容不足一屏时不触发，所以之前没发现。

## 改动

- `.event-page` 补 `flex-shrink: 0`（与 `.timeline-page` 一致）
- 说明卡片去掉 `overflow: hidden`，点阵层改用 `border-radius: inherit` 贴合圆角

## 验证

- 矮视口下复现 → 修复后说明卡片完整显示
- `npm run check`：0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QX4TpaQNasrKodJUtP1cZB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QX4TpaQNasrKodJUtP1cZB)_